### PR TITLE
[screensaver.kaster] 1.2.8

### DIFF
--- a/screensaver.kaster/addon.xml
+++ b/screensaver.kaster/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="screensaver.kaster" name="Kaster" version="1.2.7" provider-name="enen92">
+<addon id="screensaver.kaster" name="Kaster" version="1.2.8" provider-name="enen92">
 	<requires>
 		<import addon="xbmc.python" version="2.25.0"/>
 		<import addon="script.module.requests"/>
@@ -14,13 +14,15 @@
 		<summary lang="pt_PT">Um screensaver idêntico ao screensaver original chromecast</summary>
 		<summary lang="es_ES">Un protector de pantalla tipo Chromecast para Kodi</summary>
 		<summary lang="nl_NL">Een Chromecast-achtige screensaver voor Kodi</summary>
+		<summary lang="fr_FR">Un économiseur d'écran comme Chromecast pour Kodi</summary>
 		<description lang="en_GB">Display beautiful pictures originally from the chromecast screensaver. You can also display your own photos along with its respective information.</description>
 		<description lang="pt_PT">Apresenta imagens lindíssimas originalmente pertencentes ao screensaver do chromecast. Pode também apresentar as suas próprias imagens conjuntamente com a respectiva informação.</description>
 		<description lang="es_ES">Muestra bellas imágenes como las del protector de pantalla de chromecast. También puede mostrar sus propias fotos junto con su respectiva información.</description>
 		<description lang="nl_NL">Toon prachtige afbeeldingen afkomstig van de Chromecast screensaver. Je kunt ook je eigen foto's tonen met al hun informatie.</description>
-		<news>v1.2.7
-		  [fix] File extensions in uppercase
-			[new] Add aura skin font support
+		<description lang="fr_FR">Affichez de jolies images provenant de l’écran de veille de Chromecast. Vous pouvez aussi afficher vos propres images avec leurs informations respectives.</description>
+		<news>v1.2.8
+			[new] French translation
+			[new] Support for box skin fonts
 		</news>
 		<assets>
 			<icon>resources/images/icon.png</icon>

--- a/screensaver.kaster/resources/language/resource.language.fr_fr/strings.po
+++ b/screensaver.kaster/resources/language/resource.language.fr_fr/strings.po
@@ -1,0 +1,106 @@
+# Kodi Media Center language file
+# Addon Name: Kaster
+# Addon id: screensaver.kaster
+# Addon Provider: enen92
+msgid ""
+msgstr ""
+"Project-Id-Version: XBMC Addons\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
+"POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: Kodi Translation Team\n"
+"Language-Team: French (http://www.transifex.com/projects/p/xbmc-addons/language/fr/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: fr\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+msgctxt "#32000"
+msgid "Kaster"
+msgstr "Kaster"
+
+msgctxt "#32001"
+msgid "Photo by"
+msgstr "Image de"
+
+msgctxt "#32002"
+msgid "General"
+msgstr "Général"
+
+msgctxt "#32003"
+msgid "Screensaver Mode"
+msgstr "Mode d'économiseur d'écran"
+
+msgctxt "#32004"
+msgid "Only google photos"
+msgstr "Seulement des images de Google"
+
+msgctxt "#32005"
+msgid "Only my photos"
+msgstr "Seulement mes images"
+
+msgctxt "#32006"
+msgid "Google photos + my photos"
+msgstr "Images de Google + mes images"
+
+msgctxt "#32007"
+msgid "Unknown"
+msgstr "Inconnu"
+
+msgctxt "#32008"
+msgid "Wait time before changing image (s)"
+msgstr "Temps avant de changer d'image (s)"
+
+msgctxt "#32009"
+msgid "Folder with pictures"
+msgstr "Dossier avec les images"
+
+msgctxt "#32010"
+msgid "Failed to parse image dictionary"
+msgstr "Échec de l'analyse du dictionnaire d'images"
+
+msgctxt "#32011"
+msgid "Aspect"
+msgstr "Aspect"
+
+msgctxt "#32012"
+msgid "Hide Kodi logo"
+msgstr "Cacher le logo de Kodi"
+
+msgctxt "#32013"
+msgid "Hide weather info"
+msgstr "Cacher les infos météo"
+
+msgctxt "#32014"
+msgid "Hide clock info"
+msgstr "Cacher l'heure"
+
+msgctxt "#32015"
+msgid "Hide picture info"
+msgstr "Cacher les infos de l'image"
+
+msgctxt "#32016"
+msgid "Animations"
+msgstr "Animations"
+
+msgctxt "#32017"
+msgid "Enabled animation"
+msgstr "Activer l'animation"
+
+msgctxt "#32018"
+msgid "Fade"
+msgstr "Fondu"
+
+msgctxt "#32019"
+msgid "Pan and zoom"
+msgstr "Zoom et panoramique"
+
+msgctxt "#32020"
+msgid "Hide dim overlay"
+msgstr "Cacher la superposition sombre"
+
+msgctxt "#32021"
+msgid "Show black background"
+msgstr "Afficher un fond noir"
+

--- a/screensaver.kaster/resources/lib/screensaver.py
+++ b/screensaver.kaster/resources/lib/screensaver.py
@@ -144,6 +144,8 @@ class Kaster(xbmcgui.WindowXMLDialog):
             self.setProperty("clockfont", "fonteminence")
         elif "aura" in skin:
             self.setProperty("clockfont", "fontaura")
+        elif "box" in skin:
+            self.setProperty("clockfont", "box")
         else:
             self.setProperty("clockfont", "fontmainmenu")
         # Set skin properties as settings

--- a/screensaver.kaster/resources/skins/default/1080i/screensaver-kaster.xml
+++ b/screensaver.kaster/resources/skins/default/1080i/screensaver-kaster.xml
@@ -125,6 +125,17 @@
                     <label>$INFO[System.Time]</label>
                     <visible>String.IsEqual(Window.Property(clockfont),"fontaura")+!String.IsEqual(Window.Property(hide-clock-info),"true")</visible>
                 </control>
+                <control type="label">
+                    <description>Time</description>
+                    <align>left</align>
+                    <font>Clock</font>
+                    <shadowcolor>22000000</shadowcolor>
+                    <textcolor>whitesmoke</textcolor>
+                    <height>120</height>
+                    <width>auto</width>
+                    <label>$INFO[System.Time]</label>
+                    <visible>String.IsEqual(Window.Property(clockfont),"box")+!String.IsEqual(Window.Property(hide-clock-info),"true")</visible>
+                </control>
             </control>
             <control type="label" id="32503">
                 <description>Line one</description>


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: Kaster
  - Add-on ID: screensaver.kaster
  - Version number: 1.2.8
  - Kodi/repository version: krypton

- **Code location**
  - URL: https://https://github.com/enen92/screensaver.kaster
  
Display beautiful pictures originally from the chromecast screensaver. You can also display your own photos along with its respective information.

### Description of changes:

v1.2.8
			[new] French translation
			[new] Support for box skin fonts
		

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
