### PR TITLE
[service.kn.switchtimer] v2.0.3

### DIFF
--- a/service.kn.switchtimer/addon.xml
+++ b/service.kn.switchtimer/addon.xml
@@ -1,22 +1,23 @@
 <?xml version='1.0' encoding='UTF-8' standalone='yes'?>
-<addon id="service.kn.switchtimer" name="KN Switchtimer Service" provider-name="Birger Jesch" version="2.0.2">
+<addon id="service.kn.switchtimer" name="KN Switchtimer Service" provider-name="Birger Jesch" version="2.0.3">
     <requires>
         <import addon="xbmc.python" version="2.24.0"/>
+        <import addon="script.module.dateutil" version="2.5.3"/>
         <import addon="xbmc.json" version="6.20.0"/>
     </requires>
     <extension point="xbmc.service" library="service.py" start="login" />
     <extension point="xbmc.python.script" library="handler.py" />
     <extension point="kodi.context.item" library="addtimer.py">
-            <item>
-                <label>30040</label>
-                <visible>System.HasAddon(service.kn.switchtimer) + Window.IsVisible(tvguide)</visible>
-            </item>
-    </extension>
-    <extension point="kodi.context.item" library="deltimer.py">
-            <item>
-                <label>30041</label>
-                <visible>System.HasAddon(service.kn.switchtimer) + Window.IsVisible(tvguide)</visible>
-            </item>
+            <menu id="kodi.core.main">
+                <item library="addtimer.py">
+                    <label>30040</label>
+                    <visible>System.HasAddon(service.kn.switchtimer) + Window.IsVisible(tvguide)</visible>
+                </item>
+                <item library="deltimer.py">
+                    <label>30041</label>
+                    <visible>System.HasAddon(service.kn.switchtimer) + Window.IsVisible(tvguide)</visible>
+                </item>
+            </menu>
     </extension>
     <extension point="xbmc.addon.metadata">
         <summary lang="en">A switch timer for the PVR module of Kodi</summary>
@@ -29,7 +30,7 @@
         <license>GNU GENERAL PUBLIC LICENSE. Version 2, June 1991</license>
         <website>http://vdr4bj1.no-ip.org</website>
         <source>https://github.com/b-jesch/service.kn.switchtimer</source>
-        <email>Birger.Jesch@gmail.com</email>
+        <email>birger.jesch@gmail.com</email>
         <language/>
     </extension>
 </addon>

--- a/service.kn.switchtimer/addtimer.py
+++ b/service.kn.switchtimer/addtimer.py
@@ -6,7 +6,7 @@ import handler
 
 if __name__ ==  '__main__':
 
-    handler.notifyLog('Parameter handler called: add Timer')
+    handler.notifyLog('Parameter handler called: add timer')
     args = {'channel': xbmc.getInfoLabel('ListItem.ChannelName'),
             'icon': xbmc.getInfoLabel('ListItem.Icon'),
             'date': xbmc.getInfoLabel('ListItem.Date'),

--- a/service.kn.switchtimer/changelog.txt
+++ b/service.kn.switchtimer/changelog.txt
@@ -1,5 +1,8 @@
 CHANGELOG
 
+2.0.3
+- Module dateutil included.
+
 2.0.2
 - create settings path if not exists. This avoids IOExceptions when writing timers and the addon
   wasn't configured yet.

--- a/service.kn.switchtimer/deltimer.py
+++ b/service.kn.switchtimer/deltimer.py
@@ -5,5 +5,5 @@ import handler
 
 if __name__ ==  '__main__':
 
-    handler.notifyLog('Parameter handler called: Delete Timerlist')
+    handler.notifyLog('Parameter handler called: delete timerlist')
     handler.clearTimerProperties()

--- a/service.kn.switchtimer/service.py
+++ b/service.kn.switchtimer/service.py
@@ -41,7 +41,6 @@ class Service(XBMCMonitor):
 
     def __init__(self, *args):
         XBMCMonitor.__init__(self)
-        self.__dateFormat = None
         self.getSettings()
         handler.notifyLog('Init Service %s %s' % (__addonname__, __version__))
 
@@ -59,7 +58,6 @@ class Service(XBMCMonitor):
         self.__dispMsgTime = int(re.match('\d+', handler.getSetting('dispTime')).group())*1000
         self.__discardTmr = int(re.match('\d+', handler.getSetting('discardOldTmr')).group())*60
         self.__confirmTmrAdded = True if handler.getSetting('confirmTmrAdded').upper() == 'TRUE' else False
-        self.__dateFormat = handler.getDateFormat()
 
         self.SettingsChanged = False
 


### PR DESCRIPTION
### Description
Update to v2.0.3:
- Introduction and usage of module dateutil as a more robust date/time calculation/conversion between various time formats.
### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [X] Each add-on submission should be a single commit with using the following style: [script.foo.bar] v1.0.0

Additional information :
- Submitting your add-on to this specific branch makes it available to any Kodi version equal or higher than the branch name with the applicable Kodi dependencies limits.
- [add-on development](http://kodi.wiki/view/Add-on_development) wiki page.
- Kodi [pydocs](http://kodi.wiki/view/PyDocs) provide information about the Python API
- [PEP8](https://www.python.org/dev/peps/pep-0008/) codingstyle which is considered best practise but not mandatory.
- This add-on repository has automated code guideline check which could help you improve your coding. You can find the results of these check at [Codacy](https://www.codacy.com/app/Kodi/repo-scripts/dashboard). You can create your own account as well to continuously monitor your python coding before submitting to repo.
- Development questions can be asked in the [add-on development](http://forum.kodi.tv/forumdisplay.php?fid=26) section on the Kodi forum.
