### PR TITLE
[script.module.kodi-six] 0.0.2

### DIFF
--- a/script.module.kodi-six/addon.xml
+++ b/script.module.kodi-six/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="script.module.kodi-six"
        name="Kodi Six"
-       version="0.0.1"
+       version="0.0.2"
        provider-name="Roman V.M.">
   <requires>
     <import addon="xbmc.python" version="2.14.0"/>
@@ -12,7 +12,8 @@
     <description lang="en">Wrappers around Kodi Python API that normalize handling of textual and byte strings in Python 2 and 3.</description>
     <platform>all</platform>
     <license>GPL v.3</license>
-    <forum></forum>
+    <forum>https://forum.kodi.tv/showthread.php?tid=327883</forum>
     <source>https://github.com/romanvm/kodi.six</source>
+    <news>- Do not patch class __init__ methods</news>
   </extension>
 </addon>

--- a/script.module.kodi-six/libs/kodi_six/utils.py
+++ b/script.module.kodi-six/libs/kodi_six/utils.py
@@ -81,7 +81,7 @@ def patch_module(mod):
             cls = _wrap_class(obj)
             for memb_name, member in inspect.getmembers(cls):
                 # Do not patch special methods!
-                if ((memb_name == '__init__' or not memb_name.startswith('__'))
-                        and inspect.ismethoddescriptor(member)):
+                if (inspect.ismethoddescriptor(member) and
+                        not memb_name.endswith('__')):
                     setattr(cls, memb_name, encode_decode(member))
             setattr(mod, name, cls)


### PR DESCRIPTION
### Description
Removed patching `__init__` methods because it screws with class MRO in case of complex inheritance scheme.

<!--- Provide a short summary of submitted add-on in case it's a new addition. -->
<!--- If it's plugin update only highlight biggest changes if needed. -->
<!--- Make sure you follow the checklist below before finalising your pull-request. -->
### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [script.foo.bar] v1.0.0

Additional information :
- Submitting your add-on to this specific branch makes it available to any Kodi version equal or higher than the branch name with the applicable Kodi dependencies limits.
- [add-on development](http://kodi.wiki/view/Add-on_development) wiki page.
- Kodi [pydocs](http://kodi.wiki/view/PyDocs) provide information about the Python API
- [PEP8](https://www.python.org/dev/peps/pep-0008/) codingstyle which is considered best practise but not mandatory.
- This add-on repository has automated code guideline check which could help you improve your coding. You can find the results of these check at [Codacy](https://www.codacy.com/app/Kodi/repo-scripts/dashboard). You can create your own account as well to continuously monitor your python coding before submitting to repo.
- Development questions can be asked in the [add-on development](http://forum.kodi.tv/forumdisplay.php?fid=26) section on the Kodi forum.
