### PR TITLE
[script.module.buggalo] 1.1.7

### DIFF
--- a/script.module.buggalo/README.md
+++ b/script.module.buggalo/README.md
@@ -5,7 +5,7 @@ exception in a Python script as well as information about the
 users system, such as XBMC and Python versions.
 
 The collected information is then posted to the internet at a
-predefined URL or Gmail account where the addon author can
+predefined URL or email account where the addon author can
 investigate the exception.
 
 The script is somewhat similar to posting the xbmc.log to pastebin,
@@ -21,13 +21,22 @@ HOW TO USE
 ==========
 To use this script you must do these things besides importing it.
 
-1.  Choose whether to submit the collected data to a Gmail account or
+1.  Choose whether to submit the collected data to an Email account or
     a private website containing buggalo-web.
 
-    *  To use a Gmail account set the buggalo.GMAIL_RECIPIENT to the full
-       gmail.com address of the recipient.
+    *  To use an email account set the `buggalo.EMAIL_RECIPIENT` with a dict structure containing information about the recipient, the email server and the credentials.
+       ```python
+       buggalo.EMAIL_CONFIG = {"recipient":"youremail@gmail.com", 
+                        "sender":"Buggalo <buggalo_account@gmail.com>", # example
+                        "server":"smtp.googlemail.com", # example for gmail
+                        "method":"ssl",
+                        "user":"buggalo_account@gmail.com",
+                        "pass":"yourpasswordforbuggalo_account"}
+       ```
+       You should use encrypted communication with the email server via smtp. For this option, the `method` has to be `ssl` and you have to give the username (`user`) and the password (`pass`), as in the example above. These are publicly visible and should therefore be used only for the smtp server and for nothing else (like e.g. for account login). This means, you have to create an email account for your addon to send the bug report emails.  
+       Unencrypted login is also possible by setting the `method` to `default` and not giving the credentials. Most of the emails will be blocked by ISPs though for spam prevention.
 
-    *  To use a website set buggalo.SUBMIT_URL to a full URL where the
+    *  To use a website, set buggalo.SUBMIT_URL to a full URL where the
        collected data is submitted.
 
 2.  Surround the code you want to be covered by this script in a
@@ -69,6 +78,11 @@ To use this script you must do these things besides importing it.
     file which store the error report in the database.
     https://github.com/twinther/buggalo-web/blob/master/submit.php
 
+Examples for the implementation can be found in the code of the following addons that use buggalo:
+
+*  [script.tvguide](https://github.com/twinther/script.tvguide)
+*  [script.moviequiz](https://github.com/twinther/script.moviequiz)
+*  [service.watchedlist](https://github.com/SchapplM/xbmc-addon-service-watchedlist)
 
 NOTES ABOUT GMAIL RECIPIENT
 ===========================

--- a/script.module.buggalo/addon.xml
+++ b/script.module.buggalo/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.module.buggalo" name="Buggalo Exception Collector" version="1.1.6" provider-name="twinther">
+<addon id="script.module.buggalo" name="Buggalo Exception Collector" version="1.1.7" provider-name="twinther">
     <requires>
         <import addon="xbmc.python" version="2.1.0"/>
         <import addon="script.module.simplejson" version="2.0.10"/>

--- a/script.module.buggalo/addon.xml
+++ b/script.module.buggalo/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.module.buggalo" name="Buggalo Exception Collector" version="1.1.7" provider-name="twinther">
+<addon id="script.module.buggalo" name="Buggalo Exception Collector" version="1.1.7" provider-name="twinther, schapplm">
     <requires>
         <import addon="xbmc.python" version="2.1.0"/>
         <import addon="script.module.simplejson" version="2.0.10"/>

--- a/script.module.buggalo/changelog.txt
+++ b/script.module.buggalo/changelog.txt
@@ -1,3 +1,6 @@
+[B]Version 1.1.7 - 2017-12-16[/B]
+- Added SSL login for email server
+
 [B]Version 1.1.6 - 2014-10-05[/B]
 - Fixed problem when an addon is invoked through it's settings via RunScript(..)
 - Updated language files from Transifex

--- a/script.module.buggalo/lib/buggalo.py
+++ b/script.module.buggalo/lib/buggalo.py
@@ -135,8 +135,6 @@ def onExceptionRaised(extraData=None):
 
     if not GMAIL_RECIPIENT == None and EMAIL_CONFIG == None: # for backwards-compatibility
         EMAIL_CONFIG = {'recipient':GMAIL_RECIPIENT}
-    print SUBMIT_URL
-    print EMAIL_CONFIG
     d = gui.BuggaloDialog(SUBMIT_URL, EMAIL_CONFIG, heading, data)
     d.doModal()
     del d

--- a/script.module.buggalo/lib/buggalo.py
+++ b/script.module.buggalo/lib/buggalo.py
@@ -29,13 +29,23 @@ import buggalo_client as client
 import buggalo_gui as gui
 import buggalo_userflow as userflow
 
-# You must provide either the SUBMIT_URL or GMAIL_RECIPIENT
-# via buggalo.SUBMIT_URL = '' or buggalo.GMAIL_RECIPIENT = ''
+""" 
+You must provide either the SUBMIT_URL or EMAIL_CONFIG
+via buggalo.SUBMIT_URL = '' 
+or (as an example)
+buggalo.EMAIL_CONFIG = {"recipient":"youremail@gmail.com", 
+                        "sender":"Buggalo <buggalo_account@gmail.com>", # example
+                        "server":"smtp.googlemail.com", # example for gmail
+                        "method":"ssl",
+                        "user":"buggalo_account@gmail.com",
+                        "pass":"yourpasswordforbuggalo_account"}
+"""
 
 # The full URL to where the gathered data should be posted.
 SUBMIT_URL = None
-# The email address where the gathered data should be sent.
-GMAIL_RECIPIENT = None
+# The email configuration where and how the gathered data should be sent.
+EMAIL_CONFIG = None
+GMAIL_RECIPIENT = None # for backwards-compatibility
 
 EXTRA_DATA = dict()
 
@@ -107,6 +117,7 @@ def onExceptionRaised(extraData=None):
 
     @param extraData: str or dict
     """
+    global EMAIL_CONFIG, SUBMIT_URL, GMAIL_RECIPIENT, SCRIPT_ADDON, EXTRA_DATA
     # start by logging the usual info to stderr
     (etype, value, traceback) = sys.exc_info()
     tb.print_exception(etype, value, traceback)
@@ -122,6 +133,10 @@ def onExceptionRaised(extraData=None):
     heading = getRandomHeading()
     data = client.gatherData(etype, value, traceback, extraData, EXTRA_DATA)
 
-    d = gui.BuggaloDialog(SUBMIT_URL, GMAIL_RECIPIENT, heading, data)
+    if not GMAIL_RECIPIENT == None and EMAIL_CONFIG == None: # for backwards-compatibility
+        EMAIL_CONFIG = {'recipient':GMAIL_RECIPIENT}
+    print SUBMIT_URL
+    print EMAIL_CONFIG
+    d = gui.BuggaloDialog(SUBMIT_URL, EMAIL_CONFIG, heading, data)
     d.doModal()
     del d

--- a/script.module.buggalo/lib/buggalo_gui.py
+++ b/script.module.buggalo/lib/buggalo_gui.py
@@ -48,13 +48,13 @@ class BuggaloDialog(xbmcgui.WindowXMLDialog):
     THANK_YOU_GROUP = 202
     THANK_YOU_LABEL = 203
 
-    def __new__(cls, serviceUrl, gmailRecipient, heading, data):
+    def __new__(cls, serviceUrl, emailConfig, heading, data):
         return super(BuggaloDialog, cls).__new__(cls, 'buggalo-dialog.xml', buggaloAddon.getAddonInfo('path'))
 
-    def __init__(self, serviceUrl, gmailRecipient, heading, data):
+    def __init__(self, serviceUrl, emailConfig, heading, data):
         super(BuggaloDialog, self).__init__()
         self.serviceUrl = serviceUrl
-        self.gmailRecipient = gmailRecipient
+        self.emailConfig = emailConfig
         self.heading = heading
         self.data = data
         self.detailsVisible = False
@@ -102,8 +102,8 @@ class BuggaloDialog(xbmcgui.WindowXMLDialog):
             try:
                 if self.serviceUrl is not None:
                     client.submitData(self.serviceUrl, self.data)
-                elif self.gmailRecipient is not None:
-                    client.emailData(self.gmailRecipient, self.data)
+                elif self.emailConfig is not None:
+                    client.emailData(self.emailConfig, self.data)
             except Exception:
                 self.getControl(self.THANK_YOU_LABEL).setLabel(buggaloAddon.getLocalizedString(91009))
                 (etype, value, tb) = sys.exc_info()


### PR DESCRIPTION
### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [script.foo.bar] v1.0.0

Following the discussion in https://github.com/xbmc/repo-scripts/pull/679#discussion_r156290860, I would like to merge an update to script.module.buggalo. The addon does not seem to be maintained any more. The addon does not seem to be used by more than 3 addons, but it is in my opinion very helpful for more efficient addon development.

As described in my PR https://github.com/twinther/script.module.buggalo/pull/6 and in the new [buggalo Readme](https://github.com/SchapplM/script.module.buggalo/blob/email_ssl/README.md), for bug report emails to work, login credentials to an email server have to be placed in plain text in the source code of the addons.
Ideally, every developer would create email accounts for his addons and set a different password for the smtp authentification than for account login.

I am not sure how fast these credentials could be used by spambots, if passwords have to be changed often or if this in conflict with rules for addons (e.g. regarding safety).
I did not see any other way though to create the email notification, which is very helpful in the early phase of addon development.