### PR TITLE
[Matrix] set xbmc.python to 3.0.0

### DIFF
--- a/targets.cfg
+++ b/targets.cfg
@@ -77,10 +77,10 @@ minversions =
     xbmc.addon:12.0.0
 
 [matrix]
-branches = gotham,helix,isengard,jarvis,krypton,leia,matrix
+branches = matrix
 minversions =
     xbmc.gui:5.14.0,
-    xbmc.python:2.1.0,
+    xbmc.python:3.0.0,
     xbmc.json:6.0.0,
     xbmc.metadata:1.0,
     xbmc.addon:12.0.0


### PR DESCRIPTION
the addon repo currently lists both python2 and python 3 addons in Kodi Matrix.
all python 2 addons will ofcourse not work in Matrix, and shouldn't be listed.

this change will make sure only addons with xbmc.python set to 3.0.0 will be listed in the addon manager.

this should be merged once https://github.com/xbmc/xbmc/pull/17188 gets merged.