### PR TITLE
Update PR template for de facto commit name style

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -7,7 +7,7 @@
 <!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
 - [ ] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
 - [ ] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
-- [ ] Each add-on submission should be a single commit with using the following style: [script.foo.bar] v1.0.0
+- [ ] Each add-on submission should be a single commit with using the following style: [script.foo.bar] 1.0.0
 
 Additional information :
 - Submitting your add-on to this specific branch makes it available to any Kodi version equal or higher than the branch name with the applicable Kodi dependencies limits.


### PR DESCRIPTION
### Description

The current/old PR template asks for commits to use “vX.Y.Z” in commits adding add‐ons to the repository, but in actuality the vast majority of commits use “X.Y.Z” without the “v”[1]. This is just a small change to make the template reflect actual usage.

[1]
   https://github.com/xbmc/repo-scripts/commits/leia
   https://github.com/xbmc/repo-scripts/commits/krypton
   etc.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [script.foo.bar] v1.0.0