### PR TITLE
[script.tubecast@krypton] 1.4.3

### DIFF
--- a/script.tubecast/addon.xml
+++ b/script.tubecast/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.tubecast" name="TubeCast" version="1.4.2" provider-name="enen92">
+<addon id="script.tubecast" name="TubeCast" version="1.4.3" provider-name="enen92">
     <requires>
         <import addon="xbmc.python" version="2.25.0"/>
         <import addon="script.module.bottle" version="0.12.0"/>
@@ -19,9 +19,7 @@
         <email>enen92@kodi.tv</email>
         <source>https://github.com/enen92/script.tubecast</source>
         <news>
-            [ci] automated submissions to matrix
-            [fix] adapted xbmcgui methods for matrix
-            [fix] shrink screenshots
+            [ci] Simplified CI
         </news>
         <disclaimer lang="en_GB">This is not a full chromecast implementation nor will it ever be. It will only work as long as Google keep backwards compatibility with the cast v1 protocol in the Youtube application. Deeply inspired by Leapcast and gotubecast projects</disclaimer>
         <disclaimer lang="pt_PT">Este addon não é uma implementação completa do protocolo cast nem nunca será. Apenas funcionará enquanto a Google mantiver a retrocompatibilidade com o protocolo cast v1 na aplicação móvel do youtube. Inspirado no Leapcast e gotubecast</disclaimer>


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: TubeCast
  - Add-on ID: script.tubecast
  - Version number: 1.4.3
  - Kodi/repository version: krypton

- **Code location**
  - URL: https://github.com/enen92/script.tubecast
  
An implementation of the Cast V1 protocol in Kodi to act as a player for the Youtube mobile application

### Description of changes:


            [ci] Simplified CI
        

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
