### PR TITLE
[script.module.trakt] 3.1.0+matrix.2

### DIFF
--- a/script.module.trakt/addon.xml
+++ b/script.module.trakt/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="script.module.trakt"
        name="trakt.py"
-       version="3.1.0+matrix.1"
+       version="3.1.0+matrix.2"
        provider-name="Dean Gardiner">
   <requires>
     <import addon="xbmc.python" version="3.0.0"/>
@@ -15,11 +15,11 @@
     <summary lang="en_GB">Python interface for the trakt.tv API</summary>
     <description lang="en_GB">Packed for Kodi from https://github.com/fuzeman/trakt.py</description>
     <platform>all</platform>
-    <language></language>
     <license>MIT</license>
-    <forum></forum>
     <website>https://github.com/fuzeman/trakt.py</website>
     <source>https://github.com/Razzeee/script.module.trakt</source>
-    <email></email>
+    <assets>
+      <icon>icon.png</icon>
+    </assets>
   </extension>
 </addon>


### PR DESCRIPTION
The direct push to matrix of several script.modules made it skip the addon-checker checks. This is a round of pull requests to all the addons that are triggering errors in the matrix branch with a minor bump on the revision. Goal is to finally have a green branch (since matrix is pretty much starting from the beginning).

This is good to merge as long as travis does not complain.

Ping @Razzeee for reference