### PR TITLE
[service.subtitles.traduttorianonimi] 2.0.4

### DIFF
--- a/service.subtitles.traduttorianonimi/addon.xml
+++ b/service.subtitles.traduttorianonimi/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="service.subtitles.traduttorianonimi"
        name="traduttorianonimi.it"
-       version="2.0.3"
+       version="2.0.4"
        provider-name="shelladdicted">
   <requires>
     <import addon="xbmc.python" version="2.24.0"/>

--- a/service.subtitles.traduttorianonimi/changelog.txt
+++ b/service.subtitles.traduttorianonimi/changelog.txt
@@ -24,3 +24,8 @@
 - Feautures -> Nothing
 - Code:
     Converted strings.xml to strings.po
+
+2.0.4
+- Feautures -> Nothing
+- Code:
+    Fixed errors for android devices

--- a/service.subtitles.traduttorianonimi/resources/lib/TraduttoriAnonimi.py
+++ b/service.subtitles.traduttorianonimi/resources/lib/TraduttoriAnonimi.py
@@ -35,7 +35,7 @@ resource = xbmc.translatePath(os.path.join(cwd, "resources", "lib")).decode("utf
 
 sys.path.append(resource)
 from utils import *
-log=log.getChild("Core")
+#log=log #.getChild("Core") #Disabled for android compatibility
 
 def MagicInt(x): #Cast to integer (if possible) without Errors
     try:
@@ -62,13 +62,13 @@ class SearchableDict(dict):
 
 class TraduttoriAnonimi:
     def __init__(self,BaseURL="http://traduttorianonimi.it"):
-        self.log=log.getChild("TA")
+        self.log=log #.getChild("TA") #Disabled for android compatibility
         
         self.BaseURL=BaseURL
-        self.log.debug("BaseURL=> {}".format(self.BaseURL))
+        self.log.debug("BaseURL=> {0}".format(self.BaseURL))
         
         self.ShowsListURL=urlparse.urljoin(self.BaseURL,"elenco-serie/")
-        self.log.debug("ShowsListURL=> {}".format(self.ShowsListURL))
+        self.log.debug("ShowsListURL=> {0}".format(self.ShowsListURL))
         
         self.ShowsList=SearchableDict()
         self.UpdateShowsList()
@@ -83,7 +83,7 @@ class TraduttoriAnonimi:
         self.ShowsList=SearchableDict()
         for attempt in xrange(100):
             r=RetriveURL(url)
-            self.log.debug("Attempt #{}".format(attempt))
+            self.log.debug("Attempt #{0}".format(attempt))
             if (r!=None):
                 html=r.content
                 parser=BeautifulSoup(html,"html.parser")
@@ -95,7 +95,7 @@ class TraduttoriAnonimi:
                 tmp=parser.find("div",{"class":"pagination" }).find("a",{"class":"next"})
                 if (tmp!=None):
                     url=urlparse.urljoin(self.BaseURL,tmp.attrs["href"])
-                    self.log.debug("Next Page Found. Following => {}".format(url))
+                    self.log.debug("Next Page Found. Following => {0}".format(url))
                 else:
                     self.log.debug("Next Page Not Found. Exiting from loop")
                     break
@@ -119,10 +119,10 @@ class TraduttoriAnonimi:
                         
                 for ep in parser.findAll("td",{"class":"dwn"}):
                     tmp=ep.find("a")
-                    self.log.debug("Analyzing => {}".format(tmp))
+                    self.log.debug("Analyzing => {0}".format(tmp))
                     if (tmp!=None and "title" in tmp.attrs and "href" in tmp.attrs):
                         x=EpisodeRegex.search(tmp.attrs["title"])
-                        self.log.debug("Regex Groups=> {}".format(x.groups()))
+                        self.log.debug("Regex Groups=> {0}".format(x.groups()))
                         if (MagicInt(x.group("season"))==Season and MagicInt(x.group("episode"))==Episode):
                             self.log.info("Subtitle Found")
                             return [{"Name":tmp.attrs["title"],"URL":tmp.attrs["href"]}]

--- a/service.subtitles.traduttorianonimi/resources/lib/utils.py
+++ b/service.subtitles.traduttorianonimi/resources/lib/utils.py
@@ -54,7 +54,7 @@ def notify(message,header=scriptname,icon=NotifyLogo,time=5000):
 
 class LogStream(object):
     def write(self,data):
-        xbmc.log("*** [service.subtiles.traduttorianonimi] -> {}".format(data.encode('utf-8',"ignore")), level = xbmc.LOGNOTICE)
+        xbmc.log("*** [service.subtiles.traduttorianonimi] -> {0}".format(data.encode('utf-8',"ignore")), level = xbmc.LOGNOTICE)
          
 log=logging.getLogger("TraduttoriAnonimi")
 log.setLevel(logging.DEBUG)
@@ -66,9 +66,9 @@ log.addHandler(consoleHandler)
 def RetriveURL(url):
     try:
         headers={"user-agent": "Kodi-SubtitleService-TraduttoriAnonimi"}
-        log.debug("GET Request => HEADERS={} ; URL={}".format(headers,url))
+        log.debug("GET Request => HEADERS={0} ; URL={1}".format(headers,url))
         q=requests.get(url,headers=headers)
-        log.debug("GET Request <= Response HEADERS={}".format(q.headers))
+        log.debug("GET Request <= Response HEADERS={0}".format(q.headers))
         return q
     except:
         log.error("An Error is occurred",exc_info=True)

--- a/service.subtitles.traduttorianonimi/service.py
+++ b/service.subtitles.traduttorianonimi/service.py
@@ -41,7 +41,7 @@ resource = xbmc.translatePath(os.path.join(cwd, "resources", "lib")).decode("utf
 
 sys.path.append(resource)
 from utils import *
-log=log.getChild("Service")
+#log=log.getChild("Service") #Disabled for android compatibility
 
 import TraduttoriAnonimi
 
@@ -73,7 +73,7 @@ def search(item):
                     subs=download(result["URL"])
                     for sub in subs:
                         listitem = xbmcgui.ListItem(label='Italian',label2=os.path.basename(sub),thumbnailImage='it') #sub["Name"]
-                        xbmcplugin.addDirectoryItem(handle = int(sys.argv[1]), url = "plugin://{}/?action=download&url={}".format(scriptid,sub), listitem = listitem, isFolder = False)#sub["URL"]
+                        xbmcplugin.addDirectoryItem(handle = int(sys.argv[1]), url = "plugin://{0}/?action=download&url={1}".format(scriptid,sub), listitem = listitem, isFolder = False)#sub["URL"]
                     xbmcplugin.endOfDirectory(int(sys.argv[1]))	# send end of directory to XBMC
             else:
                 log.info("NO RESULTS")
@@ -85,7 +85,7 @@ def search(item):
         log.info('TraduttoriAnonimi only works with italian. Skipped')
         
 def download(url):
-    log.debug("Downloading => {}".format(url))
+    log.debug("Downloading => {0}".format(url))
     if (os.path.isfile(url)):
         log.info("url is a local path")
         return [url]
@@ -98,11 +98,11 @@ def download(url):
         tmp=StringIO.StringIO(content) # "with" can't be used because StringIO has not __exit__
         if (content[0]=="P"):
             log.info("ZipFile Detected")
-            with zipfile.ZipFile(tmp) as q:
-                for name in q.namelist():
-                    if (name.split(".")[-1] in exts):
-                        q.extract(name, temp)
-                        out.append(os.path.join(temp,name))
+            q=zipfile.ZipFile(tmp) # "with" can't be used because zipfile has not __exit__ (ANDROID FIX)
+            for name in q.namelist():
+                if (name.split(".")[-1] in exts):
+                    q.extract(name, temp)
+                    out.append(os.path.join(temp,name))
         else:
             log.info("Unpacked file detected")
             if (os.path.basename(url).split(".")[-1] in exts):
@@ -110,11 +110,11 @@ def download(url):
                     q.write(content)
                 out.append(os.path.join(temp,os.path.basename(url)))
             else:
-                log.info("Downloaded File ({}) is not in exts[{}]".format(os.path.basename(url),str(exts)))
+                log.info("Downloaded File ({0}) is not in exts[{1}]".format(os.path.basename(url),str(exts)))
     return out
 
 def main():
-    log.info("Application version: {}".format(version))
+    log.info("Application version: {0}".format(version))
     if (xbmc.Player().isPlayingVideo()):
         params = GetParams()
     


### PR DESCRIPTION
Hi. The version of my addon (2.0.3) merged 15 hours ago. works only on Windows and Linux but not on android devices (tested on Android 5.1.1 with kodi 16.1 apk downloaded from kodi.tv) because version of logging module is lower than "0.5.1.2", so now i fixed my addon and now is compatibile with lower versions of logging (removing "getChild()"), another thing, python 2.6 requires that "{}".format(something) must have and integer like this => ("{0}".format(something), so if fixed also this.
-Why the SAME version of kodi uses different version of python on android ???