### PR TITLE
[script.trakt] Update Library after minimum percent of watching

### DIFF
--- a/script.trakt/addon.xml
+++ b/script.trakt/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.trakt" name="Trakt" version="3.1.12" provider-name="Trakt.tv, Razzeee">
+<addon id="script.trakt" name="Trakt" version="3.1.13" provider-name="Trakt.tv, Razzeee">
 	<requires>
         <import addon="xbmc.python" version="2.24.0"/>
         <import addon="script.module.simplejson" version="3.3.0"/>

--- a/script.trakt/changelog.txt
+++ b/script.trakt/changelog.txt
@@ -1,3 +1,6 @@
+version 3.1.13
+  - New option for updating Library after minimum percent of watching (Made by @burekas)
+
 version 3.1.12
   - Improved id matching for krypton+
 

--- a/script.trakt/resources/language/English/strings.po
+++ b/script.trakt/resources/language/English/strings.po
@@ -733,3 +733,15 @@ msgstr ""
 msgctxt "#32186"
 msgid "Allow script exclusions"
 msgstr ""
+
+msgctxt "#32187"
+msgid "Update library after watching Movies"
+msgstr ""
+
+msgctxt "#32188"
+msgid "Update library after watching TV show episodes"
+msgstr ""
+
+msgctxt "#32189"
+msgid "Minimum percent watched to run update library"
+msgstr ""

--- a/script.trakt/resources/language/Hebrew/strings.po
+++ b/script.trakt/resources/language/Hebrew/strings.po
@@ -643,3 +643,15 @@ msgstr "Trakt - התווסף לרשימת צפייה"
 msgctxt "#32166"
 msgid "Trakt - Failed adding to watchlist"
 msgstr "Trakt - הוספה לרשימת צפייה נכשלה"
+
+msgctxt "#32187"
+msgid "עדכון ספרייה לאחר צפייה בסרטים"
+msgstr ""
+
+msgctxt "#32188"
+msgid "עדכון ספרייה לאחר צפייה בפרקי סדרות"
+msgstr ""
+
+msgctxt "#32189"
+msgid "מינימום אחוזי צפייה להרצת עדכון ספרייה"
+msgstr ""

--- a/script.trakt/resources/lib/scrobbler.py
+++ b/script.trakt/resources/lib/scrobbler.py
@@ -8,6 +8,7 @@ from resources.lib import utilities
 from resources.lib import kodiUtilities
 import math
 from resources.lib.rating import ratingCheck
+from resources.lib.updateLibrary import updateLibraryCheck
 
 logger = logging.getLogger(__name__)
 
@@ -247,6 +248,7 @@ class Scrobbler():
             if 'type' in self.curVideo:
                 self.__scrobble('stop')
                 ratingCheck(self.curVideo['type'], self.videosToRate, self.watchedTime, self.videoDuration, self.playlistLength)
+                updateLibraryCheck(self.curVideo['type'], self.videosToRate, self.watchedTime, self.videoDuration)
             self.watchedTime = 0
             self.isMultiPartEpisode = False
         self.videosToRate = []

--- a/script.trakt/resources/lib/updateLibrary.py
+++ b/script.trakt/resources/lib/updateLibrary.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+"""Module used to run update library"""
+
+import xbmc
+import xbmcaddon
+import xbmcgui
+from resources.lib import utilities
+from resources.lib import kodiUtilities
+from resources.lib import globals
+import logging
+
+logger = logging.getLogger(__name__)
+
+__addon__ = xbmcaddon.Addon("script.trakt")
+
+def updateLibraryCheck(media_type, summary_info, watched_time, total_time):
+    """Check if a video should be rated and if so running the Update Library"""
+    logger.debug("Update Library Check called for '%s'" % media_type)
+    if not kodiUtilities.getSettingAsBool("update_library_%s" % media_type):
+        logger.debug("'%s' is configured to not run an Update Library after watching." % media_type)
+        return
+    if summary_info is None:
+        logger.debug("Summary information is empty, aborting.")
+        return
+    watched = (watched_time / total_time) * 100
+    if watched >= kodiUtilities.getSettingAsFloat("update_library_min_view_time"):
+            UpdateLibraryRun()
+    else:
+        logger.debug("'%s' does not meet minimum view time for updating library (watched: %0.2f%%, minimum: %0.2f%%)" % (media_type, watched, kodiUtilities.getSettingAsFloat("update_library_min_view_time")))
+
+def UpdateLibraryRun():
+    """Launches the update library progress"""
+    logger.debug("Update Library - Start.")
+    xbmc.executebuiltin('UpdateLibrary(video)')

--- a/script.trakt/resources/settings.xml
+++ b/script.trakt/resources/settings.xml
@@ -72,7 +72,7 @@
 		<setting id="clean_trakt_episodes" type="bool" label="32058" default="false"/>
 		<setting id="trakt_episode_playcount" type="bool" label="32052" default="true"/>
 		<setting id="kodi_episode_playcount" type="bool" label="32053" default="true"/>
-        <setting id="trakt_episode_playback" type="bool" label="32118" default="false"/>
+    <setting id="trakt_episode_playback" type="bool" label="32118" default="false"/>
 		<setting type="sep"/>
 	</category>
 	<category label="32004"><!-- Rating -->
@@ -82,5 +82,10 @@
 		<setting id="rate_min_view_time" type="slider" label="32008" range="0,5,100" default="75"/>
 		<setting id="rate_rerate" type="bool" label="32009" default="false"/>
 		<setting id="rating_default" type="slider" label="32010" range="1,10" default="6" option="int"/>
+	</category>
+	<category label="Update Library"><!-- Update Library @burekas -->
+		<setting id="update_library_movie" type="bool" label="32187" default="false"/>
+		<setting id="update_library_episode" type="bool" label="32188" default="false"/>    
+		<setting id="update_library_min_view_time" type="slider" label="32189" range="0,5,100" default="75"/>    
 	</category>
 </settings>


### PR DESCRIPTION
Description

* A new option for running the Update Library after minimum percent of watching.
(Pretty similar to the "Rating" option)

* In details:
 A new category is added in settings: Update Library. 
Includes:
-- Enable/Disable Update Library after watching Movie (Default = Disabled)
-- Enable/Disable Update Library after watching TV show episodes. (Default = Disabled)
-- Minimum percent watched to run Update Library.

* Related links from the kodi forum:
https://forum.kodi.tv/showthread.php?tid=220547&pid=2681799#pid2681799
https://forum.kodi.tv/showthread.php?tid=220547&pid=2684120#pid2684120


Checklist:

- [x] My code follows the add-on rules and piracy stance of this project.
- [x] I have read the CONTRIBUTING document
- [x] Each add-on submission should be a single commit with using the following style: [script.foo.bar] v1.0.0

Additional information :
* I have tested and verified all the cases:
1. Stopped: Below minimum percentage - Not running update library.
2. Stopped: Above minimum percentage - Is running update library.
3. Ended: Is running update library.
4. Enable Update Library after watching Movie: Is running update library.
5. Disable Update Library after watching Movie: Not running update library.
6. Enable Update Library after watching TV show episodes: Is running update library.
7. Disable Update Library after watching TV show episodes: Not running update library. 