### PR TITLE
[screensaver.qlock] 0.0.6

### DIFF
--- a/screensaver.qlock/addon.xml
+++ b/screensaver.qlock/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="screensaver.qlock" name="QLock Screensaver" version="0.0.5" provider-name="phil65">
+<addon id="screensaver.qlock" name="QLock Screensaver" version="0.0.6" provider-name="phil65">
 	<requires>
 		<import addon="xbmc.python" version="2.26.0"/>
 		<import addon="service.qlock" version="0.5.3"/>
@@ -12,5 +12,9 @@
 		<language></language>
 		<platform>all</platform>
 		<license>GNU GENERAL PUBLIC LICENSE Version 2</license>
+		<assets>
+	      <icon>icon.png</icon>
+				<fanart>fanart.jpg</fanart>
+		</assets>
 	</extension>
 </addon>

--- a/screensaver.qlock/changelog.txt
+++ b/screensaver.qlock/changelog.txt
@@ -11,4 +11,7 @@ v0.0.4
 - code cleanup and small fixes
 
 v0.0.5
-- update forkodi leia
+- update for kodi leia
+
+v0.0.6
+- version bump to avoid the addon being shown in matrix


### PR DESCRIPTION
This is a version bump to screensaver.qlock just to make sure that the addon has a higher version than the one in gotham (that will be bumped to 0.0.5). Reason is that the gotham version does not depend on xbmc.python, making it available in matrix.

Found with https://github.com/xbmc/addon-check/pull/234
@ronie for your information since you were the last one touching this addon