### PR TITLE
[service.skin.widgets] 0.0.31 - Fix circular reference warnings on shutdown

### DIFF
--- a/service.skin.widgets/addon.xml
+++ b/service.skin.widgets/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="service.skin.widgets" name="Skin Widgets" version="0.0.30" provider-name="Martijn, phil65">
+<addon id="service.skin.widgets" name="Skin Widgets" version="0.0.31" provider-name="Martijn, phil65">
     <requires>
         <import addon="xbmc.addon" version="12.0.0"/>
         <import addon="xbmc.json" version="6.0.0"/>

--- a/service.skin.widgets/changelog.txt
+++ b/service.skin.widgets/changelog.txt
@@ -1,3 +1,6 @@
+v0.0.31
+- Fix circular reference warnings on shutdown
+
 v0.0.30
 - Fix possible script error on recommended episodes
 

--- a/service.skin.widgets/default.py
+++ b/service.skin.widgets/default.py
@@ -629,6 +629,10 @@ class Main:
                     home_update = False
                 elif self.RECENTITEMS_HOME_UPDATE == 'true' and not home_update and xbmcgui.getCurrentWindowId() != 10000:
                     home_update = True
+        else:
+            self.Monitor.update_listitems = None
+            self.Monitor.update_settings = None
+            self.Player.action = None
 
     def _clear_properties(self, request):
         count = 0


### PR DESCRIPTION
Circular references aren't collected by the garbage collector.
Fixes this warning on shutdown:
```
DEBUG: ADDON: Stopping service addons.
DEBUG: Skin Widgets: script version 0.0.30 stopped
INFO: CPythonInvoker(0, /Users/anaconda/Library/Application Support/Kodi/addons/service.skin.widgets/default.py): script successfully run
DEBUG: CPythonInvoker(0, /Users/anaconda/Library/Application Support/Kodi/addons/service.skin.widgets/default.py): script termination took 489ms
WARNING: CPythonInvoker(0, /Users/anaconda/Library/Application Support/Kodi/addons/service.skin.widgets/default.py): the python script "/Users/anaconda/Library/Application Support/Kodi/addons/service.skin.widgets/default.py" has left several classes in memory that we couldn't clean up. The classes include: N14PythonBindings30XBMCAddon_xbmc_Player_DirectorE,N9XBMCAddon7xbmcgui6WindowE,N14PythonBindings31XBMCAddon_xbmc_Monitor_DirectorE
INFO: Python script interrupted by user
```