### PR TITLE
[script.playrandomvideos] 1.1.2

### DIFF
--- a/script.playrandomvideos/README.md
+++ b/script.playrandomvideos/README.md
@@ -26,7 +26,7 @@ In **MyVideoNav.xml** an action like `RunScript(script.playrandomvideos, "$INFO[
 "label=$INFO[Container.FolderName]", watchmode=$INFO[Control.GetLabel(10)])`
 makes for a good button in the sidebar or as some other container-focused option. Use
 
-    <visible>ListItem.IsFolder + !ListItem.IsParentFolder + !SubString(ListItem.FolderPath, plugin, Left) + !SubString(ListItem.FolderPath, addons, Left) + !SubString(ListItem.FolderPath, sources, Left) + !StringCompare(ListItem.FolderPath, add)</visible>
+    <visible>ListItem.IsFolder + !ListItem.IsParentFolder + !String.Contains(ListItem.FolderPath, plugin, Left) + !String.Contains(ListItem.FolderPath, addons, Left) + !String.Contains(ListItem.FolderPath, sources, Left) + !String.IsEqual(ListItem.FolderPath, add)</visible>
 
 to match the context item's visibility on this window.
 

--- a/script.playrandomvideos/addon.xml
+++ b/script.playrandomvideos/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.playrandomvideos" name="Play Random Videos" version="1.1.0" provider-name="rmrector">
+<addon id="script.playrandomvideos" name="Play Random Videos" version="1.1.2" provider-name="rmrector">
 	<requires>
 		<import addon="xbmc.addon" version="15.0.0" />
 		<import addon="xbmc.python" version="2.20.0" />
@@ -15,6 +15,8 @@
 	<extension point="xbmc.addon.metadata">
 		<summary lang="en">Plays random videos from all sorts of lists.</summary>
 		<description lang="en">This add-on can quickly play random episodes from TV shows, movies from genres/sets/years/tags, and videos from playlists, the filesystem, and just about anything else, other than plugins.</description>
+		<news>v1.1.2 (2017-04-28)
+- Fix incorrect JSON-RPC notifications on Krypton</news>
 		<platform>all</platform>
 		<source>https://github.com/rmrector/script.playrandomvideos</source>
 		<forum>http://forum.kodi.tv/showthread.php?tid=238613</forum>

--- a/script.playrandomvideos/changelog.txt
+++ b/script.playrandomvideos/changelog.txt
@@ -1,3 +1,6 @@
+v1.1.2 (2017-04-28)
+- Fix incorrect JSON-RPC notifications on Krypton
+
 v1.1.0 (2016-11-07)
 - Show notification if a directory can't be played
 - Show busy notification before playing first item, and option to disable it

--- a/script.playrandomvideos/resources/lib/listitembuilder.py
+++ b/script.playrandomvideos/resources/lib/listitembuilder.py
@@ -6,10 +6,12 @@ infokey_map = {
     'track': 'tracknumber',
     'runtime': 'duration',
     'showtitle': 'tvshowtitle',
-    'imdbnumber': 'code',
-    'uniqueid': 'code',
     'firstaired': 'aired'
 }
+
+mediatype_map = {'episodeid': 'episode',
+    'movieid': 'movie',
+    'musicvideoid': 'musicvideo'}
 
 def build_video_listitem(item):
     result = xbmcgui.ListItem(item.get('label'))
@@ -20,16 +22,12 @@ def build_video_listitem(item):
     for key, value in item.iteritems():
         if isinstance(value, collections.Mapping):
             continue
-        if key in (infokey_map.keys()):
+        if key in infokey_map:
             infolabels[infokey_map[key]] = value
+        elif key in mediatype_map:
+            infolabels['dbid'] = value
+            infolabels['mediatype'] = mediatype_map[key]
 
-        infolabels[key] = value
-        if isinstance(value, basestring):
-            result.setProperty(key, value)
-        elif isinstance(value, collections.Iterable):
-            result.setProperty(key, list_to_str(value))
-        else:
-            result.setProperty(key, str(value))
     result.setInfo('video', infolabels)
 
     if 'file' in item:


### PR DESCRIPTION
### Description
- set dbid and mediatype for ListItems as required by Krypton.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [X] Each add-on submission should be a single commit with using the following style: [script.foo.bar] v1.0.0

Additional information :
- Submitting your add-on to this specific branch makes it available to any Kodi version equal or higher than the branch name with the applicable Kodi dependencies limits.
- [add-on development](http://kodi.wiki/view/Add-on_development) wiki page.
- Kodi [pydocs](http://kodi.wiki/view/PyDocs) provide information about the Python API
- [PEP8](https://www.python.org/dev/peps/pep-0008/) codingstyle which is considered best practise but not mandatory.
- This add-on repository has automated code guideline check which could help you improve your coding. You can find the results of these check at [Codacy](https://www.codacy.com/app/Kodi/repo-scripts/dashboard). You can create your own account as well to continuously monitor your python coding before submitting to repo.
- Development questions can be asked in the [add-on development](http://forum.kodi.tv/forumdisplay.php?fid=26) section on the Kodi forum.
