### PR TITLE
[script.xbmc.boblight] 2.0.16

### DIFF
--- a/script.xbmc.boblight/addon.xml
+++ b/script.xbmc.boblight/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.xbmc.boblight" name="Kodi Boblight" version="2.0.15" provider-name="bobo1on1, Memphiz">
+<addon id="script.xbmc.boblight" name="Kodi Boblight" version="2.0.16" provider-name="bobo1on1, Memphiz">
   <requires>
     <import addon="xbmc.python" version="2.1.0"/>
   </requires>

--- a/script.xbmc.boblight/changelog.txt
+++ b/script.xbmc.boblight/changelog.txt
@@ -1,3 +1,6 @@
+2.0.16
+- fixed detection of arm64 android platform and download the right shared library for it
+
 2.0.15
 - rebrand from XBMC Boblight to Kodi Boblight
 - added tvos support

--- a/script.xbmc.boblight/resources/lib/tools.py
+++ b/script.xbmc.boblight/resources/lib/tools.py
@@ -77,7 +77,7 @@ def get_platform():
   elif  xbmc.getCondVisibility('system.platform.tvos'):
     platform = "tvos"
   elif  xbmc.getCondVisibility('system.platform.android'):
-    if os.uname()[4].startswith("arm"):
+    if os.uname()[4].startswith("arm") or os.uname()[4].startswith("aarch64"):
       platform = "android"
     else:
       platform = "androidx86"


### PR DESCRIPTION
fixed aarch64 detection (nvidia shield)