### PR TITLE
[script.module.simplejson] 3.17.0+matrix.2

### DIFF
--- a/script.module.simplejson/addon.xml
+++ b/script.module.simplejson/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="script.module.simplejson"
        name="simplejson"
-       version="3.17.0+matrix.1"
+       version="3.17.0+matrix.2"
        provider-name="Bob Ippolito">
   <requires>
     <import addon="xbmc.python" version="3.0.0"/>
@@ -17,5 +17,8 @@
     <license>MIT License, Academic Free License v. 2.1</license>
     <website>https://pypi.org/project/simplejson/</website>
     <source>https://github.com/simplejson/simplejson</source>
+    <assets>
+      <icon>icon.png</icon>
+    </assets>
   </extension>
 </addon>


### PR DESCRIPTION
The direct push to matrix of several script.modules made it skip the addon-checker checks. This is a round of pull requests to all the addons that are triggering errors in the matrix branch with a minor bump on the revision. Goal is to finally have a green branch (since matrix is pretty much starting from the beginning).

This is good to merge as long as travis does not complain.