### PR TITLE
[script.module.libarte] 2.0.1

### DIFF
--- a/script.module.libarte/addon.xml
+++ b/script.module.libarte/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.module.libarte" name="libarte" version="2.0.0" provider-name="sarbes">
+<addon id="script.module.libarte" name="libarte" version="2.0.1" provider-name="sarbes">
   <requires>
     <import addon="xbmc.python" version="3.0.0"/>
     <import addon="script.module.libmediathek4" version="1.0.0"/>

--- a/script.module.libarte/lib/libarte.py
+++ b/script.module.libarte/lib/libarte.py
@@ -35,7 +35,8 @@ class libarte(lm4):
 		l.append({'metadata':{'name':self.translation(32032)}, 'params':{'mode':'libArteListData', 'data':'VIDEO_LISTING', 'uriParams':'{"videoType":"MOST_RECENT"}'}, 'type':'dir'})
 		l.append({'metadata':{'name':self.translation(32031)}, 'params':{'mode':'libArteListData', 'data':'VIDEO_LISTING', 'uriParams':'{"videoType":"MOST_VIEWED"}'}, 'type':'dir'})
 		l.append({'metadata':{'name':self.translation(32132)}, 'params':{'mode':'libArteListData', 'data':'VIDEO_LISTING', 'uriParams':'{"videoType":"MAGAZINES"}'}, 'type':'dir'})
-		l.append({'metadata':{'name':self.translation(32133)}, 'params':{'mode':'libMediathekListDate', 'subParams':'{"mode":"libArteListDateVideos"}'}, 'type':'dir'})
+		if self.parser.langGuide in ['de','fr']:
+			l.append({'metadata':{'name':self.translation(32133)}, 'params':{'mode':'libMediathekListDate', 'subParams':'{"mode":"libArteListDateVideos"}'}, 'type':'dir'})
 		l.append({'metadata':{'name':self.translation(32033)}, 'params':{'mode':'libArteListData', 'data':'VIDEO_LISTING', 'uriParams':'{"videoType":"LAST_CHANCE"}'}, 'type':'dir'})
 		l.append({'metadata':{'name':self.translation(32139)}, 'params':{'mode':'libMediathekSearch', 'searchMode':'libArteListSearch'}, 'type':'dir'})
 		return {'items':l,'name':'root'}

--- a/script.module.libarte/lib/libartewebjsonparser.py
+++ b/script.module.libarte/lib/libartewebjsonparser.py
@@ -150,7 +150,7 @@ class APIParser:
 
 
 	def parseDate(self,date='2020-01-30'):
-		j = requests.get(f'{self.baseURL}/{self.langGuide}/app/pages/TV_GUIDE/?day={date}').json()
+		j = requests.get(f'{self.baseURL}/{self.langGuide}/web/pages/TV_GUIDE/?day={date}').json()
 		for item in j['zones'][1]['data']:
 			d = {'type':'date', 'params':{'mode':'libArtePlayWeb'}, 'metadata':{'art':{}}}
 			


### PR DESCRIPTION
### Description
Small touch-ups of my Arte.tv scraper to avoid exceptions when the set language is set to anything but "de" or "fr".
### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [script.foo.bar] 1.0.0

