### PR TITLE
[script.artistslideshow] v2.1.3

### DIFF
--- a/script.artistslideshow/addon.xml
+++ b/script.artistslideshow/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.artistslideshow" name="Artist Slideshow" version="2.1.2" provider-name="pkscout,ronie">
+<addon id="script.artistslideshow" name="Artist Slideshow" version="2.1.3" provider-name="pkscout,ronie">
 	<requires>
 		<import addon="xbmc.python" version="2.19.0"/>
 		<import addon="xbmc.addon" version="14.0.0"/>
@@ -11,9 +11,8 @@
 	</extension>
 	<extension point="xbmc.addon.metadata">
 		<news>
-v.2.1.2
+v.2.1.3
 - fix for common library issue with moving a file
-- fix for crash when trying to trim cache folder
 		</news>
 		<summary lang="ar">حمل المزيد من الصور والمعلومات عن الفنان الذى يُغنِى حالياً</summary>
 		<summary lang="be">Download images and additional info of the currently playing artist</summary>

--- a/script.artistslideshow/changelog.txt
+++ b/script.artistslideshow/changelog.txt
@@ -1,3 +1,6 @@
+v.2.1.3
+- fix for common library issue with moving a file
+
 v.2.1.2
 - fix for common library issue with moving a file
 - fix for crash when trying to trim cache folder

--- a/script.artistslideshow/resources/common/fileops.py
+++ b/script.artistslideshow/resources/common/fileops.py
@@ -1,4 +1,4 @@
-# v.0.4.3
+# v.0.4.4
 
 import shutil, time
 try:
@@ -19,14 +19,12 @@ if isXBMC:
     _rmdir  = xbmcvfs.rmdir
     _exists = xbmcvfs.exists
     _delete = xbmcvfs.delete
-    _rename = xbmcvfs.rename
     _copy   = xbmcvfs.copy
 else:
     _mkdirs = os.makedirs
     _rmdir  = os.rmdir
     _exists = os.path.exists
     _delete = os.remove
-    _rename = os.rename
     _copy   = shutil.copyfile
 
 
@@ -95,24 +93,13 @@ def moveFile( src, dst ):
     log_lines = []
     cp_loglines = []
     dl_loglines = []
-    success = True
+    success = False
     if _exists( src ):
-        try:
-            log_lines.append( 'moving %s to %s' % (src, dst) )
-            _rename( src, dst )
-        except IOError:
-            log_lines.append( 'unable to move %s' % src )
-            success = False
-        except Exception as e:
-            log_lines.append( 'unknown error while attempting to move %s' % src )
-            log_lines.append( e )
-            success = False
-        if not success:
-            cp_success, cp_loglines = copyFile( src, dst )
-            if cp_success:
-                dl_success, dl_loglines = deleteFile( src )
-                if dl_success:
-                    success = True
+        cp_success, cp_loglines = copyFile( src, dst )
+        if cp_success:
+            dl_success, dl_loglines = deleteFile( src )
+            if dl_success:
+                success = True
     else:
         log_lines.append( '%s does not exist' % src)
         success = False

--- a/script.artistslideshow/resources/common/transforms.py
+++ b/script.artistslideshow/resources/common/transforms.py
@@ -1,4 +1,4 @@
-#v.0.3.0
+#v.0.3.1
 
 import imghdr, os, re
 try:
@@ -10,15 +10,28 @@ except:
 
 def itemHash(item):
     if isXBMC:
-        return xbmc.getCacheThumbName(item).replace('.tbn', '')
+        try:
+            hash_item = xbmc.getCacheThumbName(item).replace('.tbn', '')
+        except TypeError:
+            hash_item = ''  
     else:
-        return hashlib.md5( item.encode() ).hexdigest()
+        try:
+            hash_item = hashlib.md5( item.encode() ).hexdigest()
+        except TypeError:
+            hash_item = ''  
+    return hash_item
     
 def itemHashwithPath(item, thepath):
     if isXBMC:
-        thumb = xbmc.getCacheThumbName(item).replace('.tbn', '')
+        try:
+            thumb = xbmc.getCacheThumbName(item).replace('.tbn', '')
+        except TypeError:
+            return ''  
     else:
-        thumb = hashlib.md5( item.encode() ).hexdigest()
+        try:
+            thumb = hashlib.md5( item.encode() ).hexdigest()
+        except TypeError:
+            return ''  
     thumbpath = os.path.join( thepath, thumb.encode( 'utf-8' ) )
     return thumbpath
     


### PR DESCRIPTION
### Description
fix for issue when moving downloaded image files to an NFS share
fix for crash if the argument for the hash routine is not a string

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x ] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x ] Each add-on submission should be a single commit with using the following style: [script.foo.bar] v1.0.0

Additional information :
- Submitting your add-on to this specific branch makes it available to any Kodi version equal or higher than the branch name with the applicable Kodi dependencies limits.
- [add-on development](http://kodi.wiki/view/Add-on_development) wiki page.
- Kodi [pydocs](http://kodi.wiki/view/PyDocs) provide information about the Python API
- [PEP8](https://www.python.org/dev/peps/pep-0008/) codingstyle which is considered best practise but not mandatory.
- This add-on repository has automated code guideline check which could help you improve your coding. You can find the results of these check at [Codacy](https://www.codacy.com/app/Kodi/repo-scripts/dashboard). You can create your own account as well to continuously monitor your python coding before submitting to repo.
- Development questions can be asked in the [add-on development](http://forum.kodi.tv/forumdisplay.php?fid=26) section on the Kodi forum.
