### PR TITLE
[service.subsmangler] 1.2.0

### DIFF
--- a/service.subsmangler/README.md
+++ b/service.subsmangler/README.md
@@ -14,5 +14,6 @@ It allows:
 - support subtitles input formats: microDVD, SubRip, MPL2 and TMP
 - allows to filter subtitle contents based on various Regular Expression type criteria, which gives ability to remove unwanted texts, such as Hearing Impaired tags, advertisements, credits, etc.
 - allows to increase subtitle display time to match at least minimum calculated time based on subtitle text length, taking into account start time of the next subtitle line
+- allows to shrink subtitle display time to avoid overlapping the next subtitle line
 
 3) detecting if video was removed from local storage and removing any related subtitle files

--- a/service.subsmangler/addon.xml
+++ b/service.subsmangler/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="service.subsmangler" name="Subtitles Mangler" version="1.1.0" provider-name="bkiziuk">
+<addon id="service.subsmangler" name="Subtitles Mangler" version="1.2.0" provider-name="bkiziuk">
     <requires>
         <import addon="xbmc.python" version="2.25.0"/>
     </requires>
@@ -31,7 +31,10 @@
         <disclaimer lang="hu_HU">Egy teljeskörű felirat asszisztens</disclaimer>
         <disclaimer lang="pl_PL">Wszechstronny asystent napisów</disclaimer>
         <disclaimer lang="sk_SK">Kompletný sprievodca titukly</disclaimer>
-        <news>v1.1.0 (2018-10-27)
+        <news>v1.2.0 (2019-01-18)
+- add configuration option to prevent showing confirmation dialog if no subtitles file was downloaded
+- add ability to shrink subtitle time if it overlaps the next subtitle
+v1.1.0 (2018-10-27)
 - implement context menu for easier management of 'noautosubs' file/extension
 - change default logging destination to separate log file
 - decrease housekeeping timer only if player is idle

--- a/service.subsmangler/changelog.txt
+++ b/service.subsmangler/changelog.txt
@@ -1,3 +1,6 @@
+v1.2.0 (2019-01-18)
+- add configuration option to prevent showing confirmation dialog if no subtitles file was downloaded
+- add ability to shrink subtitle time if it overlaps the next subtitle
 v1.1.0 (2018-10-27)
 - implement context menu for easier management of 'noautosubs' file/extension
 - change default logging destination to separate log file

--- a/service.subsmangler/resources/language/resource.language.cs_cz/strings.po
+++ b/service.subsmangler/resources/language/resource.language.cs_cz/strings.po
@@ -53,8 +53,12 @@ msgid "Include subtitles already found on disk"
 msgstr "Obsahuje titulky již nalezené na disku"
 
 msgctxt "#32013"
-msgid "Don't invoke dialog if local unprocessed subs are found"
+msgid "Don't invoke search dialog if local unprocessed subs are found"
 msgstr "Nevyvolat dialog pokud jsou nalezené nezpracované titulky"
+
+msgctxt "#32014"
+msgid "Don't invoke confirmation dialog if downloaded subs are not found"
+msgstr "Nevyvolávat dialog potvrzení pokud nejsou nalezeny stáhnuté titulky"
 
 msgctxt "#32020"
 msgid "Logging level"
@@ -106,7 +110,7 @@ msgstr "Samostatný soubor logů(smangler.log)"
 
 msgctxt "#32033"
 msgid "Show 'noautosubs' context menu item"
-msgstr ""
+msgstr "Ukázat 'noautosubs' context menu"
 
 msgctxt "#32040"
 msgid "No new subtitles file has been detected."
@@ -203,6 +207,10 @@ msgstr "Konverze"
 msgctxt "#32081"
 msgid "Adjust subtitle display time"
 msgstr "Nastavit čas zobrazení tituklů"
+
+msgctxt "#32082"
+msgid "Shrink overlapping subtitle time"
+msgstr "Zmenšit přerývající se čas titulků"
 
 msgctxt "#32090"
 msgid "Scanning for subtitle files"

--- a/service.subsmangler/resources/language/resource.language.de_de/strings.po
+++ b/service.subsmangler/resources/language/resource.language.de_de/strings.po
@@ -53,8 +53,12 @@ msgid "Include subtitles already found on disk"
 msgstr "füge Untertitel hinzu, welche bereits auf der Festplatte vorhanden sind"
 
 msgctxt "#32013"
-msgid "Don't invoke dialog if local unprocessed subs are found"
+msgid "Don't invoke search dialog if local unprocessed subs are found"
 msgstr "das Suchfenster nicht anzeigen, wenn lokale unverarbeitete Untertitel vorhanden sind"
+
+msgctxt "#32014"
+msgid "Don't invoke confirmation dialog if downloaded subs are not found"
+msgstr "Wenn keine heruntergeladenen Untertitel gefunden werden rufe keinen Bestätigungsdialog auf"
 
 msgctxt "#32020"
 msgid "Logging level"
@@ -106,7 +110,7 @@ msgstr "eine separate Protokolldatei (smangler.log)"
 
 msgctxt "#32033"
 msgid "Show 'noautosubs' context menu item"
-msgstr ""
+msgstr "Anzeigen von 'noautosubs" im Kontextmenü"
 
 msgctxt "#32040"
 msgid "No new subtitles file has been detected."
@@ -204,6 +208,10 @@ msgctxt "#32081"
 msgid "Adjust subtitle display time"
 msgstr "Anpassung der Anzeigezeit der Untertitel"
 
+msgctxt "#32082"
+msgid "Shrink overlapping subtitle time"
+msgstr "Verkürzen der überlappenden Untertitelzeit"
+
 msgctxt "#32090"
 msgid "Scanning for subtitle files"
 msgstr "Nach Untertiteldateien suchen"
@@ -246,4 +254,4 @@ msgstr "'noautosubs' Datei IST AKTIV fuer Ordner:"
 
 msgctxt "#32108"
 msgid "'noautosubs' file IS CLEARED for folder:"
-msgstr "'noautosubs' Datei IST GELOESCHT fuer Ordner:""
+msgstr "'noautosubs' Datei IST GELOESCHT fuer Ordner:"

--- a/service.subsmangler/resources/language/resource.language.en_gb/strings.po
+++ b/service.subsmangler/resources/language/resource.language.en_gb/strings.po
@@ -53,7 +53,11 @@ msgid "Include subtitles already found on disk"
 msgstr ""
 
 msgctxt "#32013"
-msgid "Don't invoke dialog if local unprocessed subs are found"
+msgid "Don't invoke search dialog if local unprocessed subs are found"
+msgstr ""
+
+msgctxt "#32014"
+msgid "Don't invoke confirmation dialog if downloaded subs are not found"
 msgstr ""
 
 msgctxt "#32020"
@@ -203,6 +207,10 @@ msgstr ""
 msgctxt "#32081"
 msgid "Adjust subtitle display time"
 msgstr ""
+
+msgctxt "#32082"
+msgid "Shrink overlapping subtitle time"
+msgstr  ""
 
 msgctxt "#32090"
 msgid "Scanning for subtitle files"

--- a/service.subsmangler/resources/language/resource.language.hu_hu/strings.po
+++ b/service.subsmangler/resources/language/resource.language.hu_hu/strings.po
@@ -53,8 +53,12 @@ msgid "Include subtitles already found on disk"
 msgstr "Csatolt felirat található a lemezen"
 
 msgctxt "#32013"
-msgid "Don't invoke dialog if local unprocessed subs are found"
+msgid "Don't invoke search dialog if local unprocessed subs are found"
 msgstr "Ne indítsa a folyamatot ha helyi nem feldolgozott feliratot talált"
+
+msgctxt "#32014"
+msgid "Don't invoke confirmation dialog if downloaded subs are not found"
+msgstr "Ne hozza fel a megerõsítõ ablakot, ha a letöltött felirat fájlok nem találhatóak"
 
 msgctxt "#32020"
 msgid "Logging level"
@@ -106,7 +110,7 @@ msgstr "Egyedi lg fájl (smangler.log)"
 
 msgctxt "#32033"
 msgid "Show 'noautosubs' context menu item"
-msgstr ""
+msgstr "Mutassa a 'noautosubs' menü tartalmat"
 
 msgctxt "#32040"
 msgid "No new subtitles file has been detected."
@@ -203,6 +207,10 @@ msgstr "Konvertálás"
 msgctxt "#32081"
 msgid "Adjust subtitle display time"
 msgstr "Javítsa a felirat megjelenítési időt"
+
+msgctxt "#32082"
+msgid "Shrink overlapping subtitle time"
+msgstr "Felirat átfedési idõ csökkentése"
 
 msgctxt "#32090"
 msgid "Scanning for subtitle files"

--- a/service.subsmangler/resources/language/resource.language.pl_pl/strings.po
+++ b/service.subsmangler/resources/language/resource.language.pl_pl/strings.po
@@ -53,8 +53,12 @@ msgid "Include subtitles already found on disk"
 msgstr "Konwertuj napisy już istniejące na dysku"
 
 msgctxt "#32013"
-msgid "Don't invoke dialog if local unprocessed subs are found"
+msgid "Don't invoke search dialog if local unprocessed subs are found"
 msgstr "Nie pokazuj okna wyszukiwania jeśli istnieją lokalne nieprzetworzone napisy"
+
+msgctxt "#32014"
+msgid "Don't invoke confirmation dialog if downloaded subs are not found"
+msgstr "Nie pokazuj okna potwierdzenia jeśli nie znaleziono pobranych napisów"
 
 msgctxt "#32020"
 msgid "Logging level"
@@ -203,6 +207,10 @@ msgstr "Konwersja"
 msgctxt "#32081"
 msgid "Adjust subtitle display time"
 msgstr "Koryguj czas wyświetlania napisów"
+
+msgctxt "#32082"
+msgid "Shrink overlapping subtitle time"
+msgstr "Skracaj czas napisów zachodzących na siebie"
 
 msgctxt "#32090"
 msgid "Scanning for subtitle files"

--- a/service.subsmangler/resources/language/resource.language.sk_sk/strings.po
+++ b/service.subsmangler/resources/language/resource.language.sk_sk/strings.po
@@ -53,8 +53,12 @@ msgid "Include subtitles already found on disk"
 msgstr "Obsahuje titulky už nájdené na disku"
 
 msgctxt "#32013"
-msgid "Don't invoke dialog if local unprocessed subs are found"
+msgid "Don't invoke search dialog if local unprocessed subs are found"
 msgstr "Nevyvolať dialóg ak sú nájdené nespracované titulky"
+
+msgctxt "#32014"
+msgid "Don't invoke confirmation dialog if downloaded subs are not found"
+msgstr "Nevyvolávať dialóg potvrdenie pokiaľ nie sú nájdené stiahnuté titulky"
 
 msgctxt "#32020"
 msgid "Logging level"
@@ -106,7 +110,7 @@ msgstr "Samostatný súbor logov (smangler.log)"
 
 msgctxt "#32033"
 msgid "Show 'noautosubs' context menu item"
-msgstr ""
+msgstr "Ukázať 'noautosubs' context menu"
 
 msgctxt "#32040"
 msgid "No new subtitles file has been detected."
@@ -203,6 +207,10 @@ msgstr "Konverzia"
 msgctxt "#32081"
 msgid "Adjust subtitle display time"
 msgstr "Nastaviť čas zobrazenia tituklů"
+
+msgctxt "#32082"
+msgid "Shrink overlapping subtitle time"
+msgstr "Zmenšiť přerývající sa čas titulkov"
 
 msgctxt "#32090"
 msgid "Scanning for subtitle files"

--- a/service.subsmangler/resources/lib/common.py
+++ b/service.subsmangler/resources/lib/common.py
@@ -112,6 +112,7 @@ def GetSettings():
     global setting_PauseOnConversion
     global setting_AutoInvokeSubsDialog
     global setting_NoAutoInvokeIfLocalUnprocSubsFound
+    global setting_NoConfirmationInvokeIfDownloadedSubsNotFound
     global setting_AutoUpdateDef
     global setting_SeparateLogFile
     global setting_AutoRemoveOldSubs
@@ -120,9 +121,11 @@ def GetSettings():
     global setting_RemoveUnprocessedSubs
     global setting_SimulateRemovalOnly
     global setting_AdjustSubDisplayTime
+    global setting_FixOverlappingSubDisplayTime
 
     setting_AutoInvokeSubsDialog = GetBool(__addon__.getSetting("AutoInvokeSubsDialog"))
     setting_NoAutoInvokeIfLocalUnprocSubsFound = GetBool(__addon__.getSetting("NoAutoInvokeIfLocalUnprocSubsFound"))
+    setting_NoConfirmationInvokeIfDownloadedSubsNotFound = GetBool(__addon__.getSetting("NoConfirmationInvokeIfDownloadedSubsNotFound"))
     setting_ShowNoautosubsContextItem = GetBool(__addon__.getSetting("ShowNoautosubsContextItem"))
     setting_ConversionServiceEnabled = GetBool(__addon__.getSetting("ConversionServiceEnabled"))
     setting_AlsoConvertExistingSubtitles = GetBool(__addon__.getSetting("AlsoConvertExistingSubtitles"))
@@ -134,6 +137,7 @@ def GetSettings():
     setting_RemoveCCmarks = GetBool(__addon__.getSetting("RemoveCCmarks"))
     setting_RemoveAds = GetBool(__addon__.getSetting("RemoveAdds"))
     setting_AdjustSubDisplayTime = GetBool(__addon__.getSetting("AdjustSubDisplayTime"))
+    setting_FixOverlappingSubDisplayTime = GetBool(__addon__.getSetting("FixOverlappingSubDisplayTime"))
     setting_PauseOnConversion = GetBool(__addon__.getSetting("PauseOnConversion"))
     setting_BackupOldSubs = GetBool(__addon__.getSetting("BackupOldSubs"))
     setting_AutoRemoveOldSubs = GetBool(__addon__.getSetting("AutoRemoveOldSubs"))
@@ -145,28 +149,30 @@ def GetSettings():
     setting_SeparateLogFile = int(__addon__.getSetting("SeparateLogFile"))
 
     Log("Reading settings.", xbmc.LOGINFO)
-    Log("Setting:       AutoInvokeSubsDialog = " + str(setting_AutoInvokeSubsDialog), xbmc.LOGINFO)
-    Log(" NoAutoInvokeIfLocalUnprocSubsFound = " + str(setting_NoAutoInvokeIfLocalUnprocSubsFound), xbmc.LOGINFO)
-    Log("          ShowNoautosubsContextItem = " + str(setting_ShowNoautosubsContextItem), xbmc.LOGINFO)
-    Log("           ConversionServiceEnabled = " + str(setting_ConversionServiceEnabled), xbmc.LOGINFO)
-    Log("       AlsoConvertExistingSubtitles = " + str(setting_AlsoConvertExistingSubtitles), xbmc.LOGINFO)
-    Log("                       SubsFontSize = " + str(setting_SubsFontSize), xbmc.LOGINFO)
-    Log("                    ForegroundColor = " + str(setting_ForegroundColor), xbmc.LOGINFO)
-    Log("                    BackgroundColor = " + str(setting_BackgroundColor), xbmc.LOGINFO)
-    Log("             BackgroundTransparency = " + str(setting_BackgroundTransparency), xbmc.LOGINFO)
-    Log("          MaintainBiggerLineSpacing = " + str(setting_MaintainBiggerLineSpacing), xbmc.LOGINFO)
-    Log("                      RemoveCCmarks = " + str(setting_RemoveCCmarks), xbmc.LOGINFO)
-    Log("                          RemoveAds = " + str(setting_RemoveAds), xbmc.LOGINFO)
-    Log("               AdjustSubDisplayTime = " + str(setting_AdjustSubDisplayTime), xbmc.LOGINFO)
-    Log("                  PauseOnConversion = " + str(setting_PauseOnConversion), xbmc.LOGINFO)
-    Log("                      BackupOldSubs = " + str(setting_BackupOldSubs), xbmc.LOGINFO)
-    Log("                  AutoRemoveOldSubs = " + str(setting_AutoRemoveOldSubs), xbmc.LOGINFO)
-    Log("                   RemoveSubsBackup = " + str(setting_RemoveSubsBackup), xbmc.LOGINFO)
-    Log("              RemoveUnprocessedSubs = " + str(setting_RemoveUnprocessedSubs), xbmc.LOGINFO)
-    Log("                SimulateRemovalOnly = " + str(setting_SimulateRemovalOnly), xbmc.LOGINFO)
-    Log("                      AutoUpdateDef = " + str(setting_AutoUpdateDef), xbmc.LOGINFO)
-    Log("                           LogLevel = " + str(setting_LogLevel), xbmc.LOGINFO)
-    Log("                    SeparateLogFile = " + str(setting_SeparateLogFile), xbmc.LOGINFO)
+    Log("Setting:                 AutoInvokeSubsDialog = " + str(setting_AutoInvokeSubsDialog), xbmc.LOGINFO)
+    Log("           NoAutoInvokeIfLocalUnprocSubsFound = " + str(setting_NoAutoInvokeIfLocalUnprocSubsFound), xbmc.LOGINFO)
+    Log(" NoConfirmationInvokeIfDownloadedSubsNotFound = " + str(setting_NoConfirmationInvokeIfDownloadedSubsNotFound), xbmc.LOGINFO)
+    Log("                    ShowNoautosubsContextItem = " + str(setting_ShowNoautosubsContextItem), xbmc.LOGINFO)
+    Log("                     ConversionServiceEnabled = " + str(setting_ConversionServiceEnabled), xbmc.LOGINFO)
+    Log("                 AlsoConvertExistingSubtitles = " + str(setting_AlsoConvertExistingSubtitles), xbmc.LOGINFO)
+    Log("                                 SubsFontSize = " + str(setting_SubsFontSize), xbmc.LOGINFO)
+    Log("                              ForegroundColor = " + str(setting_ForegroundColor), xbmc.LOGINFO)
+    Log("                              BackgroundColor = " + str(setting_BackgroundColor), xbmc.LOGINFO)
+    Log("                       BackgroundTransparency = " + str(setting_BackgroundTransparency), xbmc.LOGINFO)
+    Log("                    MaintainBiggerLineSpacing = " + str(setting_MaintainBiggerLineSpacing), xbmc.LOGINFO)
+    Log("                                RemoveCCmarks = " + str(setting_RemoveCCmarks), xbmc.LOGINFO)
+    Log("                                    RemoveAds = " + str(setting_RemoveAds), xbmc.LOGINFO)
+    Log("                         AdjustSubDisplayTime = " + str(setting_AdjustSubDisplayTime), xbmc.LOGINFO)
+    Log("                 FixOverlappingSubDisplayTime = " + str(setting_FixOverlappingSubDisplayTime), xbmc.LOGINFO)
+    Log("                            PauseOnConversion = " + str(setting_PauseOnConversion), xbmc.LOGINFO)
+    Log("                                BackupOldSubs = " + str(setting_BackupOldSubs), xbmc.LOGINFO)
+    Log("                            AutoRemoveOldSubs = " + str(setting_AutoRemoveOldSubs), xbmc.LOGINFO)
+    Log("                             RemoveSubsBackup = " + str(setting_RemoveSubsBackup), xbmc.LOGINFO)
+    Log("                        RemoveUnprocessedSubs = " + str(setting_RemoveUnprocessedSubs), xbmc.LOGINFO)
+    Log("                          SimulateRemovalOnly = " + str(setting_SimulateRemovalOnly), xbmc.LOGINFO)
+    Log("                                AutoUpdateDef = " + str(setting_AutoUpdateDef), xbmc.LOGINFO)
+    Log("                                     LogLevel = " + str(setting_LogLevel), xbmc.LOGINFO)
+    Log("                              SeparateLogFile = " + str(setting_SeparateLogFile), xbmc.LOGINFO)
 
     # set setting value into the skin
     if setting_ShowNoautosubsContextItem:

--- a/service.subsmangler/resources/lib/smangler.py
+++ b/service.subsmangler/resources/lib/smangler.py
@@ -897,8 +897,8 @@ def MangleSubtitles(originalinputfile):
                 # 500 ms for line + 67 ms per each character (15 chars per second)
                 minCalcLength = 500 + (len(subsline) * 67)
 
-                common.Log("    Min. calculated length: " + str(minCalcLength) + " ms", xbmc.LOGDEBUG)
                 common.Log("    Actual length: " + str(line.duration) + " ms", xbmc.LOGDEBUG)
+                common.Log("    Min. calculated length: " + str(minCalcLength) + " ms", xbmc.LOGDEBUG)
 
                 # check next subtitle start time and compare it to this subtitle end time
                 ## https://stackoverflow.com/questions/1011938/python-previous-and-next-values-inside-a-loop
@@ -909,29 +909,34 @@ def MangleSubtitles(originalinputfile):
                     nextlineclearance = nextlinestart - line.end
                     common.Log("    Clearance to next sub: " + str(nextlineclearance) + " ms", xbmc.LOGDEBUG)
 
-                if minCalcLength > line.duration:
-                    # calculate amount of time to increase visibility of subtitle to reach minimum time
-                    expectedincrease = minCalcLength - line.duration
+                    if nextlineclearance < 2:
+                        if common.setting_FixOverlappingSubDisplayTime:
+                            line.duration = line.duration + nextlineclearance - 2
+                            common.Log("    Time subtracted from subtitle duration: " + str(2 - nextlineclearance) + " ms", xbmc.LOGDEBUG)
 
-                    # find amount of time to safely increase subtitle display length
-                    if nextlinestart != 0:
-                        # calculate time increase that will satisfy expectedincrease but still does not overlap next subtitle
-                        # maintain a gap of at least 2ms
-                        timetoincrease = min(nextlineclearance, expectedincrease) - 2
-                    else:
-                        # for the last subtitle, there is no limitation of next subtitle start time, so increase to minimum calculated time
-                        timetoincrease = expectedincrease
+                    elif minCalcLength > line.duration:
+                        # calculate amount of time to increase visibility of subtitle to reach minimum time
+                        expectedincrease = minCalcLength - line.duration
 
-                    # check if line.duration is positive as negative line.duration will raise ValueError in pysubs2 library
-                    if line.duration < 0:
-                        line.duration = 0
-                    # timetoincrease should be positive as well
-                    if timetoincrease < 0:
-                        timetoincrease = 0
+                        # find amount of time to safely increase subtitle display length
+                        if nextlinestart != 0:
+                            # calculate time increase that will satisfy expectedincrease but still does not overlap next subtitle
+                            # maintain a gap of at least 2ms
+                            timetoincrease = min(nextlineclearance, expectedincrease) - 2
+                        else:
+                            # for the last subtitle, there is no limitation of next subtitle start time, so increase to minimum calculated time
+                            timetoincrease = expectedincrease
 
-                    # modify subtitle object
-                    line.duration = line.duration + timetoincrease
-                    common.Log("    Time added to subtitle duration: " + str(timetoincrease) + " ms", xbmc.LOGDEBUG)
+                        # check if line.duration is positive as negative line.duration will raise ValueError in pysubs2 library
+                        if line.duration < 0:
+                            line.duration = 0
+                        # timetoincrease should be positive as well
+                        if timetoincrease < 0:
+                            timetoincrease = 0
+
+                        # modify subtitle object
+                        line.duration = line.duration + timetoincrease
+                        common.Log("    Time added to subtitle duration: " + str(timetoincrease) + " ms", xbmc.LOGDEBUG)
 
                 # remember start time of subtitle
                 nextlinestart = line.start
@@ -1311,29 +1316,33 @@ def DetectNewSubs():
 
     # check if subtitles search window was opened but there were no new subtitles processed
     if SubsSearchWasOpened:
-        common.Log("Subtitles search window was opened but no new subtitles were detected. Opening YesNo dialog.", xbmc.LOGINFO)
+        if not common.setting_NoConfirmationInvokeIfDownloadedSubsNotFound:
+            common.Log("Subtitles search window was opened but no new subtitles were detected. Opening YesNo dialog.", xbmc.LOGINFO)
 
-        # pause playbcak
-        PlaybackPause()
+            # pause playbcak
+            PlaybackPause()
 
-        # display YesNo dialog
-        # http://mirrors.xbmc.org/docs/python-docs/13.0-gotham/xbmcgui.html#Dialog-yesno
-        YesNoDialog = xbmcgui.Dialog().yesno("Subtitles Mangler", common.__addonlang__(32040).encode('utf-8'), line2=common.__addonlang__(32041).encode('utf-8'), nolabel=common.__addonlang__(32042).encode('utf-8'), yeslabel=common.__addonlang__(32043).encode('utf-8'))
-        if YesNoDialog:
-            # user does not want the subtitle search dialog to appear again for this file
-            common.Log("Answer is Yes. Setting .noautosubs extension flag for file: " + playingFilenamePath.encode('utf-8'), xbmc.LOGINFO)
+            # display YesNo dialog
+            # http://mirrors.xbmc.org/docs/python-docs/13.0-gotham/xbmcgui.html#Dialog-yesno
+            YesNoDialog = xbmcgui.Dialog().yesno("Subtitles Mangler", common.__addonlang__(32040).encode('utf-8'), line2=common.__addonlang__(32041).encode('utf-8'), nolabel=common.__addonlang__(32042).encode('utf-8'), yeslabel=common.__addonlang__(32043).encode('utf-8'))
+            if YesNoDialog:
+                # user does not want the subtitle search dialog to appear again for this file
+                common.Log("Answer is Yes. Setting .noautosubs extension flag for file: " + playingFilenamePath.encode('utf-8'), xbmc.LOGINFO)
 
-            # set '.noautosubs' extension for file being played
-            filebase, fileext = os.path.splitext(playingFilenamePath)
-            # create .noautosubs file
-            common.CreateNoAutoSubsFile(filebase + ".noautosubs")
+                # set '.noautosubs' extension for file being played
+                filebase, fileext = os.path.splitext(playingFilenamePath)
+                # create .noautosubs file
+                common.CreateNoAutoSubsFile(filebase + ".noautosubs")
+
+            else:
+                # user wants the dialog to appear again next time the video is played
+                common.Log("Answer is No. Doing nothing.", xbmc.LOGINFO)
+
+            # resume playback
+            PlaybackResume()
 
         else:
-            # user wants the dialog to appear again next time the video is played
-            common.Log("Answer is No. Doing nothing.", xbmc.LOGINFO)
-
-        # resume playback
-        PlaybackResume()
+            common.Log("Subtitles search window was opened and no new subtitles were detected, but configuration prevents YesNo dialog from opening.", xbmc.LOGINFO)
 
         # clear the flag to prevent opening dialog on next call of DetectNewSubs()
         SubsSearchWasOpened = False

--- a/service.subsmangler/resources/settings.xml
+++ b/service.subsmangler/resources/settings.xml
@@ -3,6 +3,7 @@
     <category label="32001">
       <setting id="AutoInvokeSubsDialog" type="bool" label="32010" default="true"/>
       <setting id="NoAutoInvokeIfLocalUnprocSubsFound" type="bool" label="32013" default="true" subsetting="true" enable="eq(-1,true)"/>
+      <setting id="NoConfirmationInvokeIfDownloadedSubsNotFound" type="bool" label="32014" default="false" subsetting="true" enable="eq(-1,true)"/>
       <setting type="sep"/>
       <setting id="LogLevel" type="select" label="32020" lvalues="32022|32023|32024|32025|32026|32027|32028|32029" default="2"/>
       <setting id="SeparateLogFile" type="enum" label="32030" lvalues="32031|32032" default="1"/>
@@ -22,10 +23,11 @@
       <setting id="RemoveCCmarks" type="bool" label="32004" default="true" enable="eq(-9,true)"/>
       <setting id="RemoveAdds" type="bool" label="32005" default="true" enable="eq(-10,true)"/>
       <setting id="AdjustSubDisplayTime" type="bool" label="32081" default="true" enable="eq(-11,true)"/>
-      <setting id="PauseOnConversion" type="bool" label="32011" default="true" enable="eq(-12,true)"/>
-      <setting id="BackupOldSubs" type="bool" label="32071" default="true" enable="eq(-13,true)"/>
+      <setting id="FixOverlappingSubDisplayTime" type="bool" label="32082" default="false" subsetting="true" enable="eq(-1,true)"/>
+      <setting id="PauseOnConversion" type="bool" label="32011" default="true" enable="eq(-13,true)"/>
+      <setting id="BackupOldSubs" type="bool" label="32071" default="true" enable="eq(-14,true)"/>
       <setting type="sep"/>
-      <setting id="AutoUpdateDef" type="bool" label="32006" default="true" enable="eq(-15,true)"/>
+      <setting id="AutoUpdateDef" type="bool" label="32006" default="true" enable="eq(-16,true)"/>
     </category>
     <category label="32048">
       <setting id="AutoRemoveOldSubs" type="bool" label="32070" default="true"/>


### PR DESCRIPTION
### Description
v1.2.0 (2019-01-18)
- add configuration option to prevent showing confirmation dialog if no subtitles file was downloaded
- add ability to shrink subtitle time if it overlaps the next subtitle

### Checklist:
- [X] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [X] Each add-on submission should be a single commit with using the following style: [script.foo.bar] v1.0.0