### PR TITLE
[service.subtitles.subdivx] 0.3.0

### DIFF
--- a/service.subtitles.subdivx/addon.xml
+++ b/service.subtitles.subdivx/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="service.subtitles.subdivx"
        name="Subdivx.com"
-       version="0.2.5"
+       version="0.3.0"
        provider-name="cramm">
   <requires>
     <import addon="xbmc.python" version="2.14.0"/>
@@ -11,6 +11,7 @@
              library="service.py" />
   <extension point="xbmc.addon.metadata">
     <summary lang="en">Subdivx.com</summary>
+    <description lang="es">Busca y descarga subtítulos desde Subdivx.com</description>
     <description lang="en">Search and download subtitles from Subdivx.com</description>
     <disclaimer lang="en"></disclaimer>
     <language>es en</language>
@@ -21,4 +22,8 @@
     <email></email>
     <source>https://github.com/ramiro/service.subtitles.subdivx</source>
   </extension>
+  <news lang="es">v0.3.0
+  - Se agrega compatibilidad con Kodi 18 Leia. Necesita instalar manualmente el add-on "Archive support" (por spiff)</news>
+  <news lang="en">v0.3.0
+  - Added compatibility with Kodi 18 Leia. You need to install manually the "Archive support" (by spiff) add-on</news>
 </addon>

--- a/service.subtitles.subdivx/changelog.txt
+++ b/service.subtitles.subdivx/changelog.txt
@@ -1,3 +1,21 @@
+0.3.0
+- Release changes since 0.2.5
+
+0.2.13
+- Add 'news' section to addon.xml. Translate it and description to Spanish
+
+0.2.12
+- Comply with new Kodi policies: Less verbose logging by default. Achieved
+  by moving most of it to LOGDEBUG level
+
+0.2.11
+- Remove disposable temporary directory after using it.
+
+0.2.10
+- Attempt 1 at fixing decompression of RAR files on Kodi 18. This introduces
+  a dependency on the vfs.libarchive binary addon for Kodi>=18.
+- Users need to activate and/or install 'Archive support' add-on manually.
+
 0.2.5
 - Use html2text lib to scrape comments. Thanks Iván Ridao Freitas for help.
 - Fix handling of movie path on filesystem. Thanks Santiago Ibarra for report.


### PR DESCRIPTION
### Description
Compatibility with Kodi 18. This means we now depend (only for Kodi 18) on the `vfs.libarchive` binary addon (by spiff.)
Add Spanish entries to `addon.xml`.
Remove temporary directories used during decompression of downloaded files.
### Checklist:
- [X] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [X] Each add-on submission should be a single commit with using the following style: [script.foo.bar] v1.0.0

Additional information :
- Submitting your add-on to this specific branch makes it available to any Kodi version equal or higher than the branch name with the applicable Kodi dependencies limits.
- [add-on development](http://kodi.wiki/view/Add-on_development) wiki page.
- Kodi [pydocs](http://kodi.wiki/view/PyDocs) provide information about the Python API
- [PEP8](https://www.python.org/dev/peps/pep-0008/) codingstyle which is considered best practise but not mandatory.
- This add-on repository has automated code guideline check which could help you improve your coding. You can find the results of these check at [Codacy](https://www.codacy.com/app/Kodi/repo-scripts/dashboard). You can create your own account as well to continuously monitor your python coding before submitting to repo.
- Development questions can be asked in the [add-on development](http://forum.kodi.tv/forumdisplay.php?fid=26) section on the Kodi forum.
