### PR TITLE
[service.kn.switchtimer] 2.0.2 update

### DIFF
--- a/service.kn.switchtimer/addon.xml
+++ b/service.kn.switchtimer/addon.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='yes'?>
-<addon id="service.kn.switchtimer" name="KN Switchtimer Service" provider-name="Birger Jesch" version="2.0.1">
+<addon id="service.kn.switchtimer" name="KN Switchtimer Service" provider-name="Birger Jesch" version="2.0.2">
     <requires>
         <import addon="xbmc.python" version="2.24.0"/>
         <import addon="xbmc.json" version="6.20.0"/>

--- a/service.kn.switchtimer/changelog.txt
+++ b/service.kn.switchtimer/changelog.txt
@@ -1,5 +1,9 @@
 CHANGELOG
 
+2.0.2
+- create settings path if not exists. This avoids IOExceptions when writing timers and the addon
+  wasn't configured yet.
+
 2.0.1
 - Profile paths for timer.json considered
 

--- a/service.kn.switchtimer/handler.py
+++ b/service.kn.switchtimer/handler.py
@@ -27,7 +27,10 @@ OSD = xbmcgui.Dialog()
 OSDProgress = xbmcgui.DialogProgress()
 HOME = xbmcgui.Window(10000)
 
-__timer__ = xbmc.translatePath(os.path.join(__profiles__, 'timer.json'))
+__settingspath__ = xbmc.translatePath(__profiles__)
+if not os.path.exists(__settingspath__): os.makedirs(__settingspath__, 0755)
+__timer__ = os.path.join(__settingspath__, 'timer.json')
+
 __timerdict__ = {'channel': None, 'icon': None, 'date': None, 'title': None, 'plot': None}
 
 def putTimer(timers):

--- a/service.kn.switchtimer/resources/language/Dutch/strings.po
+++ b/service.kn.switchtimer/resources/language/Dutch/strings.po
@@ -106,7 +106,11 @@ msgid "Please use the PVR OSD Guide context menue to set or reset switch timers"
 msgstr ""
 
 msgctxt "#30031"
-msgid "Timer for this time already set (%s, %s). Would You replace this timer with new new one instead?"
+msgid "Timer for this time already set (%s, %s). Would You replace this timer with the new one instead?"
+msgstr ""
+
+msgctxt "#30032"
+msgid "Channel Switch aborted"
 msgstr ""
 
 msgctxt "#30040"

--- a/service.kn.switchtimer/resources/language/English/strings.po
+++ b/service.kn.switchtimer/resources/language/English/strings.po
@@ -115,11 +115,15 @@ msgid "Please use the PVR OSD Guide context menue to set or reset switch timers"
 msgstr ""
 
 msgctxt "#30031"
-msgid "Timer for this time already set (%s, %s). Would You replace this timer with new new one instead?"
+msgid "Timer for this time already set (%s, %s). Would You replace this timer with the new one instead?"
+msgstr ""
+
+msgctxt "#30032"
+msgid "Channel Switch aborted"
 msgstr ""
 
 #Labels
-#empty strings from id 30032 to 30039
+#empty strings from id 30033 to 30039
 
 msgctxt "#30040"
 msgid "Add switchtimer"

--- a/service.kn.switchtimer/resources/language/German/strings.po
+++ b/service.kn.switchtimer/resources/language/German/strings.po
@@ -106,8 +106,12 @@ msgid "Please use the PVR OSD Guide context menue to set or reset switch timers"
 msgstr "Benutze das Kontextmenü der EPG-Zeitleiste, um Umschalttimer zu setzen oder zu löschen."
 
 msgctxt "#30031"
-msgid "Timer for this time already set (%s, %s). Would You replace this timer with new new one instead?"
+msgid "Timer for this time already set (%s, %s). Would You replace this timer with the new one instead?"
 msgstr "Ein Timer für diesen Zeitpunkt ist bereits aktiv (%s, %s). Möchtest Du diesen Timer mit dem neuen Timer ersetzen?"
+
+msgctxt "#30032"
+msgid "Channel Switch aborted"
+msgstr "Kanalumschaltung abgebrochen"
 
 msgctxt "#30040"
 msgid "Add switchtimer"

--- a/service.kn.switchtimer/resources/language/Portuguese/strings.po
+++ b/service.kn.switchtimer/resources/language/Portuguese/strings.po
@@ -106,7 +106,11 @@ msgid "Please use the PVR OSD Guide context menue to set or reset switch timers"
 msgstr ""
 
 msgctxt "#30031"
-msgid "Timer for this time already set (%s, %s). Would You replace this timer with new new one instead?"
+msgid "Timer for this time already set (%s, %s). Would You replace this timer with the new one instead?"
+msgstr ""
+
+msgctxt "#30032"
+msgid "Channel Switch aborted"
 msgstr ""
 
 msgctxt "#30040"

--- a/service.kn.switchtimer/resources/settings.xml
+++ b/service.kn.switchtimer/resources/settings.xml
@@ -2,10 +2,10 @@
 <settings>
     <!-- Service Addon settings -->
     <setting id="showNoticeBeforeSw" type="bool" label="30001" default="true" />
-    <setting id="dispTime" type="labelenum" label="30002" values="3 sec|4 sec|5 sec|6 sec|7 sec|8 sec|9 sec|10 sec|20 sec|30 sec" default="5 sec" enable="eq(-1,true)" />
+    <setting id="dispTime" type="labelenum" label="30002" values="3 sec|4 sec|5 sec|6 sec|7 sec|8 sec|9 sec|10 sec|15 sec|20 sec" default="5 sec" enable="eq(-1,true)" />
     <setting id="useCountdownTimer" type="bool" label="30012" default="false" enable="eq(-2,true)" />
     <setting id="confirmTmrAdded" type="bool" label="30003" default="true" />
-    <setting id="discardOldTmr" type="labelenum" label="30004" values="5 min|10 min|15 min|20 min|30 min|45 min|60 min|120 min" default="10 min" />
+    <setting id="discardOldTmr" type="labelenum" label="30004" values="5 min|10 min|15 min|20 min|30 min|45 min|60 min|90 min" default="10 min" />
     <setting type="sep" />
     <setting type="action" label="30011" action="RunScript(service.kn.switchtimer,action=delall)" option="close" />
 </settings>

--- a/service.kn.switchtimer/service.py
+++ b/service.kn.switchtimer/service.py
@@ -177,6 +177,7 @@ class Service(XBMCMonitor):
                                     xbmc.sleep(1000)
                                     idleTime += 1
                                     secs += 1
+                                if switchAborted: handler.notifyOSD(__LS__(30000), __LS__(30032))
 
                             if switchAborted: handler.notifyLog('Channelswitch cancelled by user')
                             else:


### PR DESCRIPTION
Changelog:

2.0.2
- create settings path if not exists. This avoids IOExceptions when writing timers and the addon
  wasn't configured yet.

- [X] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [X] Each add-on submission should be a single commit with using the following style: [sciprt.foo.bar] v1.0.0
