### PR TITLE
[script.module.unidecode] 1.1.1+matrix.2

### DIFF
--- a/script.module.unidecode/addon.xml
+++ b/script.module.unidecode/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.module.unidecode" name="unidecode" version="1.1.1+matrix.1" provider-name="Tomaz Solc (Tomaz.solc@tablix.org)">
+<addon id="script.module.unidecode" name="unidecode" version="1.1.1+matrix.2" provider-name="Tomaz Solc (Tomaz.solc@tablix.org)">
 	<requires>
 		<import addon="xbmc.python" version="3.0.0"/>
 	</requires>
@@ -12,5 +12,8 @@
 		<license>GPL-2.0-or-later</license>
 		<website>https://pypi.org/project/Unidecode</website>
 		<source>https://pypi.org/project/Unidecode</source>
+		<assets>
+			<icon>icon.png</icon>
+		</assets>
 	</extension>
 </addon>


### PR DESCRIPTION
The direct push to matrix of several script.modules made it skip the addon-checker checks. This is a round of pull requests to all the addons that are triggering errors in the matrix branch with a minor bump on the revision. Goal is to finally have a green branch (since matrix is pretty much starting from the beginning).

This is good to merge as long as travis does not complain.