### PR TITLE
[script.module.future] 0.17.1+matrix.2

### DIFF
--- a/script.module.future/addon.xml
+++ b/script.module.future/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="script.module.future"
        name="future"
-       version="0.17.1+matrix.1"
+       version="0.17.1+matrix.2"
        provider-name="Ed Schofield">
   <requires>
     <import addon="xbmc.python" version="3.0.0" />
@@ -14,5 +14,8 @@
     <license>MIT</license>
     <source>https://github.com/PythonCharmers/python-future</source>
     <website>http://python-future.org</website>
+    <assets>
+      <icon>icon.png</icon>
+    </assets>
   </extension>
 </addon>


### PR DESCRIPTION
The direct push to matrix of several script.modules made it skip the addon-checker checks. This is a round of pull requests to all the addons that are triggering errors in the matrix branch with a minor bump on the revision. Goal is to finally have a green branch (since matrix is pretty much starting from the beginning).

This is good to merge as long as travis does not complain.