### PR TITLE
[script.tag-generator] 0.5.2

### DIFF
--- a/script.tag-generator/addon.xml
+++ b/script.tag-generator/addon.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="script.tag-generator"
        name="Tag Generator"
-       version="0.5.1"
+       version="0.5.2"
        provider-name="wellspokenman">
   <requires>
     <import addon="xbmc.python" version="2.25.0"/>
     <import addon="script.module.simplejson" version="3.3.0"/>
     <import addon="script.module.requests" version="2.12.4"/>
     <import addon="script.module.six" version="1.9.0"/>
-    <import addon="script.module.oauthlib" version="2.1.0"/>
+    <import addon="script.module.oauthlib" version="2.0.1"/>
     <import addon="script.module.requests_oauthlib" version="0.7.0"/>
   </requires>
   <extension point="xbmc.service" library="main.py" start="login">


### PR DESCRIPTION
### Description
Oauth version number is 2.0.1 not 2.1.0. This incorrect version number prevented tag-generator from updating. 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [X] Each add-on submission should be a single commit with using the following style: [script.foo.bar] v1.0.0

Additional information :
- Submitting your add-on to this specific branch makes it available to any Kodi version equal or higher than the branch name with the applicable Kodi dependencies limits.
- [add-on development](http://kodi.wiki/view/Add-on_development) wiki page.
- Kodi [pydocs](http://kodi.wiki/view/PyDocs) provide information about the Python API
- [PEP8](https://www.python.org/dev/peps/pep-0008/) codingstyle which is considered best practise but not mandatory.
- This add-on repository has automated code guideline check which could help you improve your coding. You can find the results of these check at [Codacy](https://www.codacy.com/app/Kodi/repo-scripts/dashboard). You can create your own account as well to continuously monitor your python coding before submitting to repo.
- Development questions can be asked in the [add-on development](http://forum.kodi.tv/forumdisplay.php?fid=26) section on the Kodi forum.
