### PR TITLE
[script.artistslideshow] v2.1.0

### DIFF
--- a/script.artistslideshow/addon.xml
+++ b/script.artistslideshow/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.artistslideshow" name="Artist Slideshow" version="2.0.8" provider-name="pkscout,ronie">
+<addon id="script.artistslideshow" name="Artist Slideshow" version="2.1.0" provider-name="pkscout,ronie">
 	<requires>
 		<import addon="xbmc.python" version="2.19.0"/>
 		<import addon="xbmc.addon" version="14.0.0"/>
@@ -11,9 +11,12 @@
 	</extension>
 	<extension point="xbmc.addon.metadata">
 		<news>
-v.2.0.8
-- fix for crash if Kodi plugin tries to load bio with oddly encoded characters
-- fix for crash if a services cache file contains a string that doesn't evaluate to int
+v.2.1.0
+- updated AS to save and use unhashed artist and image names
+- created upgrade routine to rename hashed artist and image names
+- included new option to ONLY use local artist path for storage
+- cleaned up folder path creation routines
+- removed old download exclusion logic in favor of new _imgdb.nfo history
 		</news>
 		<summary lang="ar">حمل المزيد من الصور والمعلومات عن الفنان الذى يُغنِى حالياً</summary>
 		<summary lang="be">Download images and additional info of the currently playing artist</summary>

--- a/script.artistslideshow/changelog.txt
+++ b/script.artistslideshow/changelog.txt
@@ -1,3 +1,10 @@
+v.2.1.0
+- updated AS to save and use unhashed artist and image names
+- created upgrade routine to rename hashed artist and image names
+- included new option to ONLY use local artist path for storage
+- cleaned up folder path creation routines
+- removed old download exclusion logic in favor of new _imgdb.nfo history
+
 v.2.0.8
 - fix for crash if Kodi plugin tries to load bio with oddly encoded characters
 - fix for crash if a services cache file contains a string that doesn't evaluate to int

--- a/script.artistslideshow/resources/common/fileops.py
+++ b/script.artistslideshow/resources/common/fileops.py
@@ -1,5 +1,6 @@
-# v.0.3.4
+# v.0.3.6
 
+import subprocess, time
 try:
     import xbmcvfs
     isXBMC = True
@@ -9,12 +10,14 @@ except:
 
 if isXBMC:
     _mkdirs = xbmcvfs.mkdirs
+    _rmdir  = xbmcvfs.rmdir
     _exists = xbmcvfs.exists
     _delete = xbmcvfs.delete
     _rename = xbmcvfs.rename
     _file = xbmcvfs.File
 else:
     _mkdirs = os.makedirs
+    _rmdir  = os.rmdir
     _exists = os.path.exists
     _delete = os.remove
     _rename = os.rename
@@ -34,6 +37,7 @@ def checkPath( path, create=True ):
         log_lines.append( '%s exists' % path )
         return True, log_lines
 
+
 def deleteFile( filename ):
     log_lines = []
     if _exists( filename ):
@@ -50,6 +54,25 @@ def deleteFile( filename ):
         return True, log_lines
     else:
         log_lines.append( '%s does not exist' % filename )
+        return False, log_lines
+
+
+def deleteFolder( foldername ):
+    log_lines = []
+    if _exists( foldername ):
+        try:
+            _rmdir( foldername )
+            log_lines.append( 'deleting folder %s' % foldername )
+        except IOError:
+            log_lines.append( 'unable to delete %s' % foldername )
+            return False, log_lines
+        except Exception, e:
+            log_lines.append( 'unknown error while attempting to delete %s' % foldername )
+            log_lines.append( e )
+            return False, log_lines
+        return True, log_lines
+    else:
+        log_lines.append( '%s does not exist' % foldername )
         return False, log_lines
 
 
@@ -93,6 +116,26 @@ def renameFile ( filename, newfilename ):
     else:
         log_lines.append( '%s does not exist' % filename )
         return False, log_lines
+
+
+def popenWithTimeout( command, timeout ):
+    log_lines = []
+    try:
+        p = subprocess.Popen( command, stdout=subprocess.PIPE, stderr=subprocess.PIPE )
+    except OSError:
+        log_lines.append( 'error finding external script, terminating' )
+        return False, log_lines
+    except Exception, e:
+        log_lines.append( 'unknown error while attempting to run %s' % command )
+        log_lines.append( e )
+        return False, log_lines
+    for t in xrange( timeout * 4 ):
+        time.sleep( 0.25 )
+        if p.poll() is not None:
+            return p.communicate(), ''
+    p.kill()
+    log_lines.append( 'script took too long to run, terminating' )
+    return False, log_lines
 
 
 def writeFile( data, filename ):

--- a/script.artistslideshow/resources/common/url.py
+++ b/script.artistslideshow/resources/common/url.py
@@ -1,7 +1,9 @@
-#v.0.2.1
+#v.0.2.0
 
 import socket
 import requests as _requests
+from requests.packages.urllib3.exceptions import InsecureRequestWarning
+_requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
     
 
 class URL():
@@ -81,9 +83,15 @@ class URL():
     
     
     def _unpack_args( self, kwargs ):
-        params = kwargs.get( 'params', {} )
-        if self.returntype == 'json':
-            data = kwargs.get( 'data', [] )
-        else:
-            data = kwargs.get( 'data', '' )
+        try:
+            params = kwargs['params']
+        except:
+            params = {}
+        try:
+            data = kwargs['data']
+        except:
+            if self.returntype == 'json':
+                data = []
+            else:
+                data = ''
     	return params, data

--- a/script.artistslideshow/resources/common/xlogger.py
+++ b/script.artistslideshow/resources/common/xlogger.py
@@ -1,4 +1,4 @@
-#v.0.1.4
+#v.0.1.5
 
 try:
     import xbmc
@@ -9,15 +9,19 @@ except:
 
 #this class creates an object used to log stuff to the xbmc log file
 class Logger():
-    def __init__(self, preamble='', logfile='logfile.log', logdebug='true'):
+    def __init__( self, logconfig="file", format='%(asctime)-15s %(levelname)-8s %(message)s', logfile='logfile.log',
+                  logname='_logger', numbackups=5, logdebug='true', maxsize=100000, when='midnight', interval=1, preamble='' ):
         self.LOGPREAMBLE = preamble
         self.LOGDEBUG = logdebug
         if LOGTYPE == 'file':
-            self.logger = logging.getLogger( '_logger' )
+            self.logger = logging.getLogger( logname )                
             self.logger.setLevel( logging.DEBUG )
-            lr = logging.handlers.RotatingFileHandler( logfile, maxBytes=100000, backupCount=5 )
+            if logconfig == 'timed':
+                lr = logging.handlers.TimedRotatingFileHandler( logfile, when=when, backupCount=numbackups)
+            else:
+                lr = logging.handlers.RotatingFileHandler( logfile, maxBytes=maxsize, backupCount=numbackups )
             lr.setLevel( logging.DEBUG )
-            lr.setFormatter( logging.Formatter( "%(asctime)-15s %(levelname)-8s %(message)s" ) )
+            lr.setFormatter( logging.Formatter( format ) )
             self.logger.addHandler( lr )
 
 

--- a/script.artistslideshow/resources/language/English/strings.po
+++ b/script.artistslideshow/resources/language/English/strings.po
@@ -89,7 +89,27 @@ msgctxt "#32010"
 msgid "  Client API key"
 msgstr ""
 
-#empty strings from id 32011 to 32099
+msgctxt "#32011"
+msgid "Create artist hash mapping file"
+msgstr ""
+
+msgctxt "#32012"
+msgid "beginning work"
+msgstr ""
+
+msgctxt "#32013"
+msgid "Migrating artist information"
+msgstr ""
+
+msgctxt "#32014"
+msgid "Migrating artist images"
+msgstr ""
+
+msgctxt "#32015"
+msgid "Moving artist images to local artist location"
+msgstr ""
+
+#empty strings from id 32016 to 32099
 
 msgctxt "#32100"
 msgid "Slideshow"
@@ -143,6 +163,10 @@ msgctxt "#32112"
 msgid "Use both local and remote images"
 msgstr ""
 
+msgctxt "#32113"
+msgid "  Always use local artist path for storage"
+msgstr ""
+
 #empty strings from id 32113 to 32199
 
 msgctxt "#32200"
@@ -194,15 +218,15 @@ msgid "Enable fuzzy local artist image paths"
 msgstr ""
 
 msgctxt "#32212"
-msgid "  Platform for image storage"
+msgid "Platform for image storage"
 msgstr ""
 
 msgctxt "#32213"
-msgid "  Replace illegal path characters in artist name with"
+msgid "Replace illegal path characters in artist name with"
 msgstr ""
 
 msgctxt "#32214"
-msgid "  Replace trailing period in artist name with"
+msgid "Replace trailing period in artist name with"
 msgstr ""
 
 msgctxt "#32215"

--- a/script.artistslideshow/resources/plugins/fanarttv.py
+++ b/script.artistslideshow/resources/plugins/fanarttv.py
@@ -52,10 +52,7 @@ class objectConfig():
                 url = image.get( 'url', '' )
                 if url:
                     images.append( url )
-        if images == []:
-            return [], self.loglines
-        else: 
-            return self._remove_exclusions( images, img_params.get( 'exclusionsfile' ) ), self.loglines
+        return images, self.loglines
 
 
     def _get_cache_time( self, cachefilepath ):
@@ -105,20 +102,6 @@ class objectConfig():
         success, wloglines = writeFile( str( cachetime ), cachefilepath )
         self.loglines.append( wloglines)
         return success
-
-
-    def _remove_exclusions( self, image_list, exclusionfilepath ):
-        images = []
-        rloglines, rawdata = readFile( exclusionfilepath )
-        self.loglines.extend( rloglines )
-        if not rawdata:
-            return image_list
-        exclusionlist = rawdata.split()
-        for image in image_list:
-            for exclusion in exclusionlist:
-                if not exclusion.startswith( xbmc.getCacheThumbName( image ) ):
-                    images.append( image )
-        return images
 
 
     def _update_cache( self, filepath, cachefilepath ):

--- a/script.artistslideshow/resources/plugins/theaudiodb.py
+++ b/script.artistslideshow/resources/plugins/theaudiodb.py
@@ -97,10 +97,7 @@ class objectConfig():
                     image = artist[0].get( 'strArtistFanart' + num, '' )
                     if image:
                         images.append( image )
-        if images == []:
-            return [], self.loglines
-        else: 
-            return self._remove_exclusions( images ), self.loglines
+        return images, self.loglines
 
 
     def getMBID( self, mbid_params ):
@@ -225,20 +222,6 @@ class objectConfig():
         success, wloglines = writeFile( str( cachetime ), cachefilepath )
         self.loglines.append( wloglines)
         return success
-
-
-    def _remove_exclusions( self, image_list ):
-        images = []
-        rloglines, rawdata = readFile( self.EXCLUSIONFILEPATH )
-        self.loglines.extend( rloglines )
-        if not rawdata:
-            return image_list
-        exclusionlist = rawdata.split()
-        for image in image_list:
-            for exclusion in exclusionlist:
-                if not exclusion.startswith( xbmc.getCacheThumbName( image ) ):
-                    images.append( image )
-        return images
 
 
     def _set_filepaths( self, params ):

--- a/script.artistslideshow/resources/settings.xml
+++ b/script.artistslideshow/resources/settings.xml
@@ -10,6 +10,7 @@
     <category label="32100">
         <setting id="local_artist_path" type="folder" label="32101" default="" />
         <setting id="priority" type="enum" label="32102" lvalues="32110|32111|32112" default="0" />
+        <setting id="localstorageonly" type="bool" label="32113" default="false" />
 		<setting id="include_fanartjpg" type="bool" label="32108" default="false" />
 		<setting id="include_folderjpg" type="bool" label="32109" default="false" />
         <setting id="fallback" type="bool" label="32105" default="false" />
@@ -50,10 +51,9 @@
         <setting id="show_progress" type="enum" label="32203" lvalues="32206|32207|32208" default="0" />
         <setting id="progress_path" type="folder" label="32204" default="" visible="eq(-1,2)"/>
 		<setting id="fanart_folder" type="text" label="32205" default="" />
-        <setting id="enable_fuzzysearch" type="bool" label="32211" default="false" />
-        <setting id="storage_target" type="enum" label="32212" default="0" lvalues="32215|32217|32216" visible="eq(-1,true)" />
-        <setting id="illegal_replace" type="text" label=" 32213" default="_" visible="eq(-2,true)"/>
-        <setting id="end_replace" type="text" label="32214" default="" visible="eq(-3,true) + eq(-2,0)" />		
+        <setting id="storage_target" type="enum" label="32212" default="0" lvalues="32215|32217|32216" />
+        <setting id="illegal_replace" type="text" label=" 32213" default="_" />
+        <setting id="end_replace" type="text" label="32214" default="" visible="eq(-2,0)" />		
         <setting id="logging" type="bool" label="32209" default="false" />
     </category>
 </settings>


### PR DESCRIPTION
### Description
- updated AS to save and use unhashed artist and image names
- created upgrade routine to rename hashed artist and image names
- included new option to ONLY use local artist path for storage
- cleaned up folder path creation routines
- removed old download exclusion logic in favor of new _imgdb.nfo history
### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x ] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x ] Each add-on submission should be a single commit with using the following style: [script.foo.bar] v1.0.0