### PR TITLE
[screensaver.kaster] 1.2.7

### DIFF
--- a/screensaver.kaster/addon.xml
+++ b/screensaver.kaster/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="screensaver.kaster" name="Kaster" version="1.2.6" provider-name="enen92">
+<addon id="screensaver.kaster" name="Kaster" version="1.2.7" provider-name="enen92">
 	<requires>
 		<import addon="xbmc.python" version="2.25.0"/>
 		<import addon="script.module.requests"/>
@@ -18,9 +18,9 @@
 		<description lang="pt_PT">Apresenta imagens lindíssimas originalmente pertencentes ao screensaver do chromecast. Pode também apresentar as suas próprias imagens conjuntamente com a respectiva informação.</description>
 		<description lang="es_ES">Muestra bellas imágenes como las del protector de pantalla de chromecast. También puede mostrar sus propias fotos junto con su respectiva información.</description>
 		<description lang="nl_NL">Toon prachtige afbeeldingen afkomstig van de Chromecast screensaver. Je kunt ook je eigen foto's tonen met al hun informatie.</description>
-		<news>v1.2.6
-		  [fix] travis config
-			[new] initial support for python3 compatibility (tks rechi)
+		<news>v1.2.7
+		  [fix] File extensions in uppercase
+			[new] Add aura skin font support
 		</news>
 		<assets>
 			<icon>resources/images/icon.png</icon>

--- a/screensaver.kaster/resources/lib/screensaver.py
+++ b/screensaver.kaster/resources/lib/screensaver.py
@@ -142,6 +142,8 @@ class Kaster(xbmcgui.WindowXMLDialog):
             self.setProperty("clockfont", "fontzephyr")
         elif "eminence" in skin:
             self.setProperty("clockfont", "fonteminence")
+        elif "aura" in skin:
+            self.setProperty("clockfont", "fontaura")
         else:
             self.setProperty("clockfont", "fontmainmenu")
         # Set skin properties as settings

--- a/screensaver.kaster/resources/lib/screensaverutils.py
+++ b/screensaver.kaster/resources/lib/screensaverutils.py
@@ -68,7 +68,7 @@ class ScreenSaverUtils:
         self.__get_images_recursively(xbmc.translatePath(path))
 
         for _file in self.get_all_images():
-            if _file.endswith(('.png', '.jpg', '.jpeg')):
+            if _file.lower().endswith(('.png', '.jpg', '.jpeg')):
                 returned_dict = {
                     "url": _file,
                     "private": True

--- a/screensaver.kaster/resources/skins/default/1080i/screensaver-kaster.xml
+++ b/screensaver.kaster/resources/skins/default/1080i/screensaver-kaster.xml
@@ -114,6 +114,17 @@
                     <label>$INFO[System.Time]</label>
                     <visible>String.IsEqual(Window.Property(clockfont),"fonteminence")+!String.IsEqual(Window.Property(hide-clock-info),"true")</visible>
                 </control>
+                <control type="label">
+                    <description>Time</description>
+                    <align>left</align>
+                    <font>Font-Header</font>
+                    <shadowcolor>22000000</shadowcolor>
+                    <textcolor>whitesmoke</textcolor>
+                    <height>120</height>
+                    <width>auto</width>
+                    <label>$INFO[System.Time]</label>
+                    <visible>String.IsEqual(Window.Property(clockfont),"fontaura")+!String.IsEqual(Window.Property(hide-clock-info),"true")</visible>
+                </control>
             </control>
             <control type="label" id="32503">
                 <description>Line one</description>


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: Kaster
  - Add-on ID: screensaver.kaster
  - Version number: 1.2.7
  - Kodi/repository version: krypton

- **Code location**
  - URL: https://https://github.com/enen92/screensaver.kaster
  
Display beautiful pictures originally from the chromecast screensaver. You can also display your own photos along with its respective information.

### Description of changes:

v1.2.7
		  [fix] File extensions in uppercase
			[new] Add aura skin font support
		

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
