### PR TITLE
[script.module.codequick] 0.9.9

### DIFF
--- a/script.module.codequick/addon.xml
+++ b/script.module.codequick/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.module.codequick" name="CodeQuick" provider-name="willforde" version="0.9.8">
+<addon id="script.module.codequick" name="CodeQuick" provider-name="willforde" version="0.9.9">
     <requires>
         <import addon="xbmc.python" version="2.25.0"/>
         <import addon="script.module.youtube.dl" version="18.0.0"/>


### PR DESCRIPTION
### Description
Some feature requests
- Allow to disable automatic setting of fanart, thumbnail or icon images.
- Allow for plugin paths as folders in set_callback.
- Allow for a callback path to be passed instead of a function

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [script.foo.bar] v1.0.0