### PR TITLE
[script.module.pytz] 2019.3.0+matrix.2

### DIFF
--- a/script.module.pytz/addon.xml
+++ b/script.module.pytz/addon.xml
@@ -1,4 +1,4 @@
-<addon id="script.module.pytz" name="pytz" version="2019.3.0+matrix.1" provider-name="Stuart Bishop, Paul Backhouse">
+<addon id="script.module.pytz" name="pytz" version="2019.3.0+matrix.2" provider-name="Stuart Bishop, Paul Backhouse">
 	<requires>
 		<import addon="xbmc.python" version="3.0.0"/>
 	</requires>
@@ -7,11 +7,11 @@
 	    <summary lang="en_GB">World Timezone Definitions for Python.</summary>
 	    <description lang="en_GB">pytz brings the Olson tz database into Python. This library allows accurate and cross platform timezone calculations using Python 2.4 or higher. It also solves the issue of ambiguous times at the end of daylight saving time, which you can read more about in the Python Library Reference (datetime.tzinfo).</description>
 	    <platform>all</platform>
-	    <language></language>
 	    <license>MIT</license>
-	    <forum></forum>
 	    <website>https://pythonhosted.org/pytz/</website>
 	    <source>https://github.com/stub42/pytz</source>
-	    <email></email>
+	    <assets>
+            <icon>icon.png</icon>
+	    </assets>
 	</extension>
 </addon>


### PR DESCRIPTION
The direct push to matrix of several script.modules made it skip the addon-checker checks. This is a round of pull requests to all the addons that are triggering errors in the matrix branch with a minor bump on the revision. Goal is to finally have a green branch (since matrix is pretty much starting from the beginning).

This is good to merge as long as travis does not complain.