### PR TITLE
[script.module.kodiswift] 0.0.7

### DIFF
--- a/script.module.kodiswift/addon.xml
+++ b/script.module.kodiswift/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.module.kodiswift" name="kodiswift" provider-name="Aaron Frase (Sinap)" version="0.0.5">
+<addon id="script.module.kodiswift" name="kodiswift" provider-name="Aaron Frase (Sinap)" version="0.0.7">
   <requires>
     <import addon="xbmc.python" version="2.24.0"/>
   </requires>

--- a/script.module.kodiswift/changelog.txt
+++ b/script.module.kodiswift/changelog.txt
@@ -1,3 +1,13 @@
+0.0.7
+=====
+
+- Made `listitem.playable` use it's own property to allow `is_folder` and `playable` to be independent
+
+0.0.6
+=====
+
+- Make sure list item has 'as_tuple' method
+
 0.0.5
 =====
 

--- a/script.module.kodiswift/lib/kodiswift/listitem.py
+++ b/script.module.kodiswift/lib/kodiswift/listitem.py
@@ -38,6 +38,7 @@ class ListItem(object):
         self._thumbnail = thumbnail
         self._context_menu_items = []
         self._played = False
+        self._playable = False
         self.is_folder = True
 
     def get_context_menu_items(self):
@@ -189,27 +190,27 @@ class ListItem(object):
 
     @property
     def playable(self):
-        return not self.is_folder
+        return self._playable
 
     @playable.setter
     def playable(self, value):
-        self.is_folder = not value
-        is_playable = 'true' if value else 'false'
+        self._playable = value
+        is_playable = 'true' if self._playable else 'false'
         self.set_property('isPlayable', is_playable)
 
     def get_is_playable(self):
         warnings.warn('get_is_playable is deprecated, use playable property',
                       DeprecationWarning)
-        return not self.is_folder
+        return self._playable
 
     def set_is_playable(self, is_playable):
         warnings.warn('set_is_playable is deprecated, use playable property',
                       DeprecationWarning)
+        self._playable = is_playable
         value = 'false'
         if is_playable:
             value = 'true'
         self.set_property('isPlayable', value)
-        self.is_folder = not is_playable
 
     @property
     def played(self):

--- a/script.module.kodiswift/lib/kodiswift/xbmcmixin.py
+++ b/script.module.kodiswift/lib/kodiswift/xbmcmixin.py
@@ -381,7 +381,7 @@ class XBMCMixin(object):
             kodiswift.ListItem: The list of ListItems.
         """
         _items = [self._listitemify(item) for item in items]
-        tuples = [item.as_tuple() for item in _items]
+        tuples = [item.as_tuple() for item in _items if hasattr(item, 'as_tuple')]
         xbmcplugin.addDirectoryItems(self.handle, tuples, len(tuples))
 
         # We need to keep track internally of added items so we can return them


### PR DESCRIPTION
### Description

- Made `listitem.playable` use it's own property to allow `is_folder` and `playable` to be independent
- Make sure list item has 'as_tuple' method

### Checklist:
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a sinlge commit with using the following style: [sciprt.foo.bar] v1.0.0