### PR TITLE
[screensaver.kaster] 1.3.1

### DIFF
--- a/screensaver.kaster/addon.xml
+++ b/screensaver.kaster/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="screensaver.kaster" name="Kaster" version="1.3.0" provider-name="enen92">
+<addon id="screensaver.kaster" name="Kaster" version="1.3.1" provider-name="enen92">
 	<requires>
 		<import addon="xbmc.python" version="2.25.0"/>
 		<import addon="script.module.requests" version="2.22.0"/>


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: Kaster
  - Add-on ID: screensaver.kaster
  - Version number: 1.3.1
  - Kodi/repository version: krypton

- **Code location**
  - URL: 
  
Display beautiful pictures originally from the chromecast screensaver. You can also display your own photos along with its respective information.

### Description of changes:

v1.3.0
			[new] Trivial python3 fixes
		

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
