### PR TITLE
[script.module.uritemplate] 3.0.1+matrix.2

### DIFF
--- a/script.module.uritemplate/addon.xml
+++ b/script.module.uritemplate/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="script.module.uritemplate"
        name="uritemplate"
-       version="3.0.1+matrix.1"
+       version="3.0.1+matrix.2"
        provider-name="Ian Stapleton Cordasco">
   <requires>
     <import addon="xbmc.python" version="3.0.0"/>
@@ -10,11 +10,13 @@
              library="lib" />
   <extension point="xbmc.addon.metadata">
     <platform>all</platform>
-    <language></language>
     <summary lang="en_GB">URItemplates python module</summary>
     <description lang="en_GB">A packaged version of the uritemplates python module.</description>
-    <license>Apache 2.0, BSD</license>
+    <license>Apache-2.0, BSD-1-Clause</license>
     <website>https://github.com/python-hyper/uritemplate</website>
     <source>https://github.com/python-hyper/uritemplate</source>
+    <assets>
+      <icon>icon.png</icon>
+    </assets>
   </extension>
 </addon>


### PR DESCRIPTION
The direct push to matrix of several script.modules made it skip the addon-checker checks. This is a round of pull requests to all the addons that are triggering errors in the matrix branch with a minor bump on the revision. Goal is to finally have a green branch (since matrix is pretty much starting from the beginning).

This is good to merge as long as travis does not complain.