### PR TITLE
[weather.ozweather] v0.9.7

### DIFF
--- a/weather.ozweather/addon.xml
+++ b/weather.ozweather/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="weather.ozweather" name="Oz Weather" version="0.9.6" provider-name="Bossanova808">
+<addon id="weather.ozweather" name="Oz Weather" version="0.9.7" provider-name="Bossanova808">
 	<requires>
 		<import addon="xbmc.python" version="2.14.0"/>
 		<import addon="script.module.pil" version="1.1.7"/>

--- a/weather.ozweather/addon.xml
+++ b/weather.ozweather/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="weather.ozweather" name="Oz Weather" version="0.9.5" provider-name="Bossanova808">
+<addon id="weather.ozweather" name="Oz Weather" version="0.9.6" provider-name="Bossanova808">
 	<requires>
 		<import addon="xbmc.python" version="2.14.0"/>
 		<import addon="script.module.pil" version="1.1.7"/>

--- a/weather.ozweather/changelog.txt
+++ b/weather.ozweather/changelog.txt
@@ -1,3 +1,7 @@
+v0.9.7
+- Fixes for git hell
+- Fixes for cut and paste error and strip most strings to solve whitespace issues
+
 v0.9.4
 - Fixes for Weatherzone page changes
 

--- a/weather.ozweather/resources/lib/weatherzone.py
+++ b/weather.ozweather/resources/lib/weatherzone.py
@@ -349,7 +349,7 @@ def getWeatherData(urlPath, extendedFeatures = True, XBMC_VERSION=17.0):
         weatherData['Today.Moonphase'] = value
         
         #Sunrise/set
-        sunrise = tds[2].text.strip()
+        sunrise = tds[1].text.strip()
         sunset = tds[2].text.strip()
         weatherData['Today.Sunrise'] = sunrise
         weatherData['Today.Sunset'] = sunset

--- a/weather.ozweather/resources/lib/weatherzone.py
+++ b/weather.ozweather/resources/lib/weatherzone.py
@@ -249,14 +249,7 @@ def setKeys(index, keys, value):
     global weatherData
 
     for key in keys:
-        if index is 0:
-            weatherData['Current.' + key] = value
-            weatherData['Current.' + key] = value
-
-        weatherData['Day' + str(index) + '.' + key] = value
-        weatherData['Day' + str(index) + '.' + key] = value
-        weatherData['Daily.' + str(index+1) + '.' + key] = value
-        weatherData['Daily.' + str(index+1) + '.' + key] = value
+        setKey(index,key, value)
 
 # Set a key - for old and new weather label support
 
@@ -265,13 +258,13 @@ def setKey(index, key, value):
     global weatherData
 
     if index is 0:
-        weatherData['Current.' + key] = value
-        weatherData['Current.' + key] = value
+        weatherData['Current.' + key] = value.strip()
+        weatherData['Current.' + key] = value.strip()
 
-    weatherData['Day' + str(index) + '.' + key] = value
-    weatherData['Day' + str(index) + '.' + key] = value
-    weatherData['Daily.' + str(index+1) + '.' + key] = value
-    weatherData['Daily.' + str(index+1) + '.' + key] = value
+    weatherData['Day' + str(index) + '.' + key] = value.strip()
+    weatherData['Day' + str(index) + '.' + key] = value.strip()
+    weatherData['Daily.' + str(index+1) + '.' + key] = value.strip()
+    weatherData['Daily.' + str(index+1) + '.' + key] = value.strip()
 
 # Returns an array of dicts, each with a Locationname and LocationUrlPart.  Empty if no location found.
 # [{'LocationName': u'Ascot Vale, VIC 3032', 'LocationUrlPart': u'/vic/melbourne/ascot-vale'}, ... ]
@@ -339,7 +332,7 @@ def getWeatherData(urlPath, extendedFeatures = True, XBMC_VERSION=17.0):
     # The longer forecast text
     try:
         p = soup.find_all("p", class_="district-forecast")  
-        weatherData["Current.ConditionLong"] = cleanLongDescription(p[0].text)
+        weatherData["Current.ConditionLong"] = cleanLongDescription(p[0].text).strip()
     except Exception as inst:
         print(str(inst))
         print("Exception in ConditionLong")
@@ -351,13 +344,13 @@ def getWeatherData(urlPath, extendedFeatures = True, XBMC_VERSION=17.0):
         tds = astronomyTable.find_all("td")
         
         # Moonphase
-        value = tds[4].find("img").get('title').title()
+        value = tds[4].find("img").get('title').title().strip()
         weatherData['Today.moonphase'] = value
         weatherData['Today.Moonphase'] = value
         
         #Sunrise/set
-        sunrise = tds[2].text
-        sunset = tds[2].text
+        sunrise = tds[2].text.strip()
+        sunset = tds[2].text.strip()
         weatherData['Today.Sunrise'] = sunrise
         weatherData['Today.Sunset'] = sunset
         weatherData['Current.Sunrise'] = sunrise
@@ -712,7 +705,7 @@ if __name__ == "__main__":
     for key in sorted(weatherData):
         if weatherData[key] == "?" or weatherData[key] == "na":
             print("**** MISSING: ")
-        print("%s: %s" % (key, weatherData[key]))
+        print("[%s]: [%s]" % (key, weatherData[key]))
 
     print("\n\nGet weather data for /vic/melbourne/ascot-vale:")
     
@@ -722,4 +715,4 @@ if __name__ == "__main__":
     for key in sorted(weatherData):
         if weatherData[key] == "?" or weatherData[key] == "na":
             print("**** MISSING: ")
-        print("%s: %s" % (key, weatherData[key]))
+        print("[%s]: [%s]" % (key, weatherData[key]))


### PR DESCRIPTION
### Description

Fix for minor cut and paste error

I pulled the changes to upstream (`git pull upstream gotham`) in my repo-scripts clone before doing this...but the instructions are broken/missing something - the only way I can get a clean single commit is to re-fork and set up the whole subtree thing again each time, and that's just  too much work/time....Aus internet is generally shit and it takes up to half an hour to clone xbmc-scripts each time.

Please can someone properly fix these instructions?   (http://kodi.wiki/view/HOW-TO:Create_add-on_PRs_using_Git_Subtree_Merging).  They are not currently dealing with, when doing updates, how to properly incorporate the upstream changes that may have happened in the meantime, such that when one commits a new update, you don't get a bunch of these extra commits.

The whole thing is way more work and complicated than this used to be - very frustrating at my end.  I understand it's probably much easier when it all works at yours.  And It would be fine if the instructions were clear and complete but they're not - if you follow them to the letter (and/or add what appears to be missing - pulling in the upstream changes from the original xbmc-scripts) - any commits to the upstream repo-scripts appear in the commit log of these submissions.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [script.foo.bar] v1.0.0
