### PR TITLE
[service.subtitles.subtituloses] and [service.subtitles.tusubtitulo] broken

### DIFF
--- a/service.subtitles.subtituloses/addon.xml
+++ b/service.subtitles.subtituloses/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="service.subtitles.subtituloses"
        name="Subtitulos.es"
-       version="0.0.5"
+       version="0.0.6"
        provider-name="m0r3">
   <requires>
     <import addon="xbmc.python" version="2.14.0"/>

--- a/service.subtitles.subtituloses/addon.xml
+++ b/service.subtitles.subtituloses/addon.xml
@@ -6,6 +6,7 @@
   <requires>
     <import addon="xbmc.python" version="2.14.0"/>
   </requires>
+  <broken>deprecated</broken>
   <extension point="xbmc.subtitle.module"
              library="service.py" />
   <extension point="xbmc.addon.metadata">

--- a/service.subtitles.subtituloses/changelog.txt
+++ b/service.subtitles.subtituloses/changelog.txt
@@ -1,3 +1,6 @@
+0.0.7
+- Addon marked as broken
+
 0.0.6
 - Changed host to http://tusubtitulo.com
 - Added section 'series' to the main_url

--- a/service.subtitles.tusubtitulo/addon.xml
+++ b/service.subtitles.tusubtitulo/addon.xml
@@ -6,6 +6,7 @@
   <requires>
     <import addon="xbmc.python" version="2.1.0"/>
   </requires>
+  <broken>deprecated</broken>
   <extension point="xbmc.subtitle.module"
              library="service.py" />
   <extension point="xbmc.addon.metadata">

--- a/service.subtitles.tusubtitulo/addon.xml
+++ b/service.subtitles.tusubtitulo/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="service.subtitles.tusubtitulo"
        name="TuSubtitulo"
-       version="1.0.0"
+       version="1.1.0"
        provider-name="El_Happy">
   <requires>
     <import addon="xbmc.python" version="2.1.0"/>

--- a/service.subtitles.tusubtitulo/changelog.txt
+++ b/service.subtitles.tusubtitulo/changelog.txt
@@ -1,3 +1,6 @@
+1.1.0
+- Addon marked as broken
+
 1.0.0
 - Port from Subtitulos.es XBMC subtitles plugin by m0r3
 - Fixed recursive expresion to find the url link of subtitles


### PR DESCRIPTION
### Description
Both addons are not maintained anymore since both webpages either changed or went down so none of them work anymore.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [script.foo.bar] v1.0.0

Additional information :
- Submitting your add-on to this specific branch makes it available to any Kodi version equal or higher than the branch name with the applicable Kodi dependencies limits.
- [add-on development](http://kodi.wiki/view/Add-on_development) wiki page.
- Kodi [pydocs](http://kodi.wiki/view/PyDocs) provide information about the Python API
- [PEP8](https://www.python.org/dev/peps/pep-0008/) codingstyle which is considered best practise but not mandatory.
- This add-on repository has automated code guideline check which could help you improve your coding. You can find the results of these check at [Codacy](https://www.codacy.com/app/Kodi/repo-scripts/dashboard). You can create your own account as well to continuously monitor your python coding before submitting to repo.
- Development questions can be asked in the [add-on development](http://forum.kodi.tv/forumdisplay.php?fid=26) section on the Kodi forum.
