### PR TITLE
[service.subtitles.subscene] v1.7.2

### DIFF
--- a/service.subtitles.subscene/addon.xml
+++ b/service.subtitles.subscene/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="service.subtitles.subscene"
        name="Subscene.com"
-       version="1.7.1"
+       version="1.7.2"
        provider-name="CrowleyAJ">
     <requires>
         <import addon="xbmc.python" version="2.14.0"/>

--- a/service.subtitles.subscene/resources/lib/ordinal.py
+++ b/service.subtitles.subscene/resources/lib/ordinal.py
@@ -1,0 +1,239 @@
+# -*- coding: utf-8 -*-
+# Adapted from https://github.com/savoirfairelinux/num2words
+from __future__ import unicode_literals
+
+import math
+from collections import OrderedDict
+from decimal import Decimal
+from string import capwords
+
+
+def to_s(val):
+    try:
+        return unicode(val)
+    except NameError:
+        return str(val)
+
+class Num2Word(object):
+    CURRENCY_FORMS = {}
+    CURRENCY_ADJECTIVES = {}
+
+    def __init__(self):
+        self.cards = OrderedDict()
+        self.is_title = False
+        self.precision = 2
+        self.exclude_title = []
+        self.negword = "(-) "
+        self.pointword = "(.)"
+        self.errmsg_nonnum = "type(%s) not in [long, int, float]"
+        self.errmsg_floatord = "Cannot treat float %s as ordinal."
+        self.errmsg_negord = "Cannot treat negative num %s as ordinal."
+        self.errmsg_toobig = "abs(%s) must be less than %s."
+
+        self.base_setup()
+        self.setup()
+        self.set_numwords()
+
+        self.MAXVAL = 1000 * list(self.cards.keys())[0]
+
+    def base_setup(self):
+        lows = ["non", "oct", "sept", "sext", "quint", "quadr", "tr", "b", "m"]
+        units = ["", "un", "duo", "tre", "quattuor", "quin", "sex", "sept",
+                 "octo", "novem"]
+        tens = ["dec", "vigint", "trigint", "quadragint", "quinquagint",
+                "sexagint", "septuagint", "octogint", "nonagint"]
+        self.high_numwords = ["cent"] + self.gen_high_numwords(units, tens,
+                                                               lows)
+
+    def setup(self):
+        self.mid_numwords = [(1000, "thousand"), (100, "hundred"),
+                             (90, "ninety"), (80, "eighty"), (70, "seventy"),
+                             (60, "sixty"), (50, "fifty"), (40, "forty"),
+                             (30, "thirty")]
+        self.low_numwords = ["twenty", "nineteen", "eighteen", "seventeen",
+                             "sixteen", "fifteen", "fourteen", "thirteen",
+                             "twelve", "eleven", "ten", "nine", "eight",
+                             "seven", "six", "five", "four", "three", "two",
+                             "one", "zero"]
+        self.ords = {"one": "first",
+                     "two": "second",
+                     "three": "third",
+                     "five": "fifth",
+                     "eight": "eighth",
+                     "nine": "ninth",
+                     "twelve": "twelfth"}
+
+    def set_numwords(self):
+        self.set_high_numwords(self.high_numwords)
+        self.set_mid_numwords(self.mid_numwords)
+        self.set_low_numwords(self.low_numwords)
+
+    def set_high_numwords(self, high):
+        max = 3 + 3 * len(high)
+        for word, n in zip(high, range(max, 3, -3)):
+            self.cards[10 ** n] = word + "illion"
+
+    def gen_high_numwords(self, units, tens, lows):
+        out = [u + t for t in tens for u in units]
+        out.reverse()
+        return out + lows
+
+    def set_mid_numwords(self, mid):
+        for key, val in mid:
+            self.cards[key] = val
+
+    def set_low_numwords(self, numwords):
+        for word, n in zip(numwords, range(len(numwords) - 1, -1, -1)):
+            self.cards[n] = word
+
+    def verify_ordinal(self, value):
+        if not value == int(value):
+            raise TypeError(self.errmsg_floatord % value)
+        if not abs(value) == value:
+            raise TypeError(self.errmsg_negord % value)
+
+    def to_cardinal_float(self, value):
+        try:
+            float(value) == value
+        except (ValueError, TypeError, AssertionError):
+            raise TypeError(self.errmsg_nonnum % value)
+
+        pre, post = self.float2tuple(float(value))
+
+        post = str(post)
+        post = '0' * (self.precision - len(post)) + post
+
+        out = [self.to_cardinal(pre)]
+        if self.precision:
+            out.append(self.title(self.pointword))
+
+        for i in range(self.precision):
+            curr = int(post[i])
+            out.append(to_s(self.to_cardinal(curr)))
+
+        return " ".join(out)
+
+    def title(self, value):
+        if self.is_title:
+            out = []
+            value = value.split()
+            for word in value:
+                if word in self.exclude_title:
+                    out.append(word)
+                else:
+                    out.append(word[0].upper() + word[1:])
+            value = " ".join(out)
+        return value
+
+    def float2tuple(self, value):
+        pre = int(value)
+
+        # Simple way of finding decimal places to update the precision
+        self.precision = abs(Decimal(str(value)).as_tuple().exponent)
+
+        post = abs(value - pre) * 10**self.precision
+        if abs(round(post) - post) < 0.01:
+            # We generally floor all values beyond our precision (rather than
+            # rounding), but in cases where we have something like 1.239999999,
+            # which is probably due to python's handling of floats, we actually
+            # want to consider it as 1.24 instead of 1.23
+            post = int(round(post))
+        else:
+            post = int(math.floor(post))
+
+        return pre, post
+
+    def to_cardinal(self, value):
+        try:
+            assert int(value) == value
+        except (ValueError, TypeError, AssertionError):
+            return self.to_cardinal_float(value)
+
+        out = ""
+        if value < 0:
+            value = abs(value)
+            out = self.negword
+
+        if value >= self.MAXVAL:
+            raise OverflowError(self.errmsg_toobig % (value, self.MAXVAL))
+
+        val = self.splitnum(value)
+        words, num = self.clean(val)
+        return self.title(out + words)
+
+    def splitnum(self, value):
+        for elem in self.cards:
+            if elem > value:
+                continue
+
+            out = []
+            if value == 0:
+                div, mod = 1, 0
+            else:
+                div, mod = divmod(value, elem)
+
+            if div == 1:
+                out.append((self.cards[1], 1))
+            else:
+                if div == value:  # The system tallies, eg Roman Numerals
+                    return [(div * self.cards[elem], div*elem)]
+                out.append(self.splitnum(div))
+
+            out.append((self.cards[elem], elem))
+
+            if mod:
+                out.append(self.splitnum(mod))
+
+            return out
+
+    def merge(self, lpair, rpair):
+        ltext, lnum = lpair
+        rtext, rnum = rpair
+        if lnum == 1 and rnum < 100:
+            return (rtext, rnum)
+        elif 100 > lnum > rnum:
+            return ("%s-%s" % (ltext, rtext), lnum + rnum)
+        elif lnum >= 100 > rnum:
+            return ("%s and %s" % (ltext, rtext), lnum + rnum)
+        elif rnum > lnum:
+            return ("%s %s" % (ltext, rtext), lnum * rnum)
+        return ("%s, %s" % (ltext, rtext), lnum + rnum)
+
+    def clean(self, val):
+        out = val
+        while len(val) != 1:
+            out = []
+            left, right = val[:2]
+            if isinstance(left, tuple) and isinstance(right, tuple):
+                out.append(self.merge(left, right))
+                if val[2:]:
+                    out.append(val[2:])
+            else:
+                for elem in val:
+                    if isinstance(elem, list):
+                        if len(elem) == 1:
+                            out.append(elem[0])
+                        else:
+                            out.append(self.clean(elem))
+                    else:
+                        out.append(elem)
+            val = out
+        return out[0]
+
+    def to_ordinal(self, value):
+        self.verify_ordinal(value)
+        outwords = self.to_cardinal(value).split(" ")
+        lastwords = outwords[-1].split("-")
+        lastword = lastwords[-1].lower()
+        try:
+            lastword = self.ords[lastword]
+        except KeyError:
+            if lastword[-1] == "y":
+                lastword = lastword[:-1] + "ie"
+            lastword += "th"
+        lastwords[-1] = self.title(lastword)
+        outwords[-1] = "-".join(lastwords)
+        return capwords(" ".join(outwords))
+
+
+ordinal = Num2Word().to_ordinal


### PR DESCRIPTION
### Description

When searching for subtitles for a TV show that contains more than 29 seasons, the error below can be seen in the logs:

```
12:08:36.047 T:1364964256   ERROR: EXCEPTION Thrown (PythonToCppException) : -->Python callback/script returned the following error<--
                                             - NOTE: IGNORING THIS CAN LEAD TO MEMORY LEAKS!
                                            Error Type: <type 'exceptions.IndexError'>
                                            Error Contents: list index out of range
                                            Traceback (most recent call last):
                                              File "/storage/.kodi/addons/service.subtitles.subscene/service.py", line 532, in <module>
                                                search(item)
                                              File "/storage/.kodi/addons/service.subtitles.subscene/service.py", line 355, in search
                                                search_tvshow(item['tvshow'], item['season'], item['episode'], item['3let_language'], filename)
                                              File "/storage/.kodi/addons/service.subtitles.subscene/service.py", line 307, in search_tvshow
                                                search_string = tvshow + " - " + seasons[int(season)] + " Season"
                                            IndexError: list index out of range
                                            -->End of Python script error report<--
12:08:36.165 T:1858073504   ERROR: GetDirectory - Error getting plugin://service.subtitles.subscene/?action=search&languages=English&preferredlanguage=Unknown
```

Changes in this PR:
1. Fix the error above
2. Remove the use of reserved variable names, as per PEP8 and @learningit's [previous request](https://github.com/xbmc/repo-scripts/pull/201#issuecomment-228076865).
3. Bump version to 1.7.2

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [X] Each add-on submission should be a single commit with using the following style: [script.foo.bar] v1.0.0
