### PR TITLE
[script.module.kodi-six] 0.1.1

### DIFF
--- a/script.module.kodi-six/addon.xml
+++ b/script.module.kodi-six/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="script.module.kodi-six"
        name="Kodi Six"
-       version="0.1.0"
+       version="0.1.1"
        provider-name="Roman V.M.">
   <requires>
     <import addon="xbmc.python" version="2.26.0"/>
@@ -17,7 +17,9 @@
     <assets>
       <icon>icon.png</icon>
     </assets>
-    <news>0.1.0:
+    <news>0.1.1
+- Fixed UnicodeDecodeErrors when Kodi API returns non-UTF-8 byte strings.
+0.1.0:
 - Implemented lazy patching of Kodi API functions and classes.
 0.0.3:
 - Added xbmcdrm module.</news>

--- a/script.module.kodi-six/libs/kodi_six/utils.py
+++ b/script.module.kodi-six/libs/kodi_six/utils.py
@@ -20,25 +20,25 @@ __all__ = [
 PY2 = sys.version_info[0] == 2  #: ``True`` for Python 2
 
 
-def py2_encode(s, encoding='utf-8'):
+def py2_encode(s, encoding='utf-8', errors='strict'):
     """
     Encode Python 2 ``unicode`` to ``str``
 
     In Python 3 the string is not changed.
     """
     if PY2 and isinstance(s, unicode):
-        s = s.encode(encoding)
+        s = s.encode(encoding, errors)
     return s
 
 
-def py2_decode(s, encoding='utf-8'):
+def py2_decode(s, encoding='utf-8', errors='strict'):
     """
     Decode Python 2 ``str`` to ``unicode``
 
     In Python 3 the string is not changed.
     """
     if PY2 and isinstance(s, str):
-        s = s.decode(encoding)
+        s = s.decode(encoding, errors)
     return s
 
 
@@ -59,7 +59,7 @@ def encode_decode(func):
             mod_args = tuple(py2_encode(item) for item in args)
             mod_kwargs = {key: py2_encode(value) for key, value
                           in kwargs.iteritems()}
-            return py2_decode(func(*mod_args, **mod_kwargs))
+            return py2_decode(func(*mod_args, **mod_kwargs), errors='replace')
         wrapper.__name__ = 'wrapped_func_{0}'.format(func.__name__)
         return wrapper
     return func


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: Kodi Six
  - Add-on ID: script.module.kodi-six
  - Version number: 0.1.1
  - Kodi/repository version: leia

- **Code location**
  - URL: https://github.com/romanvm/kodi.six
  
Wrappers around Kodi Python API that normalize handling of textual and byte strings in Python 2 and 3.

### Description of changes:

0.1.1
- Fixed UnicodeDecodeErrors when Kodi API returns non-UTF-8 byte strings.
0.1.0:
- Implemented lazy patching of Kodi API functions and classes.
0.0.3:
- Added xbmcdrm module.

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
