### PR TITLE
Fixed hyperlinks

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,16 +8,16 @@ This branch is not used for public. Please use one of the other branches availab
 
 ## Quick Kodi development links
 
-* [Add-on rules] (https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md)
-* [Submitting an add-on details] (http://kodi.wiki/view/Submitting_Add-ons)
-* [Code guidelines] (http://kodi.wiki/view/Official:Code_guidelines_and_formatting_conventions)
-* [Kodi development] (http://kodi.wiki/view/Development)
+* [Add-on rules](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md)
+* [Submitting an add-on details](http://kodi.wiki/view/Submitting_Add-ons)
+* [Code guidelines](http://kodi.wiki/view/Official:Code_guidelines_and_formatting_conventions)
+* [Kodi development](http://kodi.wiki/view/Development)
 
 ## Other useful links
 
-* [Kodi wiki] (http://kodi.wiki/)
-* [Kodi bug tracker] (http://trac.kodi.tv)
-* [Kodi community forums] (http://forum.kodi.tv/)
-* [Kodi website] (http://kodi.tv)
+* [Kodi wiki](http://kodi.wiki/)
+* [Kodi bug tracker](http://trac.kodi.tv)
+* [Kodi community forums](http://forum.kodi.tv/)
+* [Kodi website](http://kodi.tv)
 
 **Enjoy Kodi and help us improve it today. :)**


### PR DESCRIPTION
The markdown syntax of the hyperlinks was incorrect in README.md.