### PR TITLE
[script.module.inputstreamhelper@krypton] 0.4.7

### DIFF
--- a/script.module.inputstreamhelper/README.md
+++ b/script.module.inputstreamhelper/README.md
@@ -90,6 +90,11 @@ Please report any issues or bug reports on the [GitHub Issues](https://github.co
 This module is licensed under the **The MIT License**. Please see the [LICENSE.txt](LICENSE.txt) file for details.
 
 ## Releases
+## v0.4.7 (2020-05-03)
+- Fix hardlink on Windows (@BarmonHammer)
+- Fix support for unicode chars in paths (@mediaminister)
+- Show remaining time during Widevine installation on ARM devices (@horstle)
+
 ## v0.4.6 (2020-04-29)
 - Compatibility fixes for Kodi 19 Matrix "pre-release" builds (@mediaminister)
 - Optimize Widevine CDM detection (@dagwieers)

--- a/script.module.inputstreamhelper/addon.xml
+++ b/script.module.inputstreamhelper/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.module.inputstreamhelper" name="InputStream Helper" version="0.4.6" provider-name="emilsvennesson, dagwieers, mediaminister">
+<addon id="script.module.inputstreamhelper" name="InputStream Helper" version="0.4.7" provider-name="emilsvennesson, dagwieers, mediaminister">
   <requires>
     <!--py3 compliant-->
     <!--<import addon="xbmc.python" version="2.25.0" targetversion="3.0.0"/>-->
@@ -24,10 +24,10 @@
     <description lang="fr_FR">Un simple module Kodi qui simplifie la vie des développeurs de modules complémentaires en s’appuyant sur des modules complémentaires basés sur InputStream et sur la lecture de DRM.</description>
     <description lang="es_ES">Un módulo Kodi simple que hace la vida más fácil para los desarrolladores de complementos que dependen de complementos basados en InputStream y reproducción de DRM.</description>
     <news>
-      v0.4.6 (2020-04-29)
-        - Compatibility fixes for Kodi 19 Matrix "pre-release" builds (@mediaminister)
-        - Optimize Widevine CDM detection (@dagwieers)
-        - Minor fixes for Widevine installation on ARM devices (@dagwieers @mediaminister @horstle)
+      v0.4.7 (2020-05-03)
+        - Fix hardlink on Windows
+        - Fix support for unicode chars in paths
+        - Show remaining time during Widevine installation on ARM devices
     </news>
     <platform>all</platform>
     <license>MIT</license>

--- a/script.module.inputstreamhelper/lib/inputstreamhelper/kodiutils.py
+++ b/script.module.inputstreamhelper/lib/inputstreamhelper/kodiutils.py
@@ -3,6 +3,7 @@
 """Implements Kodi Helper functions"""
 
 from __future__ import absolute_import, division, unicode_literals
+from contextlib import contextmanager
 import xbmc
 import xbmcaddon
 from xbmcgui import DialogProgress
@@ -51,7 +52,7 @@ def kodi_version_major():
 
 def translate_path(path):
     """Translate special xbmc paths"""
-    return to_unicode(xbmc.translatePath(path))
+    return to_unicode(xbmc.translatePath(from_unicode(path)))
 
 
 def get_addon_info(key):
@@ -66,7 +67,7 @@ def addon_id():
 
 def addon_profile():
     """Cache and return add-on profile"""
-    return translate_path(ADDON.getAddonInfo('profile'))
+    return translate_path(get_addon_info('profile'))
 
 
 def addon_version():
@@ -79,7 +80,7 @@ def browsesingle(type, heading, shares='', mask='', useThumbs=False, treatAsFold
     from xbmcgui import Dialog
     if not heading:
         heading = ADDON.getAddonInfo('name')
-    return Dialog().browseSingle(type=type, heading=heading, shares=shares, mask=mask, useThumbs=useThumbs, treatAsFolder=treatAsFolder, defaultt=defaultt)
+    return to_unicode(Dialog().browseSingle(type=type, heading=heading, shares=shares, mask=mask, useThumbs=useThumbs, treatAsFolder=treatAsFolder, defaultt=defaultt))
 
 
 def notification(heading='', message='', icon='info', time=4000):
@@ -175,7 +176,7 @@ def get_setting_int(key, default=None):
 
 
 def get_setting_float(key, default=None):
-    """Get an add-on setting"""
+    """Get an add-on setting as float"""
     try:
         return ADDON.getSettingNumber(key)
     except (AttributeError, TypeError):  # On Krypton or older, or when not a float
@@ -315,41 +316,57 @@ def kodi_to_ascii(string):
     return string
 
 
+@contextmanager
+def open_file(path, flags='r'):
+    """Open a file (using xbmcvfs)"""
+    from xbmcvfs import File
+    fdesc = File(path, flags)
+    yield fdesc
+    fdesc.close()
+
+
 def copy(src, dest):
     """Copy a file (using xbmcvfs)"""
     from xbmcvfs import copy as vfscopy
     log(2, "Copy file '{src}' to '{dest}'.", src=src, dest=dest)
-    return vfscopy(src, dest)
+    return vfscopy(from_unicode(src), from_unicode(dest))
 
 
 def delete(path):
     """Remove a file (using xbmcvfs)"""
     from xbmcvfs import delete as vfsdelete
     log(2, "Delete file '{path}'.", path=path)
-    return vfsdelete(path)
+    return vfsdelete(from_unicode(path))
 
 
 def exists(path):
     """Whether the path exists (using xbmcvfs)"""
     from xbmcvfs import exists as vfsexists
-    return vfsexists(path)
+    return vfsexists(from_unicode(path))
+
+
+def listdir(path):
+    """Return all files in a directory (using xbmcvfs)"""
+    from xbmcvfs import listdir as vfslistdir
+    dirs, files = vfslistdir(from_unicode(path))
+    return [to_unicode(item) for items in (dirs, files) for item in items]
 
 
 def mkdir(path):
     """Create a directory (using xbmcvfs)"""
     from xbmcvfs import mkdir as vfsmkdir
     log(2, "Create directory '{path}'.", path=path)
-    return vfsmkdir(path)
+    return vfsmkdir(from_unicode(path))
 
 
 def mkdirs(path):
     """Create directory including parents (using xbmcvfs)"""
     from xbmcvfs import mkdirs as vfsmkdirs
     log(2, "Recursively create directory '{path}'.", path=path)
-    return vfsmkdirs(path)
+    return vfsmkdirs(from_unicode(path))
 
 
 def stat_file(path):
     """Return information about a file (using xbmcvfs)"""
     from xbmcvfs import Stat
-    return Stat(path)
+    return Stat(from_unicode(path))

--- a/script.module.inputstreamhelper/lib/inputstreamhelper/unicodes.py
+++ b/script.module.inputstreamhelper/lib/inputstreamhelper/unicodes.py
@@ -17,3 +17,11 @@ def from_unicode(text, encoding='utf-8', errors='strict'):
     if sys.version_info.major == 2 and isinstance(text, unicode):  # noqa: F821; pylint: disable=undefined-variable,useless-suppression
         return text.encode(encoding, errors)
     return text
+
+
+def compat_path(path, encoding='utf-8', errors='strict'):
+    """Convert unicode path to bytestring if needed"""
+    import sys
+    if sys.version_info.major == 2 and isinstance(path, unicode) and not sys.platform.startswith('win'):  # noqa: F821; pylint: disable=undefined-variable,useless-suppression
+        return path.encode(encoding, errors)
+    return path

--- a/script.module.inputstreamhelper/lib/inputstreamhelper/widevine/arm.py
+++ b/script.module.inputstreamhelper/lib/inputstreamhelper/widevine/arm.py
@@ -4,10 +4,12 @@
 
 from __future__ import absolute_import, division, unicode_literals
 import os
+from time import time
 
 from .. import config
-from ..kodiutils import browsesingle, copy, exists, localize, log, mkdir, ok_dialog, progress_dialog, yesno_dialog
-from ..utils import cmd_exists, diskspace, http_download, http_get, run_cmd, sizeof_fmt, store, system_os, temp_path, unzip, update_temp_path
+from ..kodiutils import browsesingle, copy, exists, localize, log, mkdir, ok_dialog, open_file, progress_dialog, yesno_dialog
+from ..utils import cmd_exists, diskspace, http_download, http_get, run_cmd, sizeof_fmt, store, system_os, temp_path, update_temp_path
+from ..unicodes import compat_path, to_unicode
 
 
 def mnt_path():
@@ -78,7 +80,7 @@ def losetup(bin_path):
 
 def mnt_loop_dev():
     """Mount loop device to mnt_path()"""
-    cmd = ['mount', '-t', 'ext2', '-o', 'ro', store('loop_dev'), mnt_path()]
+    cmd = ['mount', '-t', 'ext2', '-o', 'ro', store('loop_dev'), compat_path(mnt_path())]
     output = run_cmd(cmd, sudo=True)
     if output['success']:
         return True
@@ -199,47 +201,49 @@ def install_widevine_arm(backup_path):  # pylint: disable=too-many-statements
         url = arm_device['url']
         downloaded = http_download(url, message=localize(30022), checksum=arm_device['sha1'], hash_alg='sha1', dl_size=int(arm_device['zipfilesize']))  # Downloading the recovery image
         if downloaded:
-            from threading import Thread
-            from xbmc import sleep
             progress = progress_dialog()
             progress.create(heading=localize(30043), message=localize(30044))  # Extracting Widevine CDM
             bin_filename = url.split('/')[-1].replace('.zip', '')
-            bin_path = os.path.join(temp_path(), bin_filename)
+            bin_path = compat_path(os.path.join(temp_path(), bin_filename))
+            starttime = time()
 
             progress.update(
                 0,
                 message='{line1}\n{line2}\n{line3}'.format(
                     line1=localize(30045),  # Uncompressing image
-                    line2=localize(30046, mins=0, secs=0),  # This may take several minutes
+                    line2=localize(30058, mins=0, secs=0),  # Time remaining
                     line3=localize(30047))  # Please do not interrupt this process
             )
-            unzip_result = []
-            unzip_thread = Thread(target=unzip, args=[store('download_path'), temp_path(), bin_filename, unzip_result], name='ImageExtraction')
-            unzip_thread.start()
 
-            time = 0
-            percent = 0
-            remaining = 95
-            while unzip_thread.is_alive():
-                offset = remaining * 0.6 / 100
-                percent += offset
-                remaining -= offset
-                time += 1
-                sleep(1000)
-                progress.update(
-                    int(percent),
-                    message='{line1}\n{line2}\n{line3}'.format(
-                        line1=localize(30045),  # Uncompressing image
-                        line2=localize(30046, mins=time // 60, secs=time % 60),  # This may take several minutes
-                        line3=localize(30047))  # Please do not interrupt this process
-                )
+            from zipfile import ZipFile
 
-            if bool(unzip_result) and check_loop() and set_loop_dev() and losetup(bin_path) and mnt_loop_dev():
+            with ZipFile(compat_path(store('download_path'))) as zip_obj:
+                bin_size = zip_obj.getinfo(bin_filename).file_size
+                chunksize = 1024**2
+
+                with zip_obj.open(bin_filename) as member:
+                    with open(bin_path, 'wb') as bin_file:
+                        bytes_to_read = bin_size
+                        while bytes_to_read > 0:
+                            chunk = member.read(chunksize)
+                            bytes_to_read -= chunksize
+                            bin_file.write(chunk)
+                            percent = 100 * (1 - bytes_to_read / bin_size) - 5
+                            time_left = int(bytes_to_read * (time() - starttime) / (bin_size - bytes_to_read))
+                            progress.update(
+                                int(percent),
+                                message='{line1}\n{line2}\n{line3}'.format(
+                                    line1=localize(30045),  # Uncompressing image
+                                    line2=localize(30058, mins=time_left // 60, secs=time_left % 60),  # Time remaining
+                                    line3=localize(30047))  # Please do not interrupt this process
+                            )
+
+            if check_loop() and set_loop_dev() and losetup(bin_path) and mnt_loop_dev():
                 import json
                 progress.update(96, message=localize(30048))  # Extracting Widevine CDM
                 extract_widevine_from_img(os.path.join(backup_path, arm_device['version']))
                 json_file = os.path.join(backup_path, arm_device['version'], os.path.basename(config.CHROMEOS_RECOVERY_URL) + '.json')
-                with open(json_file, 'w') as config_file:
+                with open_file(json_file, 'w') as config_file:
                     config_file.write(json.dumps(devices, indent=4))
 
                 return (progress, arm_device['version'])
@@ -250,10 +254,10 @@ def install_widevine_arm(backup_path):  # pylint: disable=too-many-statements
 
 def extract_widevine_from_img(backup_path):
     """Extract the Widevine CDM binary from the mounted Chrome OS image"""
-    for root, _, files in os.walk(mnt_path()):
-        if 'libwidevinecdm.so' not in files:
+    for root, _, files in os.walk(compat_path(mnt_path())):
+        if compat_path('libwidevinecdm.so') not in files:
             continue
-        cdm_path = os.path.join(root, 'libwidevinecdm.so')
+        cdm_path = os.path.join(to_unicode(root), 'libwidevinecdm.so')
         log(0, 'Found libwidevinecdm.so in {path}', path=cdm_path)
         if not exists(backup_path):
             mkdir(backup_path)
@@ -266,8 +270,8 @@ def extract_widevine_from_img(backup_path):
 
 def unmount():
     """Unmount mountpoint if mounted"""
-    while os.path.ismount(mnt_path()):
+    while os.path.ismount(compat_path(mnt_path())):
         log(0, 'Unmount {mountpoint}', mountpoint=mnt_path())
-        umount_output = run_cmd(['umount', mnt_path()], sudo=True)
+        umount_output = run_cmd(['umount', compat_path(mnt_path())], sudo=True)
         if not umount_output['success']:
             break

--- a/script.module.inputstreamhelper/resources/language/resource.language.de_de/strings.po
+++ b/script.module.inputstreamhelper/resources/language/resource.language.de_de/strings.po
@@ -190,8 +190,8 @@ msgid "Uncompressing image..."
 msgstr "Entpacke das Image..."
 
 msgctxt "#30046"
-msgid "This may take several minutes. ({mins:d}:{secs:02d})"
-msgstr "Dies kann einige Minuten in Anspruch nehmen. ({mins:d}:{secs:02d})"
+msgid "This may take several minutes."
+msgstr "Dies kann einige Minuten in Anspruch nehmen."
 
 msgctxt "#30047"
 msgid "[I]Please do not interrupt this process.[/I]"
@@ -236,6 +236,10 @@ msgstr "Keine Backups gefunden!"
 msgctxt "#30057"
 msgid "Choose a backup to restore"
 msgstr "Wählen Sie ein Backup zum Wiederherstellen aus."
+
+msgctxt "#30058"
+msgid "Time remaining: {mins:d}:{secs:02d}"
+msgstr ""
 
 
 ### INFORMATION DIALOG

--- a/script.module.inputstreamhelper/resources/language/resource.language.el_gr/strings.po
+++ b/script.module.inputstreamhelper/resources/language/resource.language.el_gr/strings.po
@@ -190,8 +190,8 @@ msgid "Uncompressing image..."
 msgstr "Εξαγωγή εικόνας..."
 
 msgctxt "#30046"
-msgid "This may take several minutes. ({mins:d}:{secs:02d})"
-msgstr "Αυτό μπορεί να διαρκέσει μερικά λεπτά. ({mins:d}:{secs:02d})"
+msgid "This may take several minutes."
+msgstr "Αυτό μπορεί να διαρκέσει μερικά λεπτά."
 
 msgctxt "#30047"
 msgid "[I]Please do not interrupt this process.[/I]"
@@ -236,6 +236,10 @@ msgstr "Δεν βρεθήκανε αντίγραφα ασφαλείας!"
 msgctxt "#30057"
 msgid "Choose a backup to restore"
 msgstr "Επιλέξτε ένα αντίγραφο ασφαλείας για επαναφορά"
+
+msgctxt "#30058"
+msgid "Time remaining: {mins:d}:{secs:02d}"
+msgstr ""
 
 
 ### INFORMATION DIALOG

--- a/script.module.inputstreamhelper/resources/language/resource.language.en_gb/strings.po
+++ b/script.module.inputstreamhelper/resources/language/resource.language.en_gb/strings.po
@@ -190,7 +190,7 @@ msgid "Uncompressing image..."
 msgstr ""
 
 msgctxt "#30046"
-msgid "This may take several minutes. ({mins:d}:{secs:02d})"
+msgid "This may take several minutes."
 msgstr ""
 
 msgctxt "#30047"
@@ -235,6 +235,10 @@ msgstr ""
 
 msgctxt "#30057"
 msgid "Choose a backup to restore"
+msgstr ""
+
+msgctxt "#30058"
+msgid "Time remaining: {mins:d}:{secs:02d}"
 msgstr ""
 
 

--- a/script.module.inputstreamhelper/resources/language/resource.language.es_es/strings.po
+++ b/script.module.inputstreamhelper/resources/language/resource.language.es_es/strings.po
@@ -190,8 +190,8 @@ msgid "Uncompressing image..."
 msgstr "Descomprimiendo la imagen..."
 
 msgctxt "#30046"
-msgid "This may take several minutes. ({mins:d}:{secs:02d})"
-msgstr "Esto puede tomar varios minutos. ({mins:d}:{secs:02d})"
+msgid "This may take several minutes."
+msgstr "Esto puede tomar varios minutos."
 
 msgctxt "#30047"
 msgid "[I]Please do not interrupt this process.[/I]"
@@ -236,6 +236,10 @@ msgstr "¡No se encontraron copias de seguridad!"
 msgctxt "#30057"
 msgid "Choose a backup to restore"
 msgstr "Seleccione una copia de seguridad a restaurar"
+
+msgctxt "#30058"
+msgid "Time remaining: {mins:d}:{secs:02d}"
+msgstr ""
 
 
 ### INFORMATION DIALOG

--- a/script.module.inputstreamhelper/resources/language/resource.language.fr_fr/strings.po
+++ b/script.module.inputstreamhelper/resources/language/resource.language.fr_fr/strings.po
@@ -190,8 +190,8 @@ msgid "Uncompressing image..."
 msgstr "Décompression de l'image ..."
 
 msgctxt "#30046"
-msgid "This may take several minutes. ({mins:d}:{secs:02d})"
-msgstr "Cela peut pendre quelques minutes. ({mins:d}:{secs:02d})"
+msgid "This may take several minutes."
+msgstr "Cela peut pendre quelques minutes."
 
 msgctxt "#30047"
 msgid "[I]Please do not interrupt this process.[/I]"
@@ -236,6 +236,10 @@ msgstr "Aucune sauvegarde trouvée!"
 msgctxt "#30057"
 msgid "Choose a backup to restore"
 msgstr "Choisissez une sauvegarde à restaurer"
+
+msgctxt "#30058"
+msgid "Time remaining: {mins:d}:{secs:02d}"
+msgstr ""
 
 
 ### INFORMATION DIALOG

--- a/script.module.inputstreamhelper/resources/language/resource.language.hr_hr/strings.po
+++ b/script.module.inputstreamhelper/resources/language/resource.language.hr_hr/strings.po
@@ -190,8 +190,8 @@ msgid "Uncompressing image..."
 msgstr "Raspakiranje preslike u tijeku…"
 
 msgctxt "#30046"
-msgid "This may take several minutes. ({mins:d}:{secs:02d})"
-msgstr "Ovo bi moglo potrajati nekoliko minuta. ({mins:d}:{secs:02d})"
+msgid "This may take several minutes."
+msgstr "Ovo bi moglo potrajati nekoliko minuta."
 
 msgctxt "#30047"
 msgid "[I]Please do not interrupt this process.[/I]"
@@ -236,6 +236,10 @@ msgstr "Nisu pronađene sigurnosne kopije!"
 msgctxt "#30057"
 msgid "Choose a backup to restore"
 msgstr "Odaberite sigurnosnu kopiju za vraćanje"
+
+msgctxt "#30058"
+msgid "Time remaining: {mins:d}:{secs:02d}"
+msgstr ""
 
 
 ### INFORMATION DIALOG

--- a/script.module.inputstreamhelper/resources/language/resource.language.hu_hu/strings.po
+++ b/script.module.inputstreamhelper/resources/language/resource.language.hu_hu/strings.po
@@ -190,8 +190,8 @@ msgid "Uncompressing image..."
 msgstr "Lemezkép kitömörítése"
 
 msgctxt "#30046"
-msgid "This may take several minutes. ({mins:d}:{secs:02d})"
-msgstr "Ez néhány percig eltarthat. ({mins:d}:{secs:02d})"
+msgid "This may take several minutes."
+msgstr "Ez néhány percig eltarthat."
 
 msgctxt "#30047"
 msgid "[I]Please do not interrupt this process.[/I]"
@@ -236,6 +236,10 @@ msgstr "Nem található mentés fájl!"
 msgctxt "#30057"
 msgid "Choose a backup to restore"
 msgstr "Válassz mentés fájlt a visszaállításhoz"
+
+msgctxt "#30058"
+msgid "Time remaining: {mins:d}:{secs:02d}"
+msgstr ""
 
 
 ### INFORMATION DIALOG

--- a/script.module.inputstreamhelper/resources/language/resource.language.it_it/strings.po
+++ b/script.module.inputstreamhelper/resources/language/resource.language.it_it/strings.po
@@ -190,8 +190,8 @@ msgid "Uncompressing image..."
 msgstr "Sto estraendo l'immagine"
 
 msgctxt "#30046"
-msgid "This may take several minutes. ({mins:d}:{secs:02d})"
-msgstr "Potrebbero volerci alcuni minuti. ({mins:d}:{secs:02d})"
+msgid "This may take several minutes."
+msgstr "Potrebbero volerci alcuni minuti."
 
 msgctxt "#30047"
 msgid "[I]Please do not interrupt this process.[/I]"
@@ -236,6 +236,10 @@ msgstr "Backup non trovato!"
 msgctxt "#30057"
 msgid "Choose a backup to restore"
 msgstr "Scegli un backup da ripristinare"
+
+msgctxt "#30058"
+msgid "Time remaining: {mins:d}:{secs:02d}"
+msgstr ""
 
 
 ### INFORMATION DIALOG

--- a/script.module.inputstreamhelper/resources/language/resource.language.ja_JP/strings.po
+++ b/script.module.inputstreamhelper/resources/language/resource.language.ja_JP/strings.po
@@ -190,8 +190,8 @@ msgid "Uncompressing image..."
 msgstr "イメージを解凍中。。。"
 
 msgctxt "#30046"
-msgid "This may take several minutes. ({mins:d}:{secs:02d})"
-msgstr "少し時間掛かります。({mins:d}:{secs:02d})"
+msgid "This may take several minutes."
+msgstr "少し時間掛かります。"
 
 msgctxt "#30047"
 msgid "[I]Please do not interrupt this process.[/I]"
@@ -236,6 +236,10 @@ msgstr "バックアップがありませんよ!"
 msgctxt "#30057"
 msgid "Choose a backup to restore"
 msgstr "バックアップを選んでください"
+
+msgctxt "#30058"
+msgid "Time remaining: {mins:d}:{secs:02d}"
+msgstr ""
 
 
 ### INFORMATION DIALOG

--- a/script.module.inputstreamhelper/resources/language/resource.language.ko_KR/strings.po
+++ b/script.module.inputstreamhelper/resources/language/resource.language.ko_KR/strings.po
@@ -190,8 +190,8 @@ msgid "Uncompressing image..."
 msgstr "이미지를 풀어 내는 중..."
 
 msgctxt "#30046"
-msgid "This may take several minutes. ({mins:d}:{secs:02d})"
-msgstr "시간이 조금 걸립니다. ({mins:d}:{secs:02d})"
+msgid "This may take several minutes."
+msgstr "시간이 조금 걸립니다."
 
 msgctxt "#30047"
 msgid "[I]Please do not interrupt this process.[/I]"
@@ -236,6 +236,10 @@ msgstr "저런! 백업이 없어요!"
 msgctxt "#30057"
 msgid "Choose a backup to restore"
 msgstr "복구할 백업을 고르시지요"
+
+msgctxt "#30058"
+msgid "Time remaining: {mins:d}:{secs:02d}"
+msgstr ""
 
 
 ### INFORMATION DIALOG

--- a/script.module.inputstreamhelper/resources/language/resource.language.nl_nl/strings.po
+++ b/script.module.inputstreamhelper/resources/language/resource.language.nl_nl/strings.po
@@ -190,8 +190,8 @@ msgid "Uncompressing image..."
 msgstr "De recovery-image wordt uitgepakt..."
 
 msgctxt "#30046"
-msgid "This may take several minutes. ({mins:d}:{secs:02d})"
-msgstr "Dit kan enkele minuten duren. ({mins:d}:{secs:02d})"
+msgid "This may take several minutes."
+msgstr "Dit kan enkele minuten duren."
 
 msgctxt "#30047"
 msgid "[I]Please do not interrupt this process.[/I]"
@@ -236,6 +236,10 @@ msgstr "Geen backups gevonden!"
 msgctxt "#30057"
 msgid "Choose a backup to restore"
 msgstr "Kies een back-up om te herstellen"
+
+msgctxt "#30058"
+msgid "Time remaining: {mins:d}:{secs:02d}"
+msgstr ""
 
 
 ### INFORMATION DIALOG

--- a/script.module.inputstreamhelper/resources/language/resource.language.ro_ro/strings.po
+++ b/script.module.inputstreamhelper/resources/language/resource.language.ro_ro/strings.po
@@ -191,8 +191,8 @@ msgid "Uncompressing image..."
 msgstr "Se decompresează imaginea..."
 
 msgctxt "#30046"
-msgid "This may take several minutes. ({mins:d}:{secs:02d})"
-msgstr "Acest proces poate dura câteva minute. ({mins:d}:{secs:02d})"
+msgid "This may take several minutes."
+msgstr "Acest proces poate dura câteva minute."
 
 msgctxt "#30047"
 msgid "[I]Please do not interrupt this process.[/I]"
@@ -237,6 +237,10 @@ msgstr "Nu au fost găsite copii de siguranță!"
 msgctxt "#30057"
 msgid "Choose a backup to restore"
 msgstr "Alegeți o copie de siguranță pentru a fi restabilită"
+
+msgctxt "#30058"
+msgid "Time remaining: {mins:d}:{secs:02d}"
+msgstr ""
 
 
 ### INFORMATION DIALOG

--- a/script.module.inputstreamhelper/resources/language/resource.language.ru_ru/strings.po
+++ b/script.module.inputstreamhelper/resources/language/resource.language.ru_ru/strings.po
@@ -190,8 +190,8 @@ msgid "Uncompressing image..."
 msgstr "Распаковка образа..."
 
 msgctxt "#30046"
-msgid "This may take several minutes. ({mins:d}:{secs:02d})"
-msgstr "Это может занять несколько минут. ({mins:d}:{secs:02d})"
+msgid "This may take several minutes."
+msgstr "Это может занять несколько минут."
 
 msgctxt "#30047"
 msgid "[I]Please do not interrupt this process.[/I]"
@@ -236,6 +236,10 @@ msgstr "Резервные копии не найдены!"
 msgctxt "#30057"
 msgid "Choose a backup to restore"
 msgstr "Выберите резервную копию для восстановления"
+
+msgctxt "#30058"
+msgid "Time remaining: {mins:d}:{secs:02d}"
+msgstr ""
 
 
 ### INFORMATION DIALOG

--- a/script.module.inputstreamhelper/resources/language/resource.language.sv_se/strings.po
+++ b/script.module.inputstreamhelper/resources/language/resource.language.sv_se/strings.po
@@ -190,8 +190,8 @@ msgid "Uncompressing image..."
 msgstr "Packar upp avbilden..."
 
 msgctxt "#30046"
-msgid "This may take several minutes. ({mins:d}:{secs:02d})"
-msgstr "Detta kan ta flera minuter. ({mins:d}:{secs:02d})"
+msgid "This may take several minutes."
+msgstr "Detta kan ta flera minuter."
 
 msgctxt "#30047"
 msgid "[I]Please do not interrupt this process.[/I]"
@@ -236,6 +236,10 @@ msgstr "Hittade inga säkerhetskopior!"
 msgctxt "#30057"
 msgid "Choose a backup to restore"
 msgstr "Välj säkerhetskopia att återställa"
+
+msgctxt "#30058"
+msgid "Time remaining: {mins:d}:{secs:02d}"
+msgstr ""
 
 
 ### INFORMATION DIALOG


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: InputStream Helper
  - Add-on ID: script.module.inputstreamhelper
  - Version number: 0.4.7
  - Kodi/repository version: krypton

- **Code location**
  - URL: https://github.com/emilsvennesson/script.module.inputstreamhelper
  
A simple Kodi module that makes life easier for add-on developers relying on InputStream based add-ons and DRM playback.

### Description of changes:


      v0.4.7 (2020-05-03)
        - Fix hardlink on Windows
        - Fix support for unicode chars in paths
        - Show remaining time during Widevine installation on ARM devices
    

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
