### PR TITLE
[script.myepisodes] 2.0.1

### DIFF
--- a/script.myepisodes/addon.xml
+++ b/script.myepisodes/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="script.myepisodes"
        name="MyEpisodes"
-       version="2.0.0"
+       version="2.0.1"
        provider-name="Maxime Hadjinlian">
   <requires>
     <import addon="xbmc.python" version="2.25.0"/>
@@ -14,8 +14,7 @@
     <description lang="en_GB">Automatically set watched episodes on MyEpisodes.com</description>
     <platform>all</platform>
     <language>en fr it pt es</language>
-    <forum></forum>
-    <website></website>
+    <website>https://www.myepisodes.com</website>
     <license>GNU GENERAL PUBLIC LICENSE. Version 2, June 1991</license>
     <source>https://github.com/maximeh/script.myepisodes</source>
     <email>maxime dot hadjinlian at gmail dot com</email>

--- a/script.myepisodes/changelog.txt
+++ b/script.myepisodes/changelog.txt
@@ -1,3 +1,5 @@
+2.0.1
++ Fix issue with Leia and remote (SMB/NFS) storage
 2.0.0
 + Rework the whole script
 1.2.8


### PR DESCRIPTION
### Description
Update due to some changes introduced in Leia in the hookup of the player playback, it created a bug with remote content media server (SMB/NFS) which introduced an enough latency to trigged the problem (basically, the length of the video was always 0 because the player was ready but not the content).
### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [X] Each add-on submission should be a single commit with using the following style: [script.foo.bar] v1.0.0

Additional information :
- Submitting your add-on to this specific branch makes it available to any Kodi version equal or higher than the branch name with the applicable Kodi dependencies limits.
- [add-on development](http://kodi.wiki/view/Add-on_development) wiki page.
- Kodi [pydocs](http://kodi.wiki/view/PyDocs) provide information about the Python API
- [PEP8](https://www.python.org/dev/peps/pep-0008/) codingstyle which is considered best practise but not mandatory.
- This add-on repository has automated code guideline check which could help you improve your coding. You can find the results of these check at [Codacy](https://www.codacy.com/app/Kodi/repo-scripts/dashboard). You can create your own account as well to continuously monitor your python coding before submitting to repo.
- Development questions can be asked in the [add-on development](http://forum.kodi.tv/forumdisplay.php?fid=26) section on the Kodi forum.
