### PR TITLE
[context.artwork.downloader.auto] 1.0.1-broken

### DIFF
--- a/context.artwork.downloader.auto/addon.xml
+++ b/context.artwork.downloader.auto/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="context.artwork.downloader.auto" name="Download All Artwork - Artwork Downloader" version="1.0.1" provider-name="rmrector">
+<addon id="context.artwork.downloader.auto" name="Download All Artwork - Artwork Downloader" version="1.0.2" provider-name="rmrector">
 	<requires>
 		<import addon="xbmc.python" version="2.20.0" />
 		<import addon="script.artwork.downloader" version="12.0.29" />


### PR DESCRIPTION
### Description
Version bump. I went with 1.0.1-broken because newer versions do exist in my dev repo to work with Artwork Beef.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [X] Each add-on submission should be a single commit with using the following style: [script.foo.bar] v1.0.0

Additional information :
- Submitting your add-on to this specific branch makes it available to any Kodi version equal or higher than the branch name with the applicable Kodi dependencies limits.
- [add-on development](http://kodi.wiki/view/Add-on_development) wiki page.
- Kodi [pydocs](http://kodi.wiki/view/PyDocs) provide information about the Python API
- [PEP8](https://www.python.org/dev/peps/pep-0008/) codingstyle which is considered best practise but not mandatory.
- This add-on repository has automated code guideline check which could help you improve your coding. You can find the results of these check at [Codacy](https://www.codacy.com/app/Kodi/repo-scripts/dashboard). You can create your own account as well to continuously monitor your python coding before submitting to repo.
- Development questions can be asked in the [add-on development](http://forum.kodi.tv/forumdisplay.php?fid=26) section on the Kodi forum.
