### PR TITLE
[screensaver.picture.slideshow] 6.3.0

### DIFF
--- a/screensaver.picture.slideshow/addon.xml
+++ b/screensaver.picture.slideshow/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="screensaver.picture.slideshow" name="Picture Slideshow Screensaver" version="6.1.0" provider-name="Team Kodi">
+<addon id="screensaver.picture.slideshow" name="Picture Slideshow Screensaver" version="6.3.0" provider-name="Team Kodi">
 	<requires>
 		<import addon="xbmc.python" version="3.0.0"/>
 	</requires>
@@ -115,8 +115,7 @@
 			<icon>resources/icon.png</icon>
 			<fanart>resources/fanart.jpg</fanart>
 		</assets>
-		<news>- update exif, iptc and xmp data parsers
-- fix: display background setting was not selectable
-- fix: slideshow with no effect was broken</news>
+		<news>- convert skin to 1080p
+- add support for more picture extensions</news>
 	</extension>
 </addon>

--- a/screensaver.picture.slideshow/changelog.txt
+++ b/screensaver.picture.slideshow/changelog.txt
@@ -1,3 +1,11 @@
+v6.3.0
+- use art table to retrieve fanart
+- use json to read and write cache
+
+v6.2.0
+- convert skin to 1080p
+- add support for more picture extensions
+
 v6.1.0
 - update exif, iptc and xmp data parsers
 - fix: display background setting was not selectable

--- a/screensaver.picture.slideshow/lib/utils.py
+++ b/screensaver.picture.slideshow/lib/utils.py
@@ -1,5 +1,6 @@
 import hashlib
 import os
+import json
 import re
 import sys
 import urllib
@@ -13,9 +14,9 @@ ADDONID = ADDON.getAddonInfo('id')
 LANGUAGE = ADDON.getLocalizedString
 
 # supported image types by the screensaver
-IMAGE_TYPES = ('.jpg', '.jpeg', '.png', '.tif', '.tiff', '.gif', '.pcx', '.bmp', '.tga', '.ico', '.nef')
+IMAGE_TYPES = ('.jpg', '.jpeg', '.png', '.tif', '.tiff', '.gif', '.pcx', '.bmp', '.tga', '.ico', '.nef', '.webp', '.jp2', '.apng')
 CACHEFOLDER = xbmc.translatePath(ADDON.getAddonInfo('profile'))
-CACHEFILE = os.path.join(CACHEFOLDER, '%s')
+CACHEFILE = os.path.join(CACHEFOLDER, 'cache_%s')
 RESUMEFILE = os.path.join(CACHEFOLDER, 'offset')
 ASFILE = xbmc.translatePath('special://profile/advancedsettings.xml')
 
@@ -36,10 +37,10 @@ def create_cache(path, hexfile):
         if item != 'settings.xml':
             xbmcvfs.delete(os.path.join(CACHEFOLDER,item))
     if images:
-        # create index file
+        # create cache file
         try:
             cache = xbmcvfs.File(CACHEFILE % hexfile, 'w')
-            cache.write(str(images))
+            json.dump(images, cache)
             cache.close()
         except:
             log('failed to save cachefile')

--- a/screensaver.picture.slideshow/resources/skins/default/1080i/script-python-slideshow.xml
+++ b/screensaver.picture.slideshow/resources/skins/default/1080i/script-python-slideshow.xml
@@ -5,8 +5,8 @@
 		<control type="image">
 			<posx>0</posx>
 			<posy>0</posy>
-			<width>1280</width>
-			<height>720</height>
+			<width>1920</width>
+			<height>1080</height>
 			<texture>screensaver-black.png</texture>
 			<animation effect="fade" start="0" end="100" time="500">WindowOpen</animation>
 		</control>
@@ -27,8 +27,8 @@
 					<control type="image" id="5">
 						<posx>0</posx>
 						<posy>0</posy>
-						<width>1280</width>
-						<height>720</height>
+						<width>1920</width>
+						<height>1080</height>
 						<texture background="true"></texture>
 						<aspectratio>scale</aspectratio>
 						<fadetime>0</fadetime>
@@ -45,8 +45,8 @@
 					<control type="image" id="6">
 						<posx>0</posx>
 						<posy>0</posy>
-						<width>1280</width>
-						<height>720</height>
+						<width>1920</width>
+						<height>1080</height>
 						<texture background="true"></texture>
 						<aspectratio>scale</aspectratio>
 						<fadetime>0</fadetime>
@@ -56,8 +56,8 @@
 					<animation effect="fade" start="80" end="80" time="0" condition="true">Conditional</animation>
 					<posx>0</posx>
 					<posy>0</posy>
-					<width>1280</width>
-					<height>720</height>
+					<width>1920</width>
+					<height>1080</height>
 					<texture>screensaver-black.png</texture>
 				</control>
 			</control>
@@ -72,16 +72,16 @@
 				<control type="image" id="1">
 					<posx>0</posx>
 					<posy>0</posy>
-					<width>1280</width>
-					<height>720</height>
+					<width>1920</width>
+					<height>1080</height>
 					<texture background="true"></texture>
 					<aspectratio>keep</aspectratio>
 					<fadetime>0</fadetime>
 					<animation type="Conditional" condition="String.IsEqual(Window.Property(SlideView.Slide1),0)" reversible="false">
-						<effect type="slide" tween="cubic" easing="inout" start="1280,0" end="0,0" time="500"/>
+						<effect type="slide" tween="cubic" easing="inout" start="1920,0" end="0,0" time="500"/>
 					</animation>
 					<animation type="Conditional" condition="String.IsEqual(Window.Property(SlideView.Slide1),1)" reversible="false">
-						<effect type="slide" tween="cubic" easing="inout" start="0,0" end="-1280,0" time="500"/>
+						<effect type="slide" tween="cubic" easing="inout" start="0,0" end="-1920,0" time="500"/>
 					</animation>
 				</control>
 			</control>
@@ -96,16 +96,16 @@
 				<control type="image" id="2">
 					<posx>0</posx>
 					<posy>0</posy>
-					<width>1280</width>
-					<height>720</height>
+					<width>1920</width>
+					<height>1080</height>
 					<texture background="true"></texture>
 					<aspectratio>keep</aspectratio>
 					<fadetime>0</fadetime>
 					<animation type="Conditional" condition="String.IsEqual(Window.Property(SlideView.Slide2),0)" reversible="false">
-						<effect type="slide" tween="cubic" easing="inout" start="1280,0" end="0,0" time="500"/>
+						<effect type="slide" tween="cubic" easing="inout" start="1920,0" end="0,0" time="500"/>
 					</animation>
 					<animation type="Conditional" condition="String.IsEqual(Window.Property(SlideView.Slide2),1)" reversible="false">
-						<effect type="slide" tween="cubic" easing="inout" start="0,0" end="-1280,0" time="500"/>
+						<effect type="slide" tween="cubic" easing="inout" start="0,0" end="-1920,0" time="500"/>
 					</animation>
 				</control>
 			</control>
@@ -120,16 +120,16 @@
 				<control type="image" id="3">
 					<posx>0</posx>
 					<posy>0</posy>
-					<width>1280</width>
-					<height>720</height>
+					<width>1920</width>
+					<height>1080</height>
 					<texture background="true"></texture>
 					<aspectratio>scale</aspectratio>
 					<fadetime>0</fadetime>
 					<animation type="Conditional" condition="String.IsEqual(Window.Property(SlideView.Slide1),0)" reversible="false">
-						<effect type="slide" tween="cubic" easing="inout" start="1280,0" end="0,0" time="500"/>
+						<effect type="slide" tween="cubic" easing="inout" start="1920,0" end="0,0" time="500"/>
 					</animation>
 					<animation type="Conditional" condition="String.IsEqual(Window.Property(SlideView.Slide1),1)" reversible="false">
-						<effect type="slide" tween="cubic" easing="inout" start="0,0" end="-1280,0" time="500"/>
+						<effect type="slide" tween="cubic" easing="inout" start="0,0" end="-1920,0" time="500"/>
 					</animation>
 				</control>
 			</control>
@@ -144,79 +144,79 @@
 				<control type="image" id="4">
 					<posx>0</posx>
 					<posy>0</posy>
-					<width>1280</width>
-					<height>720</height>
+					<width>1920</width>
+					<height>1080</height>
 					<texture background="true"></texture>
 					<aspectratio>scale</aspectratio>
 					<fadetime>0</fadetime>
 					<animation type="Conditional" condition="String.IsEqual(Window.Property(SlideView.Slide2),0)" reversible="false">
-						<effect type="slide" tween="cubic" easing="inout" start="1280,0" end="0,0" time="500"/>
+						<effect type="slide" tween="cubic" easing="inout" start="1920,0" end="0,0" time="500"/>
 					</animation>
 					<animation type="Conditional" condition="String.IsEqual(Window.Property(SlideView.Slide2),1)" reversible="false">
-						<effect type="slide" tween="cubic" easing="inout" start="0,0" end="-1280,0" time="500"/>
+						<effect type="slide" tween="cubic" easing="inout" start="0,0" end="-1920,0" time="500"/>
 					</animation>
 				</control>
 			</control>
-			<control type="label" id="99">
-				<posx>1250</posx>
-				<posy>665</posy>
-				<width>600</width>
-				<height>20</height>
-				<font>font16</font>
+			<control type="label" id="99"> <!--name-->
+				<posx>1875</posx>
+				<posy>992</posy>
+				<width>900</width>
+				<height>30</height>
+				<font>font14</font>
 				<align>right</align>
 				<textcolor>F0FFFFFF</textcolor>
 				<shadowcolor>F0000000</shadowcolor>
 			</control>
-			<control type="label" id="100">
-				<posx>1250</posx>
-				<posy>690</posy>
-				<width>600</width>
-				<height>20</height>
-				<font>font12</font>
+			<control type="label" id="100"> <!-- date -->
+				<posx>1875</posx>
+				<posy>1030</posy>
+				<width>900</width>
+				<height>30</height>
+				<font>font13</font>
 				<align>right</align>
 				<textcolor>C0FFFFFF</textcolor>
 				<shadowcolor>F0000000</shadowcolor>
 			</control>
-			<control type="textbox" id="101">
-				<posx>30</posx>
-				<posy>620</posy>
-				<width>600</width>
-				<height>90</height>
-				<font>font12</font>
+			<control type="textbox" id="101"> <!-- exif -->
+				<posx>45</posx>
+				<posy>925</posy>
+				<width>900</width>
+				<height>135</height>
+				<font>font13</font>
 				<align>left</align>
 				<textcolor>C0FFFFFF</textcolor>
 				<shadowcolor>C0000000</shadowcolor>
 				<visible>![Player.HasAudio + String.IsEqual(Window.Property(SlideView.Music),show)]</visible>
 			</control>
 			<control type="group">
-				<posx>20</posx>
-				<posy>575</posy>
+				<posx>30</posx>
+				<posy>862</posy>
 				<animation effect="fade" start="80" end="80" time="0" condition="true">Conditional</animation>
 				<visible>Player.HasAudio + String.IsEqual(Window.Property(SlideView.Music),show)</visible>
 				<control type="image">
 					<posx>0</posx>
-					<posy>-5</posy>
-					<width>140</width>
-					<height>140</height>
+					<posy>-7</posy>
+					<width>210</width>
+					<height>210</height>
 					<texture fallback="DefaultAlbumCover.png">$INFO[MusicPlayer.Cover]</texture>
 					<aspectratio>scale</aspectratio>
 				</control>
 				<control type="label">
-					<posx>160</posx>
-					<posy>50</posy>
-					<width>600</width>
-					<height>25</height>
+					<posx>240</posx>
+					<posy>60</posy>
+					<width>900</width>
+					<height>38</height>
 					<align>left</align>
-					<font>font15</font>
+					<font>font13</font>
 					<label>[B]$INFO[MusicPlayer.Title][/B]</label>
 					<textcolor>FFFFFFFF</textcolor>
 					<shadowcolor>FF000000</shadowcolor>
 				</control>
 				<control type="label">
-					<posx>160</posx>
-					<posy>72</posy>
-					<width>600</width>
-					<height>25</height>
+					<posx>240</posx>
+					<posy>95</posy>
+					<width>900</width>
+					<height>38</height>
 					<align>left</align>
 					<font>font13</font>
 					<label>$INFO[MusicPlayer.Artist]</label>
@@ -224,25 +224,25 @@
 					<shadowcolor>FF000000</shadowcolor>
 				</control>
 				<control type="label">
-					<posx>160</posx>
-					<posy>94</posy>
-					<width>600</width>
-					<height>25</height>
+					<posx>240</posx>
+					<posy>130</posy>
+					<width>900</width>
+					<height>38</height>
 					<align>left</align>
-					<font>font12</font>
+					<font>font13</font>
 					<label>$INFO[MusicPlayer.Album]</label>
 					<textcolor>FFFFFFFF</textcolor>
 					<shadowcolor>FF000000</shadowcolor>
 				</control>
 				<control type="group">
-					<posx>160</posx>
-					<posy>110</posy>
+					<posx>240</posx>
+					<posy>160</posy>
 					<control type="label">
 						<posx>0</posx>
-						<posy>8</posy>
-						<width>100</width>
-						<height>20</height>
-						<font>font12</font>
+						<posy>12</posy>
+						<width>150</width>
+						<height>30</height>
+						<font>font13</font>
 						<align>left</align>
 						<aligny>center</aligny>
 						<label>$INFO[Player.Time(hh:mm:ss)]</label>
@@ -251,23 +251,23 @@
 					</control>
 					<control type="progress">
 						<description>Progressbar</description>
-						<posx>85</posx>
-						<posy>12</posy>
-						<width>200</width>
-						<height>14</height>
+						<posx>128</posx>
+						<posy>18</posy>
+						<width>300</width>
+						<height>21</height>
 						<info>Player.Progress</info>
 						<texturebg border="3" colordiffuse="FFFFFFFF">screensaver-progress.png</texturebg>
 						<midtexture colordiffuse="FF12B2E7">screensaver-progress.png</midtexture>
-						<lefttexture>-</lefttexture>
-						<righttexture>-</righttexture>
-						<overlaytexture>-</overlaytexture>
+						<lefttexture></lefttexture>
+						<righttexture></righttexture>
+						<overlaytexture></overlaytexture>
 					</control>
 					<control type="label">
-						<posx>370</posx>
-						<posy>8</posy>
-						<width>100</width>
-						<height>20</height>
-						<font>font12</font>
+						<posx>555</posx>
+						<posy>12</posy>
+						<width>150</width>
+						<height>30</height>
+						<font>font13</font>
 						<align>right</align>
 						<aligny>center</aligny>
 						<label>$INFO[Player.Duration(hh:mm:ss)]</label>
@@ -278,8 +278,8 @@
 			</control>
 		</control>
 		<control type="image">
-			<posx>409</posx>
-			<posy>129</posy>
+			<posx>729</posx>
+			<posy>309</posy>
 			<width>461</width>
 			<height>461</height>
 			<aspectratio>keep</aspectratio>
@@ -297,8 +297,8 @@
 		<control type="image">
 			<posx>0</posx>
 			<posy>0</posy>
-			<width>1280</width>
-			<height>720</height>
+			<width>1920</width>
+			<height>1080</height>
 			<texture>screensaver-black.png</texture>
 			<colordiffuse>$INFO[Window.Property(SlideView.Dim)]</colordiffuse>
 		</control>


### PR DESCRIPTION
### Description
changes:
- converted screensaver to 1080p
- improve reading/writing cache file
- add support for more image extensions
- retrieve fanart from the art table

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [X] Each add-on submission should be a single commit with using the following style: [script.foo.bar] 1.0.0

Additional information :
- Submitting your add-on to this specific branch makes it available to any Kodi version equal or higher than the branch name with the applicable Kodi dependencies limits.
- [add-on development](http://kodi.wiki/view/Add-on_development) wiki page.
- Kodi [pydocs](http://kodi.wiki/view/PyDocs) provide information about the Python API
- [PEP8](https://www.python.org/dev/peps/pep-0008/) codingstyle which is considered best practise but not mandatory.
- This add-on repository has automated code guideline check which could help you improve your coding. You can find the results of these check at [Codacy](https://www.codacy.com/app/Kodi/repo-scripts/dashboard). You can create your own account as well to continuously monitor your python coding before submitting to repo.
- Development questions can be asked in the [add-on development](http://forum.kodi.tv/forumdisplay.php?fid=26) section on the Kodi forum.
