### PR TITLE
[service.nextup.notification] 1.0.20

### DIFF
--- a/service.nextup.notification/addon.xml
+++ b/service.nextup.notification/addon.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='yes'?>
-<addon id="service.nextup.notification" name="Nextup Service Notification" provider-name="im85288" version="1.0.19">
+<addon id="service.nextup.notification" name="Nextup Service Notification" provider-name="im85288" version="1.0.20">
     <requires>
         <import addon="xbmc.python" version="2.20.0"/>
         <import addon="script.module.addon.signals" version="0.0.1"/>

--- a/service.nextup.notification/resources/lib/Player.py
+++ b/service.nextup.notification/resources/lib/Player.py
@@ -319,9 +319,7 @@ class Player(xbmc.Player):
                 result = unicode(result, 'utf-8', errors='ignore')
                 result = json.loads(result)
                 self.logMsg("Got details of next up episode %s" % str(result), 2)
-                monitor = xbmc.Monitor()
-                monitor.waitForAbort(0.1)
-                del monitor
+                xbmc.sleep(100)
 
                 # Find the next unwatched and the newest added episodes
                 if "result" in result and "episodes" in result["result"]:
@@ -368,9 +366,7 @@ class Player(xbmc.Player):
                                 stillWatchingPage.show()
                         while xbmc.Player().isPlaying() and (
                                         totalTime - playTime > 1) and not nextUpPage.isCancel() and not nextUpPage.isWatchNow() and not stillWatchingPage.isStillWatching() and not stillWatchingPage.isCancel():
-                            monitor = xbmc.Monitor()
-                            monitor.waitForAbort(0.1)
-                            del monitor
+                            xbmc.sleep(100)
                             try:
                                 playTime = xbmc.Player().getTime()
                                 totalTime = xbmc.Player().getTotalTime()


### PR DESCRIPTION
Sorry for the quick additional PR, found a critical bug with the last changes. I put back the sleeps for the ones that are under a second.