### PR TITLE
[screensaver.kaster] 1.3.0

### DIFF
--- a/screensaver.kaster/addon.xml
+++ b/screensaver.kaster/addon.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="screensaver.kaster" name="Kaster" version="1.2.8" provider-name="enen92">
+<addon id="screensaver.kaster" name="Kaster" version="1.3.0" provider-name="enen92">
 	<requires>
 		<import addon="xbmc.python" version="2.25.0"/>
-		<import addon="script.module.requests"/>
+		<import addon="script.module.requests" version="2.22.0"/>
 	</requires>
 	<extension point="xbmc.ui.screensaver" library="entrypoint.py" />
 	<extension point="xbmc.addon.metadata">
@@ -20,9 +20,8 @@
 		<description lang="es_ES">Muestra bellas imágenes como las del protector de pantalla de chromecast. También puede mostrar sus propias fotos junto con su respectiva información.</description>
 		<description lang="nl_NL">Toon prachtige afbeeldingen afkomstig van de Chromecast screensaver. Je kunt ook je eigen foto's tonen met al hun informatie.</description>
 		<description lang="fr_FR">Affichez de jolies images provenant de l’écran de veille de Chromecast. Vous pouvez aussi afficher vos propres images avec leurs informations respectives.</description>
-		<news>v1.2.8
-			[new] French translation
-			[new] Support for box skin fonts
+		<news>v1.3.0
+			[new] Trivial python3 fixes
 		</news>
 		<assets>
 			<icon>resources/images/icon.png</icon>

--- a/screensaver.kaster/resources/lib/kodiutils.py
+++ b/screensaver.kaster/resources/lib/kodiutils.py
@@ -72,7 +72,7 @@ def get_setting_as_int(setting):
         return 0
 
 def get_string(string_id):
-    return ADDON.getLocalizedString(string_id).encode('utf-8', 'ignore')
+    return ADDON.getLocalizedString(string_id)
 
 def kodi_json_request(params):
     data = json.dumps(params)

--- a/screensaver.kaster/resources/lib/screensaver.py
+++ b/screensaver.kaster/resources/lib/screensaver.py
@@ -77,14 +77,14 @@ class Kaster(xbmcgui.WindowXMLDialog):
                         continue
 
                     # photo metadata
-                    if "location" in self.images[rand_index].keys() and "photographer" in self.images[rand_index].keys():
+                    if "location" in list(self.images[rand_index].keys()) and "photographer" in list(self.images[rand_index].keys()):
                         self.metadata_line2.setLabel(self.images[rand_index]["location"])
                         self.metadata_line3.setLabel("%s %s" % (kodiutils.get_string(32001),
                                                                 self.utils.remove_unknown_author(self.images[rand_index]["photographer"])))
-                    elif "location" in self.images[rand_index].keys() and "photographer" not in self.images[rand_index].keys():
+                    elif "location" in list(self.images[rand_index].keys()) and "photographer" not in list(self.images[rand_index].keys()):
                         self.metadata_line2.setLabel(self.images[rand_index]["location"])
                         self.metadata_line3.setLabel("")
-                    elif "location" not in self.images[rand_index].keys() and "photographer" in self.images[rand_index].keys():
+                    elif "location" not in list(self.images[rand_index].keys()) and "photographer" in list(self.images[rand_index].keys()):
                         self.metadata_line2.setLabel("%s %s" % (kodiutils.get_string(32001),
                                                                 self.utils.remove_unknown_author(self.images[rand_index]["photographer"])))
                         self.metadata_line3.setLabel("")
@@ -109,7 +109,7 @@ class Kaster(xbmcgui.WindowXMLDialog):
                 # note: abort requested is only called after kodi kills the entrypoint and we need to return
                 # as soon as possible
                 loop_count = (kodiutils.get_setting_as_int("wait-time-before-changing-image") * 1000) / 200
-                for _ in range(0, loop_count):
+                for _ in range(0, int(loop_count)):
                     if self._isactive and not self.exit_monitor.abortRequested():
                         xbmc.sleep(200)
                 # Check if images dict is empty, if so read the file again

--- a/screensaver.kaster/resources/lib/screensaverutils.py
+++ b/screensaver.kaster/resources/lib/screensaverutils.py
@@ -75,10 +75,10 @@ class ScreenSaverUtils:
                 }
                 if images_dict:
                     for image in images_dict:
-                        if "image" in image.keys() and os.path.join(xbmc.translatePath(path),image["image"]) == _file:
-                            if "line1" in image.keys():
+                        if "image" in list(image.keys()) and os.path.join(xbmc.translatePath(path),image["image"]) == _file:
+                            if "line1" in list(image.keys()):
                                 returned_dict["line1"] = image["line1"]
-                            if "line2" in image.keys():
+                            if "line2" in list(image.keys()):
                                 returned_dict["line2"] = image["line2"]
                 yield returned_dict
 


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: Kaster
  - Add-on ID: screensaver.kaster
  - Version number: 1.3.0
  - Kodi/repository version: krypton

- **Code location**
  - URL: 
  
Display beautiful pictures originally from the chromecast screensaver. You can also display your own photos along with its respective information.

### Description of changes:

v1.3.0
			[new] Trivial python3 fixes
		

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
