### PR TITLE
[screensaver.kaster@matrix] 1.3.3+matrix.1

### DIFF
--- a/screensaver.kaster/addon.xml
+++ b/screensaver.kaster/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="screensaver.kaster" name="Kaster" version="1.3.2+matrix.1" provider-name="enen92">
+<addon id="screensaver.kaster" name="Kaster" version="1.3.3+matrix.1" provider-name="enen92">
 	<requires>
 		<import addon="xbmc.python" version="3.0.0"/>
 		<import addon="script.module.requests" version="2.22.0"/>
@@ -20,9 +20,10 @@
 		<description lang="es_ES">Muestra bellas imágenes como las del protector de pantalla de chromecast. También puede mostrar sus propias fotos junto con su respectiva información.</description>
 		<description lang="nl_NL">Toon prachtige afbeeldingen afkomstig van de Chromecast screensaver. Je kunt ook je eigen foto's tonen met al hun informatie.</description>
 		<description lang="fr_FR">Affichez de jolies images provenant de l’écran de veille de Chromecast. Vous pouvez aussi afficher vos propres images avec leurs informations respectives.</description>
-		<news>v1.3.2
-			[new] Automated submissions for matrix
-			[fix] Addon.xml and screenshots (addon-checker compliance)
+		<news>v1.3.3
+			[fix] CPU usage
+			[fix] HTTP request number in case of 429 status code
+			[cosmetic] SPDX headers
 		</news>
 		<assets>
 			<icon>resources/images/icon.png</icon>

--- a/screensaver.kaster/entrypoint.py
+++ b/screensaver.kaster/entrypoint.py
@@ -1,20 +1,10 @@
 # -*- coding: utf-8 -*-
 """
-    screensaver.kaster
-    Copyright (C) 2017 enen92
+  Copyright (C) 2017-2020 enen92
+  This file is part of kaster
 
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
-    the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU General Public License for more details.
-
-    You should have received a copy of the GNU General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  SPDX-License-Identifier: GPL-2.0-or-later
+  See LICENSE for more information.
 """
 
 from resources.lib.screensaver import Kaster

--- a/screensaver.kaster/resources/lib/kodiutils.py
+++ b/screensaver.kaster/resources/lib/kodiutils.py
@@ -1,20 +1,10 @@
 # -*- coding: utf-8 -*-
 """
-    screensaver.kaster
-    Copyright (C) 2017 enen92
+  Copyright (C) 2017-2020 enen92
+  This file is part of kaster
 
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
-    the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU General Public License for more details.
-
-    You should have received a copy of the GNU General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  SPDX-License-Identifier: GPL-2.0-or-later
+  See LICENSE for more information.
 """
 import xbmc
 import xbmcaddon

--- a/screensaver.kaster/resources/lib/screensaverutils.py
+++ b/screensaver.kaster/resources/lib/screensaverutils.py
@@ -1,20 +1,10 @@
 # -*- coding: utf-8 -*-
 """
-    screensaver.kaster
-    Copyright (C) 2017 enen92
+  Copyright (C) 2017-2020 enen92
+  This file is part of kaster
 
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
-    the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU General Public License for more details.
-
-    You should have received a copy of the GNU General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  SPDX-License-Identifier: GPL-2.0-or-later
+  See LICENSE for more information.
 """
 from . import kodiutils
 import xbmcvfs


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: Kaster
  - Add-on ID: screensaver.kaster
  - Version number: 1.3.3+matrix.1
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/enen92/screensaver.kaster
  
Display beautiful pictures originally from the chromecast screensaver. You can also display your own photos along with its respective information.

### Description of changes:

v1.3.3
			[fix] CPU usage
			[fix] HTTP request number in case of 429 status code
			[cosmetic] SPDX headers
		

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
