### PR TITLE
[service.subtitles.subsceneplus] 1.1.23

### DIFF
--- a/service.subtitles.subsceneplus/addon.xml
+++ b/service.subtitles.subsceneplus/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="service.subtitles.subsceneplus"
        name="Subscene Subtitles"
-       version="1.1.22"
+       version="1.1.23"
        provider-name="Cih2001">
   <requires>
     <import addon="xbmc.python" version="2.26.0"/>

--- a/service.subtitles.subsceneplus/service.py
+++ b/service.subtitles.subsceneplus/service.py
@@ -160,6 +160,7 @@ class Subtitle:
 
 
 def Search(item):
+    tvshow = False
     if item['manualsearch']:
         movies = SearchMovie(item['manualsearchstring'], item['year'])
     elif item['tvshow']:


### PR DESCRIPTION
### Description

This is a hot-fix for a bug introduced in the previous version. The previous version was only tested with TV-Shows and not movies. Sorry for not performing the proper tests.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [script.foo.bar] 1.0.0

