### PR TITLE
[script.module.pyxbmct] 1.3.1

### DIFF
--- a/script.module.pyxbmct/addon.xml
+++ b/script.module.pyxbmct/addon.xml
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="script.module.pyxbmct"
    name="PyXBMCt"
-   version="1.3.0"
+   version="1.3.1"
    provider-name="Roman V.M.">
   <requires>
-    <import addon="xbmc.python" version="2.25.0"/>
-    <import addon="script.module.future" />
+    <import addon="xbmc.python" version="2.26.0"/>
+    <import addon="script.module.six" />
     <import addon="script.module.kodi-six" />
   </requires>
   <extension point="xbmc.python.module" library="lib" />
@@ -14,10 +14,15 @@
     <summary lang="en_GB">PyXBMCt UI framework</summary>
     <description lang="en_GB">PyXBMCt is a mini-framework for simple XBMC addon UI buliding. It is similar to PyQt and provides parent windows, a number of UI controls (widgets) and a grid layout manager to place controls.</description>
     <license>GNU GPL v.3</license>
-    <forum>http://forum.xbmc.org/showthread.php?tid=174859</forum>
+    <forum>https://forum.kodi.tv/showthread.php?tid=174859</forum>
     <website>http://romanvm.github.io/script.module.pyxbmct/</website>
     <email>roman1972@gmail.com</email>
     <source>https://github.com/romanvm/script.module.pyxbmct</source>
-    <news>Added compatibility with Python 3</news>
+    <news>1.3.1:
+- Fix incompatibility with newer Python 3 Kodi builds
+- Replace future library with six for Python 3 compatibility</news>
+    <assets>
+      <icon>icon.png</icon>
+    </assets>
   </extension>  
 </addon>

--- a/script.module.pyxbmct/lib/pyxbmct/addonskin.py
+++ b/script.module.pyxbmct/lib/pyxbmct/addonskin.py
@@ -6,9 +6,9 @@
 """Classes for defining the appearance of PyXBMCt Windows and Controls"""
 
 from __future__ import unicode_literals
-from future.utils import with_metaclass
 import os
 from abc import ABCMeta, abstractmethod
+from six import with_metaclass
 import xbmc
 from xbmcaddon import Addon
 

--- a/script.module.pyxbmct/lib/pyxbmct/addonwindow.py
+++ b/script.module.pyxbmct/lib/pyxbmct/addonwindow.py
@@ -11,8 +11,8 @@ This module contains all classes and constants of PyXBMCt framework
 """
 
 from __future__ import absolute_import, division, unicode_literals
-from future.builtins import range
 import os
+from six.moves import range
 from kodi_six import xbmc, xbmcgui
 from .addonskin import Skin
 
@@ -842,7 +842,7 @@ class DialogWindowMixin(xbmcgui.WindowDialog):
             self._executeConnected(control, self.controls_connected)
 
 
-class BlankFullWindow(FullWindowMixin, AbstractWindow):
+class BlankFullWindow(AbstractWindow, FullWindowMixin):
     """
     BlankFullWindow()
 
@@ -855,7 +855,7 @@ class BlankFullWindow(FullWindowMixin, AbstractWindow):
     pass
 
 
-class BlankDialogWindow(DialogWindowMixin, AbstractWindow):
+class BlankDialogWindow(AbstractWindow, DialogWindowMixin):
     """
     BlankDialogWindow()
 
@@ -868,7 +868,7 @@ class BlankDialogWindow(DialogWindowMixin, AbstractWindow):
     pass
 
 
-class AddonFullWindow(FullWindowMixin, AddonWindow):
+class AddonFullWindow(AddonWindow, FullWindowMixin):
 
     """
     AddonFullWindow(title='')
@@ -912,7 +912,7 @@ class AddonFullWindow(FullWindowMixin, AddonWindow):
         self.main_bg.setImage(image)
 
 
-class AddonDialogWindow(DialogWindowMixin, AddonWindow):
+class AddonDialogWindow(AddonWindow, DialogWindowMixin):
     """
     AddonDialogWindow(title='')
 


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: PyXBMCt
  - Add-on ID: script.module.pyxbmct
  - Version number: 1.3.1
  - Kodi/repository version: leia

- **Code location**
  - URL: https://github.com/romanvm/script.module.pyxbmct
  
PyXBMCt is a mini-framework for simple XBMC addon UI buliding. It is similar to PyQt and provides parent windows, a number of UI controls (widgets) and a grid layout manager to place controls.

### Description of changes:

1.3.1:
- Fix incompatibility with newer Python 3 Kodi builds
- Replace future library with six for Python 3 compatibility

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
