### PR TITLE
[script.module.oauthlib] 3.1.0+matrix.2

### DIFF
--- a/script.module.oauthlib/addon.xml
+++ b/script.module.oauthlib/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.module.oauthlib" name="oauthlib" version="3.1.0+matrix.1" provider-name="Idan Gazit">
+<addon id="script.module.oauthlib" name="oauthlib" version="3.1.0+matrix.2" provider-name="Idan Gazit">
 	<requires>
 		<import addon="xbmc.python" version="3.0.0"/>
 		<import addon="script.module.blinker" version="1.4.0+matrix.1"/>
@@ -9,12 +9,14 @@
 	<extension point="xbmc.python.module" library="lib" />
 	<extension point="xbmc.addon.metadata">
 		<platform>all</platform>
-		<language></language>
 		<summary lang="en_GB">A generic, spec-compliant, thorough implementation of the OAuth request-signing logic</summary>
 		<description lang="en_GB">A generic, spec-compliant, thorough implementation of the OAuth request-signing logic</description>
 		<disclaimer lang="en_GB">A generic, spec-compliant, thorough implementation of the OAuth request-signing logic</disclaimer>
 		<license>OAuthLib is yours to use and abuse according to the terms of the BSD license. Check the LICENSE file for full details</license>
 		<website>https://pypi.python.org/pypi/oauthlib</website>
 		<source>https://pypi.python.org/pypi/oauthlib</source>
+		<assets>
+			<icon>icon.png</icon>
+		</assets>
 	</extension>
 </addon>


### PR DESCRIPTION
The direct push to matrix of several script.modules made it skip the addon-checker checks. This is a round of pull requests to all the addons that are triggering errors in the matrix branch with a minor bump on the revision. Goal is to finally have a green branch (since matrix is pretty much starting from the beginning).

This is good to merge as long as travis does not complain.