### PR TITLE
[script.audio.mixer] 5.1.0

### DIFF
--- a/script.audio.mixer/addon.xml
+++ b/script.audio.mixer/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.audio.mixer" name="Kodi Audio Mixer" version="5.0.0" provider-name="Team Kodi">
+<addon id="script.audio.mixer" name="Kodi Audio Mixer" version="5.1.0" provider-name="Team Kodi">
 	<requires>
 		<import addon="xbmc.python" version="3.0.0"/>
 	</requires>
@@ -8,9 +8,7 @@
 		<platform>osx linux</platform>
 		<summary lang="en_GB">Kodi Audio Mixer</summary>
 		<description lang="en_GB">Kodi Audio Mixer</description>
-		<license>GNU GENERAL PUBLIC LICENSE. Version 2, June 1991</license>
-		<forum></forum>
-		<email></email>
+		<license>GPL-2.0-only</license>
 		<source>https://github.com/XBMC-Addons/script.audio.mixer</source>
 		<assets>
 			<icon>icon.png</icon>

--- a/script.audio.mixer/default.py
+++ b/script.audio.mixer/default.py
@@ -18,29 +18,19 @@
 # *
 # */
 
-
 import sys
-import os
 import xbmc
 import xbmcaddon
 
-
 ADDON = xbmcaddon.Addon()
-ADDONNAME = ADDON.getAddonInfo('name')
 ADDONID = ADDON.getAddonInfo('id')
-LANGUAGE = ADDON.getLocalizedString
-VERSION = ADDON.getAddonInfo("version")
 CWD = ADDON.getAddonInfo('path')
-PROFILE = xbmc.translatePath(ADDON.getAddonInfo('profile'))
-RESOURCE = xbmc.translatePath(os.path.join(CWD, 'resources', 'lib' ))
 
-sys.path.append(RESOURCE)
+xbmc.log("%s: started" % (ADDONID), level=xbmc.LOGDEBUG)
 
-xbmc.log("%s: version %s" % (ADDONNAME,VERSION), level=xbmc.LOGDEBUG)
-
-if ( __name__ == "__main__" ):
-    import gui
-    ui = gui.GUI( "%s.xml" % ADDONID.replace(".","-"), CWD, "Default")
+if (__name__ == "__main__"):
+    from lib import gui
+    ui = gui.GUI( "%s.xml" % ADDONID.replace(".", "-"), CWD, "Default")
     ui.doModal()
     del ui
     sys.modules.clear()

--- a/script.audio.mixer/lib/alsaMixerCore.py
+++ b/script.audio.mixer/lib/alsaMixerCore.py
@@ -26,11 +26,13 @@ import sys
 import time
 from threading import Thread
 import xbmc
+import xbmcaddon
 
-ADDONNAME = sys.modules[ "__main__" ].ADDONNAME
+ADDON = xbmcaddon.Addon()
+ADDONID = ADDON.getAddonInfo('id')
 
 def log(msg):
-    xbmc.log("%s: %s" % (ADDONNAME,msg,),level=xbmc.LOGDEBUG)
+    xbmc.log("%s: %s" % (ADDONID, msg), level=xbmc.LOGDEBUG)
 
 class WorkerThread(Thread):
     def __init__ (self, execPath):

--- a/script.audio.mixer/lib/gui.py
+++ b/script.audio.mixer/lib/gui.py
@@ -22,9 +22,10 @@ import os
 import sys
 import xbmc
 import xbmcgui
+import xbmcaddon
 
-ADDON = sys.modules[ "__main__" ].ADDON
-ADDONNAME = sys.modules[ "__main__" ].ADDONNAME
+ADDON = xbmcaddon.Addon()
+ADDONID = ADDON.getAddonInfo('id')
 
 CANCEL_DIALOG = (9, 10, 92, 216, 247, 257, 275, 61467, 61448)
 
@@ -39,9 +40,9 @@ class GUI(xbmcgui.WindowXMLDialog):
       
     def onInit(self):
       if sys.platform == "darwin":
-        import osascriptCore as alsaMixerCore
+        from lib import osascriptCore as alsaMixerCore
       else:  
-        import alsaMixerCore
+        from lib import alsaMixerCore
 
       self.alsaCore = alsaMixerCore.alsaMixerCore()
       self.controls = self.alsaCore.getPlaybackControls()
@@ -110,7 +111,7 @@ class GUI(xbmcgui.WindowXMLDialog):
             self.alsaCore.setVolume(control, label_value)
 
     def set_slider_value(self, controlId):
-      i = (controlId - 902) / 1000
+      i = int((controlId - 902) / 1000)
       self.set_mute(i + 900, False)
       control = self.getControl((1000 * i) + 900).getLabel()
       label_value = self.getControl((1000 * i) + 903).getLabel().replace(" %","")
@@ -123,9 +124,9 @@ class GUI(xbmcgui.WindowXMLDialog):
       if (controlId >= 1000):
         self.getControl(controlId + 1).setLabel("%.2d %s" % (int(self.getControl(controlId).getPercent()), "%",))
         if self.getControl(controlId).getPercent() == 0:
-          self.getControl((controlId/1000) + 900).setSelected(True)
+          self.getControl(int(controlId/1000) + 900).setSelected(True)
         else:
-          self.getControl((controlId/1000) + 900).setSelected(False)
+          self.getControl(int(controlId/1000) + 900).setSelected(False)
 
       if (controlId >= 900) and (controlId <  1000):
         self.set_mute(controlId)
@@ -151,7 +152,7 @@ class GUI(xbmcgui.WindowXMLDialog):
           self.control_state[self.controlId] = cur_slider
 
     def log(self, msg):
-      xbmc.log("%s: %s" % (ADDONNAME,msg,),level=xbmc.LOGDEBUG)
+      xbmc.log("%s: %s" % (ADDONID, msg), level=xbmc.LOGDEBUG)
 
     def onAction(self, action):    
       if (action.getButtonCode() == 61453):

--- a/script.audio.mixer/lib/osascriptCore.py
+++ b/script.audio.mixer/lib/osascriptCore.py
@@ -26,11 +26,13 @@ import sys
 import time
 from threading import Thread
 import xbmc
+import xbmcaddon
 
-ADDONNAME = sys.modules[ "__main__" ].ADDONNAME
+ADDON = xbmcaddon.Addon()
+ADDONID = ADDON.getAddonInfo('id')
 
 def log(msg):
-    xbmc.log("%s: %s" % (ADDONNAME,msg,),level=xbmc.LOGDEBUG)
+    xbmc.log("%s: %s" % (ADDONID, msg), level=xbmc.LOGDEBUG)
 
 class WorkerThread(Thread):
     def __init__ (self, execPath):


### PR DESCRIPTION
### Description
not much to see here... mainly getting rid of sys.path.append() 
since we discourage the use of it, we should at least make sure our own addons don't use it.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [script.foo.bar] 1.0.0

Additional information :
- Submitting your add-on to this specific branch makes it available to any Kodi version equal or higher than the branch name with the applicable Kodi dependencies limits.
- [add-on development](http://kodi.wiki/view/Add-on_development) wiki page.
- Kodi [pydocs](http://kodi.wiki/view/PyDocs) provide information about the Python API
- [PEP8](https://www.python.org/dev/peps/pep-0008/) codingstyle which is considered best practise but not mandatory.
- This add-on repository has automated code guideline check which could help you improve your coding. You can find the results of these check at [Codacy](https://www.codacy.com/app/Kodi/repo-scripts/dashboard). You can create your own account as well to continuously monitor your python coding before submitting to repo.
- Development questions can be asked in the [add-on development](http://forum.kodi.tv/forumdisplay.php?fid=26) section on the Kodi forum.
