### PR TITLE
[script.module.web-pdb@matrix] 1.5.4+matrix.1

### DIFF
--- a/script.module.web-pdb/addon.xml
+++ b/script.module.web-pdb/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="script.module.web-pdb"
        name="Web-PDB"
-       version="1.5.3+matrix.1"
+       version="1.5.4+matrix.1"
        provider-name="Roman V.M.">
   <requires>
     <import addon="xbmc.python" version="3.0.0"/>
@@ -22,6 +22,7 @@
       <icon>icon.png</icon>
       <screenshot>resources/screenshot.jpg</screenshot>
     </assets>
-    <news>1.5.3: Fix a rare issue when a debugger session cannot be started.</news>
+    <news>- 1.5.4: Fix info dialog in Kodi &quot;Matrix&quot;.
+- 1.5.3: Fix a rare issue when a debugger session cannot be started.</news>
   </extension>
 </addon>

--- a/script.module.web-pdb/main.py
+++ b/script.module.web-pdb/main.py
@@ -21,12 +21,11 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
-
+from __future__ import unicode_literals
 from xbmcaddon import Addon
 from xbmcgui import Dialog
 
 Dialog().ok(
     'Web-PDB',
-    Addon().getLocalizedString(32000),
-    'github.com/romanvm/kodi.web-pdb'
+    Addon().getLocalizedString(32000)
 )

--- a/script.module.web-pdb/resources/language/resource.language.en_gb/strings.po
+++ b/script.module.web-pdb/resources/language/resource.language.en_gb/strings.po
@@ -8,7 +8,7 @@ msgstr ""
 
 
 msgctxt "#32000"
-msgid "Web-based remote Python debugger:"
+msgid "Web-based remote Python debugger:[CR]github.com/romanvm/kodi.web-pdb"
 msgstr ""
 
 msgctxt "#32001"


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: Web-PDB
  - Add-on ID: script.module.web-pdb
  - Version number: 1.5.4+matrix.1
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/romanvm/kodi.web-pdb
  
Provides a web-UI for Python's built-in PDB debugger for remote debugging Kodi addons.

### Description of changes:

- 1.5.4: Fix info dialog in Kodi "Matrix".
- 1.5.3: Fix a rare issue when a debugger session cannot be started.

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
