### PR TITLE
[script.module.dropbox] 2.2.2

### DIFF
--- a/script.module.dropbox/addon.xml
+++ b/script.module.dropbox/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="script.module.dropbox"
        name="Dropbox API"
-       version="2.2.1"
+       version="2.2.2"
        provider-name="micah">
   <requires>
     <import addon="xbmc.python" version="2.1.0"/>

--- a/script.module.dropbox/changelog.txt
+++ b/script.module.dropbox/changelog.txt
@@ -1,3 +1,7 @@
+[B]Version 2.2.2[/B]
+
+- Fix utf8_params in rest API (affected android only)
+
 [B]Version 2.2.1[/B]
 
 - Fix version numbers

--- a/script.module.dropbox/lib/dropbox/rest.py
+++ b/script.module.dropbox/lib/dropbox/rest.py
@@ -412,5 +412,9 @@ def params_to_urlencoded(params):
             return o.encode('utf8')
         else:
             return str(o)
-    utf8_params = {encode(k): encode(v) for k, v in params.iteritems()}
+
+    utf8_params = {}
+    for k, v in params.iteritems():
+        utf8_params[encode(k)] = encode(v)
+
     return urllib.urlencode(utf8_params)


### PR DESCRIPTION
Hi, this fixes a problem the android version of Kodi (or its Python interpreter) had with the dropbox rest API code.