### PR TITLE
[script.common.plugin.cache] 2.5.6

### DIFF
--- a/script.common.plugin.cache/addon.xml
+++ b/script.common.plugin.cache/addon.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='yes'?>
-<addon id="script.common.plugin.cache" name="Common plugin cache" provider-name="TheCollective" version="2.5.5">
+<addon id="script.common.plugin.cache" name="Common plugin cache" provider-name="TheCollective" version="2.5.6">
   <requires>
     <import addon="xbmc.python" version="2.1.0" />
   </requires>

--- a/script.common.plugin.cache/changelog.txt
+++ b/script.common.plugin.cache/changelog.txt
@@ -1,3 +1,6 @@
+[B]Version 2.5.6[/B]
+- fixed common cache not starting on ios/tvos when socket path is to long by using AF_INET instead of AF_POSIX
+
 [B]Version 2.5.5[/B]
 - Fix ascii error with non UTF-8 characters on print statement
 


### PR DESCRIPTION
This fixes the annoying error when common cache fails to start due to too long socket path when calling bind. It uses the same approach like for win32 and android for ios and tvos now too. (with a small refactor to not dupe that code too much...)