### PR TITLE
[script.tubecast@krypton] 1.4.4

### DIFF
--- a/script.tubecast/addon.xml
+++ b/script.tubecast/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.tubecast" name="TubeCast" version="1.4.3" provider-name="enen92">
+<addon id="script.tubecast" name="TubeCast" version="1.4.4" provider-name="enen92">
     <requires>
         <import addon="xbmc.python" version="2.25.0"/>
         <import addon="script.module.bottle" version="0.12.0"/>
@@ -11,19 +11,23 @@
     <extension point="xbmc.addon.metadata">
         <summary lang="en_GB">Cast videos from the Youtube application to Kodi</summary>
         <summary lang="pt_PT">Cast de vídeos a partir da aplicação móvel Youtube para o Kodi</summary>
-        <description lang="en_GB">An implementation of the Cast V1 protocol in Kodi to act as a player for the Youtube mobile application</description>
-        <description lang="pt_PT">Uma implementação do protocolo Cast V1 no Kodi para este funcionar como player externo remotamente controlado pela aplicação móvel do YouTube</description>
-        <platform>all</platform>
+	<summary lang="es_ES">Transmitir videos desde la aplicación de Youtube a Kodi</summary>
+	<description lang="en_GB">An implementation of the Cast V1 protocol in Kodi to act as a player for the Youtube mobile application</description>
+    <description lang="pt_PT">Uma implementação do protocolo Cast V1 no Kodi para este funcionar como player externo remotamente controlado pela aplicação móvel do YouTube</description>
+	<description lang="es_ES">Una implementación del protocolo Cast V1 en Kodi para actuar como reproductor externo para la aplicación móvil de Youtube</description>
+	<platform>all</platform>
         <license>MIT</license>
         <forum>https://forum.kodi.tv/showthread.php?tid=329153</forum>
         <email>enen92@kodi.tv</email>
         <source>https://github.com/enen92/script.tubecast</source>
         <news>
-            [ci] Simplified CI
+            [new] Add spanish translation (tks roliverosc)
+            [fix] Playlist doesn't continue after second video (tks NextLight)
         </news>
         <disclaimer lang="en_GB">This is not a full chromecast implementation nor will it ever be. It will only work as long as Google keep backwards compatibility with the cast v1 protocol in the Youtube application. Deeply inspired by Leapcast and gotubecast projects</disclaimer>
         <disclaimer lang="pt_PT">Este addon não é uma implementação completa do protocolo cast nem nunca será. Apenas funcionará enquanto a Google mantiver a retrocompatibilidade com o protocolo cast v1 na aplicação móvel do youtube. Inspirado no Leapcast e gotubecast</disclaimer>
-        <assets>
+	<disclaimer lang="es_ES">Esta no es una implementación completa de Chromecast ni lo será nunca. Solo funcionará mientras Google mantenga la compatibilidad con el protocolo Cast v1 en la aplicación Youtube. Profundamente inspirado por los proyectos Leapcast y gotubecast</disclaimer>
+	<assets>
             <icon>resources/img/icon.png</icon>
             <fanart>resources/img/fanart.jpg</fanart>
             <screenshot>resources/img/screenshot-0.jpg</screenshot>

--- a/script.tubecast/resources/language/resource.language.es_es/strings.po
+++ b/script.tubecast/resources/language/resource.language.es_es/strings.po
@@ -1,0 +1,78 @@
+# Kodi Media Center language file
+# Addon Name: TubeCast
+# Addon id: script.tubecast
+# Addon Provider: enen92
+msgid ""
+msgstr ""
+"Project-Id-Version: XBMC Addons\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
+"POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: roliverosc\n"
+"Language-Team: Spanish (http://www.transifex.com/projects/p/xbmc-addons/language/es/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: es_ES\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+
+msgctxt "#32000"
+msgid "TubeCast"
+msgstr "TubeCast"
+
+msgctxt "#32001"
+msgid "Getting pairing code..."
+msgstr "Obteniendo código de emparejamiento"
+
+msgctxt "#32002"
+msgid "Please insert the following code in YouTube app settings"
+msgstr "Por favor, inserte el siguiente código en los ajustes de la aplicación YouTube"
+
+msgctxt "#32003"
+msgid "General"
+msgstr "General"
+
+msgctxt "#32004"
+msgid "Enable service discovery (SSDP)"
+msgstr "Habilitar servicio de descubrimiento (SSDP)"
+
+msgctxt "#32005"
+msgid "Debug SSDP datagrams"
+msgstr "Mostrar datagramas SSDP"
+
+msgctxt "#32006"
+msgid "connected"
+msgstr "Conectado"
+
+msgctxt "#32007"
+msgid "disconnected"
+msgstr "Desconectado"
+
+msgctxt "#32008"
+msgid "Do you want to generate a new pairing code?"
+msgstr "¿Quieré generar un nuevo código de emparejamiento?"
+
+msgctxt "#32009"
+msgid "Yes"
+msgstr "Si"
+
+msgctxt "#32010"
+msgid "No"
+msgstr "No"
+
+msgctxt "#32011"
+msgid "Debug youtube cmds"
+msgstr "Mostrar comandos YouTube"
+
+msgctxt "#32012"
+msgid "Debug"
+msgstr "Depuración"
+
+msgctxt "#32013"
+msgid "Verify SSL connections"
+msgstr "Verificar conexiones SSL"
+
+msgctxt "#32014"
+msgid "Debug HTTP requests"
+msgstr "Mostrar solicitudes HTTP"

--- a/script.tubecast/resources/lib/tubecast/youtube/player.py
+++ b/script.tubecast/resources/lib/tubecast/youtube/player.py
@@ -71,10 +71,11 @@ class CastPlayer(xbmc.Player):
         self.__report_state_change()
 
     def onPlayBackEnded(self):
-        if self.__should_report():
-            self.cast.report_playback_ended()
-
+        should_report = self.__should_report()
         self.from_yt = False
+
+        if should_report:
+            self.cast.report_playback_ended()
 
     def onPlayBackSeek(self, time, seek_offset):
         self.__report_state_change(status_code=STATUS_LOADING)


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: TubeCast
  - Add-on ID: script.tubecast
  - Version number: 1.4.4
  - Kodi/repository version: krypton

- **Code location**
  - URL: https://github.com/enen92/script.tubecast
  
An implementation of the Cast V1 protocol in Kodi to act as a player for the Youtube mobile application

### Description of changes:


            [new] Add spanish translation (tks roliverosc)
            [fix] Playlist doesn't continue after second video (tks NextLight)
        

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
