### PR TITLE
[script.module.cryptography] 2.8.0+matrix.2

### DIFF
--- a/script.module.cryptography/addon.xml
+++ b/script.module.cryptography/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.module.cryptography" name="cryptography" version="2.8.0+matrix.1" provider-name="pyca">
+<addon id="script.module.cryptography" name="cryptography" version="2.8.0+matrix.2" provider-name="pyca">
 	<requires>
 		<import addon="xbmc.python" version="3.0.0"/>
 	</requires>
@@ -12,5 +12,8 @@
 		<license>Apache, BSD</license>
 		<website>https://pypi.org/project/cryptography/</website>
 		<source>https://github.com/pyca/cryptography</source>
+		<assets>
+			<icon>icon.png</icon>
+		</assets>
 	</extension>
 </addon>


### PR DESCRIPTION
The direct push to matrix of several script.modules made it skip the addon-checker checks. This is a round of pull requests to all the addons that are triggering errors in the matrix branch with a minor bump on the revision. Goal is to finally have a green branch (since matrix is pretty much starting from the beginning).

This is good to merge as long as travis does not complain.