### PR TITLE
[service.linuxwhatelse.notify] 2.2.2

### DIFF
--- a/service.linuxwhatelse.notify/addon.xml
+++ b/service.linuxwhatelse.notify/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="service.linuxwhatelse.notify"
        name="Notify"
-       version="2.2.1"
+       version="2.2.2"
        provider-name="linuxwhatelse">
 
     <requires>

--- a/service.linuxwhatelse.notify/addon/routes/notification.py
+++ b/service.linuxwhatelse.notify/addon/routes/notification.py
@@ -54,7 +54,7 @@ def on_notification_posted(data):
                                  hashlib.md5(small_icon_data).hexdigest())
 
     if not os.path.exists(icon_path):
-        with open(icon_path, 'w') as f:
+        with open(icon_path, 'wb') as f:
             f.write(icon.decode('base64'))
 
     addon = xbmcaddon.Addon()


### PR DESCRIPTION
### Description
<!--- Provide a short summary of submitted add-on in case it's a new addition. -->
<!--- If it's plugin update only highlight biggest changes if needed. -->
<!--- Make sure you follow the checklist below before finalising your pull-request. -->
Bugfix for windows systems where writing images in non-binary format apparently causes corruption
Provided through [this issue](https://github.com/linuxwhatelse/service.linuxwhatelse.notify/issues/2)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [script.foo.bar] 1.0.0

Additional information :
- Submitting your add-on to this specific branch makes it available to any Kodi version equal or higher than the branch name with the applicable Kodi dependencies limits.
- [add-on development](http://kodi.wiki/view/Add-on_development) wiki page.
- Kodi [pydocs](http://kodi.wiki/view/PyDocs) provide information about the Python API
- [PEP8](https://www.python.org/dev/peps/pep-0008/) codingstyle which is considered best practise but not mandatory.
- This add-on repository has automated code guideline check which could help you improve your coding. You can find the results of these check at [Codacy](https://www.codacy.com/app/Kodi/repo-scripts/dashboard). You can create your own account as well to continuously monitor your python coding before submitting to repo.
- Development questions can be asked in the [add-on development](http://forum.kodi.tv/forumdisplay.php?fid=26) section on the Kodi forum.
