### PR TITLE
[screensaver.atv4] 1.4.0

### DIFF
--- a/screensaver.atv4/addon.xml
+++ b/screensaver.atv4/addon.xml
@@ -1,9 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="screensaver.atv4" name="Aerial" version="1.3.3" provider-name="enen92">
+<addon id="screensaver.atv4" name="Aerial" version="1.4.0" provider-name="enen92">
 	<requires>
 		<import addon="xbmc.python" version="2.19.0"/>
 	</requires>
-	<extension point="xbmc.ui.screensaver" library="atv.py" />
+	<extension point="xbmc.ui.screensaver" library="screensaver.py" />
+	<extension point="xbmc.python.script" library="atv.py">
+		<provides>video</provides> 
+	</extension>
+	<extension point="xbmc.service" library="service.py" start="login"/>
 	<extension point="xbmc.addon.metadata">
 		<platform>all</platform>
 		<license>GNU GENERAL PUBLIC LICENSE. Version 2, June 1991</license>
@@ -12,12 +16,14 @@
 		<summary lang="en">Apple TV 4 Screensavers in Kodi</summary>
 		<description lang="en">This screensaver addon enables the new Apple TV4 aerial screensavers in Kodi</description>
     </extension>
-    <news>v1.3.3  (2017-1-15) [CR]
-		- Added new videos from Apple [CR]
-		- Added new automated script [CR]
-		- Change downloaded function to support xbmc vfs [CR]
-		- Added 1080i interface [CR]
-		- Added Screenshots [CR]
+    <news>v1.4.0  (2017-2-11) [CR]
+    	- (thanks graysky2) [CR]
+		- Improve DPMS logic [CR]
+		- New settings for DPMS  [CR]
+		- Fix windows [CR]
+		- Video part turned into video addon [CR]
+		- New screensaver init logic [CR]
+		- Added service [CR]
 	</news>
     <assets>
 	    <icon>icon.png</icon>

--- a/screensaver.atv4/changelog.txt
+++ b/screensaver.atv4/changelog.txt
@@ -1,4 +1,19 @@
-v1.3.3 - 15/1/2017-1-15
+v1.4.0  11/2/2007 (thanks graysky2)
+- Improve DPMS logic [CR]
+- New settings for DPMS  [CR]
+- Fix windows [CR]
+- Video part turned into video addon [CR]
+- New screensaver init logic [CR]
+- Added service [CR]
+
+v1.3.4 - 18/1/2017
+-New initialization logic - screensaver/script
+- Added DPMS settings
+- Redesign settings
+- Changes to interface
+- New settings
+
+v1.3.3 - 15/1/2017
 - Added new videos from Apple
 - Added new automated script
 - Change downloaded function to support xbmc vfs

--- a/screensaver.atv4/resources/language/English/strings.po
+++ b/screensaver.atv4/resources/language/English/strings.po
@@ -113,3 +113,72 @@ msgstr ""
 msgctxt "#32024"
 msgid "Enable Hong Kong"
 msgstr ""
+
+msgctxt "#32025"
+msgid "Initializing..."
+msgstr ""
+
+msgctxt "#32026"
+msgid "DPMS*"
+msgstr ""
+
+msgctxt "#32027"
+msgid "DPMS"
+msgstr ""
+
+msgctxt "#32028"
+msgid "Toggle display off"
+msgstr ""
+
+msgctxt "#32029"
+msgid "Put playing device on standby via a CEC"
+msgstr ""
+
+msgctxt "#32030"
+msgid "Disable checksum verification"
+msgstr ""
+
+msgctxt "#32031"
+msgid "Videos"
+msgstr ""
+
+msgctxt "#32032"
+msgid "General Settings"
+msgstr ""
+
+msgctxt "#32033"
+msgid "* DPMS will check for the Power Saving Kodi settings and stop the screensaver"
+msgstr ""
+
+msgctxt "#32034"
+msgid "if the maximum allowed time to put the display to sleep is exceeded"
+msgstr ""
+
+msgctxt "#32035"
+msgid "Off"
+msgstr ""
+
+msgctxt "#32036"
+msgid "Kodi"
+msgstr ""
+
+msgctxt "#32037"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#32038"
+msgid "Manual timeout to activate DPMS (min)"
+msgstr ""
+
+msgctxt "#32039"
+msgid "DPMS action"
+msgstr ""
+
+msgctxt "#32040"
+msgid "Pause Video"
+msgstr ""
+
+msgctxt "#32041"
+msgid "Stop Video"
+msgstr ""
+

--- a/screensaver.atv4/resources/language/Portuguese/strings.po
+++ b/screensaver.atv4/resources/language/Portuguese/strings.po
@@ -113,3 +113,71 @@ msgstr "Ativar Liwa"
 msgctxt "#32024"
 msgid "Enable Hong Kong"
 msgstr "Ativar Hong Kong"
+
+msgctxt "#32025"
+msgid "Initializing..."
+msgstr "A inicializar..."
+
+msgctxt "#32026"
+msgid "DPMS*"
+msgstr "DPMS*"
+
+msgctxt "#32027"
+msgid "DPMS"
+msgstr "DPMS"
+
+msgctxt "#32028"
+msgid "Toggle display off"
+msgstr "Desligar monitor"
+
+msgctxt "#32029"
+msgid "Put playing device on standby via a CEC"
+msgstr "Colocar dispositivo em standby via CEC"
+
+msgctxt "#32030"
+msgid "Disable checksum verification"
+msgstr "Desactivar verficação de checksums"
+
+msgctxt "#32031"
+msgid "Videos"
+msgstr "Vídeos"
+
+msgctxt "#32032"
+msgid "General Settings"
+msgstr "Definições gerais"
+
+msgctxt "#32033"
+msgid "* DPMS will check for the Power Saving Kodi settings and stop the screensaver"
+msgstr "* O DPMS irá verificar as definiçoes de gestão de energia do kodi e parar o screensaver"
+
+msgctxt "#32034"
+msgid "if the maximum allowed time to put the display to sleep is exceeded"
+msgstr "se o tempo máximo permitido para desligar o monitor for atingido"
+
+msgctxt "#32035"
+msgid "Off"
+msgstr "Desligado"
+
+msgctxt "#32036"
+msgid "Kodi"
+msgstr "Kodi"
+
+msgctxt "#32037"
+msgid "Manual"
+msgstr "Manual"
+
+msgctxt "#32038"
+msgid "Manual timeout to activate DPMS (min)"
+msgstr "Timeout para ativar o DPMS manual (min)"
+
+msgctxt "#32039"
+msgid "DPMS action"
+msgstr "Acção após DPMS"
+
+msgctxt "#32040"
+msgid "Pause Video"
+msgstr "Pausar Video"
+
+msgctxt "#32041"
+msgid "Stop Video"
+msgstr "Parar Video"

--- a/screensaver.atv4/resources/lib/downloader.py
+++ b/screensaver.atv4/resources/lib/downloader.py
@@ -39,22 +39,27 @@ class Downloader:
         self.dp = xbmcgui.DialogProgress()
         self.dp.create(translate(32000),translate(32019))
         #video checksums - download only the videos that were not downloaded previously
-        with open(os.path.join(addon_path,"resources","checksums.json")) as f:
-            checksums = f.read()
+        if addon.getSetting("enable-checksums") == "true":
+            with open(os.path.join(addon_path,"resources","checksums.json")) as f:
+                checksums = f.read()
         
-        checksums = json.loads(checksums)
+            checksums = json.loads(checksums)
+
         for url in urllist:
             if not self.stop:
                 video_file = url.split("/")[-1]
                 localfile = os.path.join(addon.getSetting("download-folder"),video_file)
 
                 if xbmcvfs.exists(localfile):
-                    f = xbmcvfs.File(xbmc.translatePath(localfile))
-                    file_checksum = hashlib.md5(f.read()).hexdigest()
-                    f.close()
-            
-                    if video_file in checksums.keys() and checksums[video_file] != file_checksum:
-                       self.download(localfile,url,url.split("/")[-1]) 
+                    if addon.getSetting("enable-checksums") == "true":
+                        f = xbmcvfs.File(xbmc.translatePath(localfile))
+                        file_checksum = hashlib.md5(f.read()).hexdigest()
+                        f.close()
+                
+                        if video_file in checksums.keys() and checksums[video_file] != file_checksum:
+                           self.download(localfile,url,url.split("/")[-1])
+                    else:
+                        self.download(localfile,url,url.split("/")[-1])
                 else:
                     self.download(localfile,url,url.split("/")[-1])
             else: break

--- a/screensaver.atv4/resources/settings.xml
+++ b/screensaver.atv4/resources/settings.xml
@@ -1,6 +1,20 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <settings>
 	<category label="32000">
+		<setting label="32032" type="lsep" />
+		<setting id="time-of-day" type="enum" values="All|Day only|Night only|Smart" label="32006" visible="true" default="0"/>
+		<setting id="show-notifications" type="bool" label="32018" default="true" />
+		<setting label="32026" type="lsep" />
+		<setting label="32027" type="enum" id="check-dpms" lvalues="32035|32036|32037"/>
+		<setting label="32039" type="enum" id="dpms-action" lvalues="32040|32041" visible="eq(-1,1)|eq(-1,2)" option="int" default="0"/>
+		<setting label="32038" type="slider" id="manual-dpms" default="5" range="1,5,120" visible="eq(-2,2)" option="int" />
+		<setting id="toggle-displayoff" type="bool" label="32028" default="false" visible="eq(-3,1)|eq(-3,2)"/>
+		<setting id="toggle-cecoff" type="bool" label="32029" default="false" visible="eq(-4,1)|eq(-5,2)"/>
+		<setting label="32033" type="lsep" />
+		<setting label="32034" type="lsep" />
+		<setting id="is_locked" visible="false" default="false" />
+	</category>
+	<category label="32031">
 		<setting id="enable-hawaii" type="bool" label="32001" default="true" />
 		<setting id="enable-london" type="bool" label="32002" default="true" />
 		<setting id="enable-newyorkcity" type="bool" label="32003" default="true" />
@@ -9,14 +23,12 @@
 		<setting id="enable-greenland" type="bool" label="32020" default="true" />
 		<setting id="enable-dubai" type="bool" label="32021" default="true" />
 		<setting id="enable-losangeles" type="bool" label="32022" default="true" />
-		<setting id="enable-liwa" type="bool" label="32023" default="true" />
+		<setting id="enable-liwa" type="bool" label="32023" default="true"/>
 		<setting id="enable-hongkong" type="bool" label="32024" default="true" />
-		<setting id="time-of-day" type="enum" values="All|Day only|Night only|Smart" label="32006" visible="true" default="0"/>
-		<setting label="" type="lsep" />
-		<setting id="show-notifications" type="bool" label="32018" default="true" />
 	</category>
 	<category label="32009">
 		<setting id="download-folder" type="folder" label="32010"/>
-		<setting type="action" label="32011" action="RunScript(screensaver.atv4,,/offline)" />
+		<setting id="enable-checksums" type="bool" label="32030" default="true" />
+		<setting type="action" label="32011" action="RunAddon(screensaver.atv4,,/offline)" />
 	</category>
 </settings>

--- a/screensaver.atv4/resources/skins/default/1080i/screensaver-atv4-trans.xml
+++ b/screensaver.atv4/resources/skins/default/1080i/screensaver-atv4-trans.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<window type="window">
+    <controls>
+   </controls>
+</window>

--- a/screensaver.atv4/resources/skins/default/1080i/screensaver-atv4.xml
+++ b/screensaver.atv4/resources/skins/default/1080i/screensaver-atv4.xml
@@ -2,7 +2,7 @@
 <window type="window">
     <controls>
 
-        <control type="image" id="1">
+        <control type="image" id="32500">
             <description>Background image</description>
             <posx>0</posx>
             <posy>0</posy>
@@ -11,16 +11,9 @@
             <width>1920</width>
             <height>1080</height>
             <texture>sanfrancisco.jpg</texture>
+            <visible>!IsEmpty(Window(home).Property(screensaver-atv4-loading))</visible>
         </control>
-        <control type="videowindow" id="2">
-			<description>VideoWindow</description>
-		    <posx>0</posx>
-		    <posy>0</posy>
-		    <width>1920</width>
-		    <height>1080</height>
-		    <visible>true</visible>
-		</control>
-		<control type="image">
+		<control type="image" id ="32501">
 				<description>Busy animation</description>
 				<posx>40</posx>
 				<posy>1000</posy>
@@ -29,10 +22,9 @@
 				<texture>busy.png</texture>
 				<aspectratio>keep</aspectratio>
 				<animation effect="rotate" start="0" end="360" center="55,1015" time="1200" loop="true" condition="true">conditional</animation>
-				<visible>!IsEmpty(Window(home).Property(loading))</visible>
+				<visible>!IsEmpty(Window(home).Property(screensaver-atv4-loading))</visible>
 			</control>
-		
-		<control type="label" id ="4">
+		<control type="label" id ="32502">
 				<top>975</top>
 				<left>90</left>
 				<width>600</width>
@@ -42,9 +34,9 @@
 				<aligny>center</aligny>
 				<align>left</align>
 				<label></label>
-				<visible>!IsEmpty(Window(home).Property(loading))</visible>
+				<visible>!IsEmpty(Window(home).Property(screensaver-atv4-loading))</visible>
 		</control>
-		<control type="label" id="3">
+		<control type="label" id="32503">
 				<top>975</top>
 				<left>40</left>
 				<width>600</width>
@@ -56,6 +48,13 @@
 				<label></label>
 				<visible>false</visible>
 		</control>
-		
+		<control type="videowindow">
+			<description>VideoWindow</description>
+		    <posx>0</posx>
+		    <posy>0</posy>
+		    <width>1920</width>
+		    <height>1080</height>
+		    <visible>true</visible>
+		</control>
    </controls>
 </window>

--- a/screensaver.atv4/resources/skins/default/720p/screensaver-atv4-trans.xml
+++ b/screensaver.atv4/resources/skins/default/720p/screensaver-atv4-trans.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<window type="window">
+    <controls>
+   </controls>
+</window>

--- a/screensaver.atv4/resources/skins/default/720p/screensaver-atv4.xml
+++ b/screensaver.atv4/resources/skins/default/720p/screensaver-atv4.xml
@@ -2,7 +2,7 @@
 <window type="window">
     <controls>
 
-        <control type="image" id="1">
+        <control type="image" id="32500">
             <description>Background image</description>
             <posx>0</posx>
             <posy>0</posy>
@@ -11,16 +11,9 @@
             <width>1280</width>
             <height>720</height>
             <texture>sanfrancisco.jpg</texture>
+            <visible>!IsEmpty(Window(home).Property(screensaver-atv4-loading))</visible>
         </control>
-        <control type="videowindow" id="2">
-			<description>VideoWindow</description>
-		    <posx>0</posx>
-		    <posy>0</posy>
-		    <width>1280</width>
-		    <height>720</height>
-		    <visible>true</visible>
-		</control>
-		<control type="image">
+		<control type="image" id ="32501">
 				<description>Busy animation</description>
 				<posx>40</posx>
 				<posy>685</posy>
@@ -29,10 +22,10 @@
 				<texture>busy.png</texture>
 				<aspectratio>keep</aspectratio>
 				<animation effect="rotate" start="0" end="360" center="55,700" time="1200" loop="true" condition="true">conditional</animation>
-				<visible>!IsEmpty(Window(home).Property(loading))</visible>
+				<visible>!IsEmpty(Window(home).Property(screensaver-atv4-loading))</visible>
 			</control>
 		
-		<control type="label" id ="4">
+		<control type="label" id ="32502">
 				<top>655</top>
 				<left>90</left>
 				<width>600</width>
@@ -42,9 +35,9 @@
 				<aligny>center</aligny>
 				<align>left</align>
 				<label></label>
-				<visible>!IsEmpty(Window(home).Property(loading))</visible>
+				<visible>!IsEmpty(Window(home).Property(screensaver-atv4-loading))</visible>
 		</control>
-		<control type="label" id="3">
+		<control type="label" id="32503">
 				<top>655</top>
 				<left>40</left>
 				<width>600</width>
@@ -56,6 +49,13 @@
 				<label></label>
 				<visible>false</visible>
 		</control>
-		
+		<control type="videowindow">
+			<description>VideoWindow</description>
+		    <posx>0</posx>
+		    <posy>0</posy>
+		    <width>1280</width>
+		    <height>720</height>
+		    <visible>true</visible>
+		</control>
    </controls>
 </window>

--- a/screensaver.atv4/screensaver.py
+++ b/screensaver.atv4/screensaver.py
@@ -1,0 +1,74 @@
+# -*- coding: utf-8 -*-
+'''
+    screensaver.atv4
+    Copyright (C) 2015 enen92
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+'''
+import xbmc
+from trans import ScreensaverTrans
+from resources.lib.commonatv import *
+
+
+class ScreensaverPreview(xbmcgui.WindowXMLDialog):
+    
+    class ExitMonitor(xbmc.Monitor):
+
+        def __init__(self, exit_callback):
+            self.exit_callback = exit_callback
+
+        def onScreensaverDeactivated(self):
+            self.exit_callback()
+
+    def onInit(self):
+        self.exit_monitor = self.ExitMonitor(self.exit)
+        self.getControl(32502).setLabel(translate(32025))
+        xbmc.executebuiltin("SetProperty(screensaver-atv4-loading,1,home)")
+        xbmc.sleep(1000)
+        xbmc.executeJSONRPC('{"jsonrpc": "2.0", "method": "Input.ContextMenu", "id": 1}')
+
+    def exit(self):
+        xbmc.executebuiltin("ClearProperty(screensaver-atv4-loading,Home)")
+        self.close()
+
+        #Call the script and die
+        xbmc.executebuiltin('RunAddon(screensaver.atv4)')
+
+
+if __name__ == '__main__':
+    if addon.getSetting("is_locked") == "false":
+        if addon.getSetting("show-notifications") == "true":
+            xbmc.executebuiltin("Notification(%s,%s,%i,%s)" % (translate(32000), translate(32017),1,os.path.join(addon_path,"icon.png")))
+        
+        #Start window
+        screensaver = ScreensaverPreview(
+            'screensaver-atv4.xml',
+            addon_path,
+            'default',
+            '',
+        )
+        screensaver.doModal()
+        xbmc.sleep(100)
+        del screensaver
+    else:
+        #Transparent placeholder
+        trans = ScreensaverTrans(
+            'screensaver-atv4-trans.xml',
+            addon_path,
+            'default',
+            '',
+        )
+        trans.doModal()
+        xbmc.sleep(100)
+        del trans

--- a/screensaver.atv4/service.py
+++ b/screensaver.atv4/service.py
@@ -16,22 +16,7 @@
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 '''
+from resources.lib.commonatv import *
 
-import xbmc
-import xbmcgui
-import playlist
-
-class ATVPlayer(xbmc.Player):
-    def __init__(self,):
-        xbmc.log(msg='ATV4 Screensaver player has been created', level=xbmc.LOGDEBUG)
-
-    def onPlayBackStarted(self):
-        xbmc.log(msg='ATV4 Screensaver player has started. Toggling repeatAll', level=xbmc.LOGDEBUG)
-        xbmc.executebuiltin("PlayerControl(RepeatAll)")
-
-    def onPlaybackEnded(self):
-        self.onPlayBackStopped()
-
-    def onPlayBackStopped(self):
-        xbmc.log(msg='ATV4 Screensaver player has been stopped', level=xbmc.LOGDEBUG)
-        xbmc.executebuiltin("PlayerControl(RepeatOff)", True)
+#set locked setting back to false on startup just in case kodi had crashed during playback
+addon.setSetting("is_locked","false")

--- a/screensaver.atv4/trans.py
+++ b/screensaver.atv4/trans.py
@@ -16,22 +16,27 @@
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 '''
-
 import xbmc
-import xbmcgui
-import playlist
+import sys
+from resources.lib.commonatv import *
 
-class ATVPlayer(xbmc.Player):
-    def __init__(self,):
-        xbmc.log(msg='ATV4 Screensaver player has been created', level=xbmc.LOGDEBUG)
 
-    def onPlayBackStarted(self):
-        xbmc.log(msg='ATV4 Screensaver player has started. Toggling repeatAll', level=xbmc.LOGDEBUG)
-        xbmc.executebuiltin("PlayerControl(RepeatAll)")
+class ScreensaverTrans(xbmcgui.WindowXMLDialog):
+    
+    class ExitMonitor(xbmc.Monitor):
 
-    def onPlaybackEnded(self):
-        self.onPlayBackStopped()
+        def __init__(self, activated_callback):
+            self.activated_callback = activated_callback
 
-    def onPlayBackStopped(self):
-        xbmc.log(msg='ATV4 Screensaver player has been stopped', level=xbmc.LOGDEBUG)
-        xbmc.executebuiltin("PlayerControl(RepeatOff)", True)
+        def onScreensaverDeactivated(self):
+            self.activated_callback()
+
+    def onInit(self):
+        self.exit_monitor = self.ExitMonitor(self.exit)
+
+    def exit(self):
+        addon.setSetting("is_locked","false")
+        self.close()
+
+    def onAction(self,action):
+        self.exit()


### PR DESCRIPTION
-Changed overall screensaver init logic (made it a video addon so when the screensaver deactivates it just calls the video addon). Current logic is wrong, lead to errors and playback stuttering.

-Implemented DPMS so users can pause or stop the video if a certain playback time is reached (plus trigger DPMS or display off via cec) - in order to avoid wasted cpu cycles.