### PR TITLE
[script.module.kodi-six] 0.0.4

### DIFF
--- a/script.module.kodi-six/addon.xml
+++ b/script.module.kodi-six/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="script.module.kodi-six"
        name="Kodi Six"
-       version="0.0.2"
+       version="0.0.4"
        provider-name="Roman V.M.">
   <requires>
     <import addon="xbmc.python" version="2.14.0"/>
@@ -14,6 +14,10 @@
     <license>GPL v.3</license>
     <forum>https://forum.kodi.tv/showthread.php?tid=327883</forum>
     <source>https://github.com/romanvm/kodi.six</source>
-    <news>- Do not patch class __init__ methods</news>
+    <assets>
+      <icon>icon.png</icon>
+    </assets>
+    <news>0.1.0:
+- Implemented lazy patching of Kodi API functions and classes.</news>
   </extension>
 </addon>

--- a/script.module.kodi-six/libs/kodi_six/utils.py
+++ b/script.module.kodi-six/libs/kodi_six/utils.py
@@ -8,7 +8,14 @@ Utility functions for string conversion depending on Python version
 import sys
 import inspect
 
-__all__ = ['PY2', 'py2_encode', 'py2_decode', 'patch_module', 'encode_decode']
+__all__ = [
+    'PY2',
+    'py2_encode',
+    'py2_decode',
+    'encode_decode',
+    'patch_object',
+    'ModuleWrapper',
+]
 
 PY2 = sys.version_info[0] == 2  #: ``True`` for Python 2
 
@@ -49,7 +56,7 @@ def encode_decode(func):
     """
     if PY2:
         def wrapper(*args, **kwargs):
-            mod_args = tuple((py2_encode(item) for item in args))
+            mod_args = tuple(py2_encode(item) for item in args)
             mod_kwargs = {key: py2_encode(value) for key, value
                           in kwargs.iteritems()}
             return py2_decode(func(*mod_args, **mod_kwargs))
@@ -65,23 +72,44 @@ def _wrap_class(cls):
     return ClassWrapper
 
 
-def patch_module(mod):
+def patch_object(obj):
     """
-    Applies :func:`encode_decode` decorator to all
-    functions and classes in a module
+    Applies func:`encode_decode` decorator to an object
 
-    :param mod: module for patching
-    :type mod: types.ModuleType
+    :param obj: object for patching
+    :return: patched object
     """
-    for name, obj in inspect.getmembers(mod):
-        if inspect.isbuiltin(obj):
-            setattr(mod, name, encode_decode(obj))
-        elif inspect.isclass(obj):
-            # We cannot patch methods of Kodi classes directly.
-            cls = _wrap_class(obj)
-            for memb_name, member in inspect.getmembers(cls):
-                # Do not patch special methods!
-                if (inspect.ismethoddescriptor(member) and
-                        not memb_name.endswith('__')):
-                    setattr(cls, memb_name, encode_decode(member))
-            setattr(mod, name, cls)
+    if inspect.isbuiltin(obj):
+        obj = encode_decode(obj)
+    elif inspect.isclass(obj):
+        # We cannot patch methods of Kodi classes directly.
+        obj = _wrap_class(obj)
+        for memb_name, member in inspect.getmembers(obj):
+            # Do not patch special methods!
+            if (inspect.ismethoddescriptor(member) and
+                    not memb_name.endswith('__')):
+                setattr(obj, memb_name, encode_decode(member))
+    return obj
+
+
+class ModuleWrapper(object):
+    """
+    Implements lazy patching of Kodi Python API modules
+
+    This class applies func:`encode_decode` decorator to Kodi API functions
+    and classes on demand when a function or a class is first used.
+    """
+    def __init__(self, base_module):
+        self._base_module = base_module
+
+    def __getattr__(self, item):
+        if not hasattr(self._base_module, item):
+            raise AttributeError(
+                'Module {0} does not have attribute "{1}"!'.format(
+                    self._base_module, item
+                )
+            )
+        obj = getattr(self._base_module, item)
+        obj = patch_object(obj)
+        setattr(self, item, obj)
+        return obj

--- a/script.module.kodi-six/libs/kodi_six/xbmc.py
+++ b/script.module.kodi-six/libs/kodi_six/xbmc.py
@@ -7,8 +7,11 @@ General classes and functions for interacting with Kodi
 
 from __future__ import absolute_import
 import sys as _sys
-from xbmc import *
-from .utils import PY2 as _PY2, patch_module as _patch_module
+from .utils import PY2 as _PY2, ModuleWrapper as _ModuleWrapper
 
 if _PY2:
-    _patch_module(_sys.modules[__name__])
+    import xbmc as _xbmc
+    _wrapped_xbmc = _ModuleWrapper(_xbmc)
+    _sys.modules[__name__] = _wrapped_xbmc
+else:
+    from xbmc import *

--- a/script.module.kodi-six/libs/kodi_six/xbmcaddon.py
+++ b/script.module.kodi-six/libs/kodi_six/xbmcaddon.py
@@ -7,8 +7,11 @@ A class for accessing addon properties
 
 from __future__ import absolute_import
 import sys as _sys
-from xbmcaddon import *
-from .utils import PY2 as _PY2, patch_module as _patch_module
+from .utils import PY2 as _PY2, ModuleWrapper as _ModuleWrapper
 
 if _PY2:
-    _patch_module(_sys.modules[__name__])
+    import xbmcaddon as _xbmcaddon
+    _wrapped_xbmcaddon = _ModuleWrapper(_xbmcaddon)
+    _sys.modules[__name__] = _wrapped_xbmcaddon
+else:
+    from xbmcaddon import *

--- a/script.module.kodi-six/libs/kodi_six/xbmcgui.py
+++ b/script.module.kodi-six/libs/kodi_six/xbmcgui.py
@@ -7,8 +7,11 @@ Classes and functions for interacting with Kodi GUI
 
 from __future__ import absolute_import
 import sys as _sys
-from xbmcgui import *
-from .utils import PY2 as _PY2, patch_module as _patch_module
+from .utils import PY2 as _PY2, ModuleWrapper as _ModuleWrapper
 
 if _PY2:
-    _patch_module(_sys.modules[__name__])
+    import xbmcgui as _xbmcgui
+    _wrapped_xbmcgui = _ModuleWrapper(_xbmcgui)
+    _sys.modules[__name__] = _wrapped_xbmcgui
+else:
+    from xbmcgui import *

--- a/script.module.kodi-six/libs/kodi_six/xbmcplugin.py
+++ b/script.module.kodi-six/libs/kodi_six/xbmcplugin.py
@@ -7,8 +7,11 @@ Functions to create media contents plugins
 
 from __future__ import absolute_import
 import sys as _sys
-from xbmcplugin import *
-from .utils import PY2 as _PY2, patch_module as _patch_module
+from .utils import PY2 as _PY2, ModuleWrapper as _ModuleWrapper
 
 if _PY2:
-    _patch_module(_sys.modules[__name__])
+    import xbmcplugin as _xbmcplugin
+    _wrapped_xbmcplugin = _ModuleWrapper(_xbmcplugin)
+    _sys.modules[__name__] = _wrapped_xbmcplugin
+else:
+    from xbmcplugin import *

--- a/script.module.kodi-six/libs/kodi_six/xbmcvfs.py
+++ b/script.module.kodi-six/libs/kodi_six/xbmcvfs.py
@@ -7,8 +7,11 @@ Functions and classes to work with files and folders
 
 from __future__ import absolute_import
 import sys as _sys
-from xbmcvfs import *
-from .utils import PY2 as _PY2, patch_module as _patch_module
+from .utils import PY2 as _PY2, ModuleWrapper as _ModuleWrapper
 
 if _PY2:
-    _patch_module(_sys.modules[__name__])
+    import xbmcvfs as _xbmcvfs
+    _wrapped_xbmcvfs = _ModuleWrapper(_xbmcvfs)
+    _sys.modules[__name__] = _wrapped_xbmcvfs
+else:
+    from xbmcvfs import *


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: Kodi Six
  - Add-on ID: script.module.kodi-six
  - Version number: 0.0.4
  - Kodi/repository version: gotham

- **Code location**
  - URL: https://https://github.com/romanvm/kodi.six
  
Wrappers around Kodi Python API that normalize handling of textual and byte strings in Python 2 and 3.

### Description of changes:

0.1.0:
- Implemented lazy patching of Kodi API functions and classes.

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
