### PR TITLE
[script.myepisodes] 1.2.8: mark as broken

### DIFF
--- a/script.myepisodes/addon.xml
+++ b/script.myepisodes/addon.xml
@@ -18,6 +18,7 @@
     <license>GNU GENERAL PUBLIC LICENSE. Version 2, June 1991</license>
     <source>https://github.com/maximeh/script.myepisodes</source>
     <email>maxime dot hadjinlian at gmail dot com</email>
+    <broken>Not compatible with MyEpisodes anymore. Please update Kodi and this addon</broken>
   </extension>
 </addon>
 


### PR DESCRIPTION
### Description
Mark addon as broken; a new version will be available for Krypton and up.
### Checklist:
- [X] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [X] Each add-on submission should be a single commit with using the following style: [script.foo.bar] v1.0.0