### PR TITLE
Fixed plugin loading on Windows

### DIFF
--- a/script.common.plugin.cache/default.py
+++ b/script.common.plugin.cache/default.py
@@ -27,7 +27,7 @@ dbglevel = 3
 
 
 def run():
-    sys.path = [settings.getAddonInfo('path') + "/lib"] + sys.path
+    sys.path = [settings.getAddonInfo('path').decode('utf-8') + "/lib"] + sys.path
     import StorageServer
     s = StorageServer.StorageServer(False)
     print " StorageServer Module loaded RUN"


### PR DESCRIPTION
Fixed: Plugin fails to load on Windows when the username contains UTF-8 characters (e.g. "š")