### PR TITLE
[script.module.requests_oauthlib] 1.3.0+matrix.2

### DIFF
--- a/script.module.requests_oauthlib/addon.xml
+++ b/script.module.requests_oauthlib/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.module.requests_oauthlib" name="requests_oauthlib" version="1.3.0+matrix.1" provider-name="Ib Lundgren">
+<addon id="script.module.requests_oauthlib" name="requests_oauthlib" version="1.3.0+matrix.2" provider-name="Ib Lundgren">
 	<requires>
 		<import addon="xbmc.python" version="3.0.0"/>
 		<import addon="script.module.oauthlib" version="3.1.0+matrix.1"/>
@@ -13,7 +13,10 @@
 		<description lang="en_GB">This project provides first-class OAuth library support for Requests.</description>
 		<disclaimer lang="en_GB">This project provides first-class OAuth library support for Requests.</disclaimer>
 		<license>ISC</license>
-		<website>https://pypi.python.org/pypi/requests-oauthlib</website>
+		<website>https://pypi.org/project/requests-oauthlib</website>
 		<source>https://github.com/requests/requests-oauthlib</source>
+		<assets>
+			<icon>icon.png</icon>
+		</assets>
 	</extension>
 </addon>


### PR DESCRIPTION
The direct push to matrix of several script.modules made it skip the addon-checker checks. This is a round of pull requests to all the addons that are triggering errors in the matrix branch with a minor bump on the revision. Goal is to finally have a green branch (since matrix is pretty much starting from the beginning).

This is good to merge as long as travis does not complain.