### PR TITLE
[script.video.randomtv] 1.1.1

### DIFF
--- a/script.video.randomtv/addon.py
+++ b/script.video.randomtv/addon.py
@@ -113,6 +113,8 @@ if addon.getSetting("ShowNotifications") == "true": xbmc.executebuiltin('Notific
 log("-------------------------------------------------------------------------")
 log("Starting")
 busyDiag.create()
+backWindow = xbmcgui.Window()
+backWindow.show()
 
 
 # Get TV Episodes
@@ -229,20 +231,26 @@ while (not xbmc.Monitor().waitForAbort(1)):
 
 	if player.mediaEnded:
 		log("--------- mediaEnded")
+		log("-- Playlist Position: " + str(myPlaylist.getposition()))
 		
-		if addon.getSetting("RepeatPlaylist") == "true":
-			if addon.getSetting("ShuffleOnRepeat") == "true":
-				busyDiag.create()
-				log("-- Shuffling Playlist")
-				if addon.getSetting("ShowNotifications") == "true": xbmc.executebuiltin('Notification(%s, %s, %d, %s)'%(name, xbmcaddon.Addon().getLocalizedString(32010), 5000, icon))
-				random.shuffle(myEpisodes)
-				buildPlaylist(myEpisodes)
-			#
+		if myPlaylist.getposition() < 0:
+			log("-- Playlist Finished")
+			if addon.getSetting("RepeatPlaylist") == "true":
+				if addon.getSetting("ShuffleOnRepeat") == "true":
+					busyDiag.create()
+					log("-- Shuffling Playlist")
+					if addon.getSetting("ShowNotifications") == "true": xbmc.executebuiltin('Notification(%s, %s, %d, %s)'%(name, xbmcaddon.Addon().getLocalizedString(32010), 5000, icon))
+					random.shuffle(myEpisodes)
+					buildPlaylist(myEpisodes)
+				#
 
-			log("-- Restarting Playlist")
-			player.play(item=myPlaylist)
+				log("-- Restarting Playlist")
+				player.play(item=myPlaylist)
+			else:
+				player.scriptStopped = True
 		else:
-			player.scriptStopped = True
+			log("-- Playlist still going")
+		#
 
 		player.mediaEnded = False
 	#
@@ -261,5 +269,6 @@ while (not xbmc.Monitor().waitForAbort(1)):
 
 # Display Stopping Notification
 if addon.getSetting("ShowNotifications") == "true": xbmc.executebuiltin('Notification(%s, %s, %d, %s)'%(name, xbmcaddon.Addon().getLocalizedString(32011), 2000, icon))
+backWindow.close()
 log("Stopping")
 log("-------------------------------------------------------------------------")

--- a/script.video.randomtv/addon.xml
+++ b/script.video.randomtv/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.video.randomtv" name="RandomTV" version="1.1.0" provider-name="gmccauley">
+<addon id="script.video.randomtv" name="RandomTV" version="1.1.1" provider-name="gmccauley">
   <requires>
     <import addon="xbmc.python" version="2.25.0"/>
   </requires>
@@ -18,6 +18,9 @@
     <email></email>
     <source>https://github.com/gmccauley/script.video.randomtv</source>
     <news>
+v1.1.1 (29 April 2017)
+  - Fixed Bug where Playlist would be shuffled after each video ended
+  - Added Empty Window to prevent Kodi from being displayed between Playlist Shuffles
 v1.1.0 (28 April 2017)
   - Added Auto Stop Feature
   - Replaced xbmc.sleep with xbmc.Monitor().waitForAbort


### PR DESCRIPTION
### Description
v1.1.1 (29 April 2017)
  - Fixed Bug where Playlist would be shuffled after each video ended
  - Added Empty Window to prevent Kodi from being displayed between Playlist Shuffles

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [X] Each add-on submission should be a single commit with using the following style: [script.foo.bar] v1.0.0