### PR TITLE
[script.module.codequick] 0.9.12

### DIFF
--- a/script.module.codequick/addon.xml
+++ b/script.module.codequick/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.module.codequick" name="CodeQuick" provider-name="willforde" version="0.9.10">
+<addon id="script.module.codequick" name="CodeQuick" provider-name="willforde" version="0.9.12">
     <requires>
         <import addon="xbmc.python" version="2.25.0"/>
         <import addon="script.module.youtube.dl" version="18.0.0"/>

--- a/script.module.codequick/lib/codequick/support.py
+++ b/script.module.codequick/lib/codequick/support.py
@@ -2,6 +2,7 @@
 from __future__ import absolute_import
 
 # Standard Library Imports
+import importlib
 import binascii
 import inspect
 import logging
@@ -35,6 +36,13 @@ logger = logging.getLogger("%s.support" % logger_id)
 
 # Listitem auto sort methods
 auto_sort = set()
+
+
+class RouteMissing(KeyError):
+    """
+    Exception class that is raisd when no
+    route is found in the registered routes.
+    """
 
 
 class LoggingMap(dict):
@@ -231,7 +239,21 @@ class Dispatcher(object):
 
     def get_route(self, path=None):  # type: (str) -> Route
         """Return the given route object."""
-        return self.registered_routes[path if path else self.selector]
+        path = path if path else self.selector
+
+        # Attempt to import the module where the route
+        # is located if it's not already registered
+        if path not in self.registered_routes:
+            module_path = "resources.lib.main" if path == "root" else ".".join(path.strip("/").split("/")[:-1])
+            logger.debug("Attempting to import route: %s", module_path)
+            try:
+                importlib.import_module(module_path)
+            except ImportError:
+                raise RouteMissing("unable to import route module: %s" % module_path)
+        try:
+            return self.registered_routes[path]
+        except KeyError:
+            raise RouteMissing(path)
 
     def register_callback(self, callback, parent):
         """
@@ -358,7 +380,10 @@ def build_path(callback=None, args=None, query=None, **extra_query):
     """
 
     # Set callback to current callback if not given
-    route = callback.route if callback else dispatcher.get_route()
+    if callback and hasattr(callback, "route"):
+        route = callback.route
+    else:
+        route = dispatcher.get_route(callback)
 
     # Convert args to keyword args if required
     if args:

--- a/script.module.codequick/lib/codequick/youtube.py
+++ b/script.module.codequick/lib/codequick/youtube.py
@@ -452,11 +452,18 @@ class APIControl(Route):
             for video in feed[u"items"]:
                 snippet = video[u"snippet"]
                 content_details = video[u"contentDetails"]
-                data = {"title": snippet[u"localized"][u"title"], "thumb": snippet[u"thumbnails"][u"medium"][u"url"],
-                        "description": snippet[u"localized"][u"description"], "date": snippet[u"publishedAt"],
-                        "count": int(video[u"statistics"][u"viewCount"]), "channel_id": snippet[u"channelId"],
-                        "video_id": video[u"id"], "hd": int(content_details[u"definition"] == u"hd"),
-                        "duration": "", "genre_id": int(snippet[u"categoryId"])}
+                data = {
+                    "title": snippet[u"localized"][u"title"],
+                    "thumb": snippet[u"thumbnails"][u"medium"][u"url"],
+                    "description": snippet[u"localized"][u"description"],
+                    "date": snippet[u"publishedAt"],
+                    "count": int(video["statistics"]["viewCount"]) if "statistics" in video else 0,
+                    "channel_id": snippet[u"channelId"],
+                    "video_id": video[u"id"],
+                    "hd": int(content_details[u"definition"] == u"hd"),
+                    "duration": "",
+                    "genre_id": int(snippet[u"categoryId"])
+                }
 
                 # Convert duration to what kodi is expecting (duration in seconds)
                 duration_str = content_details[u"duration"]
@@ -523,7 +530,8 @@ class APIControl(Route):
             item.info["studio"] = video_data["channel_title"]
 
             # Fetch Viewcount
-            item.info["count"] = video_data["count"]
+            if video_data["count"]:
+                item.info["count"] = video_data["count"]
 
             # Fetch Possible Date
             date = video_data["date"]


### PR DESCRIPTION
### Description
#### Fixed
- Attempt fix for 'import _strptime' failure.

#### Changed
- Run method now returns the exception that was raise when error occurs
- 'set_callback' now excepts a path to a callback.
- No need to always import callback modules. Modules are auto loaded based on the specified path.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [script.foo.bar] 1.0.0
