### PR TITLE
[script.module.kodi-six] 0.1.3

### DIFF
--- a/script.module.kodi-six/addon.xml
+++ b/script.module.kodi-six/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="script.module.kodi-six"
        name="Kodi Six"
-       version="0.1.2"
+       version="0.1.3"
        provider-name="Roman V.M.">
   <requires>
     <import addon="xbmc.python" version="2.26.0"/>
@@ -17,13 +17,7 @@
     <assets>
       <icon>icon.png</icon>
     </assets>
-    <news>0.1.2:
-- Use different method for Unicode error handling.
-0.1.1:
-- Fixed UnicodeDecodeErrors when Kodi API returns non-UTF-8 byte strings.
-0.1.0:
-- Implemented lazy patching of Kodi API functions and classes.
-0.0.3:
-- Added xbmcdrm module.</news>
+    <news>0.1.3:
+- Fix non-UTF-8 byte string decoding in Python 2.</news>
   </extension>
 </addon>

--- a/script.module.kodi-six/libs/kodi_six/utils.py
+++ b/script.module.kodi-six/libs/kodi_six/utils.py
@@ -60,7 +60,7 @@ def encode_decode(func):
             mod_kwargs = {key: py2_encode(value) for key, value
                           in kwargs.iteritems()}
             return py2_decode(func(*mod_args, **mod_kwargs),
-                              errors='surrogateescape')
+                              errors='replace')
         wrapper.__name__ = 'wrapped_func_{0}'.format(func.__name__)
         return wrapper
     return func


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: Kodi Six
  - Add-on ID: script.module.kodi-six
  - Version number: 0.1.3
  - Kodi/repository version: leia

- **Code location**
  - URL: https://github.com/romanvm/kodi.six
  
Wrappers around Kodi Python API that normalize handling of textual and byte strings in Python 2 and 3.

### Description of changes:

0.1.3:
- Fix non-UTF-8 byte string decoding in Python 2.

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
