### PR TITLE
[service.subtitles.rvm.addic7ed] 3.1.2

### DIFF
--- a/service.subtitles.rvm.addic7ed/addic7ed/core.py
+++ b/service.subtitles.rvm.addic7ed/addic7ed/core.py
@@ -122,7 +122,8 @@ def download_subs(link, referrer, filename):
         shutil.rmtree(temp_dir)
     xbmcvfs.mkdirs(temp_dir)
     # Combine a path where to download the subs
-    subspath = os.path.join(temp_dir, filename[:-3] + 'srt')
+    filename = os.path.splitext(filename)[0] + '.srt'
+    subspath = os.path.join(temp_dir, filename)
     # Download the subs from addic7ed.com
     try:
         parser.download_subs(link, referrer, subspath)
@@ -203,21 +204,23 @@ def search_subs(params):
     languages = get_languages(
         urlparse.unquote_plus(params['languages']).split(',')
     )
-    try:
-        episode_data = extract_episode_data()
-    except ParseError:
-        return
     # Search subtitles in Addic7ed.com.
     if params['action'] == 'search':
+        try:
+            episode_data = extract_episode_data()
+        except ParseError:
+            return
         # Create a search query string
         query = '{0} {1}x{2}'.format(
             normalize_showname(episode_data.showname),
             episode_data.season,
             episode_data.episode
         )
+        filename = episode_data.filename
     else:
         # Get the query string typed on the on-screen keyboard
         query = params['searchstring']
+        filename = query
     if query:
         logger.debug('Search query: {0}'.format(query))
         try:
@@ -251,7 +254,7 @@ def search_subs(params):
                     return
             logger.notice('Found subs for "{0}"'.format(query))
             display_subs(results.subtitles, results.episode_url,
-                         episode_data.filename)
+                         filename)
 
 
 def router(paramstring):

--- a/service.subtitles.rvm.addic7ed/addic7ed/utils.py
+++ b/service.subtitles.rvm.addic7ed/addic7ed/utils.py
@@ -124,6 +124,7 @@ def parse_filename(filename):
     :return: parsed showname, season and episode
     :raises ParseError: if the filename does not match any episode patterns
     """
+    filename = filename.replace(' ', '.')
     for regexp in episode_patterns:
         episode_data = regexp.search(filename)
         if episode_data is not None:

--- a/service.subtitles.rvm.addic7ed/addon.xml
+++ b/service.subtitles.rvm.addic7ed/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon id="service.subtitles.rvm.addic7ed"
   name="Addic7ed.com"
-  version="3.1.1"
+  version="3.1.2"
   provider-name="Roman V.M.">
 <requires>
   <import addon="xbmc.python" version="2.25.0"/>
@@ -32,15 +32,8 @@
     <icon>icon.png</icon>
     <fanart>fanart.jpg</fanart>
   </assets>
-  <news>v.3.1.1:
-- Fixed search enpdoint URL.
-- Added French translation
-- Added Dutch translation
-
-v.3.1.0:
-- Removed login feature because of changes on Addic7ed.com.
-- Fixed exception when a filename contained a non-ASCII character.
-- Various optimizations.</news>
+  <news>v.3.1.2:
+- Fixed manual search (thanks to [B]quthla[/B].</news>
   <reuselanguageinvoker>false</reuselanguageinvoker>
 </extension>
 </addon>


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: Addic7ed.com
  - Add-on ID: service.subtitles.rvm.addic7ed
  - Version number: 3.1.2
  - Kodi/repository version: krypton

- **Code location**
  - URL: https://github.com/romanvm/service.addic7ed
  
Subtitles service for Addic7ed.com. It supports only TV shows.

### Description of changes:

v.3.1.2:
- Fixed manual search (thanks to [B]quthla[/B].

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
