### PR TITLE
[screensaver.qlock] 0.0.5

### DIFF
--- a/screensaver.qlock/addon.xml
+++ b/screensaver.qlock/addon.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="screensaver.qlock" name="QLock Screensaver" version="0.0.4" provider-name="phil65">
+<addon id="screensaver.qlock" name="QLock Screensaver" version="0.0.5" provider-name="phil65">
 	<requires>
+	  <import addon="xbmc.python" version="2.14.0"/>
 		<import addon="service.qlock" version="0.5.3"/>
 	</requires>
 	<extension point="xbmc.ui.screensaver" library="default.py"/>


### PR DESCRIPTION
This makes sure the addon depends on `xbmc.python` to avoid it showing on matrix.
Depends: https://github.com/xbmc/repo-scripts/pull/1520

Found with: https://github.com/xbmc/addon-check/pull/234