### PR TITLE
[service.subtitles.legendasdivx] 0.2.8

### DIFF
--- a/service.subtitles.legendasdivx/addon.xml
+++ b/service.subtitles.legendasdivx/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="service.subtitles.legendasdivx"
        name="LegendasDivx.com"
-       version="0.2.7"
+       version="0.2.8"
        provider-name="HiGhLaNdeR">
   <requires>
     <import addon="xbmc.python" version="2.14.0"/>

--- a/service.subtitles.legendasdivx/changelog.txt
+++ b/service.subtitles.legendasdivx/changelog.txt
@@ -1,3 +1,5 @@
+0.2.8
+- Android\Linux crash solved. _temp variable not decoded to utf-8 by default.
 0.2.7
 - BUGFix when DEBUG is on making the script to crash
 0.2.6

--- a/service.subtitles.legendasdivx/service.py
+++ b/service.subtitles.legendasdivx/service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Service LegendasDivx.com version 0.2.7
+# Service LegendasDivx.com version 0.2.8
 # Code based on Undertext (FRODO) service
 # Coded by HiGhLaNdR@OLDSCHOOL
 # Ported to Gotham by HiGhLaNdR@OLDSCHOOL
@@ -38,7 +38,7 @@ _language   = _addon.getLocalizedString
 _cwd        = xbmc.translatePath(_addon.getAddonInfo('path')).decode("utf-8")
 _profile    = xbmc.translatePath(_addon.getAddonInfo('profile')).decode("utf-8")
 _resource   = xbmc.translatePath(os.path.join(_cwd, 'resources', 'lib' )).decode("utf-8")
-_temp       = xbmc.translatePath(os.path.join(_profile, 'temp')).decode("utf-8")
+_temp       = xbmc.translatePath(os.path.join(_profile, 'temp'))
 
 if os.path.isdir(_temp):shutil.rmtree(_temp)
 xbmcvfs.mkdirs(_temp)


### PR DESCRIPTION
Android\Linux crash solved. _temp variable not decoded to utf-8 by default.