### PR TITLE
[script.xbmc.lcdproc] 3.0.1

### DIFF
--- a/script.xbmc.lcdproc/addon.xml
+++ b/script.xbmc.lcdproc/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.xbmc.lcdproc" name="XBMC LCDproc" version="3.0.0" provider-name="Team Kodi: Memphiz, Daniel 'herrnst' Scheller">
+<addon id="script.xbmc.lcdproc" name="XBMC LCDproc" version="3.0.1" provider-name="Team Kodi: Memphiz, Daniel 'herrnst' Scheller">
   <requires>
     <import addon="xbmc.python" version="2.25.0"/>
   </requires>
@@ -22,13 +22,9 @@
     <assets>
       <icon>resources/icon.png</icon>
     </assets>
-    <news>3.0.0 (Leia)
-- Compatibility with Kodi 18 Leia
-- Polish translation by mskalski (thanks!)
-- French translation by fengalin (thanks!)
-- Strings finally migrated to strings.po format
-- New progressbar+time linetype by Truong Ta (thanks!)
-- Fixes, cleanups, cosmetics and optimizations all over the place
+    <news>3.0.1
+- Imports cleaned up
+- Compatibility with Python 3
 </news>
   </extension>
 </addon>

--- a/script.xbmc.lcdproc/changelog.txt
+++ b/script.xbmc.lcdproc/changelog.txt
@@ -1,3 +1,6 @@
+3.0.1
+- Imports cleaned up
+- Compatibility with Python 3
 3.0.0 (Leia)
 - Compatibility with Kodi 18 Leia
 - Polish translation by mskalski (thanks!)

--- a/script.xbmc.lcdproc/main.py
+++ b/script.xbmc.lcdproc/main.py
@@ -23,12 +23,9 @@
 
 # base imports
 import time
-import os
-import sys
 
 # Kodi imports
 import xbmc
-import xbmcaddon
 import xbmcgui
 
 from resources.lib.common import *

--- a/script.xbmc.lcdproc/resources/LCD.xml.defaults
+++ b/script.xbmc.lcdproc/resources/LCD.xml.defaults
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <lcd>
    <!-- advanced configurables, XML-uncomment and set options as desired -->
 

--- a/script.xbmc.lcdproc/resources/lib/charset_hd44780.py
+++ b/script.xbmc.lcdproc/resources/lib/charset_hd44780.py
@@ -21,8 +21,8 @@
 '''
 
 import codecs
-from charset_map_hd44780_a00 import *
-from charset_map_hd44780_a02 import *
+from .charset_map_hd44780_a00 import *
+from .charset_map_hd44780_a02 import *
 
 class HD44780_Codec(codecs.Codec):
 

--- a/script.xbmc.lcdproc/resources/lib/charset_map_hd44780_a02.py
+++ b/script.xbmc.lcdproc/resources/lib/charset_map_hd44780_a02.py
@@ -20,8 +20,6 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 '''
 
-import codecs
-
 encmap_hd44780_a02 = {
   0x0000: 0x0000,     #  NULL
   # 0x0001: 0x0001,     #  START OF HEADING

--- a/script.xbmc.lcdproc/resources/lib/common.py
+++ b/script.xbmc.lcdproc/resources/lib/common.py
@@ -25,7 +25,6 @@
 '''
 
 import os
-import sys
 
 import xbmc
 import xbmcaddon

--- a/script.xbmc.lcdproc/resources/lib/extraicons.py
+++ b/script.xbmc.lcdproc/resources/lib/extraicons.py
@@ -23,8 +23,6 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 '''
 
-from common import *
-
 LCD_EXTRABARS_MAX = 4
 
 class LCD_EXTRAICONS:

--- a/script.xbmc.lcdproc/resources/lib/infolabels.py
+++ b/script.xbmc.lcdproc/resources/lib/infolabels.py
@@ -23,16 +23,13 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 '''
 
-import os
-import string
 import sys
 import time
 
 import xbmc
-import xbmcaddon
 import xbmcgui
 
-from settings import *
+from .settings import *
 
 # interesting XBMC GUI Window IDs (no defines seem to exist for this)
 class WINDOW_IDS:
@@ -66,7 +63,11 @@ def InfoLabel_Initialize():
   g_InfoLabel_navTimer = time.time()
 
 def InfoLabel_GetInfoLabel(strLabel):
-  return xbmc.getInfoLabel(strLabel)
+  ret = xbmc.getInfoLabel(strLabel)
+  # pre-py3 compat
+  if sys.version_info.major < 3:
+    return ret.decode("utf-8")
+  return ret
 
 def InfoLabel_GetBool(strBool):
   return xbmc.getCondVisibility(strBool)
@@ -171,7 +172,7 @@ def InfoLabel_IsMuted():
   return InfoLabel_GetBool("Player.Muted")
 
 def InfoLabel_GetVolumePercent():
-  volumedb = float(string.replace(string.replace(InfoLabel_GetInfoLabel("Player.Volume"), ",", "."), " dB", ""))
+  volumedb = float(InfoLabel_GetInfoLabel("Player.Volume").replace(",", ".").replace(" dB", ""))
   return (100 * (60.0 + volumedb) / 60)
 
 def InfoLabel_GetPlayerTimeSecs():
@@ -201,8 +202,6 @@ def InfoLabel_IsNavigationActive():
   global g_InfoLabel_oldMenu
   global g_InfoLabel_oldSubMenu
   global g_InfoLabel_navTimer
-
-  #from settings import settings_getNavTimeout
 
   ret = False
 

--- a/script.xbmc.lcdproc/resources/lib/lcdbase.py
+++ b/script.xbmc.lcdproc/resources/lib/lcdbase.py
@@ -21,12 +21,9 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 '''
 
-import platform
-import sys
 import os
-import shutil
 import re
-import telnetlib
+import shutil
 import time
 
 from xml.etree import ElementTree as xmltree
@@ -35,11 +32,11 @@ from array import array
 import xbmc
 import xbmcgui
 
-from common import *
-from settings import *
-from extraicons import *
-from infolabels import *
-from charset_hd44780 import *
+from .common import *
+from .settings import *
+from .extraicons import *
+from .infolabels import *
+from .charset_hd44780 import *
 
 __lcdxml__        = xbmc.translatePath(os.path.join("special://masterprofile", "LCD.xml"))
 __lcddefaultxml__ = xbmc.translatePath(os.path.join(KODI_ADDON_ROOTPATH, "resources", "LCD.xml.defaults"))
@@ -90,7 +87,6 @@ class LcdBase():
     self.m_strScrollSeparator = " "
 
     # runtime vars/state tracking
-    self.m_strInfoLabelEncoding = "utf-8" # http://forum.xbmc.org/showthread.php?tid=125492&pid=1045926#pid1045926
     self.m_timeDisableOnPlayTimer = time.time()
     self.m_bCurrentlyDimmed = False
     self.m_bHaveHD44780Charmap = False
@@ -393,7 +389,7 @@ class LcdBase():
         linetext = ""
       else:
         # prepare text line for XBMC's expected encoding
-        linetext = line.text.strip().encode(self.m_strInfoLabelEncoding, "ignore")
+        linetext = line.text.strip()
 
       # make sure linetext has something so re.match won't fail
       if linetext != "":
@@ -506,19 +502,10 @@ class LcdBase():
         if self.m_lcdMode[mode][inLine]['type'] == LCD_LINETYPE.LCD_LINETYPE_ICONTEXT:
           self.SetPlayingStateIcon()
 
-        srcline = InfoLabel_GetInfoLabel(self.m_lcdMode[mode][inLine]['text'])
+        line = InfoLabel_GetInfoLabel(self.m_lcdMode[mode][inLine]['text'])
 
-        if len(srcline) > 0:
-          srcline = self.StripBBCode(srcline)
-
-        if self.m_strInfoLabelEncoding != self.m_strLCDEncoding:
-          try:
-            line = srcline.decode(self.m_strInfoLabelEncoding).encode(self.m_strLCDEncoding, "replace")
-          except:
-            log(LOGDEBUG, "Caught exception on charset conversion: " + srcline)
-            line = "---"
-        else:
-          line = srcline
+        if len(line) > 0:
+          line = self.StripBBCode(line)
 
         self.SetProgressBar(0, -1)
 
@@ -536,7 +523,7 @@ class LcdBase():
 
     if self.m_cExtraIcons is not None:
       self.SetExtraInformation()
-      self.m_strSetLineCmds += self.m_cExtraIcons.GetOutputCommands()
+      self.m_bstrSetLineCmds += self.m_cExtraIcons.GetOutputCommands()
 
     self.FlushLines()
 

--- a/script.xbmc.lcdproc/resources/lib/lcdproc_extra_base.py
+++ b/script.xbmc.lcdproc/resources/lib/lcdproc_extra_base.py
@@ -23,8 +23,6 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 '''
 
-import sys
-
 class LCDproc_extra_base():
   def __init__(self):
     pass

--- a/script.xbmc.lcdproc/resources/lib/lcdproc_extra_imon.py
+++ b/script.xbmc.lcdproc/resources/lib/lcdproc_extra_imon.py
@@ -24,14 +24,10 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 '''
 
-import xbmc
-import sys
 import time
 
-from lcdproc import *
-from lcdbase import LCD_EXTRAICONS
-from extraicons import *
-from lcdproc_extra_base import *
+from .extraicons import *
+from .lcdproc_extra_base import *
 
 IMON_OUTPUT_INTERVAL = 0.2 # seconds
 
@@ -145,33 +141,33 @@ class LCDproc_extra_imon(LCDproc_extra_base):
       self.SetBar(i, float(0))
 
   def SetOutputIcons(self):
-    ret = ""
+    ret = b""
 
     # Make sure we don't send "0" to LCDproc, this would reset bars
     self.m_iOutputValueIcons |= IMON_ICONS.ICON_DUMMY
 
     if self.m_iOutputValueIcons != self.m_iOutputValueOldIcons:
       self.m_iOutputValueOldIcons = self.m_iOutputValueIcons
-      ret += "output %d\n" % (self.m_iOutputValueIcons)
+      ret += b"output %d\n" % (self.m_iOutputValueIcons)
 
     return ret
 
   def SetOutputBars(self):
-    ret = ""
+    ret = b""
 
     if self.m_iOutputValueBars != self.m_iOutputValueOldBars:
       self.m_iOutputValueOldBars = self.m_iOutputValueBars
-      ret += "output %d\n" % (self.m_iOutputValueBars)
+      ret += b"output %d\n" % (self.m_iOutputValueBars)
 
     return ret
 
   def GetOutputCommands(self):
-    ret = ""
+    ret = b""
 
     if self._DoOutputCommand():
       ret += self.SetOutputIcons()
 
-      if ret == "":
+      if ret == b"":
         ret += self.SetOutputBars()
 
     return ret
@@ -351,4 +347,4 @@ class LCDproc_extra_imon(LCDproc_extra_base):
     self.m_iOutputValueIcons = 0
     self.m_iOutputValueBars = 0
 
-    return "output 0\n"
+    return b"output 0\n"

--- a/script.xbmc.lcdproc/resources/lib/lcdproc_extra_mdm166a.py
+++ b/script.xbmc.lcdproc/resources/lib/lcdproc_extra_mdm166a.py
@@ -24,13 +24,8 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 '''
 
-import xbmc
-import sys
-
-from lcdproc import *
-from lcdbase import LCD_EXTRAICONS
-from extraicons import *
-from lcdproc_extra_base import *
+from .extraicons import *
+from .lcdproc_extra_base import *
 
 # extra icon bitmasks
 class MDM166A_ICONS:
@@ -93,11 +88,11 @@ class LCDproc_extra_mdm166a(LCDproc_extra_base):
       self.SetBar(i, float(0))
 
   def SetOutputIcons(self):
-    ret = ""
+    ret = b""
 
     if self.m_iOutputValueIcons != self.m_iOutputValueOldIcons:
       self.m_iOutputValueOldIcons = self.m_iOutputValueIcons
-      ret += "output %d\n" % (self.m_iOutputValueIcons)
+      ret += b"output %d\n" % (self.m_iOutputValueIcons)
 
     return ret
 
@@ -154,4 +149,4 @@ class LCDproc_extra_mdm166a(LCDproc_extra_base):
     self.m_iOutputValueOldIcons = 0
     self.m_iOutputValueIcons = 0
 
-    return "output 0\n"
+    return b"output 0\n"

--- a/script.xbmc.lcdproc/resources/lib/settings.py
+++ b/script.xbmc.lcdproc/resources/lib/settings.py
@@ -21,13 +21,9 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 '''
 
-import string
-import sys
 import time
 
-import xbmc
-
-from common import *
+from .common import *
 
 #general
 global g_hostip
@@ -266,15 +262,15 @@ def settings_handleLcdSettings():
 
   g_settingsChanged = False
 
-  scrolldelay = int(float(string.replace(KODI_ADDON_SETTINGS.getSetting("scrolldelay"), ",", ".")))
+  scrolldelay = int(float(KODI_ADDON_SETTINGS.getSetting("scrolldelay").replace(",", ".")))
   scrollmode = KODI_ADDON_SETTINGS.getSetting("scrollmode")
   dimonscreensaver = KODI_ADDON_SETTINGS.getSetting("dimonscreensaver") == "true"
   dimonshutdown = KODI_ADDON_SETTINGS.getSetting("dimonshutdown") == "true"
   dimonvideoplayback = KODI_ADDON_SETTINGS.getSetting("dimonvideoplayback") == "true"
   dimonmusicplayback = KODI_ADDON_SETTINGS.getSetting("dimonmusicplayback") == "true"
-  dimdelay = int(float(string.replace(KODI_ADDON_SETTINGS.getSetting("dimdelay"), ",", ".")))
-  navtimeout = int(float(string.replace(KODI_ADDON_SETTINGS.getSetting("navtimeout"), ",", ".")))
-  refreshrate = int(float(string.replace(KODI_ADDON_SETTINGS.getSetting("refreshrate"), ",", ".")))
+  dimdelay = int(float(KODI_ADDON_SETTINGS.getSetting("dimdelay").replace(",", ".")))
+  navtimeout = int(float(KODI_ADDON_SETTINGS.getSetting("navtimeout").replace(",", ".")))
+  refreshrate = int(float(KODI_ADDON_SETTINGS.getSetting("refreshrate").replace(",", ".")))
   hideconnpopups = KODI_ADDON_SETTINGS.getSetting("hideconnpopups") == "true"
   usealternatecharset = KODI_ADDON_SETTINGS.getSetting("usealternatecharset") == "true"
   charset = KODI_ADDON_SETTINGS.getSetting("charset")


### PR DESCRIPTION
### Description

From changelog.txt and addon.xml:
    3.0.1
    - Imports cleaned up
    - Compatibility with Python 3

Re py3 compat: Tested with Python2.7 on Gentoo and Ubuntu 18, and Python3.5 and 3.6 on Gentoo. Everything working without issues, no need for any future imports or such things. The only "compat" thing needed is the different handling of xbmc.GetInfoLabel() in infolabels.py:InfoLabel_GetInfoLabel(), which for some reason works without the need to call .decode() on my Gentoo system, but would bail out on Ubuntu with a conversion error, where it believes it should decode from ascii (where umlauts don't fit in 7 bits).

**EDIT**: "Tested with Python 3.5 and 3.6" means runtime-tested with Kodi built from the feature_python3 branch.

### Checklist:
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [script.foo.bar] v1.0.0

