### PR TITLE
[script.module.kodi-six] 0.0.7

### DIFF
--- a/script.module.kodi-six/addon.xml
+++ b/script.module.kodi-six/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="script.module.kodi-six"
        name="Kodi Six"
-       version="0.0.5"
+       version="0.0.7"
        provider-name="Roman V.M.">
   <requires>
     <import addon="xbmc.python" version="2.14.0"/>
@@ -17,9 +17,10 @@
     <assets>
       <icon>icon.png</icon>
     </assets>
-    <news>0.0.5:
-- Fixed Unicode decode errors when Kodi API returns non-UTF-8 byte strings.
-0.0.4:
-- Implemented lazy patching of Kodi API functions and classes.</news>
+    <news>0.0.7:
+- Use dict function instead of dictionary comprehension for compatibility with Python 2.6.
+0.0.6:
+- Replace surrogateescape error handler with replace.
+- </news>
   </extension>
 </addon>

--- a/script.module.kodi-six/libs/kodi_six/utils.py
+++ b/script.module.kodi-six/libs/kodi_six/utils.py
@@ -57,10 +57,10 @@ def encode_decode(func):
     if PY2:
         def wrapper(*args, **kwargs):
             mod_args = tuple(py2_encode(item) for item in args)
-            mod_kwargs = {key: py2_encode(value) for key, value
-                          in kwargs.iteritems()}
+            mod_kwargs = dict((key, py2_encode(value))
+                              for key, value in kwargs.iteritems())
             return py2_decode(func(*mod_args, **mod_kwargs),
-                              errors='surrogateescape')
+                              errors='replace')
         wrapper.__name__ = 'wrapped_func_{0}'.format(func.__name__)
         return wrapper
     return func


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: Kodi Six
  - Add-on ID: script.module.kodi-six
  - Version number: 0.0.7
  - Kodi/repository version: gotham

- **Code location**
  - URL: https://github.com/romanvm/kodi.six
  
Wrappers around Kodi Python API that normalize handling of textual and byte strings in Python 2 and 3.

### Description of changes:

0.0.7:
- Use dict function instead of dictionary comprehension for compatibility with Python 2.6.
0.0.6:
- Replace surrogateescape error handler with replace.
- 

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
