### PR TITLE
[service.subtitles.rvm.addic7ed] 3.0.4

### DIFF
--- a/service.subtitles.rvm.addic7ed/addon.xml
+++ b/service.subtitles.rvm.addic7ed/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon id="service.subtitles.rvm.addic7ed"
   name="Addic7ed.com"
-  version="3.0.1"
+  version="3.0.4"
   provider-name="Roman V.M.">
 <requires>
   <import addon="xbmc.python" version="2.25.0"/>
@@ -27,8 +27,11 @@
     <icon>icon.png</icon>
     <fanart>fanart.jpg</fanart>
   </assets>
-  <news>v.3.0.1:
-- Fixed potential crash because of NameError exception.</news>
+  <news>v.3.0.4:
+- Synced subs are shown first in the list.
+- Unfinished translations are hidden from users that aren't logged in.
+- Fixed parsing translated episode pages (non-English).
+- Fixed re-synced subtitles marked as "sync".</news>
   <reuselanguageinvoker>false</reuselanguageinvoker>
 </extension>
 </addon>


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: Addic7ed.com
  - Add-on ID: service.subtitles.rvm.addic7ed
  - Version number: 3.0.4
  - Kodi/repository version: krypton

- **Code location**
  - URL: https://https://github.com/romanvm/service.addic7ed
  
Subtitles service for Addic7ed.com. It supports only TV shows.

### Description of changes:

v.3.0.4:
- Synced subs are shown first in the list.
- Unfinished translations are hidden from users that aren't logged in.
- Fixed parsing translated episode pages (non-English).
- Fixed re-synced subtitles marked as "sync".

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
