### PR TITLE
[script.artistslideshow] 2.1.1

### DIFF
--- a/script.artistslideshow/addon.xml
+++ b/script.artistslideshow/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.artistslideshow" name="Artist Slideshow" version="2.1.0" provider-name="pkscout,ronie">
+<addon id="script.artistslideshow" name="Artist Slideshow" version="2.1.1" provider-name="pkscout,ronie">
 	<requires>
 		<import addon="xbmc.python" version="2.19.0"/>
 		<import addon="xbmc.addon" version="14.0.0"/>
@@ -11,12 +11,13 @@
 	</extension>
 	<extension point="xbmc.addon.metadata">
 		<news>
-v.2.1.0
-- updated AS to save and use unhashed artist and image names
-- created upgrade routine to rename hashed artist and image names
-- included new option to ONLY use local artist path for storage
-- cleaned up folder path creation routines
-- removed old download exclusion logic in favor of new _imgdb.nfo history
+v.2.1.1
+- added option to download artist thumb from theaudiodb.com
+- added option to store service information files in local artist path
+- change to cache timing including decreased cache time if donating to image services
+- rearranged settings
+- fixes to exception handling syntax to be consistent with Python3
+- fixes for compatibility with Windows Store version of Kodi
 		</news>
 		<summary lang="ar">حمل المزيد من الصور والمعلومات عن الفنان الذى يُغنِى حالياً</summary>
 		<summary lang="be">Download images and additional info of the currently playing artist</summary>

--- a/script.artistslideshow/changelog.txt
+++ b/script.artistslideshow/changelog.txt
@@ -1,3 +1,12 @@
+v.2.1.1
+- added option to download artist thumb from theaudiodb.com
+- added option to store service information files in local artist path
+- change to cache timing including decreased cache time if donating to image services
+- rearranged settings
+- fixes to exception handling syntax to be consistent with Python3
+- refactored some common functions
+- change to fileops common module to not use subprocess (unavailable in Windows Store version of Kodi)
+
 v.2.1.0
 - updated AS to save and use unhashed artist and image names
 - created upgrade routine to rename hashed artist and image names

--- a/script.artistslideshow/resources/common/transforms.py
+++ b/script.artistslideshow/resources/common/transforms.py
@@ -1,4 +1,4 @@
-#v.0.2.0
+#v.0.3.0
 
 import imghdr, os, re
 try:
@@ -25,7 +25,7 @@ def itemHashwithPath(item, thepath):
 def getImageType( filename ):
     try:
         new_ext = '.' + imghdr.what( filename ).replace( 'jpeg', 'jpg' )
-    except Exception, e:
+    except Exception as e:
         new_ext = '.tbn'
     return new_ext
 

--- a/script.artistslideshow/resources/common/url.py
+++ b/script.artistslideshow/resources/common/url.py
@@ -1,9 +1,7 @@
-#v.0.2.0
+#v.0.3.0
 
 import socket
 import requests as _requests
-from requests.packages.urllib3.exceptions import InsecureRequestWarning
-_requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
     
 
 class URL():
@@ -44,19 +42,19 @@ class URL():
             loglines.append( params )
             loglines.append( 'the data are: ')
             loglines.append( data )
-        except _requests.exceptions.ConnectionError, e:
+        except _requests.exceptions.ConnectionError as e:
             loglines.append( 'site unreachable at ' + url )
             loglines.append( e )
-        except _requests.exceptions.Timeout, e:
+        except _requests.exceptions.Timeout as e:
             loglines.append( 'timeout error while downloading from ' + url )
             loglines.append( e )
-        except socket.timeout, e:
+        except socket.timeout as e:
             loglines.append( 'timeout error while downloading from ' + url )
             loglines.append( e )
-        except _requests.exceptions.HTTPError, e:
+        except _requests.exceptions.HTTPError as e:
             loglines.append( 'HTTP Error while downloading from ' + url )
             loglines.append( e )
-        except _requests.exceptions.RequestException, e:
+        except _requests.exceptions.RequestException as e:
             loglines.append( 'unknown error while downloading from ' + url )
             loglines.append( e )
         if urldata:
@@ -94,4 +92,4 @@ class URL():
                 data = []
             else:
                 data = ''
-    	return params, data
+        return params, data

--- a/script.artistslideshow/resources/common/xlogger.py
+++ b/script.artistslideshow/resources/common/xlogger.py
@@ -1,4 +1,4 @@
-#v.0.1.5
+#v.0.3.0
 
 try:
     import xbmc
@@ -45,7 +45,7 @@ class Logger():
                 if type(line).__name__=='unicode':
                     line = line.encode('utf-8')
                 str_line = line.__str__()
-            except Exception, e:
+            except Exception as e:
                 str_line = ''
                 self._output( 'error parsing logline', loglevel )
                 self._output( e, loglevel )
@@ -64,7 +64,7 @@ class Logger():
         if not (self.LOGDEBUG.lower() == 'false' and loglevel == self.logger.debug):
             try:
                 loglevel( "%s %s" % (self.LOGPREAMBLE, line.__str__()) )
-            except Exception, e:
+            except Exception as e:
                 self.logger.debug( "%s unable to output logline" % self.LOGPREAMBLE )
                 self.logger.debug( "%s %s" % (self.LOGPREAMBLE, e.__str__()) )
 
@@ -73,6 +73,6 @@ class Logger():
         if not (self.LOGDEBUG.lower() == 'false' and (loglevel == xbmc.LOGINFO or loglevel == xbmc.LOGDEBUG)):
             try:
                 xbmc.log( "%s %s" % (self.LOGPREAMBLE, line.__str__()), loglevel)
-            except Exception, e:
+            except Exception as e:
                 xbmc.log( "%s unable to output logline" % self.LOGPREAMBLE, loglevel)
                 xbmc.log ("%s %s" % (self.LOGPREAMBLE, e.__str__()), loglevel)

--- a/script.artistslideshow/resources/language/English/strings.po
+++ b/script.artistslideshow/resources/language/English/strings.po
@@ -109,7 +109,15 @@ msgctxt "#32015"
 msgid "Moving artist images to local artist location"
 msgstr ""
 
-#empty strings from id 32016 to 32099
+msgctxt "#32016"
+msgid "  I donate to this service"
+msgstr ""
+
+msgctxt "#32017"
+msgid "Moving artist service information files to local artist location"
+msgstr ""
+
+#empty strings from id 32018 to 32099
 
 msgctxt "#32100"
 msgid "Slideshow"
@@ -164,7 +172,11 @@ msgid "Use both local and remote images"
 msgstr ""
 
 msgctxt "#32113"
-msgid "  Always use local artist path for storage"
+msgid "  Always use local artist path for image storage"
+msgstr ""
+
+msgctxt "#32114"
+msgid "Alternate Slideshow"
 msgstr ""
 
 #empty strings from id 32113 to 32199
@@ -241,7 +253,11 @@ msgctxt "#32217"
 msgid "Other"
 msgstr ""
 
-#empty strings from id 32210 to 32299
+msgctxt "#32218"
+msgid "  Always use local artist path for service information storage"
+msgstr ""
+
+#empty strings from id 32219 to 32299
 
 msgctxt "#32300"
 msgid "Album Info"

--- a/script.artistslideshow/resources/plugins/fanarttv.py
+++ b/script.artistslideshow/resources/plugins/fanarttv.py
@@ -1,6 +1,6 @@
 #v.0.1.0
 
-import os, time, sys, random, xbmc
+import os, time, sys, random, xbmc, xbmcvfs
 from ..common.url import URL
 from ..common.fileops import readFile, writeFile, deleteFile, checkPath
 if sys.version_info >= (2, 7):
@@ -22,9 +22,13 @@ class objectConfig():
         self.URL = 'http://webservice.fanart.tv/v3/music/'
         self.FILENAME = 'fanarttvartistimages.nfo'
         self.CACHETIMEFILENAME = 'fanarttvcachetime.nfo'
+        self.HASCLIENTKEY = False
+        self.HASDONATION = False
         self.CACHEEXPIRE = {}
-        self.CACHEEXPIRE['low'] = int( 12*secsinweek )
-        self.CACHEEXPIRE['high'] = int( 24*secsinweek )
+        self.CACHEEXPIRE['low'] = int( 3*secsinweek )
+        self.CACHEEXPIRE['high'] = int( 4*secsinweek )
+        self.CACHEEXPIREWITHCLIENTKEY = int( 2*secsinweek )
+        self.CACHEEXPIREWITHDONATION = int( secsinweek/7 )
         self.loglines = []
         self.JSONURL = URL( 'json' )
 
@@ -42,7 +46,15 @@ class objectConfig():
         url = self.URL + img_params.get( 'mbid', '' )
         url_params['api_key'] = clowncar.decode( 'base64' )
         if img_params.get( 'clientapikey', False ):
+            self.HASCLIENTKEY = True
             url_params['client_key'] = img_params.get( 'clientapikey', '' )
+            if img_params.get( 'donate' ) == 'true':
+                self.HASDONATION = True
+                self.CACHEEXPIRE['low'] = self.CACHEEXPIREWITHDONATION
+                self.CACHEEXPIRE['high'] = self.CACHEEXPIREWITHDONATION
+            else:
+                self.CACHEEXPIRE['low'] = self.CACHEEXPIREWITHCLIENTKEY
+                self.CACHEEXPIRE['high'] = self.CACHEEXPIREWITHCLIENTKEY            
         json_data = self._get_data( filepath, cachefilepath, url, url_params )
         if json_data:
             image_list = json_data.get( 'artistbackground', [] )
@@ -71,7 +83,13 @@ class objectConfig():
             cachetime = int( rawdata )
         except ValueError:
             cachetime = 0
-        return cachetime
+        # this is to honor donation or client key cache time immediately instead of after old cache expires
+        if self.HASDONATION and cachetime > self.CACHEEXPIREWITHDONATION:
+            return self.CACHEEXPIREWITHDONATION
+        elif self.HASCLIENTKEY and cachetime > self.CACHEEXPIREWITHCLIENTKEY:
+            return self.CACHEEXPIREWITHCLIENTKEY
+        else:
+            return cachetime
 
 
     def _get_data( self, filepath, cachefilepath, url, url_params ):
@@ -108,7 +126,8 @@ class objectConfig():
         exists, cloglines = checkPath( filepath, False )
         self.loglines.extend( cloglines )
         if exists:
-            if time.time() - os.path.getmtime( filepath ) < self._get_cache_time( cachefilepath ):
+            st = xbmcvfs.Stat( filepath )
+            if time.time() - st.st_mtime() < self._get_cache_time( cachefilepath ):
                 self.loglines.append( 'cached artist info found for fanarttv' )
                 return False
             else:

--- a/script.artistslideshow/resources/settings.xml
+++ b/script.artistslideshow/resources/settings.xml
@@ -1,29 +1,30 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <settings>
-	<category label="32600">
-		<setting label="32601" type="lsep" />
-		<setting label="32602" type="lsep" />
-		<setting label="32603" type="lsep" />
-		<setting label="32604" type="lsep" />
-		<setting label="32605" type="lsep" />
-	</category>
     <category label="32100">
         <setting id="local_artist_path" type="folder" label="32101" default="" />
         <setting id="priority" type="enum" label="32102" lvalues="32110|32111|32112" default="0" />
         <setting id="localstorageonly" type="bool" label="32113" default="false" />
+        <setting id="localinfostorage" type="bool" label="32218" default="false" />
 		<setting id="include_fanartjpg" type="bool" label="32108" default="false" />
 		<setting id="include_folderjpg" type="bool" label="32109" default="false" />
+        <setting id="disable_multiartist" type="bool" label="32210" default="false" />
+        <setting id="transparent" type="bool" label="32107" default="false" />
+    </category>
+	<category label="32114">
+		<setting id="fanart_folder" type="text" label="32205" default="" />
         <setting id="fallback" type="bool" label="32105" default="false" />
         <setting id="fallback_path" type="folder" label="32103" default="" visible="eq(-1,true)" />
         <setting id="slideshow" type="bool" label="32106" default="false" />
         <setting id="slideshow_path" type="folder" label="32104" default="" visible="eq(-1,true)" />
-        <setting id="transparent" type="bool" label="32107" default="false" />
-    </category>
+	</category>
     <category label="32000">
         <setting id="fanarttv" type="bool" label="32008" default="false" />
         <setting id="fanarttv_clientapikey" type="text" label="32010" visible="eq(-1,true)" default="" />
         <setting id="fanarttv_all" type="bool" label="32007" visible="eq(-2,true)" default="false" />
+        <setting id="fanarttv_donated" type="bool" label="32016" visible="eq(-3,true)" default="false" />
         <setting id="theaudiodb" type="bool" label="32009" default="false" />
+        <setting id="theaudiodb_all" type="bool" label="32007" visible="eq(-1,true)" default="false" />
+        <setting id="theaudiodb_donated" type="bool" label="32016" visible="eq(-2,true)" default="false" />
     </category>
     <category label="32300">
         <setting id="ai_theaudiodb" type="bool" label="32302" default="false" />
@@ -45,15 +46,13 @@
         <setting id="sa_priority_lastfm" type="slider" label="32301" visible="eq(-1,true)" default="5" range='1,1,10' option='int' />
     </category>
     <category label="32200">
-        <setting id="disable_multiartist" type="bool" label="32210" default="false" />
-        <setting id="restrict_cache" type="bool" label="32201" default="false" />
-        <setting id="max_cache_size" label="32202" type="labelenum" values="128|256|512|768|1024|2048|3072|4096" visible="eq(-1,true)" default="1024" />
         <setting id="show_progress" type="enum" label="32203" lvalues="32206|32207|32208" default="0" />
         <setting id="progress_path" type="folder" label="32204" default="" visible="eq(-1,2)"/>
-		<setting id="fanart_folder" type="text" label="32205" default="" />
         <setting id="storage_target" type="enum" label="32212" default="0" lvalues="32215|32217|32216" />
         <setting id="illegal_replace" type="text" label=" 32213" default="_" />
         <setting id="end_replace" type="text" label="32214" default="" visible="eq(-2,0)" />		
+        <setting id="restrict_cache" type="bool" label="32201" default="false" />
+        <setting id="max_cache_size" label="32202" type="labelenum" values="128|256|512|768|1024|2048|3072|4096" visible="eq(-1,true)" default="1024" />
         <setting id="logging" type="bool" label="32209" default="false" />
     </category>
 </settings>


### PR DESCRIPTION
### Description
v.2.1.1
- added option to download artist thumb from theaudiodb.com
- added option to store service information files in local artist path
- change to cache timing including decreased cache time if donating to image services
- rearranged settings
- fixes to exception handling syntax to be consistent with Python3
- refactored some common functions
- change to fileops common module for compatibility with Windows Store version of Kodi
### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x ] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [ x ] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [ x ] Each add-on submission should be a single commit with using the following style: [script.foo.bar] v1.0.0

Additional information :
- Submitting your add-on to this specific branch makes it available to any Kodi version equal or higher than the branch name with the applicable Kodi dependencies limits.
- [add-on development](http://kodi.wiki/view/Add-on_development) wiki page.
- Kodi [pydocs](http://kodi.wiki/view/PyDocs) provide information about the Python API
- [PEP8](https://www.python.org/dev/peps/pep-0008/) codingstyle which is considered best practise but not mandatory.
- This add-on repository has automated code guideline check which could help you improve your coding. You can find the results of these check at [Codacy](https://www.codacy.com/app/Kodi/repo-scripts/dashboard). You can create your own account as well to continuously monitor your python coding before submitting to repo.
- Development questions can be asked in the [add-on development](http://forum.kodi.tv/forumdisplay.php?fid=26) section on the Kodi forum.
