### PR TITLE
[script.screensaver.football.panel] 1.3.1

### DIFF
--- a/script.screensaver.football.panel/addon.xml
+++ b/script.screensaver.football.panel/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.screensaver.football.panel" name="Football Panel" version="1.3.0" provider-name="enen92">
+<addon id="script.screensaver.football.panel" name="Football Panel" version="1.3.1" provider-name="enen92">
 	<requires>
 		<import addon="xbmc.python" version="2.20.0"/>
 		<import addon="script.module.thesportsdb" version="1.0.1"/>

--- a/script.screensaver.football.panel/changelog.txt
+++ b/script.screensaver.football.panel/changelog.txt
@@ -1,2 +1,5 @@
+Version 1.3.1 (22/8/2016)
+-Changed default timezone to match XMLSoccer timezone (UTC)
+
 Version 1.3.0 (17/7/2016)
 -Fixes for Kodi Krypton

--- a/script.screensaver.football.panel/interface.py
+++ b/script.screensaver.football.panel/interface.py
@@ -245,7 +245,7 @@ class Main(xbmcgui.WindowXMLDialog):
 							#Convert event time to user timezone
 							if livegame.Time.lower() == "not started":
 								try:
-									db_time = pytz.timezone(str(pytz.timezone("Europe/London"))).localize(livegame.DateTime)
+									db_time = pytz.timezone(str(pytz.timezone("Etc/UTC"))).localize(livegame.DateTime)
 									my_location=pytz.timezone(pytz.all_timezones[int(my_timezone)])
 									converted_time=db_time.astimezone(my_location)
 									starttime=converted_time.strftime("%H:%M")


### PR DESCRIPTION
Currently the start times for the matches are incorrect since XML Soccer (the site thesportsdb uses to grab information) started to provide the match times based on UTC instead of the former GMT.
This is a really simple commit to fix it.

Regards