### PR TITLE
[script.module.pymysql] 3.1.0+matrix.3

### DIFF
--- a/script.module.pymysql/addon.xml
+++ b/script.module.pymysql/addon.xml
@@ -1,11 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="script.module.pymysql"
        name="pymysql"
-       version="0.9.3+matrix.2"
+       version="0.9.3+matrix.3"
        provider-name="PyMySQL">
   <requires>
     <import addon="xbmc.python" version="3.0.0"/>
-    <import addon="script.module.cryptography" version="2.8.0+matrix.1"/>
   </requires>
   <extension point="xbmc.python.module"
              library="lib" />


### PR DESCRIPTION
drop the cryptography dependency.
it's an optional dependency (https://github.com/PyMySQL/PyMySQL/blob/master/CHANGELOG#L7), so i don't expect any issues.