### PR TITLE
[script.xbmcbackup] 1.6.3

### DIFF
--- a/script.xbmcbackup/addon.xml
+++ b/script.xbmcbackup/addon.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="script.xbmcbackup"
-    name="Backup" version="1.6.2" provider-name="robweber">
+    name="Backup" version="1.6.3" provider-name="robweber">
   <requires>
     <import addon="xbmc.python" version="3.0.0"/>
     <import addon="script.module.dateutil" version="2.8.0" />
@@ -89,12 +89,14 @@
 		<screenshot>resources/images/screenshot3.jpg</screenshot>
 		<screenshot>resources/images/screenshot4.jpg</screenshot>
     </assets>
-    <news>Version 1.6.2
+    <news>Version 1.6.3
+ - fixed validatePath error (issue #166)
+Version 1.6.2
  - replaced PNG screenshots with JPG
 Version 1.6.1
  - added file transfer size to progress bar
  - progress bar now based on transfer size, not total file count
  - fixed rotate backups error - thanks @AnonTester
-   	</news>
+</news>
   </extension>
 </addon>

--- a/script.xbmcbackup/resources/lib/backup.py
+++ b/script.xbmcbackup/resources/lib/backup.py
@@ -571,7 +571,7 @@ class FileManager:
             if(recurse):
                 # create all the subdirs first
                 for aDir in dirs:
-                    dirPath = xbmc.validatePath(xbmc.translatePath(directory + self.pathSep + aDir))
+                    dirPath = xbmcvfs.validatePath(xbmc.translatePath(directory + self.pathSep + aDir))
                     file_ext = aDir.split('.')[-1]
 
                     # check if directory is excluded


### PR DESCRIPTION
### Description
Fixes issue where the ```validatePath()``` function was moved from the ```xbmc``` module to the ```xbmcvfs``` module in Matrix. 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [script.foo.bar] 1.0.0

Additional information :
- Submitting your add-on to this specific branch makes it available to any Kodi version equal or higher than the branch name with the applicable Kodi dependencies limits.
- [add-on development](http://kodi.wiki/view/Add-on_development) wiki page.
- Kodi [pydocs](http://kodi.wiki/view/PyDocs) provide information about the Python API
- [PEP8](https://www.python.org/dev/peps/pep-0008/) codingstyle which is considered best practise but not mandatory.
- This add-on repository has automated code guideline check which could help you improve your coding. You can find the results of these check at [Codacy](https://www.codacy.com/app/Kodi/repo-scripts/dashboard). You can create your own account as well to continuously monitor your python coding before submitting to repo.
- Development questions can be asked in the [add-on development](http://forum.kodi.tv/forumdisplay.php?fid=26) section on the Kodi forum.
