### PR TITLE
[service.subtitles.torec] 1.2.1

### DIFF
--- a/service.subtitles.torec/addon.xml
+++ b/service.subtitles.torec/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="service.subtitles.torec"
        name="Torec"
-       version="1.2.0"
+       version="1.2.1"
        provider-name="slmosl">
   <requires>
     <import addon="xbmc.python" version="2.14.0"/>

--- a/service.subtitles.torec/changelog.txt
+++ b/service.subtitles.torec/changelog.txt
@@ -1,3 +1,8 @@
+1.2.1 
+- Improvement for the option of using the addon when kodi is not playing (@burekas7)
+- Add support for local tvshow content (@burekas7)
+- Fix bug for last episode in a season that didn't return results. (@burekas7)
+
 1.2.0
 - added support for the new download code screen
 - fix Manual Search, Empty Title&Kodi isn't playing (@burekas7)

--- a/service.subtitles.torec/resources/lib/TorecSubtitlesDownloader.py
+++ b/service.subtitles.torec/resources/lib/TorecSubtitlesDownloader.py
@@ -41,7 +41,7 @@ class TVShowPage():
             return None
 
         episode_options = season_div[0].findAll("a")
-        episode_option = next((episode_option for episode_option in episode_options if (episode_option.contents[0] == u'פרק %s' % episode_number)), None)
+        episode_option = next((episode_option for episode_option in episode_options if ((episode_option.contents[0] == u'פרק %s' % episode_number) or (episode_option.contents[0] == u'פרק %s - אחרון לעונה' % episode_number))), None)
         if not episode_option:
             return None
 

--- a/service.subtitles.torec/service.py
+++ b/service.subtitles.torec/service.py
@@ -38,7 +38,7 @@ xbmcvfs.mkdirs(__temp__)
 
 sys.path.append(__resource__)
 
-from SubtitleHelper import log, normalize_string, convert_to_utf, check_and_parse_if_title_is_TVshow
+from SubtitleHelper import log, normalize_string, convert_to_utf, check_and_parse_if_title_is_TVshow, take_title_from_focused_item, parse_rls_title, clean_title
 from TorecSubtitlesDownloader import TorecSubtitlesDownloader
 
 def search(item):
@@ -203,12 +203,12 @@ if params['action'] == 'search' or params['action'] == 'manualsearch':
     else:
         item['temp'] = False
         item['rar'] = False
-        item['mansearch'] = False
         item['year'] = ""
         item['season'] = ""
         item['episode'] = ""
         item['tvshow'] = ""
-        item['title'] = "SearchFor..." # Needed to avoid showing previous search result.
+        item['title'] = take_title_from_focused_item()
+        item['mansearch'] = True
         item['file_original_path'] = ""
         item['3let_language'] = []
 
@@ -219,6 +219,15 @@ if params['action'] == 'search' or params['action'] == 'manualsearch':
     if 'searchstring' in params:
         item['mansearch'] = True
         item['title'] = params['searchstring']
+
+    for lang in unicode(urllib.unquote(params['languages']), 'utf-8').split(","):
+        item['3let_language'].append(xbmc.convertLanguage(lang, xbmc.ISO_639_2))
+
+    if xbmc.Player().isPlaying():
+        log(__name__, "Item before cleaning: \n    %s" % item)
+        # clean title + tvshow params
+        clean_title(item)
+        parse_rls_title(item)
 
     if item['episode'].lower().find("s") > -1:  # Check if season is "Special"
         item['season'] = "0"

--- a/service.subtitles.torec/tests/tvshow_tests.py
+++ b/service.subtitles.torec/tests/tvshow_tests.py
@@ -22,6 +22,17 @@ class TVShowTests(unittest.TestCase):
 		self.assertIsNotNone(options)
 		self.assertGreaterEqual(len(options), 5)
 
+	def test_search_tvshow_last_season_episode(self):
+		item    = {
+			'tvshow': 'house of cards',
+			'season': '3',
+			'episode': '13'
+		}
+
+		options = self.downloader.search_tvshow(item['tvshow'], item['season'], item['episode'])
+		self.assertIsNotNone(options)
+		self.assertGreaterEqual(len(options), 5)
+
 	def test_search_inexisting_tvshow(self):
 		item = {
 			'tvshow': 'house of lards',


### PR DESCRIPTION
### Description
- Improvement for the option of using the addon when kodi is not playing (@burekas7)
- Add support for local tvshow content (@burekas7)
- Fix bug for last episode in a season that didn't return results. (@burekas7)
### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [sciprt.foo.bar] v1.0.0

Additional information :
- Submitting your add-on to this specific branch makes it available to any Kodi version equal or higher than the branch name with the applicable Kodi dependencies limits.
- [add-on development](http://kodi.wiki/view/Add-on_development) wiki page.
- Kodi [pydocs](http://kodi.wiki/view/PyDocs) provide information about the Python API
- [PEP8](https://www.python.org/dev/peps/pep-0008/) codingstyle which is considered best practise but not mandatory.
- This add-on repository has automated code guideline check which could help you improve your coding. You can find the results of these check at [Codacy](https://www.codacy.com/app/Kodi/repo-scripts/dashboard). You can create your own account as well to continuously monitor your python coding before submitting to repo.
- Development questions can be asked in the [add-on development](http://forum.kodi.tv/forumdisplay.php?fid=26) section on the Kodi forum.

