### PR TITLE
[service.library.data.provider] 0.1.5 - Fix circular reference warnings on shutdown

### DIFF
--- a/service.library.data.provider/addon.xml
+++ b/service.library.data.provider/addon.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='yes'?>
-<addon id="service.library.data.provider" name="Library Data Provider" provider-name="BigNoid, Martijn" version="0.1.4">
+<addon id="service.library.data.provider" name="Library Data Provider" provider-name="BigNoid, Martijn" version="0.1.5">
 	<requires>
 		<import addon="xbmc.addon" version="12.0.0"/>
 		<import addon="xbmc.json" version="6.0.0"/>

--- a/service.library.data.provider/changelog.txt
+++ b/service.library.data.provider/changelog.txt
@@ -1,4 +1,7 @@
-[B]0.1.3[/B]
+[B]0.1.5[/B]
+- Fix circular reference warnings on shutdown.
+
+[B]0.1.4[/B]
 - Added missing 'director" property for recommended episodes.
 
 [B]0.1.3[/B]

--- a/service.library.data.provider/service.py
+++ b/service.library.data.provider/service.py
@@ -97,6 +97,8 @@ class Main:
         while not self.Monitor.abortRequested() and self.WINDOW.getProperty('LibraryDataProvider_Running') == 'true':
             if self.Monitor.waitForAbort(1):
                 # Abort was requested while waiting. We should exit
+                self.Monitor.update_listitems = None
+                self.Player.action = None
                 break
             if not xbmc.Player().isPlayingVideo():
                 # Update random items


### PR DESCRIPTION
Same as #35