### PR TITLE
[script.module.qrcode] 6.1.0+matrix.3

### DIFF
--- a/script.module.qrcode/addon.xml
+++ b/script.module.qrcode/addon.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="script.module.qrcode"
        name="qrcode"
-       version="6.1.0+matrix.2"
+       version="6.1.0+matrix.3"
        provider-name="Lincoln Loop">
   <requires>
     <import addon="xbmc.python" version="3.0.0"/>
     <import addon="script.module.six" version="1.14.0+matrix.1"/>
-    <import addon="script.module.pil" version="1.1.7+matrix.1"/> <!-- Python Image Library required to create QR images -->
+    <import addon="script.module.pil" version="1.1.7"/> <!-- Python Image Library required to create QR images -->
   </requires>
   <extension point="xbmc.python.module" library="lib" />
   <extension point="xbmc.addon.metadata">


### PR DESCRIPTION
This addon was imported in #1289 and #1407 to matrix from previous Kodi versions (#1171 in isengard). From my assumption for matrix never tested by clean install.
The dependency script.module.pil does not exist in matrix, but is not needed anyway, since it is included in this addon (verified on Ubuntu 18.04). No current maintainer is known to me, therefore the explanation here.
