### PR TITLE
[script.module.chardet] 3.0.4+matrix.2

### DIFF
--- a/script.module.chardet/addon.xml
+++ b/script.module.chardet/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="script.module.chardet"
        name="chardet"
-       version="3.0.4+matrix.1"
+       version="3.0.4+matrix.2"
        provider-name="Dan Blanchard">
   <requires>
     <import addon="xbmc.python" version="3.0.0"/>
@@ -16,7 +16,7 @@
     <language></language>
     <forum></forum>
     <website>https://chardet.readthedocs.io/en/latest/</website>
-    <source>https://github.com/beenje/script.module.chardet</source>
+    <source>https://github.com/Freso/script.module.chardet</source>
     <email>beenje AT gmail.com</email>
   </extension>
 </addon>


### PR DESCRIPTION
The direct push to matrix of several script.modules made it skip the addon-checker checks. This is a round of pull requests to all the addons that are triggering errors in the matrix branch with a minor bump on the revision. Goal is to finally have a green branch (since matrix is pretty much starting from the beginning).

This is good to merge as long as travis does not complain.