### PR TITLE
[service.subsmangler] 1.3.0

### DIFF
--- a/service.subsmangler/README.md
+++ b/service.subsmangler/README.md
@@ -11,9 +11,14 @@ It allows:
 
 2) detecting if subtitle file was downloaded locally and perform conversion
 - gives ability to customize subtitle font color (foreground) and its background color and transparency, which makes subtitles more easy to read
-- support subtitles input formats: microDVD, SubRip, MPL2 and TMP
+- support subtitle input formats: microDVD, SubRip, MPL2, Substation Alpha and TMP
 - allows to filter subtitle contents based on various Regular Expression type criteria, which gives ability to remove unwanted texts, such as Hearing Impaired tags, advertisements, credits, etc.
 - allows to increase subtitle display time to match at least minimum calculated time based on subtitle text length, taking into account start time of the next subtitle line
 - allows to shrink subtitle display time to avoid overlapping the next subtitle line
 
 3) detecting if video was removed from local storage and removing any related subtitle files
+
+
+Note:
+- As Kodi 18 (Leia) introduced native support for adding solid background to displayed subtitles and also because Substation Alpha type subtitles are scaled to fit within the bottom of the movie image (not the bottom of the physical screen), an option was added to allow subtitle conversion (filtering contents, correcting duration) without changing it to Substation Alpha format. In this case file is saved in SubRip format.
+- Beginning with version 1.3.0 the file extension of subtitle output file was changed to .utf (instead of previous .ass) in order to distinguish converted subtitles from original ones. Substation Alpha format (.ass) is now supported as input format.

--- a/service.subsmangler/addon.xml
+++ b/service.subsmangler/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="service.subsmangler" name="Subtitles Mangler" version="1.2.0" provider-name="bkiziuk">
+<addon id="service.subsmangler" name="Subtitles Mangler" version="1.3.0" provider-name="bkiziuk">
     <requires>
         <import addon="xbmc.python" version="2.25.0"/>
     </requires>
@@ -31,7 +31,10 @@
         <disclaimer lang="hu_HU">Egy teljeskörű felirat asszisztens</disclaimer>
         <disclaimer lang="pl_PL">Wszechstronny asystent napisów</disclaimer>
         <disclaimer lang="sk_SK">Kompletný sprievodca titukly</disclaimer>
-        <news>v1.2.0 (2019-01-18)
+        <news>v1.3.0 (2019-02-10)
+- add ability to convert subtitles without enforcing .ass format (and therefore adding custom font/background color and opacity). In this case file is saved in SubRip format.
+- please note that the output file extension was changed to .utf. Therefore existing .ass subtitle file may be reconverted automatically at the next playback.
+v1.2.0 (2019-01-18)
 - add configuration option to prevent showing confirmation dialog if no subtitles file was downloaded
 - add ability to shrink subtitle time if it overlaps the next subtitle
 v1.1.0 (2018-10-27)

--- a/service.subsmangler/changelog.txt
+++ b/service.subsmangler/changelog.txt
@@ -1,3 +1,6 @@
+v1.3.0 (2019-02-10)
+- add ability to convert subtitles without enforcing .ass format (and therefore adding custom font/background color and opacity). In this case file is saved in SubRip format.
+- please note that the output file extension was changed to .utf. Therefore existing .ass subtitle file may be reconverted automatically at the next playback.
 v1.2.0 (2019-01-18)
 - add configuration option to prevent showing confirmation dialog if no subtitles file was downloaded
 - add ability to shrink subtitle time if it overlaps the next subtitle

--- a/service.subsmangler/resources/language/resource.language.cs_cz/strings.po
+++ b/service.subsmangler/resources/language/resource.language.cs_cz/strings.po
@@ -60,6 +60,18 @@ msgctxt "#32014"
 msgid "Don't invoke confirmation dialog if downloaded subs are not found"
 msgstr "Nevyvolávat dialog potvrzení pokud nejsou nalezeny stáhnuté titulky"
 
+msgctxt "#32015"
+msgid "Subtitle output format"
+msgstr "Formát výstupu titulků"
+
+msgctxt "#32016"
+msgid "Substation Alpha"
+msgstr "Substation Alpha"
+
+msgctxt "#32017"
+msgid "SubRip"
+msgstr "SubRip"
+
 msgctxt "#32020"
 msgid "Logging level"
 msgstr "Úroveň logů"

--- a/service.subsmangler/resources/language/resource.language.de_de/strings.po
+++ b/service.subsmangler/resources/language/resource.language.de_de/strings.po
@@ -60,6 +60,18 @@ msgctxt "#32014"
 msgid "Don't invoke confirmation dialog if downloaded subs are not found"
 msgstr "Wenn keine heruntergeladenen Untertitel gefunden werden rufe keinen Bestätigungsdialog auf"
 
+msgctxt "#32015"
+msgid "Subtitle output format"
+msgstr "Ausgabeformat für Untertitel"
+
+msgctxt "#32016"
+msgid "Substation Alpha"
+msgstr "Substation Alpha"
+
+msgctxt "#32017"
+msgid "SubRip"
+msgstr "SubRip"
+
 msgctxt "#32020"
 msgid "Logging level"
 msgstr "Protokollierungsstufe"

--- a/service.subsmangler/resources/language/resource.language.en_gb/strings.po
+++ b/service.subsmangler/resources/language/resource.language.en_gb/strings.po
@@ -60,6 +60,18 @@ msgctxt "#32014"
 msgid "Don't invoke confirmation dialog if downloaded subs are not found"
 msgstr ""
 
+msgctxt "#32015"
+msgid "Subtitle output format"
+msgstr ""
+
+msgctxt "#32016"
+msgid "Substation Alpha"
+msgstr ""
+
+msgctxt "#32017"
+msgid "SubRip"
+msgstr ""
+
 msgctxt "#32020"
 msgid "Logging level"
 msgstr ""

--- a/service.subsmangler/resources/language/resource.language.hu_hu/strings.po
+++ b/service.subsmangler/resources/language/resource.language.hu_hu/strings.po
@@ -60,6 +60,18 @@ msgctxt "#32014"
 msgid "Don't invoke confirmation dialog if downloaded subs are not found"
 msgstr "Ne hozza fel a megerõsítõ ablakot, ha a letöltött felirat fájlok nem találhatóak"
 
+msgctxt "#32015"
+msgid "Subtitle output format"
+msgstr "Felirat kimeneti formátum"
+
+msgctxt "#32016"
+msgid "Substation Alpha"
+msgstr "Substation Alpha"
+
+msgctxt "#32017"
+msgid "SubRip"
+msgstr "SubRip"
+
 msgctxt "#32020"
 msgid "Logging level"
 msgstr "Logolási szint"

--- a/service.subsmangler/resources/language/resource.language.pl_pl/strings.po
+++ b/service.subsmangler/resources/language/resource.language.pl_pl/strings.po
@@ -60,6 +60,18 @@ msgctxt "#32014"
 msgid "Don't invoke confirmation dialog if downloaded subs are not found"
 msgstr "Nie pokazuj okna potwierdzenia jeśli nie znaleziono pobranych napisów"
 
+msgctxt "#32015"
+msgid "Subtitle output format"
+msgstr "Wyjściowy format napisów"
+
+msgctxt "#32016"
+msgid "Substation Alpha"
+msgstr "Substation Alpha"
+
+msgctxt "#32017"
+msgid "SubRip"
+msgstr "SubRip"
+
 msgctxt "#32020"
 msgid "Logging level"
 msgstr "Poziom logowania zdarzeń"

--- a/service.subsmangler/resources/language/resource.language.sk_sk/strings.po
+++ b/service.subsmangler/resources/language/resource.language.sk_sk/strings.po
@@ -60,6 +60,18 @@ msgctxt "#32014"
 msgid "Don't invoke confirmation dialog if downloaded subs are not found"
 msgstr "Nevyvolávať dialóg potvrdenie pokiaľ nie sú nájdené stiahnuté titulky"
 
+msgctxt "#32015"
+msgid "Subtitle output format"
+msgstr "Formát výstupu titulkov"
+
+msgctxt "#32016"
+msgid "Substation Alpha"
+msgstr "Substation Alpha"
+
+msgctxt "#32017"
+msgid "SubRip"
+msgstr "SubRip"
+
 msgctxt "#32020"
 msgid "Logging level"
 msgstr "Úroveň logů"

--- a/service.subsmangler/resources/lib/common.py
+++ b/service.subsmangler/resources/lib/common.py
@@ -102,6 +102,7 @@ def GetSettings():
 
     global setting_ConversionServiceEnabled
     global setting_AlsoConvertExistingSubtitles
+    global setting_SubsOutputFormat
     global setting_SubsFontSize
     global setting_ForegroundColor
     global setting_BackgroundColor
@@ -129,6 +130,7 @@ def GetSettings():
     setting_ShowNoautosubsContextItem = GetBool(__addon__.getSetting("ShowNoautosubsContextItem"))
     setting_ConversionServiceEnabled = GetBool(__addon__.getSetting("ConversionServiceEnabled"))
     setting_AlsoConvertExistingSubtitles = GetBool(__addon__.getSetting("AlsoConvertExistingSubtitles"))
+    setting_SubsOutputFormat = int(__addon__.getSetting("SubsOutputFormat"))
     setting_SubsFontSize = int(__addon__.getSetting("SubsFontSize"))
     setting_ForegroundColor = int(__addon__.getSetting("ForegroundColor"))
     setting_BackgroundColor = int(__addon__.getSetting("BackgroundColor"))
@@ -155,6 +157,7 @@ def GetSettings():
     Log("                    ShowNoautosubsContextItem = " + str(setting_ShowNoautosubsContextItem), xbmc.LOGINFO)
     Log("                     ConversionServiceEnabled = " + str(setting_ConversionServiceEnabled), xbmc.LOGINFO)
     Log("                 AlsoConvertExistingSubtitles = " + str(setting_AlsoConvertExistingSubtitles), xbmc.LOGINFO)
+    Log("                             SubsOutputFormat = " + str(setting_SubsOutputFormat), xbmc.LOGINFO)
     Log("                                 SubsFontSize = " + str(setting_SubsFontSize), xbmc.LOGINFO)
     Log("                              ForegroundColor = " + str(setting_ForegroundColor), xbmc.LOGINFO)
     Log("                              BackgroundColor = " + str(setting_BackgroundColor), xbmc.LOGINFO)
@@ -212,7 +215,7 @@ def CreateNoAutoSubsFile(file):
     # create .noautosubs file
     try:
         f = xbmcvfs.File (file, 'w')
-        result = f.write("# This file was created by Subtitles Mangler.\n# Presence of this file prevents automatical opening of subtitles search dialog.")
+        _result = f.write("# This file was created by Subtitles Mangler.\n# Presence of this file prevents automatical opening of subtitles search dialog.")
         f.close()
     except Exception as e:
         Log("Can not create noautosubs file.", xbmc.LOGERROR)

--- a/service.subsmangler/resources/lib/contextmenu.py
+++ b/service.subsmangler/resources/lib/contextmenu.py
@@ -61,7 +61,7 @@ def main():
         else:
             common.Log("'noautosubs' file does not exist in: " + filepath.encode('utf-8'), xbmc.LOGDEBUG)
             # check if .noautosubs extension exists
-            filebase, fileext = os.path.splitext(filepathname)
+            filebase, _fileext = os.path.splitext(filepathname)
             if (xbmcvfs.exists(filebase + ".noautosubs")):
                 # extension flag is set for this file
                 common.Log("'.noautosubs' file exists: " + filebase.encode('utf-8') + ".noautosubs   Opening YesNoDialog.", xbmc.LOGDEBUG)

--- a/service.subsmangler/resources/lib/smangler.py
+++ b/service.subsmangler/resources/lib/smangler.py
@@ -153,9 +153,9 @@ def PreparePlugin():
 
     # list of input file extensions
     # extensions in lowercase with leading dot
-    # note: we do not include output extension .ass
+    # note: we do not include output extension .utf
     global SubExtList
-    SubExtList = [ '.txt', '.srt', '.sub', '.subrip', '.microdvd', '.mpl', '.tmp' ]
+    SubExtList = [ '.txt', '.srt', '.sub', '.subrip', '.microdvd', '.mpl', '.tmp', '.ass' ]
 
     # list of video file extensions
     # extensions in lowercase with leading dot
@@ -192,7 +192,7 @@ def PreparePlugin():
             xbmc.log("SubsMangler: profile directory created: " + common.__addonworkdir__.encode('utf-8'), level=xbmc.LOGNOTICE)
         except OSError as e:
             xbmc.log("SubsMangler: Log: can't create directory: " + common.__addonworkdir__.encode('utf-8'), level=xbmc.LOGERROR)
-            xbmc.Log("Exception: " + str(e.message).encode('utf-8'), xbmc.LOGERROR)
+            xbmc.log("Exception: " + str(e.message).encode('utf-8'), xbmc.LOGERROR)
 
     # load settings
     common.GetSettings()
@@ -324,7 +324,7 @@ def GetSubtitles():
         common.Log("Kodi's preferred audio language: " + prefaudiolanguage, xbmc.LOGINFO)
         common.Log("Kodi's preferred subtitles language: " + prefsubtitlelanguage, xbmc.LOGINFO)
 
-        # check if there is .ass subtitle file already on disk matching video being played
+        # check if there is .utf subtitle file already on disk matching video being played
         # if not, automatically open subtitlesearch dialog
         #
         # set initial value for SubsSearchWasOpened flag
@@ -336,13 +336,13 @@ def GetSubtitles():
             extlist = list()
 
             if common.setting_NoAutoInvokeIfLocalUnprocSubsFound:
-                # optionally search for all subtitle extensions, not only '.ass'
+                # optionally search for all subtitle extensions, not only '.utf'
                 # assignment operator just makes an alias for the list
                 # https://stackoverflow.com/questions/2612802/how-to-clone-or-copy-a-list
                 extlist = list(SubExtList)
 
-            # search for target extension '.ass'
-            extlist.append('.ass')
+            # search for target extension '.utf'
+            extlist.append('.utf')
 
             # get all file names matching name of file being played
             localsubs = GetSubtitleFiles(subtitlePath, extlist)
@@ -386,17 +386,17 @@ def GetSubtitles():
                     else:
                         common.Log("Video or subtitle language match Kodi's preferred settings. Not opening subtitle search dialog.", xbmc.LOGINFO)
                 else:
-                    # enable .ass subtitles if they are present on the list
+                    # enable .utf subtitles if they are present on the list
                     asssubs = False
                     for item in localsubs:
-                        if ".ass" in item[-4:]:
-                            common.Log("Local 'ass' subtitles matching video being played detected. Enabling subtitles: " + os.path.join(subtitlePath, item), xbmc.LOGINFO)
+                        if ".utf" in item[-4:]:
+                            common.Log("Local 'utf' subtitles matching video being played detected. Enabling subtitles: " + os.path.join(subtitlePath, item), xbmc.LOGINFO)
                             xbmc.Player().setSubtitles(os.path.join(subtitlePath, item))
                             asssubs = True
                             break
 
                     if not asssubs:
-                        common.Log("Local non 'ass' subtitles matching video being played detected. Not opening subtitle search dialog.", xbmc.LOGINFO)
+                        common.Log("Local non 'utf' subtitles matching video being played detected. Not opening subtitle search dialog.", xbmc.LOGINFO)
             else:
                 common.Log("'noautosubs' file or extension detected. Not opening subtitle search dialog.", xbmc.LOGINFO)
         else:
@@ -592,9 +592,9 @@ def MangleSubtitles(originalinputfile):
 
     # get subtitles language by splitting it from filename
     # split file and extension
-    subfilebase, subfileext = os.path.splitext(originalinputfile)
+    subfilebase, _subfileext = os.path.splitext(originalinputfile)
     # from filename split language designation
-    subfilecore, subfilelang = os.path.splitext(subfilebase)
+    _subfilecore, subfilelang = os.path.splitext(subfilebase)
 
     common.Log("Read subtitle language designation: " + subfilelang[1:],xbmc.LOGINFO)
     # try to find ISO639-2 designation
@@ -606,7 +606,7 @@ def MangleSubtitles(originalinputfile):
     # construct input_file name
     tempinputfile = os.path.join(common.__addonworkdir__, tempfile + "_in.txt")
     # construct output_file name
-    tempoutputfile = os.path.join(common.__addonworkdir__, tempfile + "_out.ass")
+    tempoutputfile = os.path.join(common.__addonworkdir__, tempfile + "_out.utf")
     # copy file to temp
     copy_file(originalinputfile, tempinputfile)
 
@@ -661,7 +661,7 @@ def MangleSubtitles(originalinputfile):
     enc = ""
     try:
         with codecs.open(tempinputfile, mode="rb", encoding='utf-8') as reader:
-            temp = reader.read()
+            _temp = reader.read()
             # still no exception - seems to be a success
             common.Log("UTF-8 encoding seems to be valid.", xbmc.LOGINFO)
             enc = "utf-8"
@@ -681,7 +681,7 @@ def MangleSubtitles(originalinputfile):
             # try to read file using language specific encoding
             try:
                 with codecs.open(tempinputfile, mode="rb", encoding=enc) as reader:
-                    temp = reader.read()
+                    _temp = reader.read()
                     # still no exception - seems to be a success
                     common.Log("Chosen encoding: " + enc + " based on language: " + subslang + " seems to be valid.", xbmc.LOGINFO)
             except Exception as e:
@@ -702,7 +702,7 @@ def MangleSubtitles(originalinputfile):
         for enc in encodings:
             try:
                 with codecs.open(tempinputfile, mode="rb", encoding=enc) as reader:
-                    temp = reader.read()
+                    _temp = reader.read()
                     break
             except Exception as e:
                 # no encoding fits the file
@@ -882,9 +882,10 @@ def MangleSubtitles(originalinputfile):
         else:
             # increase line spacing if subtitle is multiline
             # use Max Deryagin's solution: https://www.md-subs.com/line-spacing-in-ssa
+            # do it only if subtitle output format is Substation Alpha (setting_SubsOutputFormat == 0)
             # FIXME - currently only 2-line is supported
             # check if subtitle is multiline
-            if common.setting_MaintainBiggerLineSpacing and re.search(r"\N", subsline):
+            if common.setting_MaintainBiggerLineSpacing and re.search(r"\N", subsline) and common.setting_SubsOutputFormat == 0:
                 # line is multiline - add tags
                 subsline = r"{\org(-2000000,0)\fr0.00012}" + subsline
                 subsline = subsline.replace(r"\N", r"{\r}\N")
@@ -947,8 +948,12 @@ def MangleSubtitles(originalinputfile):
 
     common.Log("Filtering lists applied.", xbmc.LOGINFO)
 
-    #save subs
-    subs.save(tempoutputfile)
+    # save subs in a proper format
+    if common.setting_SubsOutputFormat == 0:
+        outfileformat = "ass"
+    else:
+        outfileformat = "srt"
+    subs.save(tempoutputfile, format_= outfileformat)
 
     # wait until file is saved
     wait_for_file(tempoutputfile, True)
@@ -968,8 +973,8 @@ def MangleSubtitles(originalinputfile):
         common.Log("Exception: " + str(e.message), xbmc.LOGERROR)
 
     # copy new file back to its original location changing only its extension
-    filebase, fileext = os.path.splitext(originalinputfile)
-    originaloutputfile = filebase + '.ass'
+    filebase, _fileext = os.path.splitext(originalinputfile)
+    originaloutputfile = filebase + '.utf'
     copy_file(tempoutputfile, originaloutputfile)
 
     # make a backup copy of subtitle file or remove file
@@ -1153,17 +1158,17 @@ def GetSubtitleFiles(subspath, substypelist):
 
     # use dictionary solution - load all files in directory to dictionary and remove those not fulfiling criteria
     # Python doesn't support smb:// paths. Use xbmcvfs: https://forum.kodi.tv/showthread.php?tid=211821
-    dirs, files = xbmcvfs.listdir(subtitlePath)
+    _dirs, files = xbmcvfs.listdir(subtitlePath)
     SubsFiles = dict ([(f, None) for f in files])
     # filter dictionary, leaving only subtitle files matching played video
     # https://stackoverflow.com/questions/5384914/how-to-delete-items-from-a-dictionary-while-iterating-over-it
-    playingFilenameBase, playingFilenameExt = os.path.splitext(playingFilename)
+    playingFilenameBase, _playingFilenameExt = os.path.splitext(playingFilename)
 
     for item in SubsFiles.keys():
         # split file and extension
         subfilebase, subfileext = os.path.splitext(item)
         # from filename split language designation
-        subfilecore, subfilelang = os.path.splitext(subfilebase)
+        subfilecore, _subfilelang = os.path.splitext(subfilebase)
         # remove files that do not meet criteria
         if not ((((subfilebase.lower() == playingFilenameBase.lower() or subfilecore.lower() == playingFilenameBase.lower()) and (subfileext.lower() in substypelist)) \
             or ((subfilebase.lower() == playingFilenameBase.lower()) and (subfileext.lower() == ".noautosubs"))) \
@@ -1172,7 +1177,7 @@ def GetSubtitleFiles(subspath, substypelist):
             # subfilename matches video name AND fileext is on the list of supported extensions
             # OR subfilename matches video name AND fileext matches '.noautosubs'
             # OR subfilename matches 'noautosubs'
-            # FIXME - now we assume that .ass subtitle will not be processed
+            # FIXME - now we assume that .utf subtitle will not be processed
             del SubsFiles[item]
 
     return SubsFiles
@@ -1256,7 +1261,7 @@ def DetectNewSubs():
             common.Log("Clearing temporary files.", xbmc.LOGINFO)
             for item in tempfilelist:
                 filebase, fileext = os.path.splitext(item)
-                if (fileext.lower() in SubExtList) or fileext.lower().endswith(".ass"):
+                if (fileext.lower() in SubExtList) or fileext.lower().endswith(".utf"):
                     os.remove(os.path.join(common.__addonworkdir__, item))
                     common.Log("       File: " + os.path.join(common.__addonworkdir__, item) + "  removed.", xbmc.LOGINFO)
 
@@ -1311,7 +1316,7 @@ def DetectNewSubs():
             SubsSearchWasOpened = False
 
             # sleep for 10 seconds to avoid processing newly added subititle file
-            #this should not be needed since we do not support .ass as input file at the moment
+            #this should not be needed since we do not support .utf as input file at the moment
             #xbmc.sleep(10000)
 
     # check if subtitles search window was opened but there were no new subtitles processed
@@ -1472,7 +1477,7 @@ def RemoveOldSubs():
 
     # construct target list for file candidate extensions to be removed
     # remove processed subs and .noautosubs files
-    extRemovalList = [ '.ass', '.noautosubs' ]
+    extRemovalList = [ '.utf', '.noautosubs' ]
     # remove processed subs backup files
     if common.setting_RemoveSubsBackup:
         for ext in SubExtList:
@@ -1509,7 +1514,7 @@ def RemoveOldSubs():
             # check every file in the current subdir and add it to appropriate list
             for thisfile in files:
                 fullfilepath = os.path.join(directory, thisfile.decode('utf-8'))
-                filebase, fileext = os.path.splitext(fullfilepath)
+                _filebase, fileext = os.path.splitext(fullfilepath)
                 if fileext in VideoExtList:
                     # this file is video - add to video list
                     common.Log("Adding to video list: " + fullfilepath.encode('utf-8'),xbmc.LOGDEBUG)
@@ -1537,7 +1542,7 @@ def RemoveOldSubs():
         dirs, files = xbmcvfs.listdir(subspath)
         for thisfile in files:
             fullfilepath = os.path.join(subspath, thisfile.decode('utf-8'))
-            filebase, fileext = os.path.splitext(fullfilepath)
+            _filebase, fileext = os.path.splitext(fullfilepath)
             if fileext in extRemovalList:
                 # this file is subs related - add to subs list
                 common.Log("Adding to subs list: " + fullfilepath,xbmc.LOGDEBUG)
@@ -1555,9 +1560,9 @@ def RemoveOldSubs():
         # split filename from full path
         subfilename = os.path.basename(subfile)
         # split filename and extension
-        subfilebase, subfileext = os.path.splitext(subfilename)
+        subfilebase, _subfileext = os.path.splitext(subfilename)
         # from filename split language designation
-        subfilecore, subfilelang = os.path.splitext(subfilebase)
+        subfilecore, _subfilelang = os.path.splitext(subfilebase)
 
         # check if there is a video matching subfile
         videoexists = False
@@ -1565,7 +1570,7 @@ def RemoveOldSubs():
             # split filename from full path
             videofilename = os.path.basename(videofile)
             # split filename and extension
-            videofilebase, videofileext = os.path.splitext(videofilename)
+            videofilebase, _videofileext = os.path.splitext(videofilename)
 
             # check if subfile basename or corename equals videofile basename
             if subfilebase.lower() == videofilebase.lower() or subfilecore.lower() == videofilebase.lower():

--- a/service.subsmangler/resources/regexdef.def
+++ b/service.subsmangler/resources/regexdef.def
@@ -54,7 +54,7 @@
 
 
 
-# Language specific Ads secions include language specific definitions.
+# Language specific Ads sections include language specific definitions.
 # Only one section is loaded based on subtitles language designation in subtitles file name
 # Language codes must confirm to ISO 639-2
 [Ads_eng]   # English

--- a/service.subsmangler/resources/settings.xml
+++ b/service.subsmangler/resources/settings.xml
@@ -14,15 +14,16 @@
       <setting id="ConversionServiceEnabled" type="bool" label="32002" default="true"/>
       <setting id="AlsoConvertExistingSubtitles" type="bool" label="32012" default="true" subsetting="true" enable="eq(-1,true)"/>
       <setting type="sep"/>
-      <setting id="SubsFontSize" type="slider" label="32003" default="18" range="10,30" option="int" enable="eq(-3,true)"/>
-      <setting id="ForegroundColor" type="select" label="32049" lvalues="32051|32052|32053|32054|32055|32056|32057|32058|32059" default="8" enable="eq(-4,true)"/>
-      <setting id="BackgroundColor" type="select" label="32050" lvalues="32051|32052|32053|32054|32055|32056|32057|32058|32059" default="0" enable="eq(-5,true)"/>
-      <setting id="BackgroundTransparency" type="slider" label="32007" default="0" range="0,100" option="percent" enable="eq(-6,true)"/>
-      <setting id="MaintainBiggerLineSpacing" type="bool" label="32075" default="false" enable="eq(-7,true)"/>
+      <setting id="SubsOutputFormat" type="select" label="32015" lvalues="32016|32017" default="0" enable="eq(-3,true)"/>
+      <setting id="SubsFontSize" type="slider" label="32003" default="18" range="10,30" option="int" subsetting="true" enable="eq(-1,0)"/>
+      <setting id="ForegroundColor" type="select" label="32049" lvalues="32051|32052|32053|32054|32055|32056|32057|32058|32059" default="8" subsetting="true" enable="eq(-2,0)"/>
+      <setting id="BackgroundColor" type="select" label="32050" lvalues="32051|32052|32053|32054|32055|32056|32057|32058|32059" default="0" subsetting="true" enable="eq(-3,0)"/>
+      <setting id="BackgroundTransparency" type="slider" label="32007" default="0" range="0,100" option="percent" subsetting="true" enable="eq(-4,0)"/>
+      <setting id="MaintainBiggerLineSpacing" type="bool" label="32075" default="false" subsetting="true" enable="eq(-5,0)"/>
       <setting type="sep"/>
-      <setting id="RemoveCCmarks" type="bool" label="32004" default="true" enable="eq(-9,true)"/>
-      <setting id="RemoveAdds" type="bool" label="32005" default="true" enable="eq(-10,true)"/>
-      <setting id="AdjustSubDisplayTime" type="bool" label="32081" default="true" enable="eq(-11,true)"/>
+      <setting id="RemoveCCmarks" type="bool" label="32004" default="true" enable="eq(-10,true)"/>
+      <setting id="RemoveAdds" type="bool" label="32005" default="true" enable="eq(-11,true)"/>
+      <setting id="AdjustSubDisplayTime" type="bool" label="32081" default="true" enable="eq(-12,true)"/>
       <setting id="FixOverlappingSubDisplayTime" type="bool" label="32082" default="false" subsetting="true" enable="eq(-1,true)"/>
       <setting id="PauseOnConversion" type="bool" label="32011" default="true" enable="eq(-13,true)"/>
       <setting id="BackupOldSubs" type="bool" label="32071" default="true" enable="eq(-14,true)"/>


### PR DESCRIPTION
### Description
- add ability to convert subtitles without enforcing .ass format (and therefore adding custom font/background color and opacity). In this case file is saved in SubRip format.

### Checklist:
- [X] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [X] Each add-on submission should be a single commit with using the following style: [script.foo.bar] v1.0.0
