### PR TITLE
[script.module.pyserial] 3.4.0+matrix.2

### DIFF
--- a/script.module.pyserial/addon.xml
+++ b/script.module.pyserial/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="script.module.pyserial"
        name="pyserial"
-       version="3.4.0+matrix.1"
+       version="3.4.0+matrix.2"
        provider-name="Chris Liechti">
   <requires>
     <import addon="xbmc.python" version="3.0.0"/>
@@ -12,11 +12,12 @@
     <summary lang="en_GB">Python serial port access library</summary>
     <description lang="en_GB">Packed for KODI from https://github.com/pyserial/pyserial</description>
     <platform>all</platform>
-    <language></language>
     <license>BSD-3-Clause</license>
-    <forum></forum>
     <website>https://github.com/pyserial/pyserial</website>
     <source>https://github.com/pyserial/pyserial</source>
     <email>projcontrol _at_ wb9.se</email>
+    <assets>
+      <icon>icon.png</icon>
+    </assets>
   </extension>
 </addon>


### PR DESCRIPTION
Adds the missing icon to assets.