### PR TITLE
[script.module.inputstreamhelper] 0.3.0

### DIFF
--- a/script.module.inputstreamhelper/README.md
+++ b/script.module.inputstreamhelper/README.md
@@ -4,7 +4,9 @@ A simple Kodi module that makes life easier for add-on developers relying on Inp
 ## Features ##
 * Displays informative dialogs if required InputStream components are unavailable
 * Checks if HLS is supported in inputstream.adaptive
-* Automatically installs Widevine DRM on supported platforms (optional)
+* Automatically installs Widevine CDM on supported platforms (optional)
+  * Keeps Widevine CDM up-to-date with the latest version available (Kodi 18 and higher)
+  * Checks for missing depending libraries by parsing the output from  `ldd`
 
 ## Example ##
 
@@ -14,9 +16,9 @@ import xbmcgui
 import inputstreamhelper
 
 def play_item():
-    inputstream_helper = inputstreamhelper.Helper('mpd', drm='widevine')
+    is_helper = inputstreamhelper.Helper('mpd', drm='widevine')
     stream_url = 'http://yt-dash-mse-test.commondatastorage.googleapis.com/media/car-20120827-manifest.mpd'
-    if inputstream_helper.check_inputstream():
+    if is_helper.check_inputstream():
         playitem = xbmcgui.ListItem(path=stream_url)
         playitem.setProperty('inputstreamaddon', 'inputstream.adaptive')
         playitem.setProperty('inputstream.adaptive.manifest_type', 'mpd')

--- a/script.module.inputstreamhelper/addon.xml
+++ b/script.module.inputstreamhelper/addon.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon id="script.module.inputstreamhelper"
-       version="0.2.4"
+       version="0.3.0"
        name="InputStream Helper"
        provider-name="emilsvennesson">
   <requires>
@@ -10,9 +10,11 @@
   <extension library="lib" point="xbmc.python.module"/>
   <extension point="xbmc.addon.metadata">
     <description lang="en_GB">A simple Kodi module that makes life easier for add-on developers relying on InputStream based add-ons and DRM playback.</description>
-    <news>2018.01.01 v0.2.4
-    + Fix ARM download on systems with sudo (OSMC etc)
-    + Actually bump version in addon.xml, unlike v0.2.3...
+    <news>2018.01.29 v0.3.0
+	+ Bug fix: module left xbmcaddon class in memory
+    + Keep Widevine CDM up-to-date with the latest version available (Kodi 18 and higher)
+    + Check for missing depending libraries by parsing the output from ldd
+	+ Use older Widevine binaries on Kodi Krypton (fixes nss/nspr dependency issues)
     </news>
     <platform>all</platform>
     <license>MIT License</license>

--- a/script.module.inputstreamhelper/changelog.txt
+++ b/script.module.inputstreamhelper/changelog.txt
@@ -1,3 +1,9 @@
+2018.01.29 v0.3.0
++ Bug fix: module left xbmcaddon class in memory
++ Keep Widevine CDM up-to-date with the latest version available (Kodi 18 and higher)
++ Check for missing depending libraries by parsing the output from ldd
++ Use older Widevine binaries on Kodi Krypton (fixes nss/nspr dependency issues)
+
 2018.01.01 v0.2.4
 + Fix ARM download on systems with sudo (OSMC etc)
 + Actually bump version in addon.xml, unlike v0.2.3...

--- a/script.module.inputstreamhelper/lib/config.py
+++ b/script.module.inputstreamhelper/lib/config.py
@@ -13,8 +13,7 @@ DRM_SCHEMES = {
 CDM_EXTENSIONS = (
     '.so',
     '.dll',
-    '.dylib',
-    '.json'
+    '.dylib'
 )
 
 X86_MAP = {
@@ -25,13 +24,17 @@ X86_MAP = {
     'i686': 'x86'
 }
 
+ARM_MAP = {
+    'armv7': 'arm',
+    'armv8': 'arm',
+    'aarch64': 'arm',
+    'aarch64_be': 'arm'
+}
+
 WIDEVINE_SUPPORTED_ARCHS = [
     'x86_64',
     'x86',
-    'armv7',
-    'armv8',
-    'aarch64',
-    'aarch64_be'
+    'arm'
 ]
 
 WIDEVINE_ARCH_MAP_X86 = {
@@ -46,14 +49,18 @@ WIDEVINE_OS_MAP = {
 }
 
 WIDEVINE_SUPPORTED_OS = [
+    'Android',
     'Linux',
     'Windows',
     'Darwin'
 ]
 
-WIDEVINE_ANDROID_MINIMUM_KODI_VERSION = '18.0'
-
-WIDEVINE_MINIMUM_KODI_VERSION = '17.4'
+WIDEVINE_MINIMUM_KODI_VERSION = {
+    'Android': '18.0',
+    'Windows': '17.4',
+    'Linux': '17.4',
+    'Darwin': '17.4'
+}
 
 WIDEVINE_CURRENT_VERSION_URL = 'https://dl.google.com/widevine-cdm/current.txt'
 
@@ -63,7 +70,15 @@ WIDEVINE_LICENSE_FILE = 'LICENSE.txt'
 
 WIDEVINE_MANIFEST_FILE = 'manifest.json'
 
-CHROMEOS_RECOVERY_CONF = 'https://dl.google.com/dl/edgedl/chromeos/recovery/recovery.conf'
+WIDEVINE_CONFIG_NAME = 'widevine_config.json'
+
+WIDEVINE_UPDATE_INTERVAL_DAYS = 1
+
+WIDEVINE_LEGACY_VERSION = '903'
+
+CHROMEOS_RECOVERY_URL = 'https://dl.google.com/dl/edgedl/chromeos/recovery/recovery.conf'
+
+CHROMEOS_RECOVERY_URL_LEGACY = 'https://gist.githubusercontent.com/emilsvennesson/5e74181c9a833129ad0bb03ccb41d81f/raw/8d162568277caaa31b54f4773e75a20514856825/recovery.conf'
 
 CHROMEOS_ARM_HWID = 'SPRING'
 

--- a/script.module.inputstreamhelper/resources/language/resource.language.de_de/strings.po
+++ b/script.module.inputstreamhelper/resources/language/resource.language.de_de/strings.po
@@ -18,28 +18,28 @@ msgid "Information"
 msgstr "Informationen"
 
 msgctxt "#30002"
-msgid "[B]Widevine CDM[/B] is required to play this content.[CR][CR]Do you want to install [B]Widevine DRM[/B]?"
-msgstr "Die [B]Widevine DRM[/B] Bibliothek ist nicht installiert, ist aber nötig um den Inhalt wiederzugeben.[CR][CR]Soll die [B]Widevine DRM[/B] Bibliothek installiert werden?"
+msgid "[B]Widevine CDM[/B] is required to play this content.[CR][CR]Do you want to install [B]Widevine CDM[/B]?"
+msgstr "Die [B]Widevine CDM[/B] Bibliothek ist nicht installiert, ist aber nötig um den Inhalt wiederzugeben.[CR][CR]Soll die [B]Widevine CDM[/B] Bibliothek installiert werden?"
 
 msgctxt "#30003"
-msgid "[B]Widevine DRM[/B] was successfully installed!"
-msgstr "[B]Widevine DRM[/B] Bibliothek wurde erfolgreich installiert"
+msgid "[B]Widevine CDM[/B] was successfully installed!"
+msgstr "[B]Widevine CDM[/B] Bibliothek wurde erfolgreich installiert"
 
 msgctxt "#30004"
 msgid "Error"
 msgstr "Fehler"
 
 msgctxt "#30005"
-msgid "An error occurred while installing [B]Widevine DRM[/B]. Please enable debug logging and file a bug report at:[CR][CR]github.com/emilsvennesson/script.module.inputstreamhelper"
-msgstr "Während der Installation der [B]Widevine DRM[/B] Bibliothek ist ein Fehler aufgetreten. Bitte debug logging aktivieren und den Fehler melden:[CR][CR]github.com/emilsvennesson/script.module.inputstreamhelper"
+msgid "An error occurred while installing [B]Widevine CDM[/B]. Please enable debug logging and file a bug report at:[CR][CR]github.com/emilsvennesson/script.module.inputstreamhelper"
+msgstr "Während der Installation der [B]Widevine CDM[/B] Bibliothek ist ein Fehler aufgetreten. Bitte debug logging aktivieren und den Fehler melden:[CR][CR]github.com/emilsvennesson/script.module.inputstreamhelper"
 
 msgctxt "#30006"
-msgid "Due to distributing issues, [B]Widevine DRM[/B] has to be extracted from a Chrome OS recovery image. This process requires at least [B]{0}[/B] of free disk space. Do you wish to continue?"
-msgstr "Durch lizenzrechtliche Reglementierungen der muss die [B]Widevine DRM[/B] Bibliotke aus einem Chrome OS image extrahiert werden. Dafür sind mindestens [B]{0}[/B] freier Festplattenspeicher notwendig. Soll der Vorgang fortgesetzt werden?"
+msgid "Due to distributing issues, [B]Widevine CDM[/B] has to be extracted from a Chrome OS recovery image. This process requires at least [B]{0}[/B] of free disk space. Do you wish to continue?"
+msgstr "Durch lizenzrechtliche Reglementierungen der muss die [B]Widevine CDM[/B] Bibliotke aus einem Chrome OS image extrahiert werden. Dafür sind mindestens [B]{0}[/B] freier Festplattenspeicher notwendig. Soll der Vorgang fortgesetzt werden?"
 
 msgctxt "#30007"
-msgid "[B]Widevine DRM[/B] is unfortunately not available on this system architecture."
-msgstr "Die [B]Widevine DRM[/B] Bibliotke ist leider für diese System Architektur nicht verfügbar."
+msgid "[B]Widevine CDM[/B] is unfortunately not available on this system architecture."
+msgstr "Die [B]Widevine CDM[/B] Bibliotke ist leider für diese System Architektur nicht verfügbar."
 
 msgctxt "#30008"
 msgid "[B]{0}[/B] is missing on your Kodi install. This add-on is required to play this content."
@@ -50,16 +50,16 @@ msgid "[B]{0}[/B] is not enabled. This add-on is required to play this content.[
 msgstr "[B]{0}[/B] ist nicht aktiviert. Das Add-on wird benötigt um den Inhalt wiederzugeben.[CR][CR]Soll [B]{1}[/B] aktiviert werden?"
 
 msgctxt "#30010"
-msgid "[B]Kodi {0}[/B] or higher is required for [B]Widevine DRM[/B] content playback."
-msgstr "[B]Kodi in der Version {0}[/B] oder höher wird benötigt um [B]Widevine DRM[/B] geschützte Inhalte wiederzugeben."
+msgid "[B]Kodi {0}[/B] or higher is required for [B]Widevine CDM[/B] content playback."
+msgstr "[B]Kodi in der Version {0}[/B] oder höher wird benötigt um [B]Widevine CDM[/B] geschützte Inhalte wiederzugeben."
 
 msgctxt "#30011"
-msgid "This operating system ([B]{0}[/B]) is not supported by Widevine DRM."
-msgstr "Das genutzte Betriebssystem ([B]{0}[/B]) wird aktuell nicht von der Widevine DRM Bibliothek unterstützt"
+msgid "This operating system ([B]{0}[/B]) is not supported by [B]Widevine CDM[/B]."
+msgstr "Das genutzte Betriebssystem ([B]{0}[/B]) wird aktuell nicht von der [B]Widevine CDM[/B] Bibliothek unterstützt"
 
 msgctxt "#30012"
-msgid "The Windows Store version of Kodi does not support [B]Widevine DRM[/B].[CR][CR]Please use the installer from kodi.tv instead."
-msgstr "Die Windows Store version von Kodi unterstützt die [B]Widevine DRM[/B] Bibliothek nicht.[CR][CR]Es wird empfohlen Kodi mit einem installer von kodi.tv zu installieren."
+msgid "The Windows Store version of Kodi does not support [B]Widevine CDM[/B].[CR][CR]Please use the installer from kodi.tv instead."
+msgstr "Die Windows Store version von Kodi unterstützt die [B]Widevine CDM[/B] Bibliothek nicht.[CR][CR]Es wird empfohlen Kodi mit einem installer von kodi.tv zu installieren."
 
 msgctxt "#30013"
 msgid "Failed to retrieve [B]{0}[/B]."
@@ -74,28 +74,28 @@ msgid "Downloading [B]{0}[/B]..."
 msgstr "Download von [B]{0}[/B]..."
 
 msgctxt "#30016"
-msgid "Failed to extract [B]Widevine DRM[/B] from zip file."
-msgstr "Fehler beim entpacken der [B]Widevine DRM[/B] Bibliothek."
+msgid "Failed to extract [B]Widevine CDM[/B] from zip file."
+msgstr "Fehler beim entpacken der [B]Widevine CDM[/B] Bibliothek."
 
 msgctxt "#30017"
 msgid "[B]{0}[/B] {1} or later is required to play this content."
 msgstr "[B]{0}[/B] {1} oder höher ist notwendig um den Inhalt wiederzugeben."
 
 msgctxt "#30018"
-msgid "You do not have enough free disk space to install [B]Widevine DRM[/B]. Free up at least [B]{0}[/B] and try again."
-msgstr "Es ist nicht genug Festplattenspeicher zur Installation der [B]Widevine DRM[/B] Bibliothek vorhanden. Es müssen [B]{0}[/B] verfügbar gemacht werden um es erneut zu versuchen."
+msgid "You do not have enough free disk space to install [B]Widevine CDM[/B]. Free up at least [B]{0}[/B] and try again."
+msgstr "Es ist nicht genug Festplattenspeicher zur Installation der [B]Widevine CDM[/B] Bibliothek vorhanden. Es müssen [B]{0}[/B] verfügbar gemacht werden um es erneut zu versuchen."
 
 msgctxt "#30019"
-msgid "This operating system ([B]{0}[/B]) is not supported by [B]Widevine DRM[/B] for ARM devices."
-msgstr "Das Betriebssystem ([B]{0}[/B]) wird auf ARM Systemarchitekturen nicht von der [B]Widevine DRM[/B] Bibliothek unterstützt."
+msgid "This operating system ([B]{0}[/B]) is not supported by [B]Widevine CDM[/B] for ARM devices."
+msgstr "Das Betriebssystem ([B]{0}[/B]) wird auf ARM Systemarchitekturen nicht von der [B]Widevine CDM[/B] Bibliothek unterstützt."
 
 msgctxt "#30020"
-msgid "[B]'{0}'[/B] or [B]'{1}'[/B] command needs to exist on system to extract the [B]Widevine DRM[/B]."
-msgstr "Die Systembefehlehle [B]'{0}'[/B] oder [B]'{1}'[/B] müssen verfügbar sein um die [B]Widevine DRM[/B] Bibliothek zu extrahieren."
+msgid "[B]'{0}'[/B] or [B]'{1}'[/B] command needs to exist on system to extract the [B]Widevine CDM[/B]."
+msgstr "Die Systembefehlehle [B]'{0}'[/B] oder [B]'{1}'[/B] müssen verfügbar sein um die [B]Widevine CDM[/B] Bibliothek zu extrahieren."
 
 msgctxt "#30021"
-msgid "[B]'{0}'[/B] command needs to exist on system to extract the [B]Widevine DRM[/B]."
-msgstr "Der Systembefehl [B]'{0}'[/B] muss verfügbar sein um die [B]Widevine DRM[/B] Bibliothek zu extrahieren."
+msgid "[B]'{0}'[/B] command needs to exist on system to extract the [B]Widevine CDM[/B]."
+msgstr "Der Systembefehl [B]'{0}'[/B] muss verfügbar sein um die [B]Widevine CDM[/B] Bibliothek zu extrahieren."
 
 msgctxt "#30022"
 msgid "Downloading Chrome OS recovery image."
@@ -106,16 +106,16 @@ msgid "Download completed!"
 msgstr "Download erfolgreich abgeschlossen!"
 
 msgctxt "#30024"
-msgid "The installation now needs to unzip, mount and extract [B]Widevine DRM[/B] from the recovery image.[CR][CR]This process may take up to five minutes to complete."
-msgstr "Das Chrome OS recovery image wird nun extrahiert und gemounted um die [B]Widevine DRM[/B] zu extrahieren.[CR][CR]Dieser Prozess kann bis zu zehn Minuten dauern."
+msgid "The installation now needs to unzip, mount and extract [B]Widevine CDM[/B] from the recovery image.[CR][CR]This process may take up to five minutes to complete."
+msgstr "Das Chrome OS recovery image wird nun extrahiert und gemounted um die [B]Widevine CDM[/B] zu extrahieren.[CR][CR]Dieser Prozess kann bis zu zehn Minuten dauern."
 
 msgctxt "#30025"
 msgid "Acquiring EULA."
 msgstr "Laden der EULA"
 
 msgctxt "#30026"
-msgid "Widevine DRM EULA"
-msgstr "Widevine DRM EULA"
+msgid "Widevine CDM EULA"
+msgstr "Widevine CDM EULA"
 
 msgctxt "#30027"
 msgid "I accept"
@@ -134,5 +134,17 @@ msgid "Administrative rights ([B]sudo[/B]) is required to mount the Chrome OS im
 msgstr "Administratiren Rechte ([B]sudo[/B]) sind erforderlich um das Chrome OS Image zu mounten. Mit OK bestätigen sie, dass der mount befehl via [B]sudo[/B] ausgeführt werden darf."
 
 msgctxt "#30031"
-msgid "An update of [B]Widevine DRM[/B] is required to play this content."
+msgid "An update of [B]Widevine CDM[/B] is required to play this content."
+msgstr ""
+
+msgctxt "#30032"
+msgid "Your system is missing the following libraries required by Widevine CDM: [B]{0}[/B]. Install the libraries to play this content."
+msgstr ""
+
+msgctxt "#30033"
+msgid "There is an update available for [B]Widevine CDM[/B].[CR][CR]Do you want to install the update?"
+msgstr ""
+
+msgctxt "#30034"
+msgid "Update"
 msgstr ""

--- a/script.module.inputstreamhelper/resources/language/resource.language.en_gb/strings.po
+++ b/script.module.inputstreamhelper/resources/language/resource.language.en_gb/strings.po
@@ -18,11 +18,11 @@ msgid "Information"
 msgstr ""
 
 msgctxt "#30002"
-msgid "[B]Widevine CDM[/B] is required to play this content.[CR][CR]Do you want to install [B]Widevine DRM[/B]?"
+msgid "[B]Widevine CDM[/B] is required to play this content.[CR][CR]Do you want to install [B]Widevine CDM[/B]?"
 msgstr ""
 
 msgctxt "#30003"
-msgid "[B]Widevine DRM[/B] was successfully installed!"
+msgid "[B]Widevine CDM[/B] was successfully installed!"
 msgstr ""
 
 msgctxt "#30004"
@@ -30,15 +30,15 @@ msgid "Error"
 msgstr ""
 
 msgctxt "#30005"
-msgid "An error occurred while installing [B]Widevine DRM[/B]. Please enable debug logging and file a bug report at:[CR][CR]github.com/emilsvennesson/script.module.inputstreamhelper"
+msgid "An error occurred while installing [B]Widevine CDM[/B]. Please enable debug logging and file a bug report at:[CR][CR]github.com/emilsvennesson/script.module.inputstreamhelper"
 msgstr ""
 
 msgctxt "#30006"
-msgid "Due to distributing issues, [B]Widevine DRM[/B] has to be extracted from a Chrome OS recovery image. This process requires at least [B]{0}[/B] of free disk space. Do you wish to continue?"
+msgid "Due to distributing issues, [B]Widevine CDM[/B] has to be extracted from a Chrome OS recovery image. This process requires at least [B]{0}[/B] of free disk space. Do you wish to continue?"
 msgstr ""
 
 msgctxt "#30007"
-msgid "[B]Widevine DRM[/B] is unfortunately not available on this system architecture."
+msgid "[B]Widevine CDM[/B] is unfortunately not available on this system architecture."
 msgstr ""
 
 msgctxt "#30008"
@@ -50,15 +50,15 @@ msgid "[B]{0}[/B] is not enabled. This add-on is required to play this content.[
 msgstr ""
 
 msgctxt "#30010"
-msgid "[B]Kodi {0}[/B] or higher is required for [B]Widevine DRM[/B] content playback."
+msgid "[B]Kodi {0}[/B] or higher is required for [B]Widevine CDM[/B] content playback."
 msgstr ""
 
 msgctxt "#30011"
-msgid "This operating system ([B]{0}[/B]) is not supported by Widevine DRM."
+msgid "This operating system ([B]{0}[/B]) is not supported by [B]Widevine CDM[/B]."
 msgstr ""
 
 msgctxt "#30012"
-msgid "The Windows Store version of Kodi does not support [B]Widevine DRM[/B].[CR][CR]Please use the installer from kodi.tv instead."
+msgid "The Windows Store version of Kodi does not support [B]Widevine CDM[/B].[CR][CR]Please use the installer from kodi.tv instead."
 msgstr ""
 
 msgctxt "#30013"
@@ -74,7 +74,7 @@ msgid "Downloading [B]{0}[/B]..."
 msgstr ""
 
 msgctxt "#30016"
-msgid "Failed to extract [B]Widevine DRM[/B] from zip file."
+msgid "Failed to extract [B]Widevine CDM[/B] from zip file."
 msgstr ""
 
 msgctxt "#30017"
@@ -82,19 +82,19 @@ msgid "[B]{0}[/B] {1} or later is required to play this content."
 msgstr ""
 
 msgctxt "#30018"
-msgid "You do not have enough free disk space to install [B]Widevine DRM[/B]. Free up at least [B]{0}[/B] and try again."
+msgid "You do not have enough free disk space to install [B]Widevine CDM[/B]. Free up at least [B]{0}[/B] and try again."
 msgstr ""
 
 msgctxt "#30019"
-msgid "This operating system ([B]{0}[/B]) is not supported by [B]Widevine DRM[/B] for ARM devices."
+msgid "This operating system ([B]{0}[/B]) is not supported by [B]Widevine CDM[/B] for ARM devices."
 msgstr ""
 
 msgctxt "#30020"
-msgid "[B]'{0}'[/B] or [B]'{1}'[/B] command needs to exist on system to extract the [B]Widevine DRM[/B]."
+msgid "[B]'{0}'[/B] or [B]'{1}'[/B] command needs to exist on system to extract the [B]Widevine CDM[/B]."
 msgstr ""
 
 msgctxt "#30021"
-msgid "[B]'{0}'[/B] command needs to exist on system to extract the [B]Widevine DRM[/B]."
+msgid "[B]'{0}'[/B] command needs to exist on system to extract the [B]Widevine CDM[/B]."
 msgstr ""
 
 msgctxt "#30022"
@@ -106,7 +106,7 @@ msgid "Download completed!"
 msgstr ""
 
 msgctxt "#30024"
-msgid "The installation now needs to unzip, mount and extract [B]Widevine DRM[/B] from the recovery image.[CR][CR]This process may take up to ten minutes to complete."
+msgid "The installation now needs to unzip, mount and extract [B]Widevine CDM[/B] from the recovery image.[CR][CR]This process may take up to ten minutes to complete."
 msgstr ""
 
 msgctxt "#30025"
@@ -114,7 +114,7 @@ msgid "Acquiring EULA."
 msgstr ""
 
 msgctxt "#30026"
-msgid "Widevine DRM EULA"
+msgid "Widevine CDM EULA"
 msgstr ""
 
 msgctxt "#30027"
@@ -134,5 +134,17 @@ msgid "Administrative rights ([B]sudo[/B]) is required to mount the Chrome OS im
 msgstr ""
 
 msgctxt "#30031"
-msgid "An update of [B]Widevine DRM[/B] is required to play this content."
+msgid "An update of [B]Widevine CDM[/B] is required to play this content."
+msgstr ""
+
+msgctxt "#30032"
+msgid "Your system is missing the following libraries required by Widevine CDM: [B]{0}[/B]. Install the libraries to play this content."
+msgstr ""
+
+msgctxt "#30033"
+msgid "There is an update available for [B]Widevine CDM[/B].[CR][CR]Do you want to install the update?"
+msgstr ""
+
+msgctxt "#30034"
+msgid "Update"
 msgstr ""

--- a/script.module.inputstreamhelper/resources/settings.xml
+++ b/script.module.inputstreamhelper/resources/settings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<settings>
+   <setting id="last_update" value="" visible="false" />
+</settings>


### PR DESCRIPTION
### Description
2018.01.29 v0.3.0
+ Bug fix: module left xbmcaddon class in memory
+ Keep Widevine CDM up-to-date with the latest version available (Kodi 18 and higher)
+ Check for missing depending libraries by parsing the output from ldd
+ Use older Widevine binaries on Kodi Krypton (fixes nss/nspr dependency issues)
### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [X] Each add-on submission should be a single commit with using the following style: [script.foo.bar] v1.0.0

Additional information :
- Submitting your add-on to this specific branch makes it available to any Kodi version equal or higher than the branch name with the applicable Kodi dependencies limits.
- [add-on development](http://kodi.wiki/view/Add-on_development) wiki page.
- Kodi [pydocs](http://kodi.wiki/view/PyDocs) provide information about the Python API
- [PEP8](https://www.python.org/dev/peps/pep-0008/) codingstyle which is considered best practise but not mandatory.
- This add-on repository has automated code guideline check which could help you improve your coding. You can find the results of these check at [Codacy](https://www.codacy.com/app/Kodi/repo-scripts/dashboard). You can create your own account as well to continuously monitor your python coding before submitting to repo.
- Development questions can be asked in the [add-on development](http://forum.kodi.tv/forumdisplay.php?fid=26) section on the Kodi forum.
