### PR TITLE
[service.subtitles.subdivx] 0.3.2

### DIFF
--- a/service.subtitles.subdivx/addon.xml
+++ b/service.subtitles.subdivx/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="service.subtitles.subdivx"
        name="Subdivx.com"
-       version="0.3.0"
+       version="0.3.2"
        provider-name="cramm">
   <requires>
     <import addon="xbmc.python" version="2.14.0"/>

--- a/service.subtitles.subdivx/changelog.txt
+++ b/service.subtitles.subdivx/changelog.txt
@@ -1,3 +1,11 @@
+0.3.2
+- Be less verbose when removing old temporary dirs.
+
+0.3.1
+- Attempt at fixing a timing bug that can happen when removing the temporary
+  directory used for decompression of the downloaded file. Happens usually
+  on Android.
+
 0.3.0
 - Release changes since 0.2.5
 


### PR DESCRIPTION
### Description
Fix a race condition with a Kodi API call introduced in v0.3.0 which causes problems for many users. Also, reduce verbosity of old temporary dirs non-fatal removal failures.
### Checklist:
- [X] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [X] Each add-on submission should be a single commit with using the following style: [script.foo.bar] v1.0.0
