### PR TITLE
[script.module.inputstreamhelper@krypton] 0.5.0

### DIFF
--- a/script.module.inputstreamhelper/README.md
+++ b/script.module.inputstreamhelper/README.md
@@ -90,6 +90,13 @@ Please report any issues or bug reports on the [GitHub Issues](https://github.co
 This module is licensed under the **The MIT License**. Please see the [LICENSE.txt](LICENSE.txt) file for details.
 
 ## Releases
+## v0.5.0 (2020-06-25)
+- Extract Widevine CDM directly from Chrome OS, minimizing disk space usage and eliminating the need for root access (@horstle)
+- Improve progress dialog while extracting Widevine CDM on ARM devices (@horstle, @mediaminister)
+- Support resuming interrupted downloads on unreliable internet connections (@horstle, @mediaminister)
+- Reshape InputStream Helper information dialog (@horstle, @dagwieers)
+- Updated Dutch, English, French, German, Greek, Hungarian, Romanian, Russian, Spanish and Swedish translations (@dagwieers, @horstle, @mediaminister, @tweimer, @Twilight0, @frodo19, @tmihai20, @vlmaksime, @roliverosc, @Sopor)
+
 ## v0.4.7 (2020-05-03)
 - Fix hardlink on Windows (@BarmonHammer)
 - Fix support for unicode chars in paths (@mediaminister)

--- a/script.module.inputstreamhelper/addon.xml
+++ b/script.module.inputstreamhelper/addon.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.module.inputstreamhelper" name="InputStream Helper" version="0.4.7" provider-name="emilsvennesson, dagwieers, mediaminister">
+<addon id="script.module.inputstreamhelper" name="InputStream Helper" version="0.5.0" provider-name="emilsvennesson, dagwieers, mediaminister, horstle">
   <requires>
     <!--py3 compliant-->
-    <!--<import addon="xbmc.python" version="2.25.0" targetversion="3.0.0"/>-->
     <import addon="xbmc.python" version="2.25.0"/>
     <import addon="script.module.pysocks" version="1.6.8" optional="true"/>
   </requires>
@@ -24,10 +23,12 @@
     <description lang="fr_FR">Un simple module Kodi qui simplifie la vie des développeurs de modules complémentaires en s’appuyant sur des modules complémentaires basés sur InputStream et sur la lecture de DRM.</description>
     <description lang="es_ES">Un módulo Kodi simple que hace la vida más fácil para los desarrolladores de complementos que dependen de complementos basados en InputStream y reproducción de DRM.</description>
     <news>
-      v0.4.7 (2020-05-03)
-        - Fix hardlink on Windows
-        - Fix support for unicode chars in paths
-        - Show remaining time during Widevine installation on ARM devices
+     v0.5.0 (2020-06-25)
+        - Extract Widevine CDM directly from Chrome OS, minimizing disk space usage and eliminating the need for root access
+        - Improve progress dialog while extracting Widevine CDM on ARM devices
+        - Support resuming interrupted downloads on unreliable internet connections
+        - Reshape InputStream Helper information dialog
+        - Updated Dutch, English, French, German, Greek, Hungarian, Romanian, Russian, Spanish and Swedish translations
     </news>
     <platform>all</platform>
     <license>MIT</license>

--- a/script.module.inputstreamhelper/lib/inputstreamhelper/config.py
+++ b/script.module.inputstreamhelper/lib/inputstreamhelper/config.py
@@ -77,7 +77,7 @@ WIDEVINE_MANIFEST_FILE = 'manifest.json'
 
 WIDEVINE_CONFIG_NAME = 'manifest.json'
 
-CHROMEOS_RECOVERY_URL = 'https://dl.google.com/dl/edgedl/chromeos/recovery/recovery.conf'
+CHROMEOS_RECOVERY_URL = 'https://dl.google.com/dl/edgedl/chromeos/recovery/recovery.json'
 
 # Last updated: 2019-08-20 (version 12239.67.0)
 CHROMEOS_RECOVERY_ARM_HWIDS = [
@@ -118,3 +118,5 @@ CHROMEOS_BLOCK_SIZE = 512
 HLS_MINIMUM_IA_VERSION = '2.0.10'
 
 ISSUE_URL = 'https://github.com/emilsvennesson/script.module.inputstreamhelper/issues'
+
+SHORT_ISSUE_URL = 'https://git.io/JfKJb'

--- a/script.module.inputstreamhelper/lib/inputstreamhelper/unicodes.py
+++ b/script.module.inputstreamhelper/lib/inputstreamhelper/unicodes.py
@@ -22,6 +22,7 @@ def from_unicode(text, encoding='utf-8', errors='strict'):
 def compat_path(path, encoding='utf-8', errors='strict'):
     """Convert unicode path to bytestring if needed"""
     import sys
-    if sys.version_info.major == 2 and isinstance(path, unicode) and not sys.platform.startswith('win'):  # noqa: F821; pylint: disable=undefined-variable,useless-suppression
+    if (sys.version_info.major == 2 and isinstance(path, unicode)  # noqa: F821; pylint: disable=undefined-variable,useless-suppression
+            and not sys.platform.startswith('win')):
         return path.encode(encoding, errors)
     return path

--- a/script.module.inputstreamhelper/lib/inputstreamhelper/utils.py
+++ b/script.module.inputstreamhelper/lib/inputstreamhelper/utils.py
@@ -5,15 +5,24 @@
 from __future__ import absolute_import, division, unicode_literals
 import os
 from time import time
+from socket import timeout
+from ssl import SSLError
+
+try:  # Python 3
+    from urllib.error import HTTPError, URLError
+    from urllib.request import Request, urlopen
+except ImportError:  # Python 2
+    from urllib2 import HTTPError, Request, URLError, urlopen
 
 from . import config
-from .kodiutils import copy, delete, exists, get_setting, localize, log, mkdirs, ok_dialog, progress_dialog, set_setting, stat_file, translate_path
+from .kodiutils import (bg_progress_dialog, copy, delete, exists, get_setting, localize, log, mkdirs,
+                        progress_dialog, set_setting, stat_file, translate_path, yesno_dialog)
 from .unicodes import compat_path, from_unicode, to_unicode
 
 
 def temp_path():
-    """Return temporary path, usually ~/.kodi/userdata/addon_data/script.module.inputstreamhelper/temp"""
-    tmp_path = translate_path(os.path.join(get_setting('temp_path', 'special://masterprofile/addon_data/script.module.inputstreamhelper'), 'temp'))
+    """Return temporary path, usually ~/.kodi/userdata/addon_data/script.module.inputstreamhelper/temp/"""
+    tmp_path = translate_path(os.path.join(get_setting('temp_path', 'special://masterprofile/addon_data/script.module.inputstreamhelper'), 'temp', ''))
     if not exists(tmp_path):
         mkdirs(tmp_path)
 
@@ -30,26 +39,25 @@ def update_temp_path(new_temp_path):
         move(old_temp_path, temp_path())
 
 
-def _http_request(url):
+def _http_request(url, headers=None, time_out=10):
     """Perform an HTTP request and return request"""
-
-    try:  # Python 3
-        from urllib.error import HTTPError
-        from urllib.request import urlopen
-    except ImportError:  # Python 2
-        from urllib2 import HTTPError, urlopen
-
     log(0, 'Request URL: {url}', url=url)
-    filename = url.split('/')[-1]
 
     try:
-        req = urlopen(url, timeout=5)
+        if headers:
+            request = Request(url, headers=headers)
+        else:
+            request = Request(url)
+        req = urlopen(request, timeout=time_out)
         log(0, 'Response code: {code}', code=req.getcode())
         if 400 <= req.getcode() < 600:
             raise HTTPError('HTTP %s Error for url: %s' % (req.getcode(), url), response=req)
-    except HTTPError:
-        ok_dialog(localize(30004), localize(30013, filename=filename))  # Failed to retrieve file
+    except (HTTPError, URLError) as err:
+        log(2, 'Download failed with error {}'.format(err))
+        if yesno_dialog(localize(30004), '{line1}\n{line2}'.format(line1=localize(30063), line2=localize(30065))):  # Internet down, try again?
+            return _http_request(url, headers, time_out)
         return None
+
     return req
 
 
@@ -65,7 +73,7 @@ def http_get(url):
     return content.decode()
 
 
-def http_download(url, message=None, checksum=None, hash_alg='sha1', dl_size=None):
+def http_download(url, message=None, checksum=None, hash_alg='sha1', dl_size=None, background=False):  # pylint: disable=too-many-statements
     """Makes HTTP request and displays a progress dialog on download."""
     if checksum:
         from hashlib import sha1, md5
@@ -86,46 +94,67 @@ def http_download(url, message=None, checksum=None, hash_alg='sha1', dl_size=Non
         message = localize(30015, filename=filename)  # Downloading file
 
     download_path = os.path.join(temp_path(), filename)
-    total_length = float(req.info().get('content-length'))
-    progress = progress_dialog()
-    progress.create(
-        localize(30014),  # Download in progress
-        message='{line1}\n{line2}'.format(
-            line1=message,
-            line2=localize(30058, mins=0, secs=0))  # Time remaining
-    )
+    total_length = int(req.info().get('content-length'))
+    if dl_size and dl_size != total_length:
+        log(2, 'The given file size does not match the request!')
+        dl_size = total_length  # Otherwise size check at end would fail even if dl succeeded
+
+    if background:
+        progress = bg_progress_dialog()
+    else:
+        progress = progress_dialog()
+    progress.create(localize(30014), message=message)  # Download in progress
 
     starttime = time()
     chunk_size = 32 * 1024
     with open(compat_path(download_path), 'wb') as image:
         size = 0
-        while True:
-            chunk = req.read(chunk_size)
-            if not chunk:
-                break
+        while size < total_length:
+            try:
+                chunk = req.read(chunk_size)
+            except (timeout, SSLError):
+                req.close()
+                if not yesno_dialog(localize(30004), '{line1}\n{line2}'.format(line1=localize(30064),
+                                                                               line2=localize(30065))):  # Could not finish dl. Try again?
+                    progress.close()
+                    return False
+
+                headers = {'Range': 'bytes={}-{}'.format(size, total_length)}
+                req = _http_request(url, headers=headers)
+                if req is None:
+                    return None
+                continue
+
             image.write(chunk)
             if checksum:
                 calc_checksum.update(chunk)
             size += len(chunk)
-            percent = int(size * 100 / total_length)
-            time_left = int((total_length - size) * (time() - starttime) / size)
-            if progress.iscanceled():
+            percent = int(round(size * 100 / total_length))
+            if not background and progress.iscanceled():
                 progress.close()
                 req.close()
                 return False
-            progress.update(
-                percent,
-                message='{line1}\n{line2}'.format(
+            if time() - starttime > 5:
+                time_left = int(round((total_length - size) * (time() - starttime) / size))
+                prog_message = '{line1}\n{line2}'.format(
                     line1=message,
                     line2=localize(30058, mins=time_left // 60, secs=time_left % 60))  # Time remaining
-            )
+            else:
+                prog_message = message
 
-    if checksum and not calc_checksum.hexdigest() == checksum:
+            progress.update(percent, prog_message)
+
+    if checksum and calc_checksum.hexdigest() != checksum:
+        progress.close()
+        req.close()
         log(4, 'Download failed, checksums do not match!')
         return False
 
-    if dl_size and not stat_file(download_path).st_size() == dl_size:
-        log(4, 'Download failed, filesize does not match!')
+    if dl_size and stat_file(download_path).st_size() != dl_size:
+        progress.close()
+        req.close()
+        free_space = sizeof_fmt(diskspace())
+        log(4, 'Download failed, filesize does not match! Filesystem full? Remaining diskspace in temp: {}.'.format(free_space))
         return False
 
     progress.close()

--- a/script.module.inputstreamhelper/lib/inputstreamhelper/widevine/arm.py
+++ b/script.module.inputstreamhelper/lib/inputstreamhelper/widevine/arm.py
@@ -4,42 +4,23 @@
 
 from __future__ import absolute_import, division, unicode_literals
 import os
+import json
 from time import time
 
 from .. import config
 from ..kodiutils import browsesingle, copy, exists, localize, log, mkdir, ok_dialog, open_file, progress_dialog, yesno_dialog
 from ..utils import cmd_exists, diskspace, http_download, http_get, run_cmd, sizeof_fmt, store, system_os, temp_path, update_temp_path
 from ..unicodes import compat_path, to_unicode
+from .arm_chromeos import ChromeOSImage
 
 
-def mnt_path():
-    """Return mount path, usually ~/.kodi/userdata/addon_data/script.module.inputstreamhelper/temp/mnt"""
-    mount_path = os.path.join(temp_path(), 'mnt')
-    if not exists(mount_path):
+def mnt_path(make=True):
+    """Return mount path, usually ~/.kodi/userdata/addon_data/script.module.inputstreamhelper/temp/mnt/"""
+    mount_path = os.path.join(temp_path(), 'mnt', '')
+    if make and not exists(mount_path):
         mkdir(mount_path)
 
     return mount_path
-
-
-def chromeos_offset(bin_path):
-    """Calculate the Chrome OS losetup start offset using fdisk/parted."""
-    if cmd_exists('fdisk'):
-        cmd = ['fdisk', bin_path, '-l']
-    else:  # parted
-        cmd = ['parted', '-s', bin_path, 'unit s print']
-
-    output = run_cmd(cmd, sudo=False)
-    if output['success']:
-        import re
-        for line in output['output'].splitlines():
-            partition_data = re.match(r'^\s?(3|.+bin3)\s+(\d+)s?\s+\d+', line)
-            if partition_data:
-                if partition_data.group(1) == '3' or partition_data.group(1).endswith('.bin3'):
-                    offset = int(partition_data.group(2))
-                    return str(offset * config.CHROMEOS_BLOCK_SIZE)
-
-    log(4, 'Failed to calculate losetup offset.')
-    return '0'
 
 
 def check_loop():
@@ -69,7 +50,9 @@ def set_loop_dev():
 
 def losetup(bin_path):
     """Setup Chrome OS loop device."""
-    cmd = ['losetup', '-o', chromeos_offset(bin_path), store('loop_dev'), bin_path]
+    cos_offset = str(ChromeOSImage(bin_path).chromeos_offset())
+
+    cmd = ['losetup', '-o', cos_offset, store('loop_dev'), bin_path]
     output = run_cmd(cmd, sudo=True)
     if output['success']:
         store('attached_loop_dev', True)
@@ -90,7 +73,7 @@ def mnt_loop_dev():
 
 def select_best_chromeos_image(devices):
     """Finds the newest and smallest of the ChromeOS images given"""
-    log(0, 'Find best ARM image to use from the Chrome OS recovery.conf')
+    log(0, 'Find best ARM image to use from the Chrome OS recovery.json')
 
     best = None
     for device in devices:
@@ -135,35 +118,79 @@ def select_best_chromeos_image(devices):
 
 
 def chromeos_config():
-    """Parse the Chrome OS recovery configuration and put it in a dictionary"""
-    url = config.CHROMEOS_RECOVERY_URL
-    conf = [line for line in http_get(url).split('\n\n') if 'hwidmatch=' in line]
-
-    devices = []
-    for device in conf:
-        device_dict = dict()
-        for device_info in device.splitlines():
-            if not device_info:
-                continue
-            try:
-                key, value = device_info.split('=')
-                device_dict[key] = value
-            except ValueError:
-                continue
-        devices.append(device_dict)
-
-    return devices
+    """Reads the Chrome OS recovery configuration"""
+    return json.loads(http_get(config.CHROMEOS_RECOVERY_URL))
 
 
-def install_widevine_arm(backup_path):  # pylint: disable=too-many-statements
+def install_widevine_arm(backup_path):
     """Installs Widevine CDM on ARM-based architectures."""
+    devices = chromeos_config()
+    arm_device = select_best_chromeos_image(devices)
+    if arm_device is None:
+        log(4, 'We could not find an ARM device in the Chrome OS recovery.json')
+        ok_dialog(localize(30004), localize(30005))
+        return False
+    # Estimated required disk space: takes into account an extra 20 MiB buffer
+    required_diskspace = 20971520 + int(arm_device['zipfilesize'])
+    if yesno_dialog(localize(30001),  # Due to distributing issues, this takes a long time
+                    localize(30006, diskspace=sizeof_fmt(required_diskspace))):
+        if system_os() != 'Linux':
+            ok_dialog(localize(30004), localize(30019, os=system_os()))
+            return False
+
+        while required_diskspace >= diskspace():
+            if yesno_dialog(localize(30004), localize(30055)):  # Not enough space, alternative path?
+                update_temp_path(browsesingle(3, localize(30909), 'files'))  # Temporary path
+                continue
+
+            ok_dialog(localize(30004),  # Not enough free disk space
+                      localize(30018, diskspace=sizeof_fmt(required_diskspace)))
+            return False
+
+        url = arm_device['url']
+        downloaded = http_download(url, message=localize(30022), checksum=arm_device['sha1'], hash_alg='sha1',
+                                   dl_size=int(arm_device['zipfilesize']))  # Downloading the recovery image
+        if downloaded:
+            progress = progress_dialog()
+            progress.create(heading=localize(30043), message=localize(30044))  # Extracting Widevine CDM
+
+            extracted = ChromeOSImage(store('download_path')).extract_file(
+                filename=config.WIDEVINE_CDM_FILENAME[system_os()],
+                extract_path=os.path.join(backup_path, arm_device['version']),
+                progress=progress)
+
+            if not extracted:
+                log(3, 'Directly extracting widevine from the zip failed, using legacy method.')
+                progress.close()
+                if yesno_dialog(heading=localize(30004),
+                                message='{line1}\n{line2}\n{line3}'.format(
+                                    line1=localize(30016),
+                                    line2=localize(30830, url=config.ISSUE_URL),
+                                    line3=localize(30059))):
+                    return install_wv_arm_legacy(backup_path)
+                return False
+
+            recovery_file = os.path.join(backup_path, arm_device['version'], os.path.basename(config.CHROMEOS_RECOVERY_URL))
+            config_file = os.path.join(backup_path, arm_device['version'], 'config.json')
+            with open_file(recovery_file, 'w') as reco_file:
+                reco_file.write(json.dumps(devices, indent=4))
+            with open_file(config_file, 'w') as conf_file:
+                conf_file.write(json.dumps(arm_device))
+
+            return (progress, arm_device['version'])
+
+    return False
+
+
+def install_wv_arm_legacy(backup_path):
+    """Legacy method to install Widevine CDM on ARM-based architectures."""
     root_cmds = ['mount', 'umount', 'losetup', 'modprobe']
     devices = chromeos_config()
     arm_device = select_best_chromeos_image(devices)
     if arm_device is None:
-        log(4, 'We could not find an ARM device in the Chrome OS recovery.conf')
+        log(4, 'We could not find an ARM device in the Chrome OS recovery.json')
         ok_dialog(localize(30004), localize(30005))
-        return ''
+        return False
     # Estimated required disk space: takes into account an extra 20 MiB buffer
     required_diskspace = 20971520 + int(arm_device['zipfilesize']) + int(arm_device['filesize'])
     if yesno_dialog(localize(30001),  # Due to distributing issues, this takes a long time
@@ -199,55 +226,52 @@ def install_widevine_arm(backup_path):  # pylint: disable=too-many-statements
             return False
 
         url = arm_device['url']
-        downloaded = http_download(url, message=localize(30022), checksum=arm_device['sha1'], hash_alg='sha1', dl_size=int(arm_device['zipfilesize']))  # Downloading the recovery image
-        if downloaded:
-            progress = progress_dialog()
-            progress.create(heading=localize(30043), message=localize(30044))  # Extracting Widevine CDM
-            bin_filename = url.split('/')[-1].replace('.zip', '')
-            bin_path = compat_path(os.path.join(temp_path(), bin_filename))
-            starttime = time()
+        progress = progress_dialog()
+        progress.create(heading=localize(30043), message=localize(30044))  # Extracting Widevine CDM
+        bin_filename = url.split('/')[-1].replace('.zip', '')
+        bin_path = compat_path(os.path.join(temp_path(), bin_filename))
+        starttime = time()
 
-            progress.update(
-                0,
-                message='{line1}\n{line2}\n{line3}'.format(
-                    line1=localize(30045),  # Uncompressing image
-                    line2=localize(30058, mins=0, secs=0),  # Time remaining
-                    line3=localize(30047))  # Please do not interrupt this process
-            )
+        progress.update(
+            0,
+            message='{line1}\n{line2}\n{line3}'.format(
+                line1=localize(30045),  # Uncompressing image
+                line2=localize(30058, mins=0, secs=0),  # Time remaining
+                line3=localize(30047))  # Please do not interrupt this process
+        )
 
-            from zipfile import ZipFile
+        from zipfile import ZipFile
 
-            with ZipFile(compat_path(store('download_path'))) as zip_obj:
-                bin_size = zip_obj.getinfo(bin_filename).file_size
-                chunksize = 1024**2
+        with ZipFile(compat_path(store('download_path'))) as zip_obj:
+            bin_size = zip_obj.getinfo(bin_filename).file_size
+            chunksize = 1024**2
 
-                with zip_obj.open(bin_filename) as member:
-                    with open(bin_path, 'wb') as bin_file:
-                        bytes_to_read = bin_size
-                        while bytes_to_read > 0:
-                            chunk = member.read(chunksize)
-                            bytes_to_read -= chunksize
-                            bin_file.write(chunk)
-                            percent = 100 * (1 - bytes_to_read / bin_size) - 5
-                            time_left = int(bytes_to_read * (time() - starttime) / (bin_size - bytes_to_read))
-                            progress.update(
-                                int(percent),
-                                message='{line1}\n{line2}\n{line3}'.format(
-                                    line1=localize(30045),  # Uncompressing image
-                                    line2=localize(30058, mins=time_left // 60, secs=time_left % 60),  # Time remaining
-                                    line3=localize(30047))  # Please do not interrupt this process
-                            )
+            with zip_obj.open(bin_filename) as member:
+                with open(bin_path, 'wb') as bin_file:
+                    bytes_to_read = bin_size
+                    while bytes_to_read > 0:
+                        chunk = member.read(chunksize)
+                        bytes_to_read -= chunksize
+                        bin_file.write(chunk)
+                        percent = 100 * (1 - bytes_to_read / bin_size) - 5
+                        time_left = int(bytes_to_read * (time() - starttime) / (bin_size - bytes_to_read))
+                        progress.update(
+                            int(percent),
+                            message='{line1}\n{line2}\n{line3}'.format(
+                                line1=localize(30045),  # Uncompressing image
+                                line2=localize(30058, mins=time_left // 60, secs=time_left % 60),  # Time remaining
+                                line3=localize(30047))  # Please do not interrupt this process
+                        )
 
-            if check_loop() and set_loop_dev() and losetup(bin_path) and mnt_loop_dev():
-                import json
-                progress.update(96, message=localize(30048))  # Extracting Widevine CDM
-                extract_widevine_from_img(os.path.join(backup_path, arm_device['version']))
-                json_file = os.path.join(backup_path, arm_device['version'], os.path.basename(config.CHROMEOS_RECOVERY_URL) + '.json')
-                with open_file(json_file, 'w') as config_file:
-                    config_file.write(json.dumps(devices, indent=4))
+        if check_loop() and set_loop_dev() and losetup(bin_path) and mnt_loop_dev():
+            progress.update(96, message=localize(30048))  # Extracting Widevine CDM
+            extract_widevine_from_img(os.path.join(backup_path, arm_device['version'], ''))
+            json_file = os.path.join(backup_path, arm_device['version'], os.path.basename(config.CHROMEOS_RECOVERY_URL))
+            with open_file(json_file, 'w') as config_file:
+                config_file.write(json.dumps(devices, indent=4))
 
-                return (progress, arm_device['version'])
-            progress.close()
+            return (progress, arm_device['version'])
+        progress.close()
 
     return False
 
@@ -270,7 +294,7 @@ def extract_widevine_from_img(backup_path):
 
 def unmount():
     """Unmount mountpoint if mounted"""
-    while os.path.ismount(compat_path(mnt_path())):
+    while os.path.ismount(compat_path(mnt_path(make=False))):
         log(0, 'Unmount {mountpoint}', mountpoint=mnt_path())
         umount_output = run_cmd(['umount', compat_path(mnt_path())], sudo=True)
         if not umount_output['success']:

--- a/script.module.inputstreamhelper/lib/inputstreamhelper/widevine/arm_chromeos.py
+++ b/script.module.inputstreamhelper/lib/inputstreamhelper/widevine/arm_chromeos.py
@@ -1,0 +1,326 @@
+# -*- coding: utf-8 -*-
+# MIT License (see LICENSE.txt or https://opensource.org/licenses/MIT)
+"""Implements a class with methods related to the Chrome OS image"""
+
+from __future__ import absolute_import, division, unicode_literals
+import os
+from struct import calcsize, unpack
+from zipfile import ZipFile
+from io import UnsupportedOperation
+
+from ..kodiutils import exists, localize, log, mkdirs
+from .. import config
+from ..unicodes import compat_path
+
+
+class ChromeOSImage:
+    """
+    The main class handling a Chrome OS image
+
+    Information related to ext2 is sourced from here: https://www.nongnu.org/ext2-doc/ext2.html
+    """
+
+    def __init__(self, imgpath):
+        """Prepares the image"""
+        self.imgpath = imgpath
+        self.bstream = self.get_bstream(imgpath)
+        self.part_offset = None
+        self.sb_dict = None
+        self.blocksize = None
+        self.blk_groups = None
+        self.progress = None
+
+    def gpt_header(self):
+        """Returns the needed parts of the GPT header, can be easily expanded if necessary"""
+        header_fmt = '<8s4sII4x4Q16sQ3I'
+        header_size = calcsize(header_fmt)
+        lba_size = config.CHROMEOS_BLOCK_SIZE  # assuming LBA size
+        self.seek_stream(lba_size)
+
+        # GPT Header entries: signature, revision, header_size, header_crc32, (reserved 4x skipped,) current_lba, backup_lba,
+        #                     first_usable_lba, last_usable_lba, disk_guid, start_lba_part_entries, num_part_entries,
+        #                     size_part_entry, crc32_part_entries
+        _, _, _, _, _, _, _, _, _, start_lba_part_entries, num_part_entries, size_part_entry, _ = unpack(header_fmt, self.read_stream(header_size))
+
+        return (start_lba_part_entries, num_part_entries, size_part_entry)
+
+    def chromeos_offset(self):
+        """Calculate the Chrome OS losetup start offset"""
+        part_format = '<16s16sQQQ72s'
+        entries_start, entries_num, entry_size = self.gpt_header()  # assuming partition table is GPT
+        lba_size = config.CHROMEOS_BLOCK_SIZE  # assuming LBA size
+        self.seek_stream(entries_start * lba_size)
+
+        if not calcsize(part_format) == entry_size:
+            log(4, 'Partition table entries are not 128 bytes long')
+            return 0
+
+        for index in range(1, entries_num + 1):  # pylint: disable=unused-variable
+            # Entry: type_guid, unique_guid, first_lba, last_lba, attr_flags, part_name
+            _, _, first_lba, _, _, part_name = unpack(part_format, self.read_stream(entry_size))
+            part_name = part_name.decode('utf-16').strip('\x00')
+            if part_name == 'ROOT-A':  # assuming partition name is ROOT-A
+                offset = first_lba * lba_size
+                break
+
+        if not offset:
+            log(4, 'Failed to calculate losetup offset.')
+            return 0
+
+        return offset
+
+    def extract_file(self, filename, extract_path, progress):
+        """Extracts the file from the image"""
+        self.progress = progress
+
+        self.progress.update(2, localize(30060))
+        self.part_offset = self.chromeos_offset()
+        self.sb_dict = self.superblock()
+        self.blk_groups = self.block_groups()
+
+        bin_filename = filename.encode('ascii')
+        chunksize = 4 * 1024**2
+        percent8 = 40
+        self.progress.update(int(percent8 / 8), localize(30061))
+        chunk1 = self.read_stream(chunksize)
+        while True:
+            chunk2 = self.read_stream(chunksize)
+            if not chunk2:
+                log(4, 'File {filename} not found in the ChromeOS image', filename=filename)
+                return False
+
+            chunk = chunk1 + chunk2
+            if bin_filename in chunk:
+                i_index_pos = chunk.index(bin_filename) - 8
+                dir_dict = self.dir_entry(chunk[i_index_pos:i_index_pos + len(filename) + 8])
+                if dir_dict['inode'] < self.sb_dict['s_inodes_count'] and dir_dict['name_len'] == len(filename):
+                    break
+            chunk1 = chunk2
+            if percent8 < 240:
+                percent8 += 1
+                self.progress.update(int(percent8 / 8))
+
+        self.progress.update(32, localize(30062))
+
+        blk_group_num = (dir_dict['inode'] - 1) // self.sb_dict['s_inodes_per_group']
+        blk_group = self.blk_groups[blk_group_num]
+        i_index_in_group = (dir_dict['inode'] - 1) % self.sb_dict['s_inodes_per_group']
+
+        inode_pos = self.part_offset + self.blocksize * blk_group['bg_inode_table'] + self.sb_dict['s_inode_size'] * i_index_in_group
+        inode_dict, _ = self.inode_table(inode_pos)
+
+        return self.write_file(inode_dict, os.path.join(extract_path, filename))
+
+    def superblock(self):
+        """Get relevant info from the superblock, assert it's an ext2 fs"""
+        names = ('s_inodes_count', 's_blocks_count', 's_r_blocks_count', 's_free_blocks_count', 's_free_inodes_count', 's_first_data_block',
+                 's_log_block_size', 's_log_frag_size', 's_blocks_per_group', 's_frags_per_group', 's_inodes_per_group', 's_mtime', 's_wtime',
+                 's_mnt_count', 's_max_mnt_count', 's_magic', 's_state', 's_errors', 's_minor_rev_level', 's_lastcheck', 's_checkinterval',
+                 's_creator_os', 's_rev_level', 's_def_resuid', 's_def_resgid', 's_first_ino', 's_inode_size', 's_block_group_nr',
+                 's_feature_compat', 's_feature_incompat', 's_feature_ro_compat', 's_uuid', 's_volume_name', 's_last_mounted',
+                 's_algorithm_usage_bitmap', 's_prealloc_block', 's_prealloc_dir_blocks')
+        fmt = '<13I6H4I2HI2H3I16s16s64sI2B818x'
+        fmt_len = calcsize(fmt)
+
+        self.seek_stream(self.part_offset + 1024)  # superblock starts after 1024 byte
+        pack = self.read_stream(fmt_len)
+        sb_dict = dict(zip(names, unpack(fmt, pack)))
+
+        sb_dict['s_magic'] = hex(sb_dict['s_magic'])
+        assert sb_dict['s_magic'] == '0xef53'  # assuming/checking this is an ext2 fs
+
+        block_groups_count1 = sb_dict['s_blocks_count'] / sb_dict['s_blocks_per_group']
+        block_groups_count1 = int(block_groups_count1) if float(int(block_groups_count1)) == block_groups_count1 else int(block_groups_count1) + 1
+        block_groups_count2 = sb_dict['s_inodes_count'] / sb_dict['s_inodes_per_group']
+        block_groups_count2 = int(block_groups_count2) if float(int(block_groups_count2)) == block_groups_count2 else int(block_groups_count2) + 1
+        assert block_groups_count1 == block_groups_count2
+        sb_dict['block_groups_count'] = block_groups_count1
+
+        self.blocksize = 1024 << sb_dict['s_log_block_size']
+
+        return sb_dict
+
+    def block_group(self):
+        """Get info about a block group"""
+        names = ('bg_block_bitmap', 'bg_inode_bitmap', 'bg_inode_table', 'bg_free_blocks_count', 'bg_free_inodes_count', 'bg_used_dirs_count', 'bg_pad')
+        fmt = '<3I4H12x'
+        fmt_len = calcsize(fmt)
+
+        pack = self.read_stream(fmt_len)
+        blk = unpack(fmt, pack)
+
+        blk_dict = dict(zip(names, blk))
+
+        return blk_dict
+
+    def block_groups(self):
+        """Get info about all block groups"""
+        if self.blocksize == 1024:
+            self.seek_stream(self.part_offset + 2 * self.blocksize)
+        else:
+            self.seek_stream(self.part_offset + self.blocksize)
+
+        blk_groups = []
+        for i in range(self.sb_dict['block_groups_count']):  # pylint: disable=unused-variable
+            blk_group = self.block_group()
+            blk_groups.append(blk_group)
+
+        return blk_groups
+
+    def inode_table(self, inode_pos):
+        """Reads and returns an inode table and inode size"""
+        names = ('i_mode', 'i_uid', 'i_size', 'i_atime', 'i_ctime', 'i_mtime', 'i_dtime', 'i_gid', 'i_links_count', 'i_blocks', 'i_flags',
+                 'i_osd1', 'i_block0', 'i_block1', 'i_block2', 'i_block3', 'i_block4', 'i_block5', 'i_block6', 'i_block7', 'i_block8',
+                 'i_block9', 'i_block10', 'i_block11', 'i_blocki', 'i_blockii', 'i_blockiii', 'i_generation', 'i_file_acl', 'i_dir_acl', 'i_faddr')
+        fmt = '<2Hi4I2H3I15I4I12x'
+        fmt_len = calcsize(fmt)
+        inode_size = self.sb_dict['s_inode_size']
+
+        self.seek_stream(inode_pos)
+        pack = self.read_stream(fmt_len)
+        inode = unpack(fmt, pack)
+
+        inode_dict = dict(zip(names, inode))
+        inode_dict['i_mode'] = hex(inode_dict['i_mode'])
+
+        blocks = inode_dict['i_size'] / self.blocksize
+        inode_dict['blocks'] = int(blocks) if float(int(blocks)) == blocks else int(blocks) + 1
+
+        self.read_stream(inode_size - fmt_len)
+        return inode_dict, inode_size
+
+    @staticmethod
+    def dir_entry(chunk):
+        """Returns the directory entry found in chunk"""
+        dir_names = ('inode', 'rec_len', 'name_len', 'file_type', 'name')
+        dir_fmt = '<IHBB' + str(len(chunk) - 8) + 's'
+
+        dir_dict = dict(zip(dir_names, unpack(dir_fmt, chunk)))
+
+        return dir_dict
+
+    def iblock_ids(self, blk_id, ids_to_read):
+        """Reads the block indices/IDs from an indirect block"""
+        seek_pos = self.part_offset + self.blocksize * blk_id
+        self.seek_stream(seek_pos)
+        fmt = '<' + str(int(self.blocksize / 4)) + 'I'
+        ids = list(unpack(fmt, self.read_stream(self.blocksize)))
+        ids_to_read -= len(ids)
+
+        return ids, ids_to_read
+
+    def iiblock_ids(self, blk_id, ids_to_read):
+        """Reads the block indices/IDs from a doubly-indirect block"""
+        seek_pos = self.part_offset + self.blocksize * blk_id
+        self.seek_stream(seek_pos)
+        fmt = '<' + str(int(self.blocksize / 4)) + 'I'
+        iids = unpack(fmt, self.read_stream(self.blocksize))
+
+        ids = []
+        for iid in iids:
+            if ids_to_read <= 0:
+                break
+            ind_block_ids, ids_to_read = self.iblock_ids(iid, ids_to_read)
+            ids += ind_block_ids
+
+        return ids, ids_to_read
+
+    def seek_stream(self, seek_pos):
+        """Move position of bstream to seek_pos"""
+        try:
+            self.bstream[0].seek(seek_pos)
+            self.bstream[1] = seek_pos
+            return
+
+        except UnsupportedOperation:
+            chunksize = 4 * 1024**2
+
+            if seek_pos >= self.bstream[1]:
+                while seek_pos - self.bstream[1] > chunksize:
+                    self.read_stream(chunksize)
+                self.read_stream(seek_pos - self.bstream[1])
+                return
+
+            self.bstream[0].close()
+            self.bstream[1] = 0
+            self.bstream = self.get_bstream(self.imgpath)
+
+            while seek_pos - self.bstream[1] > chunksize:
+                self.read_stream(chunksize)
+            self.read_stream(seek_pos - self.bstream[1])
+
+            return
+
+    def read_stream(self, num_of_bytes):
+        """Read and return a chunk of the bytestream"""
+        self.bstream[1] += num_of_bytes
+
+        return self.bstream[0].read(num_of_bytes)
+
+    def get_block_ids(self, inode_dict):
+        """Get all block indices/IDs of an inode"""
+        ids_to_read = inode_dict['blocks']
+        block_ids = [inode_dict['i_block' + str(i)] for i in range(12)]
+        ids_to_read -= 12
+
+        if not inode_dict['i_blocki'] == 0:
+            iblocks, ids_to_read = self.iblock_ids(inode_dict['i_blocki'], ids_to_read)
+            block_ids += iblocks
+        if not inode_dict['i_blockii'] == 0:
+            iiblocks, ids_to_read = self.iiblock_ids(inode_dict['i_blockii'], ids_to_read)
+            block_ids += iiblocks
+
+        return block_ids[:inode_dict['blocks']]
+
+    def read_file(self, block_ids):
+        """Read blocks specified by IDs into a dict"""
+        block_dict = {}
+        for block_id in block_ids:
+            percent = int(35 + 60 * block_ids.index(block_id) / len(block_ids))
+            self.progress.update(percent, localize(30048))
+            seek_pos = self.part_offset + self.blocksize * block_id
+            self.seek_stream(seek_pos)
+            block_dict[block_id] = self.read_stream(self.blocksize)
+
+        return block_dict
+
+    @staticmethod
+    def write_file_chunk(opened_file, chunk, bytes_to_write):
+        """Writes bytes to file in chunks"""
+        if len(chunk) > bytes_to_write:
+            opened_file.write(chunk[:bytes_to_write])
+            return 0
+
+        opened_file.write(chunk)
+        return bytes_to_write - len(chunk)
+
+    def write_file(self, inode_dict, filepath):
+        """Writes file specified by its inode to filepath"""
+        bytes_to_write = inode_dict['i_size']
+        block_ids = self.get_block_ids(inode_dict)
+
+        block_ids_sorted = block_ids[:]
+        block_ids_sorted.sort()
+        block_dict = self.read_file(block_ids_sorted)
+
+        write_dir = os.path.join(os.path.dirname(filepath), '')
+        if not exists(write_dir):
+            mkdirs(write_dir)
+
+        with open(compat_path(filepath), 'wb') as opened_file:
+            for block_id in block_ids:
+                bytes_to_write = self.write_file_chunk(opened_file, block_dict[block_id], bytes_to_write)
+                if bytes_to_write == 0:
+                    return True
+
+        return False
+
+    @staticmethod
+    def get_bstream(imgpath):
+        """Get a bytestream of the image"""
+        if imgpath.endswith('.zip'):
+            bstream = ZipFile(compat_path(imgpath), 'r').open(os.path.basename(imgpath).strip('.zip'), 'r')
+        else:
+            bstream = open(compat_path(imgpath), 'rb')
+
+        return [bstream, 0]

--- a/script.module.inputstreamhelper/resources/language/resource.language.de_de/strings.po
+++ b/script.module.inputstreamhelper/resources/language/resource.language.de_de/strings.po
@@ -4,8 +4,8 @@ msgstr ""
 "Project-Id-Version: script.module.inputstreamhelper\n"
 "Report-Msgid-Bugs-To: https://github.com/emilsvennesson/script.module.inputstreamhelper\n"
 "POT-Creation-Date: 2013-11-18 16:15+0000\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: Sebastian Golasch <public@asciidisco.com\n"
+"PO-Revision-Date: 2020-06-14 10:35+0000\n"
+"Last-Translator: Tobias Weimer\n"
 "Language-Team: German\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -235,61 +235,77 @@ msgstr "Keine Backups gefunden!"
 
 msgctxt "#30057"
 msgid "Choose a backup to restore"
-msgstr "Wählen Sie ein Backup zum Wiederherstellen aus."
+msgstr "Wählen Sie ein Backup zum Wiederherstellen aus"
 
 msgctxt "#30058"
 msgid "Time remaining: {mins:d}:{secs:02d}"
-msgstr ""
+msgstr "Verbleibende Zeit: {mins:d}:{secs:02d}"
+
+msgctxt "#30059"
+msgid "Meanwhile, should we try extracting Widevine CDM using the legacy method?"
+msgstr "Sollen wir währenddessen versuchen, Widevine CDM über die Legacy-Methode zu extrahieren?"
+
+msgctxt "#30060"
+msgid "Identifying wanted partition..."
+msgstr "Identifiziere gewünschte Partition..."
+
+msgctxt "#30061"
+msgid "Scanning the filesystem for the Widevine CDM..."
+msgstr "Durchsuche das Dateisystem nach Widevine CDM..."
+
+msgctxt "#30062"
+msgid "Widevine CDM found, analyzing..."
+msgstr "Widevine CDM gefunden, analysiere..."
+
+msgctxt "#30063"
+msgid "Could not make the request. Your internet may be down."
+msgstr "Kann die Anfrage nicht machen. Ihr Internet könnte nicht verfügbar sein."
+
+msgctxt "#30064"
+msgid "Could not finish the download."
+msgstr "Konnte das Herunterladen nicht beenden."
+
+msgctxt "#30065"
+msgid "Shall we try again?"
+msgstr "Sollen wir es nochmal versuchen?"
 
 
 ### INFORMATION DIALOG
 msgctxt "#30800"
-msgid "[B]Kodi information[/B]"
-msgstr "[B]Kodi Informationen[/B]"
-
-msgctxt "#30801"
-msgid "Kodi version: [B]{version}[/B]"
-msgstr "Kodi Version: [B]{version}[/B]"
-
-msgctxt "#30802"
-msgid "Kodi platform/architecture: [B]{platform}[/B]/[B]{arch}[/B]"
-msgstr "Kodi Plattform/Architektur: [B]{platform}[/B]/[B]{arch}[/B]"
+msgid "[B]Kodi[/B] version [B]{version}[/B] is running on a [B]{system}[/B] system with [B]{arch}[/B] architecture."
+msgstr "[B]Kodi[/B] Version [B]{version}[/B] läuft auf einem [B]{system}[/B] System mit [B]{arch}[/B] Architektur."
 
 msgctxt "#30810"
-msgid "[B]InputStream information[/B]"
-msgstr "[B]InputStream Informationen[/B]"
+msgid "[B]InputStream Helper[/B] is at version [B]{version}[/B] {state}"
+msgstr "[B]InputStream Helper[/B] ist in Version [B]{version}[/B] {state}"
 
 msgctxt "#30811"
-msgid "InputStream Helper version: [B]{version}[/B] {state}"
-msgstr "InputStream Helper Version: [B]{version}[/B] {state}"
-
-msgctxt "#30812"
-msgid "InputStream Adaptive version: [B]{version}[/B] {state}"
-msgstr "InputStream Adaptive Version: [B]{version}[/B] {state}"
+msgid "[B]InputStream Adaptive[/B] is at version [B]{version}[/B] {state}"
+msgstr "[B]InputStream Adaptive[/B] ist in Version [B]{version}[/B] {state}"
 
 msgctxt "#30820"
-msgid "[B]Widevine information[/B]"
-msgstr "[B]Widevine Informationen[/B]"
+msgid "[B]Widevine CDM[/B] is [B]built into Android[/B]"
+msgstr "[B]Widevine CDM[/B] ist [B]in Android eingebaut[/B]"
 
 msgctxt "#30821"
-msgid "Widevine version: [B]Built into Android[/B]"
-msgstr "Widevine Version: [B]In Android eingebaut[/B]"
+msgid "[B]Widevine CDM[/B] is at version [B]{version}[/B] and was installed on [B]{date}[/B]"
+msgstr "[B]Widevine CDM[/B] ist in Version [B]{version}[/B] und wurde installiert am [B]{date}[/B]"
 
 msgctxt "#30822"
-msgid "Widevine version: [B]{version}[/B] [COLOR gray](last updated on [B]{date}[/B])[/COLOR]"
-msgstr "Widevine Version: [B]{version}[/B] [COLOR gray](zuletzt aktualisiert am [B]{date}[/B])[/COLOR]"
+msgid "It was extracted from Chrome OS image [B]{name}[/B] with version [B]{version}[/B]"
+msgstr "Es wurde extrahiert aus Chrome OS Image [B]{name}[/B] mit Version [B]{version}[/B]"
 
 msgctxt "#30823"
-msgid "Widevine CDM path: [B]{path}[/B]"
-msgstr "Widevine CDM Pfad: [B]{path}[/B]"
+msgid "It was last checked for updates on [B]{date}[/B]"
+msgstr "Zuletzt am [B]{date}[/B] auf Aktualisierungen geprüft"
 
 msgctxt "#30824"
-msgid "Chrome OS version: [B]{version}[/B]"
-msgstr "Chrome OS Version: [B]{version}[/B]"
+msgid "It is installed at [B]{path}[/B]"
+msgstr "Es ist installiert in [B]{path}[/B]"
 
 msgctxt "#30830"
-msgid "Please report issues to:\n - [COLOR yellow]{url}[/COLOR]"
-msgstr "Bitte melden Sie Fehler hier:\n - [COLOR yellow]{url}[/COLOR]"
+msgid "Please report issues to: [COLOR yellow]{url}[/COLOR]"
+msgstr "Bitte melden Sie Fehler hier: [COLOR yellow]{url}[/COLOR]"
 
 
 ### SETTINGS

--- a/script.module.inputstreamhelper/resources/language/resource.language.el_gr/strings.po
+++ b/script.module.inputstreamhelper/resources/language/resource.language.el_gr/strings.po
@@ -239,63 +239,79 @@ msgstr "Επιλέξτε ένα αντίγραφο ασφαλείας για ε�
 
 msgctxt "#30058"
 msgid "Time remaining: {mins:d}:{secs:02d}"
-msgstr ""
+msgstr "Χρόνος που απομένει: {mins:d}:{secs:02d}"
+
+msgctxt "#30059"
+msgid "Meanwhile, should we try extracting Widevine CDM using the legacy method?"
+msgstr "Εν τω μεταξύ, θέλετε να κάνετε εξαγωγή της βιβλιοθήκης Widevine CDM κάνωντας χρήση της παλαιάς μεθόδου;"
+
+msgctxt "#30060"
+msgid "Identifying wanted partition..."
+msgstr "Αναγνώριση ηθελημένης κατάτμησης..."
+
+msgctxt "#30061"
+msgid "Scanning the filesystem for the Widevine CDM..."
+msgstr "Σάρωση του συστήματος αρχείων για το Widevine CDM"
+
+msgctxt "#30062"
+msgid "Widevine CDM found, analyzing..."
+msgstr "Το Widevine CDM βρέθηκε, ανάλυση..."
+
+msgctxt "#30063"
+msgid "Could not make the request. Your internet may be down."
+msgstr "Δεν μπορεί να γίνει αίτημα. Μπορεί το διαδίκτυο σας να μην λειτουργεί."
+
+msgctxt "#30064"
+msgid "Could not finish the download."
+msgstr "Αδυναμία ολοκλήρωσης μεταφόρτωσης"
+
+msgctxt "#30065"
+msgid "Shall we try again?"
+msgstr "Θέλετε να ξαναπροσπαθήσουμε;"
 
 
 ### INFORMATION DIALOG
 msgctxt "#30800"
-msgid "[B]Kodi information[/B]"
-msgstr "[B]Πληροφορίες του Kodi[/B]"
-
-msgctxt "#30801"
-msgid "Kodi version: [B]{version}[/B]"
-msgstr "Έκδοση Kodi: [B]{version}[/B]"
-
-msgctxt "#30802"
-msgid "Kodi platform/architecture: [B]{platform}[/B]/[B]{arch}[/B]"
-msgstr "Αρχιτεκτονική/πλατφόρμα του Kodi: [B]{platform}[/B]/[B]{arch}[/B]"
+msgid "[B]Kodi[/B] version [B]{version}[/B] is running on a [B]{system}[/B] system with [B]{arch}[/B] architecture."
+msgstr "Η έκδοση [B]{version}[/B] του [B]Kodi[/B] εκτελείται σε σύστημα [B]{system}[/B] με αρχιτεκτονική [B]{arch}[/B]."
 
 msgctxt "#30810"
-msgid "[B]InputStream information[/B]"
-msgstr "[B]Πληροφορίες inputstream[/B]"
+msgid "[B]InputStream Helper[/B] is at version [B]{version}[/B] {state}"
+msgstr "Ο [B]InputStream Helper[/B] είναι στην έκδοση [B]{version}[/B] {state}"
 
 msgctxt "#30811"
-msgid "InputStream Helper version: [B]{version}[/B] {state}"
-msgstr "Εκδοση του Βοηθού Inputstream: [B]{version}[/B] {state}"
-
-msgctxt "#30812"
-msgid "InputStream Adaptive version: [B]{version}[/B] {state}"
-msgstr "Έκδοση InputStream Adaptive: [B]{version}[/B] {state}"
+msgid "[B]InputStream Adaptive[/B] is at version [B]{version}[/B] {state}"
+msgstr "Το [B]InputStream Adaptive[/B] είναι στην έκδοση [B]{version}[/B] {state}"
 
 msgctxt "#30820"
-msgid "[B]Widevine information[/B]"
-msgstr "[B]Πληροφορίες Widevine[/B]"
+msgid "[B]Widevine CDM[/B] is [B]built into Android[/B]"
+msgstr "Το [B]Widevine CDM[/B] είναι [B]ενσωματωμένο στο Android[/B]"
 
 msgctxt "#30821"
-msgid "Widevine version: [B]Built into Android[/B]"
-msgstr "Έκδοση Widevine: [B]Ενδωματωμένη στο Android[/B]"
+msgid "[B]Widevine CDM[/B] is at version [B]{version}[/B] and was installed on [B]{date}[/B]"
+msgstr "Το [B]Widevine CDM[/B] είναι στην έκδοση [B]{version}[/B] και εγκαταστάθηκε στην [B]{date}[/B]"
 
 msgctxt "#30822"
-msgid "Widevine version: [B]{version}[/B] [COLOR gray](last updated on [B]{date}[/B])[/COLOR]"
-msgstr "Έκδοση Widevina: [B]{version}[/B] [COLOR gray](τελευταία ενημερωση [B]{date}[/B])[/COLOR]"
+msgid "It was extracted from Chrome OS image [B]{name}[/B] with version [B]{version}[/B]"
+msgstr "Έχει εξαχθεί από την εικόνα του Chrome OS [B]{name}[/B] με έκδοση [B]{version}[/B]"
 
 msgctxt "#30823"
-msgid "Widevine CDM path: [B]{path}[/B]"
-msgstr "Διαδρομη CDM του Widevine: [B]{path}[/B]"
+msgid "It was last checked for updates on [B]{date}[/B]"
+msgstr "Τελευταίος έλεγχος ενημερώσεων στην [B]{date}[/B]"
 
 msgctxt "#30824"
-msgid "Chrome OS version: [B]{version}[/B]"
-msgstr "Έκδοση του Chrome OS: [B]{version}[/B]"
+msgid "It is installed at [B]{path}[/B]"
+msgstr "Έχει εγκατασταθεί στο [B]{path}[/B]"
 
 msgctxt "#30830"
-msgid "Please report issues to:\n - [COLOR yellow]{url}[/COLOR]"
-msgstr "Παρακαλω αναφέρατε σφάλματα στο:\n - [COLOR yellow]{url}[/COLOR]"
+msgid "Please report issues to: [COLOR yellow]{url}[/COLOR]"
+msgstr "Παρακαλω αναφέρατε σφάλματα στο: [COLOR yellow]{url}[/COLOR]"
 
 
 ### SETTINGS
 msgctxt "#30900"
 msgid "Expert"
-msgstr "Ειδικός"
+msgstr "Για ειδικούς"
 
 msgctxt "#30901"
 msgid "InputStream Helper information"

--- a/script.module.inputstreamhelper/resources/language/resource.language.en_gb/strings.po
+++ b/script.module.inputstreamhelper/resources/language/resource.language.en_gb/strings.po
@@ -241,54 +241,70 @@ msgctxt "#30058"
 msgid "Time remaining: {mins:d}:{secs:02d}"
 msgstr ""
 
+msgctxt "#30059"
+msgid "Meanwhile, should we try extracting Widevine CDM using the legacy method?"
+msgstr ""
+
+msgctxt "#30060"
+msgid "Identifying wanted partition..."
+msgstr ""
+
+msgctxt "#30061"
+msgid "Scanning the filesystem for the Widevine CDM..."
+msgstr ""
+
+msgctxt "#30062"
+msgid "Widevine CDM found, analyzing..."
+msgstr ""
+
+msgctxt "#30063"
+msgid "Could not make the request. Your internet may be down."
+msgstr ""
+
+msgctxt "#30064"
+msgid "Could not finish the download."
+msgstr ""
+
+msgctxt "#30065"
+msgid "Shall we try again?"
+msgstr ""
+
 
 ### INFORMATION DIALOG
 msgctxt "#30800"
-msgid "[B]Kodi information[/B]"
-msgstr ""
-
-msgctxt "#30801"
-msgid "Kodi version: [B]{version}[/B]"
-msgstr ""
-
-msgctxt "#30802"
-msgid "Kodi platform/architecture: [B]{platform}[/B]/[B]{arch}[/B]"
+msgid "[B]Kodi[/B] version [B]{version}[/B] is running on a [B]{system}[/B] system with [B]{arch}[/B] architecture."
 msgstr ""
 
 msgctxt "#30810"
-msgid "[B]InputStream information[/B]"
+msgid "[B]InputStream Helper[/B] is at version [B]{version}[/B] {state}"
 msgstr ""
 
 msgctxt "#30811"
-msgid "InputStream Helper version: [B]{version}[/B] {state}"
-msgstr ""
-
-msgctxt "#30812"
-msgid "InputStream Adaptive version: [B]{version}[/B] {state}"
+msgid "[B]InputStream Adaptive[/B] is at version [B]{version}[/B] {state}"
 msgstr ""
 
 msgctxt "#30820"
-msgid "[B]Widevine information[/B]"
+msgid "[B]Widevine CDM[/B] is [B]built into Android[/B]"
 msgstr ""
 
 msgctxt "#30821"
-msgid "Widevine version: [B]Built into Android[/B]"
+msgid "[B]Widevine CDM[/B] is at version [B]{version}[/B] and was installed on [B]{date}[/B]"
 msgstr ""
 
 msgctxt "#30822"
-msgid "Widevine version: [B]{version}[/B] [COLOR gray](last updated on [B]{date}[/B])[/COLOR]"
+msgid "It was extracted from Chrome OS image [B]{name}[/B] with version [B]{version}[/B]"
 msgstr ""
 
 msgctxt "#30823"
-msgid "Widevine CDM path: [B]{path}[/B]"
+msgid "It was last checked for updates on [B]{date}[/B]"
 msgstr ""
 
 msgctxt "#30824"
-msgid "Chrome OS version: [B]{version}[/B]"
+msgid "It is installed at [B]{path}[/B]"
 msgstr ""
 
 msgctxt "#30830"
-msgid "Please report issues to:\n - [COLOR yellow]{url}[/COLOR]"
+msgid "Please report issues to: [COLOR yellow]{url}[/COLOR]"
 msgstr ""
 
 

--- a/script.module.inputstreamhelper/resources/language/resource.language.es_es/strings.po
+++ b/script.module.inputstreamhelper/resources/language/resource.language.es_es/strings.po
@@ -27,7 +27,7 @@ msgstr "Error"
 
 msgctxt "#30005"
 msgid "An error occurred while installing [B]Widevine CDM[/B]. Please enable debug logging and file a bug report at:[CR][CR]github.com/emilsvennesson/script.module.inputstreamhelper"
-msgstr "Se produjo un error al instalar [B]Widevine CDM[/B]. Por favor, habilite el registro de depuración y presente un informe de error en:[CR][CR]github.com/emilsvennesson/script.module.inputstreamhelper"
+msgstr "Se produjo un error al instalar [B]Widevine CDM[/B]. Por favor, active el registro de depuración y presente un informe de error en:[CR][CR]github.com/emilsvennesson/script.module.inputstreamhelper"
 
 msgctxt "#30006"
 msgid "Due to distribution rights, [B]Widevine CDM[/B] has to be extracted from a Chrome OS recovery image. This process requires at least [B]{diskspace}[/B] of free disk space. Do you wish to continue?"
@@ -63,7 +63,7 @@ msgstr "Error al recuperar [B]{filename}[/B]."
 
 msgctxt "#30014"
 msgid "Download in progress..."
-msgstr "Descargar en progreso..."
+msgstr "Descarga en progreso..."
 
 msgctxt "#30015"
 msgid "Downloading [B]{filename}[/B]..."
@@ -239,57 +239,73 @@ msgstr "Seleccione una copia de seguridad a restaurar"
 
 msgctxt "#30058"
 msgid "Time remaining: {mins:d}:{secs:02d}"
-msgstr ""
+msgstr "Tiempo restante: {mins:d}:{secs:02d}"
+
+msgctxt "#30059"
+msgid "Meanwhile, should we try extracting Widevine CDM using the legacy method?"
+msgstr "Mientras tanto, ¿deberíamos intentar extraer Widevine CDM utilizando el método heredado?"
+
+msgctxt "#30060"
+msgid "Identifying wanted partition..."
+msgstr "Identificando partición deseada..."
+
+msgctxt "#30061"
+msgid "Scanning the filesystem for the Widevine CDM..."
+msgstr "Escaneando el sistema de archivos para Widevine CDM..."
+
+msgctxt "#30062"
+msgid "Widevine CDM found, analyzing..."
+msgstr "Encontrado Widevine CDM, analizando..."
+
+msgctxt "#30063"
+msgid "Could not make the request. Your internet may be down."
+msgstr "No se pudo realizar la solicitud. Su conexión a internet puede estar caída."
+
+msgctxt "#30064"
+msgid "Could not finish the download."
+msgstr "No se pudo finalizar la descarga."
+
+msgctxt "#30065"
+msgid "Shall we try again?"
+msgstr "¿Lo intentamos de nuevo?"
 
 
 ### INFORMATION DIALOG
 msgctxt "#30800"
-msgid "[B]Kodi information[/B]"
-msgstr "[B]Información Kodi[/B]"
-
-msgctxt "#30801"
-msgid "Kodi version: [B]{version}[/B]"
-msgstr "Versión Kodi: [B]{version}[/B]"
-
-msgctxt "#30802"
-msgid "Kodi platform/architecture: [B]{platform}[/B]/[B]{arch}[/B]"
-msgstr "Plataforma/arquitectura: [B]{platform}[/B]/[B]{arch}[/B]"
+msgid "[B]Kodi[/B] version [B]{version}[/B] is running on a [B]{system}[/B] system with [B]{arch}[/B] architecture."
+msgstr "Se está ejecutando [B]Kodi[/B] versión [B]{version}[/B] en un sistema [B]{system}[/B] con arquitectura [B]{arch}[/B]."
 
 msgctxt "#30810"
-msgid "[B]InputStream information[/B]"
-msgstr "[B]Información InputStream[/B]"
+msgid "[B]InputStream Helper[/B] is at version [B]{version}[/B] {state}"
+msgstr "[B]InputStream Helper[/B] está en la versión [B]{version}[/B] {state}"
 
 msgctxt "#30811"
-msgid "InputStream Helper version: [B]{version}[/B] {state}"
-msgstr "Versión InputStream Helper: [B]{version}[/B] {state}"
-
-msgctxt "#30812"
-msgid "InputStream Adaptive version: [B]{version}[/B] {state}"
-msgstr "Versión InputStream Adaptive: [B]{version}[/B] {state}"
+msgid "[B]InputStream Adaptive[/B] is at version [B]{version}[/B] {state}"
+msgstr "[B]InputStream Adaptive[/B] está en la versión [B]{version}[/B] {state}"
 
 msgctxt "#30820"
-msgid "[B]Widevine information[/B]"
-msgstr "[B]Información Widevine[/B]"
+msgid "[B]Widevine CDM[/B] is [B]built into Android[/B]"
+msgstr "[B]Widevine CDM[/B] está [/B]integrado en Android[/B]"
 
 msgctxt "#30821"
-msgid "Widevine version: [B]Built into Android[/B]"
-msgstr "Versión Widevine: [B]Incorporado en Android[/B]"
+msgid "[B]Widevine CDM[/B] is at version [B]{version}[/B] and was installed on [B]{date}[/B]"
+msgstr "[B]Widevine CDM[/B] está en la versión [B]{version}[/B] y fue instalado el [B]{date}[/B]"
 
 msgctxt "#30822"
-msgid "Widevine version: [B]{version}[/B] [COLOR gray](last updated on [B]{date}[/B])[/COLOR]"
-msgstr "Versión Widevine: [B]{versión}[/B] [COLOR gray](última actualización [B]{date}[/B])[/COLOR]"
+msgid "It was extracted from Chrome OS image [B]{name}[/B] with version [B]{version}[/B]"
+msgstr "Se extrajo de la imagen de Chrome OS [B]{name}[/B] con versión [B]{version}[/B]"
 
 msgctxt "#30823"
-msgid "Widevine CDM path: [B]{path}[/B]"
-msgstr "Ruta Widevine CDM: [B]{path}[/B]"
+msgid "It was last checked for updates on [B]{date}[/B]"
+msgstr "Se comprobó por última vez las actualizaciones el [B]{date}[/B]"
 
 msgctxt "#30824"
-msgid "Chrome OS version: [B]{version}[/B]"
-msgstr "Versión Chrome OS: [B]{version}[/B]"
+msgid "It is installed at [B]{path}[/B]"
+msgstr "Se instala en [B]{path}[/B]"
 
 msgctxt "#30830"
-msgid "Please report issues to:\n - [COLOR yellow]{url}[/COLOR]"
-msgstr "Por favor, reporte sus problemas a:\n - [COLOR yellow]{url}[/COLOR]"
+msgid "Please report issues to: [COLOR yellow]{url}[/COLOR]"
+msgstr "Por favor, reporte sus problemas a: [COLOR yellow]{url}[/COLOR]"
 
 
 ### SETTINGS

--- a/script.module.inputstreamhelper/resources/language/resource.language.fr_fr/strings.po
+++ b/script.module.inputstreamhelper/resources/language/resource.language.fr_fr/strings.po
@@ -239,57 +239,73 @@ msgstr "Choisissez une sauvegarde à restaurer"
 
 msgctxt "#30058"
 msgid "Time remaining: {mins:d}:{secs:02d}"
-msgstr ""
+msgstr "Temps restant: {mins:d}:{secs:02d}"
+
+msgctxt "#30059"
+msgid "Meanwhile, should we try extracting Widevine CDM using the legacy method?"
+msgstr "En attendant, devrions-nous essayer d'extraire Widevine CDM en utilisant la méthode ancienne?"
+
+msgctxt "#30060"
+msgid "Identifying wanted partition..."
+msgstr "Identifier la partition souhaitée..."
+
+msgctxt "#30061"
+msgid "Scanning the filesystem for the Widevine CDM..."
+msgstr "Analyse du système de fichiers pour le CDM Widevine..."
+
+msgctxt "#30062"
+msgid "Widevine CDM found, analyzing..."
+msgstr "Widevine CDM trouvé, en cours d'analyser..."
+
+msgctxt "#30063"
+msgid "Could not make the request. Your internet may be down."
+msgstr "Impossible de faire la demande. Votre connexion Internet est peut-être en panne."
+
+msgctxt "#30064"
+msgid "Could not finish the download."
+msgstr "Impossible de terminer le téléchargement."
+
+msgctxt "#30065"
+msgid "Shall we try again?"
+msgstr "Allons-nous réessayer?"
 
 
 ### INFORMATION DIALOG
 msgctxt "#30800"
-msgid "[B]Kodi information[/B]"
-msgstr "[B]Informations Kodi[/B]"
-
-msgctxt "#30801"
-msgid "Kodi version: [B]{version}[/B]"
-msgstr "Version de Kodi : [B]{version}[/B]"
-
-msgctxt "#30802"
-msgid "Kodi platform/architecture: [B]{platform}[/B]/[B]{arch}[/B]"
-msgstr "Platforme/architecture de Kodi : [B]{platform}[/B]/[B]{arch}[/B]"
+msgid "[B]Kodi[/B] version [B]{version}[/B] is running on a [B]{system}[/B] system with [B]{arch}[/B] architecture."
+msgstr "Version [B]Kodi[/B] [B]{version}[/B] opère sur un système [B]{system}[/B] avec l'architecture [B]{arch}[/B]."
 
 msgctxt "#30810"
-msgid "[B]InputStream information[/B]"
-msgstr "[B]Informations InputStream[/B]"
+msgid "[B]InputStream Helper[/B] is at version [B]{version}[/B] {state}"
+msgstr "[B]InputStream Helper[/B] est à la version [B]{version}[/B] {state}"
 
 msgctxt "#30811"
-msgid "InputStream Helper version: [B]{version}[/B] {state}"
-msgstr "Version InputStream Helper : [B]{version}[/B] {state}"
-
-msgctxt "#30812"
-msgid "InputStream Adaptive version: [B]{version}[/B] {state}"
-msgstr "Version InputStream Adaptive : [B]{version}[/B] {state}"
+msgid "[B]InputStream Adaptive[/B] is at version [B]{version}[/B] {state}"
+msgstr "[B]InputStream Adaptive[/B] est à la version [B]{version}[/B] {state}"
 
 msgctxt "#30820"
-msgid "[B]Widevine information[/B]"
-msgstr "[B]Information Widevine[/B]"
+msgid "[B]Widevine CDM[/B] is [B]built into Android[/B]"
+msgstr "[B]Widevine CDM[/B] est [B]intégré à Android[/B]"
 
 msgctxt "#30821"
-msgid "Widevine version: [B]Built into Android[/B]"
-msgstr "Version Widevine : [B]Intégré dans Android[/B]"
+msgid "[B]Widevine CDM[/B] is at version [B]{version}[/B] and was installed on [B]{date}[/B]"
+msgstr "[B]Widevine CDM[/B] est à la version [B]{version}[/B] et a été installé le [B]{date}[/B]"
 
 msgctxt "#30822"
-msgid "Widevine version: [B]{version}[/B] [COLOR gray](last updated on [B]{date}[/B])[/COLOR]"
-msgstr "Version Widevine : [B]{version}[/B] [COLOR gray](mise à jour le [B]{date}[/B])[/COLOR]"
+msgid "It was extracted from Chrome OS image [B]{name}[/B] with version [B]{version}[/B]"
+msgstr "Il a été extrait de l'image de Chrome OS [B]{name}[/B] avec la version [B]{version}[/B]"
 
 msgctxt "#30823"
-msgid "Widevine CDM path: [B]{path}[/B]"
-msgstr "Emplacement de Widevine CDM : [B]{path}[/B]"
+msgid "It was last checked for updates on [B]{date}[/B]"
+msgstr "La dernière vérification des mises à jour a eu lieu le [B]{date}[/B]"
 
 msgctxt "#30824"
-msgid "Chrome OS version: [B]{version}[/B]"
-msgstr "Version de ChromeOS : [B]{version}[/B]"
+msgid "It is installed at [B]{path}[/B]"
+msgstr "Il est installé dans [B]{path}[/B]"
 
 msgctxt "#30830"
-msgid "Please report issues to:\n - [COLOR yellow]{url}[/COLOR]"
-msgstr "Veuillez signaler les problèmes à :\n - [COLOR yellow]{url}[/COLOR]"
+msgid "Please report issues to: [COLOR yellow]{url}[/COLOR]"
+msgstr "Veuillez signaler les problèmes à : [COLOR yellow]{url}[/COLOR]"
 
 
 ### SETTINGS

--- a/script.module.inputstreamhelper/resources/language/resource.language.hr_hr/strings.po
+++ b/script.module.inputstreamhelper/resources/language/resource.language.hr_hr/strings.po
@@ -241,55 +241,71 @@ msgctxt "#30058"
 msgid "Time remaining: {mins:d}:{secs:02d}"
 msgstr ""
 
+msgctxt "#30059"
+msgid "Meanwhile, should we try extracting Widevine CDM using the legacy method?"
+msgstr ""
+
+msgctxt "#30060"
+msgid "Identifying wanted partition..."
+msgstr ""
+
+msgctxt "#30061"
+msgid "Scanning the filesystem for the Widevine CDM..."
+msgstr ""
+
+msgctxt "#30062"
+msgid "Widevine CDM found, analyzing..."
+msgstr ""
+
+msgctxt "#30063"
+msgid "Could not make the request. Your internet may be down."
+msgstr ""
+
+msgctxt "#30064"
+msgid "Could not finish the download."
+msgstr ""
+
+msgctxt "#30065"
+msgid "Shall we try again?"
+msgstr ""
+
 
 ### INFORMATION DIALOG
 msgctxt "#30800"
-msgid "[B]Kodi information[/B]"
-msgstr "[B]Kodi informacije[/B]"
-
-msgctxt "#30801"
-msgid "Kodi version: [B]{version}[/B]"
-msgstr "Kodi verzija: [B]{version}[/B]"
-
-msgctxt "#30802"
-msgid "Kodi platform/architecture: [B]{platform}[/B]/[B]{arch}[/B]"
-msgstr "Kodi platforma/arhitektura: [B]{platform}[/B]/[B]{arch}[/B]"
+msgid "[B]Kodi[/B] version [B]{version}[/B] is running on a [B]{system}[/B] system with [B]{arch}[/B] architecture."
+msgstr ""
 
 msgctxt "#30810"
-msgid "[B]InputStream information[/B]"
-msgstr "[B]InputStream informacije[/B]"
+msgid "[B]InputStream Helper[/B] is at version [B]{version}[/B] {state}"
+msgstr ""
 
 msgctxt "#30811"
-msgid "InputStream Helper version: [B]{version}[/B] {state}"
-msgstr "InputStream Helper verzija: [B]{version}[/B] {state}"
-
-msgctxt "#30812"
-msgid "InputStream Adaptive version: [B]{version}[/B] {state}"
-msgstr "InputStream Adaptive verzija: [B]{version}[/B] {state}"
+msgid "[B]InputStream Adaptive[/B] is at version [B]{version}[/B] {state}"
+msgstr ""
 
 msgctxt "#30820"
-msgid "[B]Widevine information[/B]"
-msgstr "[B]Widevine informacije[/B]"
+msgid "[B]Widevine CDM[/B] is [B]built into Android[/B]"
+msgstr ""
 
 msgctxt "#30821"
-msgid "Widevine version: [B]Built into Android[/B]"
-msgstr "Widevine verzija: [B]Ugrađen u Android[/B]"
+msgid "[B]Widevine CDM[/B] is at version [B]{version}[/B] and was installed on [B]{date}[/B]"
+msgstr ""
 
 msgctxt "#30822"
-msgid "Widevine version: [B]{version}[/B] [COLOR gray](last updated on [B]{date}[/B])[/COLOR]"
-msgstr "Widevine verzija: [B]{version}[/B] [COLOR gray](zadnja nadogradnja [B]{date}[/B])[/COLOR]"
+msgid "It was extracted from Chrome OS image [B]{name}[/B] with version [B]{version}[/B]"
+msgstr ""
 
 msgctxt "#30823"
-msgid "Widevine CDM path: [B]{path}[/B]"
-msgstr "Widevine CDM mapa: [B]{path}[/B]"
+msgid "It was last checked for updates on [B]{date}[/B]"
+msgstr ""
 
 msgctxt "#30824"
-msgid "Chrome OS version: [B]{version}[/B]"
-msgstr "Chrome OS verzija: [B]{version}[/B]"
+msgid "It is installed at [B]{path}[/B]"
+msgstr ""
 
 msgctxt "#30830"
-msgid "Please report issues to:\n - [COLOR yellow]{url}[/COLOR]"
-msgstr "Molim prijavite probleme na:\n - [COLOR yellow]{url}[/COLOR]"
+msgid "Please report issues to: [COLOR yellow]{url}[/COLOR]"
+msgstr "Molim prijavite probleme na: [COLOR yellow]{url}[/COLOR]"
 
 
 ### SETTINGS

--- a/script.module.inputstreamhelper/resources/language/resource.language.hu_hu/strings.po
+++ b/script.module.inputstreamhelper/resources/language/resource.language.hu_hu/strings.po
@@ -4,7 +4,7 @@ msgstr ""
 "Project-Id-Version: script.module.inputstreamhelper\n"
 "Report-Msgid-Bugs-To: https://github.com/emilsvennesson/script.module.inputstreamhelper\n"
 "POT-Creation-Date: 2013-11-18 16:15+0000\n"
-"PO-Revision-Date: 2020-02-17 16:30+0000\n"
+"PO-Revision-Date: 2020-06-21 9:30+0000\n"
 "Last-Translator: frodo19\n"
 "Language-Team: Hungarian\n"
 "MIME-Version: 1.0\n"
@@ -239,57 +239,73 @@ msgstr "Válassz mentés fájlt a visszaállításhoz"
 
 msgctxt "#30058"
 msgid "Time remaining: {mins:d}:{secs:02d}"
-msgstr ""
+msgstr "Hátralevő idő: {mins:d}:{secs:02d}"
+
+msgctxt "#30059"
+msgid "Meanwhile, should we try extracting Widevine CDM using the legacy method?"
+msgstr "Megpróbáljuk a Widevine CDM kinyerését a régi módszerrel?"
+
+msgctxt "#30060"
+msgid "Identifying wanted partition..."
+msgstr "A kívánt partíció azonosítása ..."
+
+msgctxt "#30061"
+msgid "Scanning the filesystem for the Widevine CDM..."
+msgstr "A fájlrendszer szkennelése a Widevine CDM számára ..."
+
+msgctxt "#30062"
+msgid "Widevine CDM found, analyzing..."
+msgstr "A Widevine CDM megtalálva, elemzés ..."
+
+msgctxt "#30063"
+msgid "Could not make the request. Your internet may be down."
+msgstr "Nem sikerült teljesíteni a kérést. Lehet, hogy az internet nem működik."
+
+msgctxt "#30064"
+msgid "Could not finish the download."
+msgstr "A letöltés megszakadt"
+
+msgctxt "#30065"
+msgid "Shall we try again?"
+msgstr "Megpróbáljuk újra?"
 
 
 ### INFORMATION DIALOG
 msgctxt "#30800"
-msgid "[B]Kodi information[/B]"
-msgstr "[B]Kodi információ[/B]"
-
-msgctxt "#30801"
-msgid "Kodi version: [B]{version}[/B]"
-msgstr "Kodi verzió: [B]{version}[/B]"
-
-msgctxt "#30802"
-msgid "Kodi platform/architecture: [B]{platform}[/B]/[B]{arch}[/B]"
-msgstr "Kodi platform/architectúra: [B]{platform}[/B]/[B]{arch}[/B]"
+msgid "[B]Kodi[/B] version [B]{version}[/B] is running on a [B]{system}[/B] system with [B]{arch}[/B] architecture."
+msgstr "[B]Kodi[/B] verzió [B]{version}[/B] fut a [B]{system}[/B] rendszeren [B]{arch}[/B] architecturával."
 
 msgctxt "#30810"
-msgid "[B]InputStream information[/B]"
-msgstr "[B]InputStream információ[/B]"
+msgid "[B]InputStream Helper[/B] is at version [B]{version}[/B] {state}"
+msgstr "[B]InputStream Helper[/B] verzió [B]{version}[/B] {state}"
 
 msgctxt "#30811"
-msgid "InputStream Helper version: [B]{version}[/B] {state}"
-msgstr "InputStream Helper verzió: [B]{version}[/B] {state}"
-
-msgctxt "#30812"
-msgid "InputStream Adaptive version: [B]{version}[/B] {state}"
-msgstr "InputStream Adaptive verzió: [B]{version}[/B] {state}"
+msgid "[B]InputStream Adaptive[/B] is at version [B]{version}[/B] {state}"
+msgstr "[B]InputStream Adaptive[/B] verzió [B]{version}[/B] {state}"
 
 msgctxt "#30820"
-msgid "[B]Widevine information[/B]"
-msgstr "[B]Widevine információ[/B]"
+msgid "[B]Widevine CDM[/B] is [B]built into Android[/B]"
+msgstr "[B]Widevine CDM[/B] az [B]Androidba épülve[/B]"
 
 msgctxt "#30821"
-msgid "Widevine version: [B]Built into Android[/B]"
-msgstr "Widevine verzió: [B]Androiddal telepített[/B]"
+msgid "[B]Widevine CDM[/B] is at version [B]{version}[/B] and was installed on [B]{date}[/B]"
+msgstr "[B]Widevine CDM[/B] verzió [B]{version}[/B] telepítve [B]{date}[/B]"
 
 msgctxt "#30822"
-msgid "Widevine version: [B]{version}[/B] [COLOR gray](last updated on [B]{date}[/B])[/COLOR]"
-msgstr "Widevine verzió: [B]{version}[/B] [COLOR gray](utolsó frissítés [B]{date}[/B])[/COLOR]"
+msgid "It was extracted from Chrome OS image [B]{name}[/B] with version [B]{version}[/B]"
+msgstr "Legutóbb kicsomagolva a Chrome OS image-ból [B]{name}[/B] verzió [B]{version}[/B]"
 
 msgctxt "#30823"
-msgid "Widevine CDM path: [B]{path}[/B]"
-msgstr "Widevine CDM elérési út: [B]{path}[/B]"
+msgid "It was last checked for updates on [B]{date}[/B]"
+msgstr "Legutóbbi frissítés keresése [B]{date}[/B]"
 
 msgctxt "#30824"
-msgid "Chrome OS version: [B]{version}[/B]"
-msgstr "Chrome OS verzió: [B]{version}[/B]"
+msgid "It is installed at [B]{path}[/B]"
+msgstr "Telepítve [B]{path}[/B]"
 
 msgctxt "#30830"
-msgid "Please report issues to:\n - [COLOR yellow]{url}[/COLOR]"
-msgstr "Hiba jelzése:\n - [COLOR yellow]{url}[/COLOR]"
+msgid "Please report issues to: [COLOR yellow]{url}[/COLOR]"
+msgstr "Hiba jelzése: [COLOR yellow]{url}[/COLOR]"
 
 
 ### SETTINGS

--- a/script.module.inputstreamhelper/resources/language/resource.language.it_it/strings.po
+++ b/script.module.inputstreamhelper/resources/language/resource.language.it_it/strings.po
@@ -241,55 +241,71 @@ msgctxt "#30058"
 msgid "Time remaining: {mins:d}:{secs:02d}"
 msgstr ""
 
+msgctxt "#30059"
+msgid "Meanwhile, should we try extracting Widevine CDM using the legacy method?"
+msgstr ""
+
+msgctxt "#30060"
+msgid "Identifying wanted partition..."
+msgstr ""
+
+msgctxt "#30061"
+msgid "Scanning the filesystem for the Widevine CDM..."
+msgstr ""
+
+msgctxt "#30062"
+msgid "Widevine CDM found, analyzing..."
+msgstr ""
+
+msgctxt "#30063"
+msgid "Could not make the request. Your internet may be down."
+msgstr ""
+
+msgctxt "#30064"
+msgid "Could not finish the download."
+msgstr ""
+
+msgctxt "#30065"
+msgid "Shall we try again?"
+msgstr ""
+
 
 ### INFORMATION DIALOG
 msgctxt "#30800"
-msgid "[B]Kodi information[/B]"
-msgstr "[B]Kodi info[/B]"
-
-msgctxt "#30801"
-msgid "Kodi version: [B]{version}[/B]"
-msgstr "Release: [B]{version}[/B]"
-
-msgctxt "#30802"
-msgid "Kodi platform/architecture: [B]{platform}[/B]/[B]{arch}[/B]"
-msgstr "Piattaforma/architettura: [B]{platform}[/B]/[B]{arch}[/B]"
+msgid "[B]Kodi[/B] version [B]{version}[/B] is running on a [B]{system}[/B] system with [B]{arch}[/B] architecture."
+msgstr ""
 
 msgctxt "#30810"
-msgid "[B]InputStream information[/B]"
-msgstr "[B]InputStream info[/B]"
+msgid "[B]InputStream Helper[/B] is at version [B]{version}[/B] {state}"
+msgstr ""
 
 msgctxt "#30811"
-msgid "InputStream Helper version: [B]{version}[/B] {state}"
-msgstr "InputStream Helper: [B]{version}[/B] {state}"
-
-msgctxt "#30812"
-msgid "InputStream Adaptive version: [B]{version}[/B] {state}"
-msgstr "InputStream Adaptive: [B]{version}[/B] {state}"
+msgid "[B]InputStream Adaptive[/B] is at version [B]{version}[/B] {state}"
+msgstr ""
 
 msgctxt "#30820"
-msgid "[B]Widevine information[/B]"
-msgstr "[B]Widevine info[/B]"
+msgid "[B]Widevine CDM[/B] is [B]built into Android[/B]"
+msgstr ""
 
 msgctxt "#30821"
-msgid "Widevine version: [B]Built into Android[/B]"
-msgstr "Widevine: [B]incluso in Android[/B]"
+msgid "[B]Widevine CDM[/B] is at version [B]{version}[/B] and was installed on [B]{date}[/B]"
+msgstr ""
 
 msgctxt "#30822"
-msgid "Widevine version: [B]{version}[/B] [COLOR gray](last updated on [B]{date}[/B])[/COLOR]"
-msgstr "Widevine: [B]{version}[/B] [COLOR gray](aggiornato il [B]{date}[/B])[/COLOR]"
+msgid "It was extracted from Chrome OS image [B]{name}[/B] with version [B]{version}[/B]"
+msgstr ""
 
 msgctxt "#30823"
-msgid "Widevine CDM path: [B]{path}[/B]"
-msgstr "Widevine CDM: [B]{path}[/B]"
+msgid "It was last checked for updates on [B]{date}[/B]"
+msgstr ""
 
 msgctxt "#30824"
-msgid "Chrome OS version: [B]{version}[/B]"
-msgstr "Chrome OS: [B]{version}[/B]"
+msgid "It is installed at [B]{path}[/B]"
+msgstr ""
 
 msgctxt "#30830"
-msgid "Please report issues to:\n - [COLOR yellow]{url}[/COLOR]"
-msgstr "In caso di problemi, apri una segnalazione su:\n - [COLOR yellow]{url}[/COLOR]"
+msgid "Please report issues to: [COLOR yellow]{url}[/COLOR]"
+msgstr "In caso di problemi, apri una segnalazione su: [COLOR yellow]{url}[/COLOR]"
 
 
 ### SETTINGS

--- a/script.module.inputstreamhelper/resources/language/resource.language.ja_JP/strings.po
+++ b/script.module.inputstreamhelper/resources/language/resource.language.ja_JP/strings.po
@@ -241,55 +241,71 @@ msgctxt "#30058"
 msgid "Time remaining: {mins:d}:{secs:02d}"
 msgstr ""
 
+msgctxt "#30059"
+msgid "Meanwhile, should we try extracting Widevine CDM using the legacy method?"
+msgstr ""
+
+msgctxt "#30060"
+msgid "Identifying wanted partition..."
+msgstr ""
+
+msgctxt "#30061"
+msgid "Scanning the filesystem for the Widevine CDM..."
+msgstr ""
+
+msgctxt "#30062"
+msgid "Widevine CDM found, analyzing..."
+msgstr ""
+
+msgctxt "#30063"
+msgid "Could not make the request. Your internet may be down."
+msgstr ""
+
+msgctxt "#30064"
+msgid "Could not finish the download."
+msgstr ""
+
+msgctxt "#30065"
+msgid "Shall we try again?"
+msgstr ""
+
 
 ### INFORMATION DIALOG
 msgctxt "#30800"
-msgid "[B]Kodi information[/B]"
-msgstr "[B]Kodiの情報[/B]"
-
-msgctxt "#30801"
-msgid "Kodi version: [B]{version}[/B]"
-msgstr "Kodiのバージョン: [B]{version}[/B]"
-
-msgctxt "#30802"
-msgid "Kodi platform/architecture: [B]{platform}[/B]/[B]{arch}[/B]"
-msgstr "Kodiのプラットフォーム/アーキテクチャ: [B]{platform}[/B]/[B]{arch}[/B]"
+msgid "[B]Kodi[/B] version [B]{version}[/B] is running on a [B]{system}[/B] system with [B]{arch}[/B] architecture."
+msgstr ""
 
 msgctxt "#30810"
-msgid "[B]InputStream information[/B]"
-msgstr "[B]インプットストリームの情報[/B]"
+msgid "[B]InputStream Helper[/B] is at version [B]{version}[/B] {state}"
+msgstr ""
 
 msgctxt "#30811"
-msgid "InputStream Helper version: [B]{version}[/B] {state}"
-msgstr "インプットストリームヘルパーバージョン: [B]{version}[/B] {state}"
-
-msgctxt "#30812"
-msgid "InputStream Adaptive version: [B]{version}[/B] {state}"
-msgstr "インプットストリームアドオンバージョン: [B]{version}[/B] {state}"
+msgid "[B]InputStream Adaptive[/B] is at version [B]{version}[/B] {state}"
+msgstr ""
 
 msgctxt "#30820"
-msgid "[B]Widevine information[/B]"
-msgstr "[B]Widevine情報[/B]"
+msgid "[B]Widevine CDM[/B] is [B]built into Android[/B]"
+msgstr ""
 
 msgctxt "#30821"
-msgid "Widevine version: [B]Built into Android[/B]"
+msgid "[B]Widevine CDM[/B] is at version [B]{version}[/B] and was installed on [B]{date}[/B]"
 msgstr ""
 
 msgctxt "#30822"
-msgid "Widevine version: [B]{version}[/B] [COLOR gray](last updated on [B]{date}[/B])[/COLOR]"
-msgstr "Widevineバージョン：[B]{version}[/B] [COLOR gray](直近更新日[B]{date}[/B])[/COLOR]"
+msgid "It was extracted from Chrome OS image [B]{name}[/B] with version [B]{version}[/B]"
+msgstr ""
 
 msgctxt "#30823"
-msgid "Widevine CDM path: [B]{path}[/B]"
-msgstr "Widevine CDM パス: [B]{path}[/B]"
+msgid "It was last checked for updates on [B]{date}[/B]"
+msgstr ""
 
 msgctxt "#30824"
-msgid "Chrome OS version: [B]{version}[/B]"
-msgstr "Chrome OS バージョン： [B]{version}[/B]"
+msgid "It is installed at [B]{path}[/B]"
+msgstr ""
 
 msgctxt "#30830"
-msgid "Please report issues to:\n - [COLOR yellow]{url}[/COLOR]"
-msgstr "問題があったらここへ：\n - [COLOR yellow]{url}[/COLOR]"
+msgid "Please report issues to: [COLOR yellow]{url}[/COLOR]"
+msgstr "問題があったらここへ： [COLOR yellow]{url}[/COLOR]"
 
 
 ### SETTINGS

--- a/script.module.inputstreamhelper/resources/language/resource.language.ko_KR/strings.po
+++ b/script.module.inputstreamhelper/resources/language/resource.language.ko_KR/strings.po
@@ -241,55 +241,71 @@ msgctxt "#30058"
 msgid "Time remaining: {mins:d}:{secs:02d}"
 msgstr ""
 
+msgctxt "#30059"
+msgid "Meanwhile, should we try extracting Widevine CDM using the legacy method?"
+msgstr ""
+
+msgctxt "#30060"
+msgid "Identifying wanted partition..."
+msgstr ""
+
+msgctxt "#30061"
+msgid "Scanning the filesystem for the Widevine CDM..."
+msgstr ""
+
+msgctxt "#30062"
+msgid "Widevine CDM found, analyzing..."
+msgstr ""
+
+msgctxt "#30063"
+msgid "Could not make the request. Your internet may be down."
+msgstr ""
+
+msgctxt "#30064"
+msgid "Could not finish the download."
+msgstr ""
+
+msgctxt "#30065"
+msgid "Shall we try again?"
+msgstr ""
+
 
 ### INFORMATION DIALOG
 msgctxt "#30800"
-msgid "[B]Kodi information[/B]"
-msgstr "[B]Kodi 정보[/B]"
-
-msgctxt "#30801"
-msgid "Kodi version: [B]{version}[/B]"
-msgstr "Kodi 버전: [B]{version}[/B]"
-
-msgctxt "#30802"
-msgid "Kodi platform/architecture: [B]{platform}[/B]/[B]{arch}[/B]"
-msgstr "Kodi플랫폼/아키텍춰: [B]{platform}[/B]/[B]{arch}[/B]"
+msgid "[B]Kodi[/B] version [B]{version}[/B] is running on a [B]{system}[/B] system with [B]{arch}[/B] architecture."
+msgstr ""
 
 msgctxt "#30810"
-msgid "[B]InputStream information[/B]"
-msgstr "[B]InputStream 정보[/B]"
+msgid "[B]InputStream Helper[/B] is at version [B]{version}[/B] {state}"
+msgstr ""
 
 msgctxt "#30811"
-msgid "InputStream Helper version: [B]{version}[/B] {state}"
-msgstr "InputStream Helper 버전: [B]{version}[/B] {state}"
-
-msgctxt "#30812"
-msgid "InputStream Adaptive version: [B]{version}[/B] {state}"
-msgstr "InputStream 애드온 버전: [B]{version}[/B] {state}"
+msgid "[B]InputStream Adaptive[/B] is at version [B]{version}[/B] {state}"
+msgstr ""
 
 msgctxt "#30820"
-msgid "[B]Widevine information[/B]"
-msgstr "[B]Widevine 정보[/B]"
+msgid "[B]Widevine CDM[/B] is [B]built into Android[/B]"
+msgstr ""
 
 msgctxt "#30821"
-msgid "Widevine version: [B]Built into Android[/B]"
+msgid "[B]Widevine CDM[/B] is at version [B]{version}[/B] and was installed on [B]{date}[/B]"
 msgstr ""
 
 msgctxt "#30822"
-msgid "Widevine version: [B]{version}[/B] [COLOR gray](last updated on [B]{date}[/B])[/COLOR]"
-msgstr "Widevine 버전: [B]{version}[/B] [COLOR gray]([B]{date}[/B]에 마지막으로 업데이트)[/COLOR]"
+msgid "It was extracted from Chrome OS image [B]{name}[/B] with version [B]{version}[/B]"
+msgstr ""
 
 msgctxt "#30823"
-msgid "Widevine CDM path: [B]{path}[/B]"
-msgstr "Widevine CDM 경로: [B]{path}[/B]"
+msgid "It was last checked for updates on [B]{date}[/B]"
+msgstr ""
 
 msgctxt "#30824"
-msgid "Chrome OS version: [B]{version}[/B]"
-msgstr "Chrome OS 버전: [B]{version}[/B]"
+msgid "It is installed at [B]{path}[/B]"
+msgstr ""
 
 msgctxt "#30830"
-msgid "Please report issues to:\n - [COLOR yellow]{url}[/COLOR]"
-msgstr "문제가 있으면 이쪽으로:\n - [COLOR yellow]{url}[/COLOR]"
+msgid "Please report issues to: [COLOR yellow]{url}[/COLOR]"
+msgstr "문제가 있으면 이쪽으로: [COLOR yellow]{url}[/COLOR]"
 
 
 ### SETTINGS

--- a/script.module.inputstreamhelper/resources/language/resource.language.nl_nl/strings.po
+++ b/script.module.inputstreamhelper/resources/language/resource.language.nl_nl/strings.po
@@ -239,57 +239,73 @@ msgstr "Kies een back-up om te herstellen"
 
 msgctxt "#30058"
 msgid "Time remaining: {mins:d}:{secs:02d}"
-msgstr ""
+msgstr "Resterende tijd: {mins:d}:{secs:02d}"
+
+msgctxt "#30059"
+msgid "Meanwhile, should we try extracting Widevine CDM using the legacy method?"
+msgstr "Moeten we ondertussen Widevine CDM proberen uit te pakken met de legacy-methode?"
+
+msgctxt "#30060"
+msgid "Identifying wanted partition..."
+msgstr "Bezig met de gewenste partitie te identificeren..."
+
+msgctxt "#30061"
+msgid "Scanning the filesystem for the Widevine CDM..."
+msgstr "Bezig met het bestandssysteem te scannen op Widevine CDM..."
+
+msgctxt "#30062"
+msgid "Widevine CDM found, analyzing..."
+msgstr "Widevine CDM gevonden, bezig met analyseren..."
+
+msgctxt "#30063"
+msgid "Could not make the request. Your internet may be down."
+msgstr "Het verzoek kan niet verstuurd worden. Uw internetverbinding is mogelijk niet beschikbaar."
+
+msgctxt "#30064"
+msgid "Could not finish the download."
+msgstr "Het downloaden kan niet voltooid worden."
+
+msgctxt "#30065"
+msgid "Shall we try again?"
+msgstr "Zullen we het opnieuw proberen?"
 
 
 ### INFORMATION DIALOG
 msgctxt "#30800"
-msgid "[B]Kodi information[/B]"
-msgstr "[B]Informatie over Kodi[/B]"
-
-msgctxt "#30801"
-msgid "Kodi version: [B]{version}[/B]"
-msgstr "Kodi versie: [B]{version}[/B]"
-
-msgctxt "#30802"
-msgid "Kodi platform/architecture: [B]{platform}[/B]/[B]{arch}[/B]"
-msgstr "Kodi platform/architectuur: [B]{platform}[/B]/[B]{arch}[/B]"
+msgid "[B]Kodi[/B] version [B]{version}[/B] is running on a [B]{system}[/B] system with [B]{arch}[/B] architecture."
+msgstr "[B]Kodi[/B] versie [B]{version}[/B] draait op een [B]{system}[/B] systeem met [B]{arch}[/B] architectuur."
 
 msgctxt "#30810"
-msgid "[B]InputStream information[/B]"
-msgstr "[B]Informatie over InputStream[/B]"
+msgid "[B]InputStream Helper[/B] is at version [B]{version}[/B] {state}"
+msgstr "[B]InputStream Helper[/B] is versie [B]{version}[/B] {state}"
 
 msgctxt "#30811"
-msgid "InputStream Helper version: [B]{version}[/B] {state}"
-msgstr "InputStream Helper versie: [B]{version}[/B] {state}"
-
-msgctxt "#30812"
-msgid "InputStream Adaptive version: [B]{version}[/B] {state}"
-msgstr "InputStream Adaptive versie: [B]{version}[/B] {state}"
+msgid "[B]InputStream Adaptive[/B] is at version [B]{version}[/B] {state}"
+msgstr "[B]InputStream Adaptive[/B] is versie [B]{versoin}[/B] {state}"
 
 msgctxt "#30820"
-msgid "[B]Widevine information[/B]"
-msgstr "[B]Informatie over Widevine[/B]"
+msgid "[B]Widevine CDM[/B] is [B]built into Android[/B]"
+msgstr "[B]Widevine CDM[/B] is [B]ingebouwd in Android[/B]"
 
 msgctxt "#30821"
-msgid "Widevine version: [B]Built into Android[/B]"
-msgstr "Widevine versie: [B]Ingebouwd in Android[/B]"
+msgid "[B]Widevine CDM[/B] is at version [B]{version}[/B] and was installed on [B]{date}[/B]"
+msgstr "[B]Widevine CDM[/B] is versie [B]{version}[/B] en werd geïnstalleerd op [B]{date}[/B]"
 
 msgctxt "#30822"
-msgid "Widevine version: [B]{version}[/B] [COLOR gray](last updated on [B]{date}[/B])[/COLOR]"
-msgstr "Widevine versie: [B]{version}[/B] [COLOR gray](voor het laatst geüpdatet op [B]{date}[/B])[/COLOR]"
+msgid "It was extracted from Chrome OS image [B]{name}[/B] with version [B]{version}[/B]"
+msgstr "Het werd uitgepakt uit Chrome OS image [B]{name}[/B] met versie [B]{version}[/B]"
 
 msgctxt "#30823"
-msgid "Widevine CDM path: [B]{path}[/B]"
-msgstr "Widevine CDM pad: [B]{path}[/B]"
+msgid "It was last checked for updates on [B]{date}[/B]"
+msgstr "Het werd laatste gecontroleerd op [B]{date}[/B]"
 
 msgctxt "#30824"
-msgid "Chrome OS version: [B]{version}[/B]"
-msgstr "Chrome OS versie: [B]{version}[/B]"
+msgid "It is installed at [B]{path}[/B]"
+msgstr "Het is geïnstalleerd in [B]{path}[/B]"
 
 msgctxt "#30830"
-msgid "Please report issues to:\n - [COLOR yellow]{url}[/COLOR]"
-msgstr "Problemen graag melden op:\n - [COLOR yellow]{url}[/COLOR]"
+msgid "Please report issues to: [COLOR yellow]{url}[/COLOR]"
+msgstr "Gelieve problemen te melden op: [COLOR yellow]{url}[/COLOR]"
 
 
 ### SETTINGS

--- a/script.module.inputstreamhelper/resources/language/resource.language.ro_ro/strings.po
+++ b/script.module.inputstreamhelper/resources/language/resource.language.ro_ro/strings.po
@@ -1,5 +1,4 @@
 # script.module.inputstreamhelper language file
-# Romanian translator: tmihai20
 msgid ""
 msgstr ""
 "Project-Id-Version: script.module.inputstreamhelper\n"
@@ -240,57 +239,73 @@ msgstr "Alegeți o copie de siguranță pentru a fi restabilită"
 
 msgctxt "#30058"
 msgid "Time remaining: {mins:d}:{secs:02d}"
-msgstr ""
+msgstr "Timp rămas: {mins:d}:{secs:02d}"
+
+msgctxt "#30059"
+msgid "Meanwhile, should we try extracting Widevine CDM using the legacy method?"
+msgstr "Între timp, să încercăm să extragem Widevine CDM folosing metoda clasică?"
+
+msgctxt "#30060"
+msgid "Identifying wanted partition..."
+msgstr "Se identifică partiția dorită..."
+
+msgctxt "#30061"
+msgid "Scanning the filesystem for the Widevine CDM..."
+msgstr "Se scanează sistemul după Widevine CDM..."
+
+msgctxt "#30062"
+msgid "Widevine CDM found, analyzing..."
+msgstr "S-a găsit Widevine CDM și este analizat..."
+
+msgctxt "#30063"
+msgid "Could not make the request. Your internet may be down."
+msgstr "Cererea nu s-a putut realiza. Este posibil să aveți probleme cu conexiunea la Internet."
+
+msgctxt "#30064"
+msgid "Could not finish the download."
+msgstr "Nu s-a putut termina descărcarea."
+
+msgctxt "#30065"
+msgid "Shall we try again?"
+msgstr "Doriți să re-încercăm?"
 
 
 ### INFORMATION DIALOG
 msgctxt "#30800"
-msgid "[B]Kodi information[/B]"
-msgstr "[B]Informații despre Kodi[/B]"
-
-msgctxt "#30801"
-msgid "Kodi version: [B]{version}[/B]"
-msgstr "Versiunea Kodi: [B]{version}[/B]"
-
-msgctxt "#30802"
-msgid "Kodi platform/architecture: [B]{platform}[/B]/[B]{arch}[/B]"
-msgstr "Platforma/arhitectura Kodi: [B]{platform}[/B]/[B]{arch}[/B]"
+msgid "[B]Kodi[/B] version [B]{version}[/B] is running on a [B]{system}[/B] system with [B]{arch}[/B] architecture."
+msgstr "[B]Kodi[/B] versiunea [B]{version}[/B] rulează pe un sistem [B]{system}[/B] cu arhitectura [B]{arch}[/B]."
 
 msgctxt "#30810"
-msgid "[B]InputStream information[/B]"
-msgstr "[B]Informații InputStream[/B]"
+msgid "[B]InputStream Helper[/B] is at version [B]{version}[/B] {state}"
+msgstr "[B]InputStream Helper[/B] are versiunea [B]{version}[/B] {state}"
 
 msgctxt "#30811"
-msgid "InputStream Helper version: [B]{version}[/B] {state}"
-msgstr "Versiune InputStream Helper: [B]{version}[/B] {state}"
-
-msgctxt "#30812"
-msgid "InputStream Adaptive version: [B]{version}[/B] {state}"
-msgstr "Versiune InputStream Adaptive: [B]{version}[/B] {state}"
+msgid "[B]InputStream Adaptive[/B] is at version [B]{version}[/B] {state}"
+msgstr "[B]InputStream Adaptive[/B are versiunea [B]{version}[/B] {state}"
 
 msgctxt "#30820"
-msgid "[B]Widevine information[/B]"
-msgstr "[B]Informații Widevine[/B]"
+msgid "[B]Widevine CDM[/B] is [B]built into Android[/B]"
+msgstr "[B]Widevine CDM[/B] face parte din [B]Android[/B]."
 
 msgctxt "#30821"
-msgid "Widevine version: [B]Built into Android[/B]"
-msgstr "Versiune Widevine: [B]Inclus în Android[/B]"
+msgid "[B]Widevine CDM[/B] is at version [B]{version}[/B] and was installed on [B]{date}[/B]"
+msgstr "[B]Widevine CDM[/B] are versiunea [B]{version}[/B] și a fost instalat pe [B]{date}[/B]"
 
 msgctxt "#30822"
-msgid "Widevine version: [B]{version}[/B] [COLOR gray](last updated on [B]{date}[/B])[/COLOR]"
-msgstr "Versiune Widevine: [B]{version}[/B] [COLOR gray](ultima dată actualizat pe [B]{date}[/B])[/COLOR]"
+msgid "It was extracted from Chrome OS image [B]{name}[/B] with version [B]{version}[/B]"
+msgstr "A fost extras din imaginea Chrome OS B]{name}[/B] și are versiunea [B]{version}[/B]"
 
 msgctxt "#30823"
-msgid "Widevine CDM path: [B]{path}[/B]"
-msgstr "Calea Widevine CDM: [B]{path}[/B]"
+msgid "It was last checked for updates on [B]{date}[/B]"
+msgstr "Ultima dată s-a verificat după actualizări pe [B]{date}[/B]"
 
 msgctxt "#30824"
-msgid "Chrome OS version: [B]{version}[/B]"
-msgstr "Versiune Chrome OS: [B]{version}[/B]"
+msgid "It is installed at [B]{path}[/B]"
+msgstr "Este instalat în calea [B]{path}[/B]"
 
 msgctxt "#30830"
-msgid "Please report issues to:\n - [COLOR yellow]{url}[/COLOR]"
-msgstr "Vă rugăm să raportați probleme la: \n - [COLOR yellow]{url}[/COLOR]"
+msgid "Please report issues to: [COLOR yellow]{url}[/COLOR]"
+msgstr "Vă rugăm să raportați probleme la: [COLOR yellow]{url}[/COLOR]"
 
 
 ### SETTINGS

--- a/script.module.inputstreamhelper/resources/language/resource.language.ru_ru/strings.po
+++ b/script.module.inputstreamhelper/resources/language/resource.language.ru_ru/strings.po
@@ -239,57 +239,73 @@ msgstr "Выберите резервную копию для восстанов
 
 msgctxt "#30058"
 msgid "Time remaining: {mins:d}:{secs:02d}"
-msgstr ""
+msgstr "Оставшееся время: {mins:d}:{secs:02d}"
+
+msgctxt "#30059"
+msgid "Meanwhile, should we try extracting Widevine CDM using the legacy method?"
+msgstr "Тем временем, стоит нам попробовать извлечь Widevine CDM используя устаревшие методы?"
+
+msgctxt "#30060"
+msgid "Identifying wanted partition..."
+msgstr "Определение нужного раздела..."
+
+msgctxt "#30061"
+msgid "Scanning the filesystem for the Widevine CDM..."
+msgstr "Сканирование файловой системы на наличие Widevine CDM..."
+
+msgctxt "#30062"
+msgid "Widevine CDM found, analyzing..."
+msgstr "Обнаружен Widevine CDM, анализирую..."
+
+msgctxt "#30063"
+msgid "Could not make the request. Your internet may be down."
+msgstr "Не удалось выполнить запрос. Возможно у Вас проблемы с интернетом."
+
+msgctxt "#30064"
+msgid "Could not finish the download."
+msgstr "Не удалось завершить загрузку."
+
+msgctxt "#30065"
+msgid "Shall we try again?"
+msgstr "Попробовать еще раз?"
 
 
 ### INFORMATION DIALOG
 msgctxt "#30800"
-msgid "[B]Kodi information[/B]"
-msgstr "[B]Информация о Kodi[/B]"
-
-msgctxt "#30801"
-msgid "Kodi version: [B]{version}[/B]"
-msgstr "Версия Kodi: [B]{version}[/B]"
-
-msgctxt "#30802"
-msgid "Kodi platform/architecture: [B]{platform}[/B]/[B]{arch}[/B]"
-msgstr "Платформа/архитектура Kodi: [B]{platform}[/B]/[B]{arch}[/B]"
+msgid "[B]Kodi[/B] version [B]{version}[/B] is running on a [B]{system}[/B] system with [B]{arch}[/B] architecture."
+msgstr "Версия [B]Kodi[/B] [B]{version}[/B] запущена на системе [B]{system}[/B] с архитектурой [B]{arch}[/B]."
 
 msgctxt "#30810"
-msgid "[B]InputStream information[/B]"
-msgstr "[B]Информация о InputStream[/B]"
+msgid "[B]InputStream Helper[/B] is at version [B]{version}[/B] {state}"
+msgstr "[B]InputStream Helper[/B] версии [B]{version}[/B] {state}"
 
 msgctxt "#30811"
-msgid "InputStream Helper version: [B]{version}[/B] {state}"
-msgstr "Версия InputStream Helper: [B]{version}[/B] {state}"
-
-msgctxt "#30812"
-msgid "InputStream Adaptive version: [B]{version}[/B] {state}"
-msgstr "Версия InputStream Adaptive: [B]{version}[/B] {state}"
+msgid "[B]InputStream Adaptive[/B] is at version [B]{version}[/B] {state}"
+msgstr "[B]InputStream Adaptive[/B] версии [B]{version}[/B] {state}"
 
 msgctxt "#30820"
-msgid "[B]Widevine information[/B]"
-msgstr "[B]Информация о Widevine[/B]"
+msgid "[B]Widevine CDM[/B] is [B]built into Android[/B]"
+msgstr "[B]Widevine CDM[/B] [B]встроен в Android[/B]"
 
 msgctxt "#30821"
-msgid "Widevine version: [B]Built into Android[/B]"
-msgstr "Версия Widevine: [B]Встроенный в Android[/B]"
+msgid "[B]Widevine CDM[/B] is at version [B]{version}[/B] and was installed on [B]{date}[/B]"
+msgstr "[B]Widevine CDM[/B] версии [B]{version}[/B] и установлен [B]{date}[/B]"
 
 msgctxt "#30822"
-msgid "Widevine version: [B]{version}[/B] [COLOR gray](last updated on [B]{date}[/B])[/COLOR]"
-msgstr "Версия Widevine: [B]{version}[/B] [COLOR gray](последнее обновление [B]{date}[/B])[/COLOR]"
+msgid "It was extracted from Chrome OS image [B]{name}[/B] with version [B]{version}[/B]"
+msgstr "Был извлечен из образа Chrome OS [B]{name}[/B] версии [B]{version}[/B]"
 
 msgctxt "#30823"
-msgid "Widevine CDM path: [B]{path}[/B]"
-msgstr "Путь к Widevine CDM: [B]{path}[/B]"
+msgid "It was last checked for updates on [B]{date}[/B]"
+msgstr "Последняя проверка обновления [B]{date}[/B]"
 
 msgctxt "#30824"
-msgid "Chrome OS version: [B]{version}[/B]"
-msgstr "Версия Chrome OS: [B]{version}[/B]"
+msgid "It is installed at [B]{path}[/B]"
+msgstr "Установлен в [B]{path}[/B]"
 
 msgctxt "#30830"
-msgid "Please report issues to:\n - [COLOR yellow]{url}[/COLOR]"
-msgstr "Пожалуйста, о проблемах сообщайте сюда:\n - [COLOR yellow]{url}[/COLOR]"
+msgid "Please report issues to: [COLOR yellow]{url}[/COLOR]"
+msgstr "Пожалуйста, о проблемах сообщайте сюда: [COLOR yellow]{url}[/COLOR]"
 
 
 ### SETTINGS
@@ -319,11 +335,11 @@ msgstr "Временный каталог загрузки"
 
 msgctxt "#30909"
 msgid "(Re)install Widevine CDM library..."
-msgstr "(Пере)установить модуль Widevine CDM..."
+msgstr "(Пере)установить библиотеку Widevine CDM..."
 
 msgctxt "#30911"
 msgid "Remove Widevine CDM library..."
-msgstr "Удалить модуль Widevine CDM..."
+msgstr "Удалить библиотеку Widevine CDM..."
 
 msgctxt "#30913"
 msgid "Number of backups"
@@ -331,4 +347,4 @@ msgstr "Количество резервных копий"
 
 msgctxt "#30915"
 msgid "Restore Widevine CDM library..."
-msgstr "Восстановить модуль Widevine CDM..."
+msgstr "Восстановить библиотеку Widevine CDM..."

--- a/script.module.inputstreamhelper/resources/language/resource.language.sv_se/strings.po
+++ b/script.module.inputstreamhelper/resources/language/resource.language.sv_se/strings.po
@@ -59,7 +59,7 @@ msgstr "Windows Store-versionen av Kodi stöds inte av [B]Widevine CDM[/B].[CR][
 
 msgctxt "#30013"
 msgid "Failed to retrieve [B]{filename}[/B]."
-msgstr "Det gick inte att hämta [B]{filename}[/B]."
+msgstr "Det gick inte att ladda ned [B]{filename}[/B]."
 
 msgctxt "#30014"
 msgid "Download in progress..."
@@ -239,57 +239,73 @@ msgstr "Välj säkerhetskopia att återställa"
 
 msgctxt "#30058"
 msgid "Time remaining: {mins:d}:{secs:02d}"
-msgstr ""
+msgstr "Återstående tid: {mins:d}:{secs:02d}"
+
+msgctxt "#30059"
+msgid "Meanwhile, should we try extracting Widevine CDM using the legacy method?"
+msgstr "Ska vi prova att extrahera Widevine CDM med den gamla metoden?"
+
+msgctxt "#30060"
+msgid "Identifying wanted partition..."
+msgstr "Identifiera önskad partition..."
+
+msgctxt "#30061"
+msgid "Scanning the filesystem for the Widevine CDM..."
+msgstr "Söker igenom filsystemet efter Widevine CDM..."
+
+msgctxt "#30062"
+msgid "Widevine CDM found, analyzing..."
+msgstr "Hittade Widevine CDM, analyserar..."
+
+msgctxt "#30063"
+msgid "Could not make the request. Your internet may be down."
+msgstr "Det gick inte att skicka begäran. Ditt internet kan ligga nere."
+
+msgctxt "#30064"
+msgid "Could not finish the download."
+msgstr "Det gick inte att slutföra nedladdningen"
+
+msgctxt "#30065"
+msgid "Shall we try again?"
+msgstr "Ska vi prova igen?"
 
 
 ### INFORMATION DIALOG
 msgctxt "#30800"
-msgid "[B]Kodi information[/B]"
-msgstr "[B]Kodi-information[/B]"
-
-msgctxt "#30801"
-msgid "Kodi version: [B]{version}[/B]"
-msgstr "Kodi-version: [B]{version}[/B]"
-
-msgctxt "#30802"
-msgid "Kodi platform/architecture: [B]{platform}[/B]/[B]{arch}[/B]"
-msgstr "Kodi-plattform/arkitektur: [B]{platform}[/B]/[B]{arch}[/B]"
+msgid "[B]Kodi[/B] version [B]{version}[/B] is running on a [B]{system}[/B] system with [B]{arch}[/B] architecture."
+msgstr "[B]Kodi[/B] version [B]{version}[/B] körs på ett [B]{system}[/B]-system med [B]{arch}[/B]-arkitektur."
 
 msgctxt "#30810"
-msgid "[B]InputStream information[/B]"
-msgstr "[B]InputStream-information[/B]"
+msgid "[B]InputStream Helper[/B] is at version [B]{version}[/B] {state}"
+msgstr "[B]InputStream Helper[/B] är på version [B]{version}[/B] {state}"
 
 msgctxt "#30811"
-msgid "InputStream Helper version: [B]{version}[/B] {state}"
-msgstr "InputStream Helper-version: [B]{version}[/B] {state}"
-
-msgctxt "#30812"
-msgid "InputStream Adaptive version: [B]{version}[/B] {state}"
-msgstr "InputStream Adaptive-version: [B]{version}[/B] {state}"
+msgid "[B]InputStream Adaptive[/B] is at version [B]{version}[/B] {state}"
+msgstr "[B]InputStream Adaptive[/B] är på version [B]{version}[/B] {state}"
 
 msgctxt "#30820"
-msgid "[B]Widevine information[/B]"
-msgstr "[B]Widevine-information[/B]"
+msgid "[B]Widevine CDM[/B] is [B]built into Android[/B]"
+msgstr "[B]Widevine CDM[/B] finns [B]inbyggt i Android[/B]"
 
 msgctxt "#30821"
-msgid "Widevine version: [B]Built into Android[/B]"
-msgstr "Widevine-version: [B]Inbyggd i Android[/B]"
+msgid "[B]Widevine CDM[/B] is at version [B]{version}[/B] and was installed on [B]{date}[/B]"
+msgstr "[B]Widevine CDM[/B] är på version [B]{version}[/B] och installerades den [B]{date}[/B]"
 
 msgctxt "#30822"
-msgid "Widevine version: [B]{version}[/B] [COLOR gray](last updated on [B]{date}[/B])[/COLOR]"
-msgstr "Widevine-version: [B]{version}[/B] [COLOR gray](senast uppdaterad [B]{date}[/B])[/COLOR]"
+msgid "It was extracted from Chrome OS image [B]{name}[/B] with version [B]{version}[/B]"
+msgstr "Det extraherades från en Chrome OS-avbild [B]{name}[/B] med version [B]{version}[/B]"
 
 msgctxt "#30823"
-msgid "Widevine CDM path: [B]{path}[/B]"
-msgstr "Widevine CDM-sökväg: [B]{path}[/B]"
+msgid "It was last checked for updates on [B]{date}[/B]"
+msgstr "Senaste uppdateringkontrollen gjordes [B]{date}[/B]"
 
 msgctxt "#30824"
-msgid "Chrome OS version: [B]{version}[/B]"
-msgstr "Chrome OS-version: [B]{version}[/B]"
+msgid "It is installed at [B]{path}[/B]"
+msgstr "Det är installerat på [B]{path}[/B]"
 
 msgctxt "#30830"
-msgid "Please report issues to:\n - [COLOR yellow]{url}[/COLOR]"
-msgstr "Rapportera gärna problem till:\n - [COLOR yellow]{url}[/COLOR]"
+msgid "Please report issues to: [COLOR yellow]{url}[/COLOR]"
+msgstr "Rapportera gärna problem till: [COLOR yellow]{url}[/COLOR]"
 
 
 ### SETTINGS

--- a/script.module.inputstreamhelper/resources/settings.xml
+++ b/script.module.inputstreamhelper/resources/settings.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <settings>
-    <setting id="last_update" value="0.0" visible="false"/>
+    <setting id="last_modified" value="0.0" visible="false"/>
+    <setting id="last_check" value="0.0" visible="false"/>
     <setting id="version" value="" visible="false"/>
     <category label="30900"> <!-- Expert -->
         <setting label="30901" help="30902" type="action" action="RunScript(script.module.inputstreamhelper, info)"/>


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: InputStream Helper
  - Add-on ID: script.module.inputstreamhelper
  - Version number: 0.5.0
  - Kodi/repository version: krypton

- **Code location**
  - URL: https://github.com/emilsvennesson/script.module.inputstreamhelper
  
A simple Kodi module that makes life easier for add-on developers relying on InputStream based add-ons and DRM playback.

### Description of changes:


     v0.5.0 (2020-06-25)
        - Extract Widevine CDM directly from Chrome OS, minimizing disk space usage and eliminating the need for root access
        - Improve progress dialog while extracting Widevine CDM on ARM devices
        - Support resuming interrupted downloads on unreliable internet connections
        - Reshape InputStream Helper information dialog
        - Updated Dutch, English, French, German, Greek, Hungarian, Romanian, Russian, Spanish and Swedish translations
    

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
