### PR TITLE
[script.kodi.loguploader] 0.6.0

### DIFF
--- a/script.kodi.loguploader/addon.xml
+++ b/script.kodi.loguploader/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.kodi.loguploader" name="Kodi Logfile Uploader" version="0.4.0" provider-name="Team Kodi">
+<addon id="script.kodi.loguploader" name="Kodi Logfile Uploader" version="0.6.0" provider-name="Team Kodi">
 	<requires>
 		<import addon="xbmc.python" version="2.25.0"/>
 		<import addon="script.module.pyqrcode" version="0.0.1"/>
@@ -11,15 +11,13 @@
 	<extension point="xbmc.addon.metadata">
 		<summary lang="en_GB">Uploads your kodi.log file.</summary>
 		<description lang="en_GB">Uploads your kodi.log file and returns an url you can post on http://forum.kodi.tv/</description>
-		<language></language>
 		<platform>all</platform>
-		<license>GNU GENERAL PUBLIC LICENSE Version 2</license>
+		<license>GPL-2.0-only</license>
 		<forum>https://forum.kodi.tv/showthread.php?tid=288153</forum>
-		<website>https://kodi.tv/</website>
-		<email></email>
 		<source>https://gitlab.com/ronie/script.kodi.loguploader/</source>
 		<assets>
 			<icon>resources/icon.png</icon>
 		</assets>
+		<news>- allow 2MB uploads</news>
 	</extension>
 </addon>

--- a/script.kodi.loguploader/changelog.txt
+++ b/script.kodi.loguploader/changelog.txt
@@ -1,3 +1,6 @@
+v0.6.0
+- allow 2MB uploads
+
 v0.4.0
 - krypton bump
 

--- a/script.kodi.loguploader/default.py
+++ b/script.kodi.loguploader/default.py
@@ -147,7 +147,7 @@ class Main:
         try:
             lf = xbmcvfs.File(path)
             sz = lf.size()
-            if sz > 1000000:
+            if sz > 2000000:
                 log('file is too large')
                 return False, LANGUAGE(32005)
             content = lf.read()


### PR DESCRIPTION
### Description
paste.kodi.tv now allows file uploads up to 2MB.
this change is needed to make use of the new, increased limit.
### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [X] Each add-on submission should be a single commit with using the following style: [script.foo.bar] 1.0.0

Additional information :
- Submitting your add-on to this specific branch makes it available to any Kodi version equal or higher than the branch name with the applicable Kodi dependencies limits.
- [add-on development](http://kodi.wiki/view/Add-on_development) wiki page.
- Kodi [pydocs](http://kodi.wiki/view/PyDocs) provide information about the Python API
- [PEP8](https://www.python.org/dev/peps/pep-0008/) codingstyle which is considered best practise but not mandatory.
- This add-on repository has automated code guideline check which could help you improve your coding. You can find the results of these check at [Codacy](https://www.codacy.com/app/Kodi/repo-scripts/dashboard). You can create your own account as well to continuously monitor your python coding before submitting to repo.
- Development questions can be asked in the [add-on development](http://forum.kodi.tv/forumdisplay.php?fid=26) section on the Kodi forum.
