### PR TITLE
[script.video.randomtv] 1.1.0

### DIFF
--- a/script.video.randomtv/README.md
+++ b/script.video.randomtv/README.md
@@ -6,11 +6,14 @@ I searched for an addon to play Random TV Episodes from my library and while I f
 I'm a little anal when it comes to watched status and stuff in my library with the "in progress" icon, so one of my biggest requirements was to be able to not update the Play Count or resume info. So basically, I wanted an addon that would set the playcount and resume info back to what it was before playing.
 
 There are a couple options in the setting menu:
-- Include Unwatched (only includes watched by default)
-- Update Play Count (does not update by default)
+- Include Unwatched
+- Update Play Count
 - Repeat Playlist
 - Shuffle On Repeat
 - Show Notifications
+- Enable Auto Stop
+  - Auto Stop Timer (Minutes)
+  - Time To Wait For Response (Minutes)
 - Include All TV Shows or Select certain TV Shows
 
 It seems to be working pretty well for me on a couple different Pi's running OSMC and on my Windows UWP installs, so I figured I would release it to see of others could benefit.
@@ -19,4 +22,4 @@ Comments/feedback/bug reports welcome, but be gentle, it's my first ever addon. 
 
 
 ## To Install
-Download the zip file and "Install from zip file" in Kodi
+Install from the Official Kodi Repository

--- a/script.video.randomtv/addon.py
+++ b/script.video.randomtv/addon.py
@@ -180,7 +180,7 @@ else:
 #
 
 
-while (not xbmc.Monitor().waitForAbort(0.1)):
+while (not xbmc.Monitor().waitForAbort(1)):
 	if int(time.time()) >= AutoStopCheckTime:
 		log("-- Auto Stop Timer Reached")
 		AutoStopDialog.create(name, xbmcaddon.Addon().getLocalizedString(32015))

--- a/script.video.randomtv/addon.py
+++ b/script.video.randomtv/addon.py
@@ -5,6 +5,7 @@ import json
 import random
 import threading
 import sys
+import time
 
 
 def log(msg):
@@ -23,7 +24,7 @@ def buildPlaylist(myEpisodes):
 
 
 def ResetPlayCount(myEpisode):
-	xbmc.sleep(5000)
+	xbmc.Monitor().waitForAbort(5)
 	log("--------- ResetPlayCount")
 	log("-- Episode Id: " + str(myEpisode['episodeId']))
 	log("-- Episode Name: " + str(myEpisode['episodeName']))
@@ -152,7 +153,16 @@ if len(myEpisodes) == 0:
 	quit()
 else:
 	log("--------- Episodes Found")
-	
+	# Get Auto Stop Check Time - Current Time + Auto Stop Check Timer
+	if addon.getSetting("AutoStop") == "true":
+		log("-- Auto Stop Enabled")
+		log("-- Auto Stop Timer: " + addon.getSetting("AutoStopTimer"))
+		log("-- Auto Stop Wait: " + addon.getSetting("AutoStopWait"))
+		AutoStopCheckTime = int(time.time()) + (int(addon.getSetting("AutoStopTimer")) * 60)
+		AutoStopWait = (int(addon.getSetting("AutoStopWait")) * 60)
+		AutoStopDialog = xbmcgui.DialogProgress()
+	#
+
 	# Initialize our Player
 	player = MyPlayer()
 	
@@ -167,11 +177,33 @@ else:
 
 	# Start Player
 	player.play(item=myPlaylist)
-	xbmc.sleep(100)
 #
 
 
-while (not xbmc.Monitor().abortRequested()):
+while (not xbmc.Monitor().waitForAbort(0.1)):
+	if int(time.time()) >= AutoStopCheckTime:
+		log("-- Auto Stop Timer Reached")
+		AutoStopDialog.create(name, xbmcaddon.Addon().getLocalizedString(32015))
+		while int(time.time()) < AutoStopCheckTime + AutoStopWait:
+			AutoStopDialog.update(int(int(time.time() - AutoStopCheckTime) * 100 / AutoStopWait), xbmcaddon.Addon().getLocalizedString(32015), str(AutoStopWait - int(time.time() - AutoStopCheckTime)) + " " + xbmcaddon.Addon().getLocalizedString(32016))
+			if AutoStopDialog.iscanceled():
+				log("-- Dialog Cancelled - Breaking")
+				break
+			#
+			xbmc.Monitor().waitForAbort(0.1)
+		#
+		if AutoStopDialog.iscanceled():
+			log("-- Dialog Cancelled")
+			AutoStopCheckTime = int(time.time()) + (int(addon.getSetting("AutoStopTimer")) * 60)
+		#
+		else:
+			log("-- Dialog Not Cancelled")
+			xbmc.executebuiltin('PlayerControl(Stop)')
+		#
+		AutoStopDialog.close()
+		xbmc.Monitor().waitForAbort(0.2)
+	#
+
 	if player.mediaStarted:
 		log("--------- mediaStarted")
 		busyDiag.close()
@@ -209,7 +241,6 @@ while (not xbmc.Monitor().abortRequested()):
 
 			log("-- Restarting Playlist")
 			player.play(item=myPlaylist)
-			xbmc.sleep(100)
 		else:
 			player.scriptStopped = True
 
@@ -225,8 +256,6 @@ while (not xbmc.Monitor().abortRequested()):
 			thread.start()
 		break
 	#
-
-	xbmc.sleep(100)
 #
 
 

--- a/script.video.randomtv/addon.xml
+++ b/script.video.randomtv/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.video.randomtv" name="RandomTV" version="1.0.1" provider-name="gmccauley">
+<addon id="script.video.randomtv" name="RandomTV" version="1.1.0" provider-name="gmccauley">
   <requires>
     <import addon="xbmc.python" version="2.25.0"/>
   </requires>
@@ -8,7 +8,7 @@
   </extension>
   <extension point="xbmc.addon.metadata">
     <summary lang="en_GB">RandomTV</summary>
-    <description lang="en_GB">RandomTV plays random TV episodes from your library. There are a few options: Include unwatched episodes (only watched will be included by default), Update Play Count, Repeat Playlist, Shuffle On Repeat, Show Notifications, Include All TV Shows or Select TV Shows</description>
+    <description lang="en_GB">RandomTV plays random TV episodes from your library. There are a few options: Include unwatched episodes (only watched will be included by default), Update Play Count, Repeat Playlist, Shuffle On Repeat, Show Notifications, Enable Auto Stop, Include All TV Shows or Select TV Shows</description>
     <disclaimer lang="en_GB">My First Add-On.  Please by gentle</disclaimer>
     <language></language>
     <platform>all</platform>
@@ -18,6 +18,9 @@
     <email></email>
     <source>https://github.com/gmccauley/script.video.randomtv</source>
     <news>
+v1.1.0 (28 April 2017)
+  - Added Auto Stop Feature
+  - Replaced xbmc.sleep with xbmc.Monitor().waitForAbort
 v1.0.1 (6 April 2017)
   - Updated lang tag in addon.xml
   - Added Localization

--- a/script.video.randomtv/resources/language/resource.language.en_gb/strings.po
+++ b/script.video.randomtv/resources/language/resource.language.en_gb/strings.po
@@ -56,3 +56,23 @@ msgstr ""
 msgctxt "#32012"
 msgid "Select TV Shows"
 msgstr ""
+
+msgctxt "#32013"
+msgid "Enable Auto Stop"
+msgstr ""
+
+msgctxt "#32014"
+msgid "Auto Stop Timer (Minutes)"
+msgstr ""
+
+msgctxt "#32015"
+msgid "Are You Still There?"
+msgstr ""
+
+msgctxt "#32016"
+msgid "seconds left until Auto Stop..."
+msgstr ""
+
+msgctxt "#32017"
+msgid "Time To Wait For Response (Minutes)"
+msgstr ""

--- a/script.video.randomtv/resources/settings.xml
+++ b/script.video.randomtv/resources/settings.xml
@@ -6,6 +6,10 @@
 	<setting id="ShuffleOnRepeat" label="32003" type="bool" default="true" visible="eq(-1,true)" enable="eq(-1,true)" subsetting="true"/>
     <setting id="ShowNotifications" label="32004" type="bool" default="true"/>
 	<setting type="sep"/>
+	<setting id="AutoStop" label="32013" type="bool" default="true"/>
+	<setting id="AutoStopTimer" label="32014" type="slider" option="int" default="240" range="30,30,480" visible="eq(-1,true)" enable="eq(-1,true)" subsetting="true"/>
+	<setting id="AutoStopWait" label="32017" type="slider" option="int" default="5" range="1,1,15" visible="eq(-2,true)" enable="eq(-2,true)" subsetting="true"/>
+	<setting type="sep"/>
 	<setting id="IncludeAll" label="32005" type="bool" default="true"/>
 	<setting id="SelectShowsAction" label="32006" type="action" action="RunScript(script.video.randomtv, SelectShows)" visible="eq(-1,false)" enable="eq(-1,false)" subsetting="true" option="close"/>
 </settings>


### PR DESCRIPTION
### Description
v1.1.0 (28 April 2017)
  - Added Auto Stop Feature
  - Replaced xbmc.sleep with xbmc.Monitor().waitForAbort

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [X] Each add-on submission should be a single commit with using the following style: [script.foo.bar] v1.0.0

Additional information :
- Submitting your add-on to this specific branch makes it available to any Kodi version equal or higher than the branch name with the applicable Kodi dependencies limits.
- [add-on development](http://kodi.wiki/view/Add-on_development) wiki page.
- Kodi [pydocs](http://kodi.wiki/view/PyDocs) provide information about the Python API
- [PEP8](https://www.python.org/dev/peps/pep-0008/) codingstyle which is considered best practise but not mandatory.
- This add-on repository has automated code guideline check which could help you improve your coding. You can find the results of these check at [Codacy](https://www.codacy.com/app/Kodi/repo-scripts/dashboard). You can create your own account as well to continuously monitor your python coding before submitting to repo.
- Development questions can be asked in the [add-on development](http://forum.kodi.tv/forumdisplay.php?fid=26) section on the Kodi forum.
