### PR TITLE
[service.watchedlist] 1.2.4

### DIFF
--- a/service.watchedlist/addon.xml
+++ b/service.watchedlist/addon.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="service.watchedlist"
 	name="WatchedList"
-	version="1.2.3"
+	version="1.2.4"
 	provider-name="schapplm">
 	<requires>
 		<import addon="xbmc.python" version="2.25.0"/>

--- a/service.watchedlist/changelog.txt
+++ b/service.watchedlist/changelog.txt
@@ -1,3 +1,6 @@
+version 1.2.4 (01.01.2018)
+* Fix in background user watching
+
 version 1.2.3 (28.12.2017)
 * Minor fixes (unicode support, less blocking on shutdown, backup file rotation on network shares, error handling and logging)
 

--- a/service.watchedlist/resources/language/resource.language.de_de/strings.po
+++ b/service.watchedlist/resources/language/resource.language.de_de/strings.po
@@ -324,6 +324,10 @@ msgctxt "#32607"
 msgid "Unable to merge dropbox data"
 msgstr "Zusammenführung mit Dropbox"
 
+msgctxt "#32608"
+msgid "Doing a database backup (%s)"
+msgstr "Beim Sichern der Datenbank (%s)"
+
 msgctxt "#32610"
 msgid "%d/%d: %s"
 msgstr "%d/%d: %s"

--- a/service.watchedlist/resources/language/resource.language.en_gb/strings.po
+++ b/service.watchedlist/resources/language/resource.language.en_gb/strings.po
@@ -348,6 +348,10 @@ msgctxt "#32607"
 msgid "Unable to merge dropbox data"
 msgstr ""
 
+msgctxt "#32608"
+msgid "Doing a database backup (%s)"
+msgstr ""
+
 #Progress Dialog
 #empty string with id 32609
 


### PR DESCRIPTION
minor fix and extended exception-handling.
I got some bug report emails where `SystemExit` exception was raised.
I guess this comes from the user exiting Kodi by the shutdown menu.
However I do not understand, why the bug report dialogue can still be displayed (the whole bug report process takes a few seconds).
Also I put `monitor.waitForAbort` everywhere, so exiting Kodi should not raise an exception in python.

Is catching `SystemExit` manually the right solution here?