### PR TITLE
[script.module.mechanize] 0.4.3+matrix.2

### DIFF
--- a/script.module.mechanize/addon.xml
+++ b/script.module.mechanize/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.module.mechanize" name="Mechanize" version="0.4.3+matrix.1" provider-name="Kovid Goyal">
+<addon id="script.module.mechanize" name="Mechanize" version="0.4.3+matrix.2" provider-name="Kovid Goyal">
 	<requires>
 		<import addon="xbmc.python" version="3.0.0"/>
 		<import addon="script.module.html5lib" version="1.0.1+matrix.1"/>
@@ -13,5 +13,8 @@
 		<license>BSD</license>
 		<platform>all</platform>
 		<source>https://github.com/python-mechanize/</source>
+		<assets>
+			<icon>icon.png</icon>
+		</assets>
 	</extension>
 </addon>


### PR DESCRIPTION
The direct push to matrix of several script.modules made it skip the addon-checker checks. This is a round of pull requests to all the addons that are triggering errors in the matrix branch with a minor bump on the revision. Goal is to finally have a green branch (since matrix is pretty much starting from the beginning).

This is good to merge as long as travis does not complain.