### PR TITLE
stop listing Leia compatible skins in the Matrix repo

### DIFF
--- a/targets.cfg
+++ b/targets.cfg
@@ -79,7 +79,7 @@ minversions =
 [matrix]
 branches = gotham,helix,isengard,jarvis,krypton,leia,matrix
 minversions =
-    xbmc.gui:5.14.0,
+    xbmc.gui:5.15.0,
     xbmc.python:3.0.0,
     xbmc.json:6.0.0,
     xbmc.metadata:1.0,


### PR DESCRIPTION
Leia skins will not work correctly, due to the GUI Engine changes in Matrix
and/or fail to install due to their dependency on addons that have not been ported to py3.

as requested by @jjd-uk 