### PR TITLE
[script.tag-generator] Fix broken leia repo generator

### DIFF
--- a/script.tag-generator/addon.xml
+++ b/script.tag-generator/addon.xml
@@ -28,7 +28,7 @@
     <assets>
         <icon>resources/icon.png</icon>
         <fanart>resources/fanart.jpg</fanart>
-        <clearlogo>resources/clearlogo.jpg</clearlogo>
+        <clearlogo>resources/clearlogo.png</clearlogo>
     </assets>
   </extension>
 </addon>


### PR DESCRIPTION
Leia repo generator has been broken for 2 months...
Tag generator includes a clearlogo and points to a jpeg file that doesn't exist. Correct file is has png extension. 
Wondering why addon-checker let this one pass. @Razzeee for reference (I'll look later)

Thanks to @kib for the server support.

Cross-reference: https://github.com/xbmc/repo-scripts/pull/1252