### PR TITLE
[script.module.oauthlib] 3.1.0+matrix.3

### DIFF
--- a/script.module.oauthlib/addon.xml
+++ b/script.module.oauthlib/addon.xml
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.module.oauthlib" name="oauthlib" version="3.1.0+matrix.2" provider-name="Idan Gazit">
+<addon id="script.module.oauthlib" name="oauthlib" version="3.1.0+matrix.3" provider-name="Idan Gazit">
 	<requires>
 		<import addon="xbmc.python" version="3.0.0"/>
 		<import addon="script.module.blinker" version="1.4.0+matrix.1"/>
-		<import addon="script.module.cryptography" version="2.8.0+matrix.1"/>
 		<import addon="script.module.pyjwt" version="1.7.1+matrix.1"/>
 	</requires>
 	<extension point="xbmc.python.module" library="lib" />


### PR DESCRIPTION
drop the cryptography dependency.
i've no experience with this addon, but apparently it has always worked fine without it.

we currently have it in jarvis without this dependency.
perhaps only this method will not work without it:
https://github.com/xbmc/repo-scripts/blob/jarvis/script.module.oauthlib/lib/oauthlib/oauth1/rfc5849/signature.py#L581
