### PR TITLE
[script.module.t1mlib] 1.0.18

### DIFF
--- a/script.module.t1mlib/addon.xml
+++ b/script.module.t1mlib/addon.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='yes'?>
-<addon id="script.module.t1mlib" name="t1m Library Routines" provider-name="t1m" version="1.0.15">
+<addon id="script.module.t1mlib" name="t1m Library Routines" provider-name="t1m" version="1.0.18">
   <requires>
     <import addon="xbmc.python" version="2.20.0" />
   </requires>

--- a/script.module.t1mlib/changelog.txt
+++ b/script.module.t1mlib/changelog.txt
@@ -1,2 +1,3 @@
+V1.0.18 increased urlopen timeout for Kodi 17 on Android
 V1.0.15 change default cacheToDisc parm to False
 V1.0.14 another unicode fix

--- a/script.module.t1mlib/lib/t1mlib.py
+++ b/script.module.t1mlib/lib/t1mlib.py
@@ -58,14 +58,14 @@ class t1mAddon(object):
       pass
 
 
-  def getRequest(self, url, udata=None, headers = httpHeaders, dopost = False):
+  def getRequest(self, url, udata=None, headers = httpHeaders, dopost = False, rmethod = None):
     self.log("getRequest URL:"+str(url))
     req = urllib2.Request(url.encode(UTF8), udata, headers)  
     if dopost == True:
-       method = "POST"
-       req.get_method = lambda: method
+       rmethod = "POST"
+    if rmethod is not None: req.get_method = lambda: rmethod
     try:
-      response = urllib2.urlopen(req)
+      response = urllib2.urlopen(req, timeout=60)
       page = response.read()
       if response.info().getheader('Content-Encoding') == 'gzip':
          self.log("Content Encoding == gzip")
@@ -162,6 +162,28 @@ class t1mAddon(object):
 
   def getVideo(self,url):
       self.getAddonVideo(url)
+          
+  def doResolve(self, liz, subtitles = []):
+      if subtitles == None:
+          subtitles = []
+      infoList = {}
+      infoList['mediatype'] = xbmc.getInfoLabel('ListItem.DBTYPE')
+      infoList['Title'] = xbmc.getInfoLabel('ListItem.Title')
+      infoList['TVShowTitle'] = xbmc.getInfoLabel('ListItem.TVShowTitle')
+      infoList['Year'] = xbmc.getInfoLabel('ListItem.Year')
+      infoList['Premiered'] = xbmc.getInfoLabel('Premiered')
+      infoList['Plot'] = xbmc.getInfoLabel('ListItem.Plot')
+      infoList['Studio'] = xbmc.getInfoLabel('ListItem.Studio')
+      infoList['Genre'] = xbmc.getInfoLabel('ListItem.Genre')
+      infoList['Duration'] = xbmc.getInfoLabel('ListItem.Duration')
+      infoList['MPAA'] = xbmc.getInfoLabel('ListItem.Mpaa')
+      infoList['Aired'] = xbmc.getInfoLabel('ListItem.Aired')
+      infoList['Season'] = xbmc.getInfoLabel('ListItem.Season')
+      infoList['Episode'] = xbmc.getInfoLabel('ListItem.Episode')
+      liz.setInfo('video', infoList)
+      liz.setSubtitles(subtitles)
+      xbmcplugin.setResolvedUrl(int(sys.argv[1]), True, liz)
+
 
   def procConvertSubtitles(self, suburl):
     subfile = ""

--- a/script.module.t1mlib/readme.txt
+++ b/script.module.t1mlib/readme.txt
@@ -3,6 +3,7 @@ script.module.t1mlib
 
 Library of support routines for t1m addons
 
+V1.0.18 increased urlopen timeout for Kodi 17 on Android
 V1.0.15 change default cacheToDisc parm to False
 V1.0.14 another unicode fix
 V1.0.13 fix outfile.close()


### PR DESCRIPTION
Fix for timeouts on Kodi 17.0 on android

[script.module.t1mlib] 1.0.18

### Description
<!--- Provide a short summary of submitted add-on in case it's a new addition. -->
<!--- If it's plugin update only highlight biggest changes if needed. -->
<!--- Make sure you follow the checklist below before finalising your pull-request. -->
### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x ] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x ] Each add-on submission should be a single commit with using the following style: [sciprt.foo.bar] v1.0.0

Additional information :
- Submitting your add-on to this specific branch makes it available to any Kodi version equal or higher than the branch name with the applicable Kodi dependencies limits.
- [add-on development](http://kodi.wiki/view/Add-on_development) wiki page.
- Kodi [pydocs](http://kodi.wiki/view/PyDocs) provide information about the Python API
- [PEP8](https://www.python.org/dev/peps/pep-0008/) codingstyle which is considered best practise but not mandatory.
- This add-on repository has automated code guideline check which could help you improve your coding. You can find the results of these check at [Codacy](https://www.codacy.com/app/Kodi/repo-scripts/dashboard). You can create your own account as well to continuously monitor your python coding before submitting to repo.
- Development questions can be asked in the [add-on development](http://forum.kodi.tv/forumdisplay.php?fid=26) section on the Kodi forum.
