### PR TITLE
[script.common.plugin.cache] 2.5.10

### DIFF
--- a/script.common.plugin.cache/addon.xml
+++ b/script.common.plugin.cache/addon.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='yes'?>
-<addon id="script.common.plugin.cache" name="Common plugin cache" provider-name="TheCollective" version="2.5.9">
+<addon id="script.common.plugin.cache" name="Common plugin cache" provider-name="TheCollective" version="2.5.10">
   <requires>
     <import addon="xbmc.python" version="2.24.0" />
   </requires>

--- a/script.common.plugin.cache/changelog.txt
+++ b/script.common.plugin.cache/changelog.txt
@@ -1,3 +1,6 @@
+[B]Version 2.5.10[/B]
+- Fix self usage in non instance methods
+
 [B]Version 2.5.9[/B]
 - Fix plugin loading on windows uwp
 - Replace print with xbmc.log

--- a/script.common.plugin.cache/lib/StorageServer.py
+++ b/script.common.plugin.cache/lib/StorageServer.py
@@ -752,9 +752,9 @@ def checkInstanceMode():
     settings = xbmcaddon.Addon(id='script.common.plugin.cache')
     if settings.getSetting("autostart") == "false":
         s = StorageServer(table=False, instance=True)
-        self.xbmc.log(u" StorageServer Module loaded RUN(instance only)")
+        xbmc.log(u" StorageServer Module loaded RUN(instance only)")
 
-        self.xbmc.log(s.plugin + u" Starting server")
+        xbmc.log(s.plugin + u" Starting server")
 
         run_async(s.run)
         return True


### PR DESCRIPTION
Fix `self` usage in non instance methods

@Lunatixz @rmrector should fix the issue reported at #746