### PR TITLE
[script.module.actionhandler] 1.0.4

### DIFF
--- a/script.module.actionhandler/addon.xml
+++ b/script.module.actionhandler/addon.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.module.actionhandler" name="ActionHandler" version="1.0.3" provider-name="Philipp Temminghoff (phil65)">
+<addon id="script.module.actionhandler" name="ActionHandler" version="1.0.4" provider-name="Philipp Temminghoff (phil65)">
+	<requires>
+		<import addon="xbmc.python" version="2.24.0"/>
+	</requires>
 	<extension point="xbmc.python.module" library="lib" />
 	<extension point="xbmc.addon.metadata">
 		<summary lang="en">Helper module for Event handling in WindowXMLs</summary>


### PR DESCRIPTION
The fact that this addon (no longer maintained) does not define xbmc.python as a requirement makes it available in the matrix branch. This makes the addon checker to fail while validating the krypton branch because this one has a lower version (and users can't migrate). This PR makes sure it won't be available in matrix.

Found with https://github.com/xbmc/addon-check/pull/234