### PR TITLE
[script.myepisodes] 1.2.7: mark as broken

### DIFF
--- a/script.myepisodes/addon.xml
+++ b/script.myepisodes/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="script.myepisodes"
        name="MyEpisodes"
-       version="1.0.15"
+       version="1.2.7"
        provider-name="Maxime Hadjinlian">
   <requires>
     <import addon="xbmc.python" version="2.14.0"/>
@@ -18,6 +18,7 @@
     <license>GNU GENERAL PUBLIC LICENSE. Version 2, June 1991</license>
     <source>https://github.com/maximeh/script.myepisodes</source>
     <email>maxime dot hadjinlian at gmail dot com</email>
+    <broken>Not compatible with MyEpisodes anymore. Please update Kodi and this addon</broken>
   </extension>
 </addon>
 


### PR DESCRIPTION
### Description
The bump is here to avoid marking the addon in Helix as broken too (its
version being 1.2.6; it should be enough)
### Checklist:
- [X] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [X] Each add-on submission should be a single commit with using the following style: [script.foo.bar] v1.0.0