### PR TITLE
[script.module.oauth2client] 4.1.3+matrix.2

### DIFF
--- a/script.module.oauth2client/addon.xml
+++ b/script.module.oauth2client/addon.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="script.module.oauth2client"
        name="oauth2client"
-       version="4.1.3+matrix.1"
+       version="4.1.3+matrix.2"
        provider-name="Google Inc.">
   <requires>
     <import addon="xbmc.python" version="3.0.0"/>
-	<import addon="script.module.httplib2" version="0.17.0+matrix.1" />
-	<import addon="script.module.six" version="1.14.0+matrix.1" />
-  </requires>
+	  <import addon="script.module.httplib2" version="0.17.0+matrix.1" />
+	  <import addon="script.module.six" version="1.14.0+matrix.1" />
+    </requires>
   <extension point="xbmc.python.module"
              library="lib" />
   <extension point="xbmc.addon.metadata">
@@ -17,5 +17,8 @@
     <license>Apache-2.0</license>
     <website>https://oauth2client.readthedocs.io/en/latest/</website>
     <source>https://github.com/googleapis/oauth2client</source>
+    <assets>
+      <icon>icon.png</icon>
+    </assets>
   </extension>
 </addon>


### PR DESCRIPTION
The direct push to matrix of several script.modules made it skip the addon-checker checks. This is a round of pull requests to all the addons that are triggering errors in the matrix branch with a minor bump on the revision. Goal is to finally have a green branch (since matrix is pretty much starting from the beginning).

This is good to merge as long as travis does not complain.