### PR TITLE
[script.video.randomtv] 1.2.1

### DIFF
--- a/script.video.randomtv/README.md
+++ b/script.video.randomtv/README.md
@@ -16,6 +16,8 @@ There are a couple options in the setting menu:
   - Time To Wait For Response (Minutes)
 - Include All TV Shows or Select certain TV Shows
 
+It will also add a context menu item so that you can play a specific show or season with RandomTV
+
 It seems to be working pretty well for me on a couple different Pi's running OSMC and on my Windows UWP installs, so I figured I would release it to see of others could benefit.
 
 Comments/feedback/bug reports welcome, but be gentle, it's my first ever addon.  ;-)

--- a/script.video.randomtv/addon.xml
+++ b/script.video.randomtv/addon.xml
@@ -1,27 +1,49 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.video.randomtv" name="RandomTV" version="1.1.2" provider-name="gmccauley">
+<addon id="script.video.randomtv" name="RandomTV" version="1.2.1" provider-name="gmccauley">
   <requires>
     <import addon="xbmc.python" version="2.25.0"/>
   </requires>
   <extension point="xbmc.python.script" library="addon.py">
     <provides>video</provides>
   </extension>
+  <extension point="kodi.context.item">
+	<menu id="kodi.core.main">
+		<item library="addon.py">
+			<label>32018</label>
+			<visible>String.IsEqual(ListItem.dbtype,tvshow) | String.IsEqual(ListItem.dbtype,season)</visible>
+		</item>
+	</menu>
+  </extension>
   <extension point="xbmc.addon.metadata">
     <summary lang="en_GB">RandomTV</summary>
-    <description lang="en_GB">RandomTV plays random TV episodes from your library. There are a few options: Include unwatched episodes (only watched will be included by default), Update Play Count, Repeat Playlist, Shuffle On Repeat, Show Notifications, Enable Auto Stop, Include All TV Shows or Select TV Shows</description>
+    <description lang="en_GB">
+RandomTV plays random TV episodes from your library.
+There are a few options:
+- Include unwatched episodes (only watched will be included by default)
+- Update Play Count
+- Repeat Playlist
+- Shuffle On Repeat
+- Show Notifications
+- Enable Auto Stop
+- Include All TV Shows or Select TV Shows
+It will also add a context menu item so that you can play a specific show or season with RandomTV
+	</description>
     <disclaimer lang="en_GB">My First Add-On.  Please by gentle</disclaimer>
     <language></language>
     <platform>all</platform>
     <license>GNU General Public License, v2</license>
-    <forum>http://forum.kodi.tv/showthread.php?tid=310494</forum>
-    <website></website>
-    <email></email>
+    <forum>https://forum.kodi.tv/showthread.php?tid=310494</forum>
     <source>https://github.com/gmccauley/script.video.randomtv</source>
     <news>
+v1.2.1 (27 May 2019)
+  - Updated addon.xml
+v1.2.0 (26 May 2019)
+  - Added Context Menu Item to play tv shows or seasons with RandomTV
 v1.1.2 (2 May 2017)
   - Fixed Bugs in AutoStop Feature
   - Fixed Bug where Playlist would be shuffled after each video ended
   - Added Empty Window to prevent Kodi from being displayed between Playlist Shuffles
+  - Code Optimization
 v1.1.0 (28 April 2017)
   - Added Auto Stop Feature
   - Replaced xbmc.sleep with xbmc.Monitor().waitForAbort
@@ -39,14 +61,12 @@ v0.2.1 (29 March 2017)
 v0.2 (26 March 2017)
   - Bummed Code
   - Changed Logic
-  - Set Repeat Mode back to what it was before addon changed it to all
 v0.1 (25 March 2017)
   - Initial Build (Alpha)
 	</news>
     <assets>
         <icon>resources/icon.png</icon>
         <fanart>resources/fanart.jpg</fanart>
-        <screenshot></screenshot>
     </assets>
   </extension>
 </addon>

--- a/script.video.randomtv/resources/language/resource.language.en_gb/strings.po
+++ b/script.video.randomtv/resources/language/resource.language.en_gb/strings.po
@@ -76,3 +76,7 @@ msgstr ""
 msgctxt "#32017"
 msgid "Time To Wait For Response (Minutes)"
 msgstr ""
+
+msgctxt "#32018"
+msgid "Play with RandomTV"
+msgstr ""


### PR DESCRIPTION
### Description
Updated addon to add context menu to allow the ability to play a specific tv show / season with RandomTV

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ X ] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [ X ] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [ X ] Each add-on submission should be a single commit with using the following style: [script.foo.bar] 1.0.0

Additional information :
- Submitting your add-on to this specific branch makes it available to any Kodi version equal or higher than the branch name with the applicable Kodi dependencies limits.
- [add-on development](http://kodi.wiki/view/Add-on_development) wiki page.
- Kodi [pydocs](http://kodi.wiki/view/PyDocs) provide information about the Python API
- [PEP8](https://www.python.org/dev/peps/pep-0008/) codingstyle which is considered best practise but not mandatory.
- This add-on repository has automated code guideline check which could help you improve your coding. You can find the results of these check at [Codacy](https://www.codacy.com/app/Kodi/repo-scripts/dashboard). You can create your own account as well to continuously monitor your python coding before submitting to repo.
- Development questions can be asked in the [add-on development](http://forum.kodi.tv/forumdisplay.php?fid=26) section on the Kodi forum.
