### PR TITLE
[script.xbmc.boblight] 2.0.18

### DIFF
--- a/script.xbmc.boblight/addon.xml
+++ b/script.xbmc.boblight/addon.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.xbmc.boblight" name="Kodi Boblight" version="2.0.17" provider-name="bobo1on1, Memphiz">
+<addon id="script.xbmc.boblight" name="Kodi Boblight" version="2.0.18" provider-name="bobo1on1, Memphiz">
   <requires>
     <import addon="xbmc.python" version="2.1.0"/>
   </requires>

--- a/script.xbmc.boblight/changelog.txt
+++ b/script.xbmc.boblight/changelog.txt
@@ -1,3 +1,6 @@
+2.0.18
+- fixed support for windows 32bit after last version bump
+
 2.0.17
 - add support for windows 64bit
 

--- a/script.xbmc.boblight/resources/lib/tools.py
+++ b/script.xbmc.boblight/resources/lib/tools.py
@@ -72,7 +72,7 @@ def get_platform():
   if xbmc.getCondVisibility('system.platform.osx'):
     platformstr = "osx"
   elif xbmc.getCondVisibility('system.platform.windows'):
-    if platform.machine().endswith('64'):
+    if sys.maxsize > 2**32:
       platformstr = "win64"
     else:
       platformstr = "win32"


### PR DESCRIPTION
Sorry about that rapid bump. The detection of the 64bit runtime returned true whenever a 64bit Windows was installed and didn't distinguish between kodi being 32bit or 64bit. I thought i have tested this but i didn't.

This fixes the detection.