### PR TITLE
[script.video.randomtv] 1.1.2

### DIFF
--- a/script.video.randomtv/addon.py
+++ b/script.video.randomtv/addon.py
@@ -92,7 +92,7 @@ if len(sys.argv) > 1:
 
 			
 		busyDiag.close()
-		selectedShows = xbmcgui.Dialog().multiselect(xbmcaddon.Addon().getLocalizedString(32012), listShows, preselect=listPreSelect)
+		selectedShows = xbmcgui.Dialog().multiselect(addon.getLocalizedString(32012), listShows, preselect=listPreSelect)
 
 		
 		if not selectedShows is None:
@@ -109,7 +109,7 @@ if len(sys.argv) > 1:
 
 
 # Display Starting Notification
-if addon.getSetting("ShowNotifications") == "true": xbmc.executebuiltin('Notification(%s, %s, %d, %s)'%(name, xbmcaddon.Addon().getLocalizedString(32007), 2000, icon))
+if addon.getSetting("ShowNotifications") == "true": xbmc.executebuiltin('Notification(%s, %s, %d, %s)'%(name, addon.getLocalizedString(32007), 2000, icon))
 log("-------------------------------------------------------------------------")
 log("Starting")
 busyDiag.create()
@@ -150,7 +150,7 @@ log("Total Episodes: " + str(len(myEpisodes)))
 # If no episodes, display notification and quit
 if len(myEpisodes) == 0:
 	log("--------- No episodes")
-	xbmcgui.Dialog().ok(name, xbmcaddon.Addon().getLocalizedString(32008), xbmcaddon.Addon().getLocalizedString(32009))
+	xbmcgui.Dialog().ok(name, addon.getLocalizedString(32008), addon.getLocalizedString(32009))
 	xbmc.executebuiltin('Addon.OpenSettings(%s)' % addonid)
 	quit()
 else:
@@ -186,9 +186,9 @@ while (not xbmc.Monitor().waitForAbort(1)):
 	if addon.getSetting("AutoStop") == "true":
 		if int(time.time()) >= AutoStopCheckTime:
 			log("-- Auto Stop Timer Reached")
-			AutoStopDialog.create(name, xbmcaddon.Addon().getLocalizedString(32015))
+			AutoStopDialog.create(name, addon.getLocalizedString(32015))
 			while int(time.time()) < AutoStopCheckTime + AutoStopWait:
-				AutoStopDialog.update(int(int(time.time() - AutoStopCheckTime) * 100 / AutoStopWait), xbmcaddon.Addon().getLocalizedString(32015), str(AutoStopWait - int(time.time() - AutoStopCheckTime)) + " " + xbmcaddon.Addon().getLocalizedString(32016))
+				AutoStopDialog.update(int(int(time.time() - AutoStopCheckTime) * 100 / AutoStopWait), addon.getLocalizedString(32015), str(AutoStopWait - int(time.time() - AutoStopCheckTime)) + " " + addon.getLocalizedString(32016))
 				if AutoStopDialog.iscanceled():
 					log("-- Dialog Cancelled - Breaking")
 					break
@@ -242,7 +242,7 @@ while (not xbmc.Monitor().waitForAbort(1)):
 				if addon.getSetting("ShuffleOnRepeat") == "true":
 					busyDiag.create()
 					log("-- Shuffling Playlist")
-					if addon.getSetting("ShowNotifications") == "true": xbmc.executebuiltin('Notification(%s, %s, %d, %s)'%(name, xbmcaddon.Addon().getLocalizedString(32010), 5000, icon))
+					if addon.getSetting("ShowNotifications") == "true": xbmc.executebuiltin('Notification(%s, %s, %d, %s)'%(name, addon.getLocalizedString(32010), 5000, icon))
 					random.shuffle(myEpisodes)
 					buildPlaylist(myEpisodes)
 				#
@@ -271,7 +271,7 @@ while (not xbmc.Monitor().waitForAbort(1)):
 
 
 # Display Stopping Notification
-if addon.getSetting("ShowNotifications") == "true": xbmc.executebuiltin('Notification(%s, %s, %d, %s)'%(name, xbmcaddon.Addon().getLocalizedString(32011), 2000, icon))
+if addon.getSetting("ShowNotifications") == "true": xbmc.executebuiltin('Notification(%s, %s, %d, %s)'%(name, addon.getLocalizedString(32011), 2000, icon))
 backWindow.close()
 log("Stopping")
 log("-------------------------------------------------------------------------")

--- a/script.video.randomtv/addon.py
+++ b/script.video.randomtv/addon.py
@@ -103,7 +103,7 @@ if len(sys.argv) > 1:
 			addon.setSetting("includedShows", includedShows)
 
 		xbmc.executebuiltin('Addon.OpenSettings(%s)' % addonid)
-		xbmc.executebuiltin('SetFocus(205)')
+		xbmc.executebuiltin('SetFocus(201)')
 	quit()
 #
 
@@ -113,6 +113,8 @@ if addon.getSetting("ShowNotifications") == "true": xbmc.executebuiltin('Notific
 log("-------------------------------------------------------------------------")
 log("Starting")
 busyDiag.create()
+backWindow = xbmcgui.Window()
+backWindow.show()
 
 
 # Get TV Episodes
@@ -181,29 +183,32 @@ else:
 
 
 while (not xbmc.Monitor().waitForAbort(1)):
-	if int(time.time()) >= AutoStopCheckTime:
-		log("-- Auto Stop Timer Reached")
-		AutoStopDialog.create(name, xbmcaddon.Addon().getLocalizedString(32015))
-		while int(time.time()) < AutoStopCheckTime + AutoStopWait:
-			AutoStopDialog.update(int(int(time.time() - AutoStopCheckTime) * 100 / AutoStopWait), xbmcaddon.Addon().getLocalizedString(32015), str(AutoStopWait - int(time.time() - AutoStopCheckTime)) + " " + xbmcaddon.Addon().getLocalizedString(32016))
-			if AutoStopDialog.iscanceled():
-				log("-- Dialog Cancelled - Breaking")
-				break
+	if addon.getSetting("AutoStop") == "true":
+		if int(time.time()) >= AutoStopCheckTime:
+			log("-- Auto Stop Timer Reached")
+			AutoStopDialog.create(name, xbmcaddon.Addon().getLocalizedString(32015))
+			while int(time.time()) < AutoStopCheckTime + AutoStopWait:
+				AutoStopDialog.update(int(int(time.time() - AutoStopCheckTime) * 100 / AutoStopWait), xbmcaddon.Addon().getLocalizedString(32015), str(AutoStopWait - int(time.time() - AutoStopCheckTime)) + " " + xbmcaddon.Addon().getLocalizedString(32016))
+				if AutoStopDialog.iscanceled():
+					log("-- Dialog Cancelled - Breaking")
+					break
+				#
+				xbmc.Monitor().waitForAbort(0.1)
 			#
-			xbmc.Monitor().waitForAbort(0.1)
+			if AutoStopDialog.iscanceled():
+				log("-- Dialog Cancelled")
+				AutoStopCheckTime = int(time.time()) + (int(addon.getSetting("AutoStopTimer")) * 60)
+			#
+			else:
+				log("-- Dialog Not Cancelled")
+				xbmc.executebuiltin('PlayerControl(Stop)')
+			#
+			AutoStopDialog.close()
+			xbmc.Monitor().waitForAbort(0.2)
 		#
-		if AutoStopDialog.iscanceled():
-			log("-- Dialog Cancelled")
-			AutoStopCheckTime = int(time.time()) + (int(addon.getSetting("AutoStopTimer")) * 60)
-		#
-		else:
-			log("-- Dialog Not Cancelled")
-			xbmc.executebuiltin('PlayerControl(Stop)')
-		#
-		AutoStopDialog.close()
-		xbmc.Monitor().waitForAbort(0.2)
 	#
 
+	
 	if player.mediaStarted:
 		log("--------- mediaStarted")
 		busyDiag.close()
@@ -229,20 +234,26 @@ while (not xbmc.Monitor().waitForAbort(1)):
 
 	if player.mediaEnded:
 		log("--------- mediaEnded")
+		log("-- Playlist Position: " + str(myPlaylist.getposition()))
 		
-		if addon.getSetting("RepeatPlaylist") == "true":
-			if addon.getSetting("ShuffleOnRepeat") == "true":
-				busyDiag.create()
-				log("-- Shuffling Playlist")
-				if addon.getSetting("ShowNotifications") == "true": xbmc.executebuiltin('Notification(%s, %s, %d, %s)'%(name, xbmcaddon.Addon().getLocalizedString(32010), 5000, icon))
-				random.shuffle(myEpisodes)
-				buildPlaylist(myEpisodes)
-			#
+		if myPlaylist.getposition() < 0:
+			log("-- Playlist Finished")
+			if addon.getSetting("RepeatPlaylist") == "true":
+				if addon.getSetting("ShuffleOnRepeat") == "true":
+					busyDiag.create()
+					log("-- Shuffling Playlist")
+					if addon.getSetting("ShowNotifications") == "true": xbmc.executebuiltin('Notification(%s, %s, %d, %s)'%(name, xbmcaddon.Addon().getLocalizedString(32010), 5000, icon))
+					random.shuffle(myEpisodes)
+					buildPlaylist(myEpisodes)
+				#
 
-			log("-- Restarting Playlist")
-			player.play(item=myPlaylist)
+				log("-- Restarting Playlist")
+				player.play(item=myPlaylist)
+			else:
+				player.scriptStopped = True
 		else:
-			player.scriptStopped = True
+			log("-- Playlist still going")
+		#
 
 		player.mediaEnded = False
 	#
@@ -261,5 +272,6 @@ while (not xbmc.Monitor().waitForAbort(1)):
 
 # Display Stopping Notification
 if addon.getSetting("ShowNotifications") == "true": xbmc.executebuiltin('Notification(%s, %s, %d, %s)'%(name, xbmcaddon.Addon().getLocalizedString(32011), 2000, icon))
+backWindow.close()
 log("Stopping")
 log("-------------------------------------------------------------------------")

--- a/script.video.randomtv/addon.xml
+++ b/script.video.randomtv/addon.xml
@@ -18,9 +18,8 @@
     <email></email>
     <source>https://github.com/gmccauley/script.video.randomtv</source>
     <news>
-v1.1.2 (30 April 2017)
+v1.1.2 (2 May 2017)
   - Fixed Bugs in AutoStop Feature
-v1.1.1 (29 April 2017)
   - Fixed Bug where Playlist would be shuffled after each video ended
   - Added Empty Window to prevent Kodi from being displayed between Playlist Shuffles
 v1.1.0 (28 April 2017)

--- a/script.video.randomtv/addon.xml
+++ b/script.video.randomtv/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.video.randomtv" name="RandomTV" version="1.1.0" provider-name="gmccauley">
+<addon id="script.video.randomtv" name="RandomTV" version="1.1.2" provider-name="gmccauley">
   <requires>
     <import addon="xbmc.python" version="2.25.0"/>
   </requires>
@@ -18,6 +18,11 @@
     <email></email>
     <source>https://github.com/gmccauley/script.video.randomtv</source>
     <news>
+v1.1.2 (30 April 2017)
+  - Fixed Bugs in AutoStop Feature
+v1.1.1 (29 April 2017)
+  - Fixed Bug where Playlist would be shuffled after each video ended
+  - Added Empty Window to prevent Kodi from being displayed between Playlist Shuffles
 v1.1.0 (28 April 2017)
   - Added Auto Stop Feature
   - Replaced xbmc.sleep with xbmc.Monitor().waitForAbort

--- a/script.video.randomtv/resources/settings.xml
+++ b/script.video.randomtv/resources/settings.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <settings>
+	<setting id="IncludeAll" label="32005" type="bool" default="true"/>
+	<setting id="SelectShowsAction" label="32006" type="action" action="RunScript(script.video.randomtv, SelectShows)" visible="eq(-1,false)" enable="eq(-1,false)" subsetting="true" option="close"/>
+	<setting type="sep"/>
     <setting id="IncludeUnwatched" label="32000" type="bool" default="false"/>
     <setting id="UpdatePlayCount" label="32001" type="bool" default="false"/>
 	<setting id="RepeatPlaylist" label="32002" type="bool" default="true"/>
@@ -9,7 +12,4 @@
 	<setting id="AutoStop" label="32013" type="bool" default="true"/>
 	<setting id="AutoStopTimer" label="32014" type="slider" option="int" default="240" range="30,30,480" visible="eq(-1,true)" enable="eq(-1,true)" subsetting="true"/>
 	<setting id="AutoStopWait" label="32017" type="slider" option="int" default="5" range="1,1,15" visible="eq(-2,true)" enable="eq(-2,true)" subsetting="true"/>
-	<setting type="sep"/>
-	<setting id="IncludeAll" label="32005" type="bool" default="true"/>
-	<setting id="SelectShowsAction" label="32006" type="action" action="RunScript(script.video.randomtv, SelectShows)" visible="eq(-1,false)" enable="eq(-1,false)" subsetting="true" option="close"/>
 </settings>


### PR DESCRIPTION
### Description
v1.1.2 (30 April 2017)
  - Fixed Bugs in AutoStop Feature
  - Fixed Bug where Playlist would be shuffled after each video ended
  - Added Empty Window to prevent Kodi from being displayed between Playlist Shuffles

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [X] Each add-on submission should be a single commit with using the following style: [script.foo.bar] v1.0.0
