### PR TITLE
Add addon-check as submodule and setup travis-ci

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule ".tests"]
+	path = .tests
+	url = https://github.com/xbmc/addon-check.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: python
+python:
+  - "3.6"
+
+install:
+  - pip install Pillow
+
+# command to run our tests
+script:
+  - cd .tests
+  - python check_repo.py

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ This branch is used for add-ons that are coded for Kodi v17.0 Krypton builds and
 * New add-on additions: **Accepted**
 * Updating already present add-ons: **Accepted**
 
-## Disclaimer ##
+## Disclaimer
 
 The contents of this repository mainly consist of add-on created by third party developers. Team Kodi holds no responsibility for it's contents.
 Team Kodi reserves the right to update or remove add-ons at any time as we deem necessary.


### PR DESCRIPTION
Adds the new addon-check python tool and runs it via travis.