### PR TITLE
[script.module.feedparser] 6.0.0+matrix.2

### DIFF
--- a/script.module.feedparser/addon.xml
+++ b/script.module.feedparser/addon.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.module.feedparser" name="feedparser" version="6.0.0+matrix.1" provider-name="Kurt McKee">
+<addon id="script.module.feedparser" name="feedparser" version="6.0.0+matrix.2" provider-name="Kurt McKee">
     <requires>
         <import addon="xbmc.python" version="3.0.0"/>
         <import addon="script.module.sgmllib3k" version="1.0.0+matrix.1"/>
     </requires>
-    <extension point="xbmc.python.module" library="lib" />
+    <extension point="xbmc.python.module" library="lib"/>
     <extension point="xbmc.addon.metadata">
         <language></language>
         <summary lang="en_GB">Universal feed parser, handles RSS 0.9x, RSS 1.0, RSS 2.0, CDF, Atom 0.3, and Atom 1.0 feeds</summary>
@@ -12,5 +12,8 @@
         <license>MIT</license>
         <platform>all</platform>
         <source>https://github.com/kurtmckee/feedparser</source>
+        <assets>
+            <icon>icon.png</icon>
+        </assets>
     </extension>
 </addon>


### PR DESCRIPTION
The direct push to matrix of several script.modules made it skip the addon-checker checks. This is a round of pull requests to all the addons that are triggering errors in the matrix branch with a minor bump on the revision. Goal is to finally have a green branch (since matrix is pretty much starting from the beginning).

This is good to merge as long as travis does not complain.