### PR TITLE
[service.subtitles.subtitle] v4.5.0

### DIFF
--- a/service.subtitles.subtitle/addon.xml
+++ b/service.subtitles.subtitle/addon.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?><addon id="service.subtitles.subtitle" name="Ktuvit.com" version="4.4.5" provider-name="CaTz">
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?><addon id="service.subtitles.subtitle" name="Ktuvit.com" version="4.5.0" provider-name="CaTz">
     <requires>
         <import addon="xbmc.python" version="2.14.0"/>
         <import addon="script.common.plugin.cache" version="0.9.1"/>

--- a/service.subtitles.subtitle/changelog.txt
+++ b/service.subtitles.subtitle/changelog.txt
@@ -1,3 +1,6 @@
+4.5.0 - by burekas7 (03/11/2016)
+- Add the option for using the addon when kodi isn't playing
+
 4.4.5 - by CaTz (22/10/2016)
 - Mirroring subs to the-wiz server
 

--- a/service.subtitles.subtitle/service.py
+++ b/service.subtitles.subtitle/service.py
@@ -119,17 +119,32 @@ if params['action'] in ['search', 'manualsearch']:
         params['searchstring'] = urllib.unquote(params['searchstring'])
 
     item = {}
-    item['temp'] = False
-    item['rar'] = False
-    item['year'] = xbmc.getInfoLabel("VideoPlayer.Year")  # Year
-    item['season'] = str(xbmc.getInfoLabel("VideoPlayer.Season"))  # Season
-    item['episode'] = str(xbmc.getInfoLabel("VideoPlayer.Episode"))  # Episode
-    item['tvshow'] = normalizeString(xbmc.getInfoLabel("VideoPlayer.TVshowtitle"))  # Show
-    item['title'] = normalizeString(xbmc.getInfoLabel("VideoPlayer.OriginalTitle"))  # try to get original title
-    item['file_original_path'] = urllib.unquote(unicode(xbmc.Player().getPlayingFile(), 'utf-8'))  # Full path of a playing file
-    item['3let_language'] = []
-    item['preferredlanguage'] = unicode(urllib.unquote(params.get('preferredlanguage', '')), 'utf-8')
-    item['preferredlanguage'] = xbmc.convertLanguage(item['preferredlanguage'], xbmc.ISO_639_2)
+    
+    if xbmc.Player().isPlaying():
+        item['temp'] = False
+        item['rar'] = False
+        item['year'] = xbmc.getInfoLabel("VideoPlayer.Year")  # Year
+        item['season'] = str(xbmc.getInfoLabel("VideoPlayer.Season"))  # Season
+        item['episode'] = str(xbmc.getInfoLabel("VideoPlayer.Episode"))  # Episode
+        item['tvshow'] = normalizeString(xbmc.getInfoLabel("VideoPlayer.TVshowtitle"))  # Show
+        item['title'] = normalizeString(xbmc.getInfoLabel("VideoPlayer.OriginalTitle"))  # try to get original title
+        item['file_original_path'] = urllib.unquote(unicode(xbmc.Player().getPlayingFile(), 'utf-8'))  # Full path of a playing file
+        item['3let_language'] = []
+        item['preferredlanguage'] = unicode(urllib.unquote(params.get('preferredlanguage', '')), 'utf-8')
+        item['preferredlanguage'] = xbmc.convertLanguage(item['preferredlanguage'], xbmc.ISO_639_2)
+    
+    else:
+        item['temp'] = False
+        item['rar'] = False
+        item['year'] = ""
+        item['season'] = ""
+        item['episode'] = ""
+        item['tvshow'] = ""
+        item['title'] = "Search For..." # Needed to avoid showing previous search result.
+        item['file_original_path'] = ""
+        item['3let_language'] = []
+        item['preferredlanguage'] = unicode(urllib.unquote(params.get('preferredlanguage', '')), 'utf-8')
+        item['preferredlanguage'] = xbmc.convertLanguage(item['preferredlanguage'], xbmc.ISO_639_2)
 
     if item['title'] == "":
         log("VideoPlayer.OriginalTitle not found")
@@ -172,7 +187,7 @@ elif params['action'] == 'download':
     subs = download(params["id"], params["filename"])
     ## we can return more than one subtitle for multi CD versions, for now we are still working out how to handle that in XBMC core
     for sub in subs:
-        if params["language"] == 'he':
+        if params["language"] == 'he' and xbmc.Player().isPlaying():
             mirror_sub(params["id"], params["filename"], sub)
 
         listitem = xbmcgui.ListItem(label=sub)


### PR DESCRIPTION
### Description
Add the option for using the addon when kodi isn't playing
<!--- Provide a short summary of submitted add-on in case it's a new addition. -->
<!--- If it's plugin update only highlight biggest changes if needed. -->
<!--- Make sure you follow the checklist below before finalising your pull-request. -->
### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a sinlge commit with using the following style: [sciprt.foo.bar] v1.0.0

Addtional information :
- Submitting your add-on to this specific branch makes it available to any Kodi version equal or higher than the branch name with the applicable Kodi dependencies limits.
- [add-on development](http://kodi.wiki/view/Add-on_development) wiki page.
- Kodi [pydocs](http://kodi.wiki/view/PyDocs) provide information about the Python API
- [PEP8](https://www.python.org/dev/peps/pep-0008/) codingstyle which is considered best practise but not mandatory.
- This add-on repository has automated code guideline check which could help you improve your coding. You can find the results of these check at [Codacy](https://www.codacy.com/app/Kodi/repo-scripts/dashboard). You can create your own account as well to continuesly monitor your python coding before submitting to repo.
- Development questions can be asked in the [add-on development](http://forum.kodi.tv/forumdisplay.php?fid=26) section on the Kodi forum.

