### PR TITLE
[script.trakt@matrix] 3.3.2

### DIFF
--- a/script.trakt/addon.xml
+++ b/script.trakt/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.trakt" name="Trakt" version="3.3.1" provider-name="Trakt.tv, Razzeee">
+<addon id="script.trakt" name="Trakt" version="3.3.2" provider-name="Trakt.tv, Razzeee">
     <requires>
         <import addon="xbmc.python" version="3.0.0"/>
         <import addon="script.module.trakt" version="4.1.0"/>
@@ -57,11 +57,7 @@
         <forum>https://forum.kodi.tv/showthread.php?tid=220547</forum>
         <website>https://trakt.tv</website>
         <source>https://github.com/trakt/script.trakt</source>
-        <news>  - Update to lastest trakt dependency
-  - Improved no runtime handling
-  - Fix manual set watched
-  - Fix manual watchlisting
-  - Improve manual rating matches</news>
+        <news>  - Fixes for matrix changed apis</news>
     <assets>
         <icon>icon.png</icon>
         <fanart>fanart.jpg</fanart>

--- a/script.trakt/resources/lib/sync.py
+++ b/script.trakt/resources/lib/sync.py
@@ -1,15 +1,16 @@
 # -*- coding: utf-8 -*-
 
 
+import logging
+
 import xbmc
 import xbmcgui
-import logging
-from resources.lib import syncEpisodes
-from resources.lib import syncMovies
+from resources.lib import syncEpisodes, syncMovies
 from resources.lib.kodiUtilities import getSettingAsBool
 
 progress = xbmcgui.DialogProgress()
 logger = logging.getLogger(__name__)
+
 
 class Sync():
     def __init__(self, show_progress=False, run_silent=False, library="all", api=None):
@@ -21,8 +22,8 @@ class Sync():
             logger.debug("Sync is being run silently.")
         self.sync_on_update = getSettingAsBool('sync_on_update')
         self.notify = getSettingAsBool('show_sync_notifications')
-        self.notify_during_playback = not (xbmc.Player().isPlayingVideo() and getSettingAsBool("hide_notifications_playback"))
-
+        self.notify_during_playback = not (xbmc.Player().isPlayingVideo(
+        ) and getSettingAsBool("hide_notifications_playback"))
 
     def __syncCheck(self, media_type):
         return self.__syncCollectionCheck(media_type) or self.__syncWatchedCheck(media_type) or self.__syncPlaybackCheck(media_type) or self.__syncRatingsCheck()
@@ -55,7 +56,8 @@ class Sync():
             if self.library in ["all", "movies"]:
                 syncMovies.SyncMovies(self, progress)
             else:
-                logger.debug("Movie sync is being skipped for this manual sync.")
+                logger.debug(
+                    "Movie sync is being skipped for this manual sync.")
         else:
             logger.debug("Movie sync is disabled, skipping.")
 
@@ -64,14 +66,15 @@ class Sync():
                 if not (self.__syncCheck('movies') and self.IsCanceled()):
                     syncEpisodes.SyncEpisodes(self, progress)
                 else:
-                    logger.debug("Episode sync is being skipped because movie sync was canceled.")
+                    logger.debug(
+                        "Episode sync is being skipped because movie sync was canceled.")
             else:
-                logger.debug("Episode sync is being skipped for this manual sync.")
+                logger.debug(
+                    "Episode sync is being skipped for this manual sync.")
         else:
             logger.debug("Episode sync is disabled, skipping.")
 
         logger.debug("[Sync] Finished synchronization with Trakt.tv")
-
 
     def IsCanceled(self):
         if self.show_progress and not self.run_silent and progress.iscanceled():
@@ -82,5 +85,20 @@ class Sync():
 
     def UpdateProgress(self, *args, **kwargs):
         if self.show_progress and not self.run_silent:
-            kwargs['percent'] = args[0]
-            progress.update(**kwargs)
+
+            line1 = ""
+            line2 = ""
+            line3 = ""
+
+            if 'line1' in kwargs:
+                line1 = kwargs["line1"]
+
+            if 'line2' in kwargs:
+                line2 = kwargs["line2"]
+
+            if 'line3' in kwargs:
+                line3 = kwargs["line3"]
+
+            percent = args[0]
+            message = f'{line1}\n{line2}\n{line3}'
+            progress.update(percent, message)

--- a/script.trakt/resources/lib/syncEpisodes.py
+++ b/script.trakt/resources/lib/syncEpisodes.py
@@ -1,83 +1,104 @@
 # -*- coding: utf-8 -*-
 
 import copy
-from resources.lib import utilities
-from resources.lib import kodiUtilities
 import logging
 
+from resources.lib import kodiUtilities, utilities
+
 logger = logging.getLogger(__name__)
+
 
 class SyncEpisodes:
     def __init__(self, sync, progress):
         self.sync = sync
         if not self.sync.show_progress and self.sync.sync_on_update and self.sync.notify and self.sync.notify_during_playback:
-            kodiUtilities.notification('%s %s' % (kodiUtilities.getString(32045), kodiUtilities.getString(32050)), kodiUtilities.getString(32061))  # Sync started
+            kodiUtilities.notification('%s %s' % (kodiUtilities.getString(
+                32045), kodiUtilities.getString(32050)), kodiUtilities.getString(32061))  # Sync started
         if self.sync.show_progress and not self.sync.run_silent:
-            progress.create("%s %s" % (kodiUtilities.getString(32045), kodiUtilities.getString(32050)), line1=" ", line2=" ", line3=" ")
+            progress.create("%s %s" % (kodiUtilities.getString(
+                32045), kodiUtilities.getString(32050)), "")
 
         kodiShowsCollected, kodiShowsWatched = self.__kodiLoadShows()
         if not isinstance(kodiShowsCollected, list) and not kodiShowsCollected:
-            logger.debug("[Episodes Sync] Kodi collected show list is empty, aborting tv show Sync.")
+            logger.debug(
+                "[Episodes Sync] Kodi collected show list is empty, aborting tv show Sync.")
             if self.sync.show_progress and not self.sync.run_silent:
                 progress.close()
             return
         if not isinstance(kodiShowsWatched, list) and not kodiShowsWatched:
-            logger.debug("[Episodes Sync] Kodi watched show list is empty, aborting tv show Sync.")
+            logger.debug(
+                "[Episodes Sync] Kodi watched show list is empty, aborting tv show Sync.")
             if self.sync.show_progress and not self.sync.run_silent:
                 progress.close()
             return
 
         traktShowsCollected, traktShowsWatched, traktShowsRated, traktEpisodesRated = self.__traktLoadShows()
         if not traktShowsCollected:
-            logger.debug("[Episodes Sync] Error getting Trakt.tv collected show list, aborting tv show sync.")
+            logger.debug(
+                "[Episodes Sync] Error getting Trakt.tv collected show list, aborting tv show sync.")
             if self.sync.show_progress and not self.sync.run_silent:
                 progress.close()
             return
         if not traktShowsWatched:
-            logger.debug("[Episodes Sync] Error getting Trakt.tv watched show list, aborting tv show sync.")
+            logger.debug(
+                "[Episodes Sync] Error getting Trakt.tv watched show list, aborting tv show sync.")
             if self.sync.show_progress and not self.sync.run_silent:
                 progress.close()
             return
 
         traktShowsProgress = self.__traktLoadShowsPlaybackProgress(25, 36)
 
-        self.__addEpisodesToTraktCollection(kodiShowsCollected, traktShowsCollected, 37, 47)
+        self.__addEpisodesToTraktCollection(
+            kodiShowsCollected, traktShowsCollected, 37, 47)
 
-        self.__deleteEpisodesFromTraktCollection(traktShowsCollected, kodiShowsCollected, 48, 58)
+        self.__deleteEpisodesFromTraktCollection(
+            traktShowsCollected, kodiShowsCollected, 48, 58)
 
-        self.__addEpisodesToTraktWatched(kodiShowsWatched, traktShowsWatched, 59, 69)
+        self.__addEpisodesToTraktWatched(
+            kodiShowsWatched, traktShowsWatched, 59, 69)
 
-        self.__addEpisodesToKodiWatched(traktShowsWatched, kodiShowsWatched, kodiShowsCollected, 70, 80)
+        self.__addEpisodesToKodiWatched(
+            traktShowsWatched, kodiShowsWatched, kodiShowsCollected, 70, 80)
 
-        self.__addEpisodeProgressToKodi(traktShowsProgress, kodiShowsCollected, 81, 91)
+        self.__addEpisodeProgressToKodi(
+            traktShowsProgress, kodiShowsCollected, 81, 91)
 
         self.__syncShowsRatings(traktShowsRated, kodiShowsCollected, 92, 95)
-        self.__syncEpisodeRatings(traktEpisodesRated, kodiShowsCollected, 96, 99)
+        self.__syncEpisodeRatings(
+            traktEpisodesRated, kodiShowsCollected, 96, 99)
 
         if not self.sync.show_progress and self.sync.sync_on_update and self.sync.notify and self.sync.notify_during_playback:
-            kodiUtilities.notification('%s %s' % (kodiUtilities.getString(32045), kodiUtilities.getString(32050)), kodiUtilities.getString(32062))  # Sync complete
+            kodiUtilities.notification('%s %s' % (kodiUtilities.getString(
+                32045), kodiUtilities.getString(32050)), kodiUtilities.getString(32062))  # Sync complete
 
         if self.sync.show_progress and not self.sync.run_silent:
-            self.sync.UpdateProgress(100, line1=" ", line2=kodiUtilities.getString(32075), line3=" ")
+            self.sync.UpdateProgress(
+                100, line1=" ", line2=kodiUtilities.getString(32075), line3=" ")
             progress.close()
 
-        logger.debug("[Episodes Sync] Shows on Trakt.tv (%d), shows in Kodi (%d)." % (len(traktShowsCollected['shows']), len(kodiShowsCollected['shows'])))
+        logger.debug("[Episodes Sync] Shows on Trakt.tv (%d), shows in Kodi (%d)." % (
+            len(traktShowsCollected['shows']), len(kodiShowsCollected['shows'])))
 
-        logger.debug("[Episodes Sync] Episodes on Trakt.tv (%d), episodes in Kodi (%d)." % (utilities.countEpisodes(traktShowsCollected), utilities.countEpisodes(kodiShowsCollected)))
+        logger.debug("[Episodes Sync] Episodes on Trakt.tv (%d), episodes in Kodi (%d)." % (
+            utilities.countEpisodes(traktShowsCollected), utilities.countEpisodes(kodiShowsCollected)))
         logger.debug("[Episodes Sync] Complete.")
 
     ''' begin code for episode sync '''
+
     def __kodiLoadShows(self):
-        self.sync.UpdateProgress(1, line1=kodiUtilities.getString(32094), line2=kodiUtilities.getString(32095))
+        self.sync.UpdateProgress(1, line1=kodiUtilities.getString(
+            32094), line2=kodiUtilities.getString(32095))
 
         logger.debug("[Episodes Sync] Getting show data from Kodi")
-        data = kodiUtilities.kodiJsonRequest({'jsonrpc': '2.0', 'method': 'VideoLibrary.GetTVShows', 'params': {'properties': ['title', 'uniqueid', 'year', 'userrating']}, 'id': 0})
+        data = kodiUtilities.kodiJsonRequest({'jsonrpc': '2.0', 'method': 'VideoLibrary.GetTVShows', 'params': {
+                                             'properties': ['title', 'uniqueid', 'year', 'userrating']}, 'id': 0})
         if data['limits']['total'] == 0:
             logger.debug("[Episodes Sync] Kodi json request was empty.")
             return None, None
 
         tvshows = kodiUtilities.kodiRpcToTraktMediaObjects(data)
-        logger.debug("[Episode Sync] Getting shows from kodi finished %s" % tvshows)
+        logger.debug(
+            "[Episode Sync] Getting shows from kodi finished %s" % tvshows)
 
         if tvshows is None:
             return None, None
@@ -90,17 +111,21 @@ class SyncEpisodes:
         for show_col1 in tvshows:
             i += 1
             y = ((i / x) * 8) + 2
-            self.sync.UpdateProgress(int(y), line2=kodiUtilities.getString(32097) % (i, x))
+            self.sync.UpdateProgress(
+                int(y), line2=kodiUtilities.getString(32097) % (i, x))
 
             show = {'title': show_col1['title'], 'ids': show_col1['ids'], 'year': show_col1['year'], 'rating': show_col1['rating'],
                     'tvshowid': show_col1['tvshowid'], 'seasons': []}
 
-            data = kodiUtilities.kodiJsonRequest({'jsonrpc': '2.0', 'method': 'VideoLibrary.GetEpisodes', 'params': {'tvshowid': show_col1['tvshowid'], 'properties': ['season', 'episode', 'playcount', 'uniqueid', 'lastplayed', 'file', 'dateadded', 'runtime', 'userrating']}, 'id': 0})
+            data = kodiUtilities.kodiJsonRequest({'jsonrpc': '2.0', 'method': 'VideoLibrary.GetEpisodes', 'params': {'tvshowid': show_col1['tvshowid'], 'properties': [
+                                                 'season', 'episode', 'playcount', 'uniqueid', 'lastplayed', 'file', 'dateadded', 'runtime', 'userrating']}, 'id': 0})
             if not data:
-                logger.debug("[Episodes Sync] There was a problem getting episode data for '%s', aborting sync." % show['title'])
+                logger.debug(
+                    "[Episodes Sync] There was a problem getting episode data for '%s', aborting sync." % show['title'])
                 return None, None
             elif 'episodes' not in data:
-                logger.debug("[Episodes Sync] '%s' has no episodes in Kodi." % show['title'])
+                logger.debug(
+                    "[Episodes Sync] '%s' has no episodes in Kodi." % show['title'])
                 continue
 
             if 'tvshowid' in show_col1:
@@ -110,7 +135,8 @@ class SyncEpisodes:
             data2 = copy.deepcopy(data)
             show['seasons'] = kodiUtilities.kodiRpcToTraktMediaObjects(data)
 
-            showWatched['seasons'] = kodiUtilities.kodiRpcToTraktMediaObjects(data2, 'watched')
+            showWatched['seasons'] = kodiUtilities.kodiRpcToTraktMediaObjects(
+                data2, 'watched')
 
             resultCollected['shows'].append(show)
             resultWatched['shows'].append(showWatched)
@@ -119,17 +145,21 @@ class SyncEpisodes:
         return resultCollected, resultWatched
 
     def __traktLoadShows(self):
-        self.sync.UpdateProgress(10, line1=kodiUtilities.getString(32099), line2=kodiUtilities.getString(32100))
+        self.sync.UpdateProgress(10, line1=kodiUtilities.getString(
+            32099), line2=kodiUtilities.getString(32100))
 
-        logger.debug('[Episodes Sync] Getting episode collection/watched/rated from Trakt.tv')
+        logger.debug(
+            '[Episodes Sync] Getting episode collection/watched/rated from Trakt.tv')
         try:
             traktShowsCollected = {}
-            traktShowsCollected = self.sync.traktapi.getShowsCollected(traktShowsCollected)
+            traktShowsCollected = self.sync.traktapi.getShowsCollected(
+                traktShowsCollected)
             traktShowsCollected = list(traktShowsCollected.items())
 
             self.sync.UpdateProgress(12, line2=kodiUtilities.getString(32101))
             traktShowsWatched = {}
-            traktShowsWatched = self.sync.traktapi.getShowsWatched(traktShowsWatched)
+            traktShowsWatched = self.sync.traktapi.getShowsWatched(
+                traktShowsWatched)
             traktShowsWatched = list(traktShowsWatched.items())
 
             traktShowsRated = {}
@@ -137,11 +167,13 @@ class SyncEpisodes:
             traktShowsRated = list(traktShowsRated.items())
 
             traktEpisodesRated = {}
-            traktEpisodesRated = self.sync.traktapi.getEpisodesRated(traktEpisodesRated)
+            traktEpisodesRated = self.sync.traktapi.getEpisodesRated(
+                traktEpisodesRated)
             traktEpisodesRated = list(traktEpisodesRated.items())
 
         except Exception:
-            logger.debug("[Episodes Sync] Invalid Trakt.tv show list, possible error getting data from Trakt, aborting Trakt.tv collection/watched/rated update.")
+            logger.debug(
+                "[Episodes Sync] Invalid Trakt.tv show list, possible error getting data from Trakt, aborting Trakt.tv collection/watched/rated update.")
             return False, False, False, False
 
         i = 0
@@ -150,7 +182,8 @@ class SyncEpisodes:
         for _, show in traktShowsCollected:
             i += 1
             y = ((i / x) * 4) + 12
-            self.sync.UpdateProgress(int(y), line2=kodiUtilities.getString(32102) % (i, x))
+            self.sync.UpdateProgress(
+                int(y), line2=kodiUtilities.getString(32102) % (i, x))
 
             # will keep the data in python structures - just like the KODI response
             show = show.to_dict()
@@ -163,7 +196,8 @@ class SyncEpisodes:
         for _, show in traktShowsWatched:
             i += 1
             y = ((i / x) * 4) + 16
-            self.sync.UpdateProgress(int(y), line2=kodiUtilities.getString(32102) % (i, x))
+            self.sync.UpdateProgress(
+                int(y), line2=kodiUtilities.getString(32102) % (i, x))
 
             # will keep the data in python structures - just like the KODI response
             show = show.to_dict()
@@ -176,7 +210,8 @@ class SyncEpisodes:
         for _, show in traktShowsRated:
             i += 1
             y = ((i / x) * 4) + 20
-            self.sync.UpdateProgress(int(y), line2=kodiUtilities.getString(32102) % (i, x))
+            self.sync.UpdateProgress(
+                int(y), line2=kodiUtilities.getString(32102) % (i, x))
 
             # will keep the data in python structures - just like the KODI response
             show = show.to_dict()
@@ -189,7 +224,8 @@ class SyncEpisodes:
         for _, show in traktEpisodesRated:
             i += 1
             y = ((i / x) * 4) + 20
-            self.sync.UpdateProgress(int(y), line2=kodiUtilities.getString(32102) % (i, x))
+            self.sync.UpdateProgress(
+                int(y), line2=kodiUtilities.getString(32102) % (i, x))
 
             # will keep the data in python structures - just like the KODI response
             show = show.to_dict()
@@ -202,13 +238,16 @@ class SyncEpisodes:
 
     def __traktLoadShowsPlaybackProgress(self, fromPercent, toPercent):
         if kodiUtilities.getSettingAsBool('trakt_episode_playback') and not self.sync.IsCanceled():
-            self.sync.UpdateProgress(fromPercent, line1=kodiUtilities.getString(1485), line2=kodiUtilities.getString(32119))
+            self.sync.UpdateProgress(fromPercent, line1=kodiUtilities.getString(
+                1485), line2=kodiUtilities.getString(32119))
 
-            logger.debug('[Playback Sync] Getting playback progress from Trakt.tv')
+            logger.debug(
+                '[Playback Sync] Getting playback progress from Trakt.tv')
             try:
                 traktProgressShows = self.sync.traktapi.getEpisodePlaybackProgress()
             except Exception as ex:
-                logger.debug("[Playback Sync] Invalid Trakt.tv progress list, possible error getting data from Trakt, aborting Trakt.tv playback update. Error: %s" % ex)
+                logger.debug(
+                    "[Playback Sync] Invalid Trakt.tv progress list, possible error getting data from Trakt, aborting Trakt.tv playback update. Error: %s" % ex)
                 return False
 
             i = 0
@@ -217,14 +256,16 @@ class SyncEpisodes:
             for show in traktProgressShows:
                 i += 1
                 y = ((i / x) * (toPercent-fromPercent)) + fromPercent
-                self.sync.UpdateProgress(int(y), line2=kodiUtilities.getString(32120) % (i, x))
+                self.sync.UpdateProgress(
+                    int(y), line2=kodiUtilities.getString(32120) % (i, x))
 
                 # will keep the data in python structures - just like the KODI response
                 show = show.to_dict()
 
                 showsProgress['shows'].append(show)
 
-            self.sync.UpdateProgress(toPercent, line2=kodiUtilities.getString(32121))
+            self.sync.UpdateProgress(
+                toPercent, line2=kodiUtilities.getString(32121))
 
             return showsProgress
 
@@ -240,18 +281,24 @@ class SyncEpisodes:
             # logger.debug("traktShowsAdd %s" % traktShowsAdd)
 
             if len(traktShowsAdd['shows']) == 0:
-                self.sync.UpdateProgress(toPercent, line1=kodiUtilities.getString(32068), line2=kodiUtilities.getString(32104))
-                logger.debug("[Episodes Sync] Trakt.tv episode collection is up to date.")
+                self.sync.UpdateProgress(toPercent, line1=kodiUtilities.getString(
+                    32068), line2=kodiUtilities.getString(32104))
+                logger.debug(
+                    "[Episodes Sync] Trakt.tv episode collection is up to date.")
                 return
-            logger.debug("[Episodes Sync] %i show(s) have episodes (%d) to be added to your Trakt.tv collection." % (len(traktShowsAdd['shows']), utilities.countEpisodes(traktShowsAdd)))
+            logger.debug("[Episodes Sync] %i show(s) have episodes (%d) to be added to your Trakt.tv collection." % (
+                len(traktShowsAdd['shows']), utilities.countEpisodes(traktShowsAdd)))
             for show in traktShowsAdd['shows']:
-                logger.debug("[Episodes Sync] Episodes added: %s" % self.__getShowAsString(show, short=True))
+                logger.debug("[Episodes Sync] Episodes added: %s" %
+                             self.__getShowAsString(show, short=True))
 
-            self.sync.UpdateProgress(fromPercent, line1=kodiUtilities.getString(32068), line2=kodiUtilities.getString(32067) % (len(traktShowsAdd['shows'])))
+            self.sync.UpdateProgress(fromPercent, line1=kodiUtilities.getString(
+                32068), line2=kodiUtilities.getString(32067) % (len(traktShowsAdd['shows'])))
 
             # split episode list into chunks of 50
             chunksize = 1
-            chunked_episodes = utilities.chunks(traktShowsAdd['shows'], chunksize)
+            chunked_episodes = utilities.chunks(
+                traktShowsAdd['shows'], chunksize)
             errorcount = 0
             i = 0
             x = float(len(traktShowsAdd['shows']))
@@ -260,7 +307,8 @@ class SyncEpisodes:
                     return
                 i += 1
                 y = ((i / x) * (toPercent-fromPercent)) + fromPercent
-                self.sync.UpdateProgress(int(y), line2=kodiUtilities.getString(32069) % ((i) * chunksize if (i) * chunksize < x else x, x))
+                self.sync.UpdateProgress(int(y), line2=kodiUtilities.getString(
+                    32069) % ((i) * chunksize if (i) * chunksize < x else x, x))
 
                 request = {'shows': chunk}
                 logger.debug("[traktAddEpisodes] Shows to add %s" % request)
@@ -271,8 +319,10 @@ class SyncEpisodes:
                     logging.fatal(message)
                     errorcount += 1
 
-            logger.debug("[traktAddEpisodes] Finished with %d error(s)" % errorcount)
-            self.sync.UpdateProgress(toPercent, line2=kodiUtilities.getString(32105) % utilities.countEpisodes(traktShowsAdd))
+            logger.debug(
+                "[traktAddEpisodes] Finished with %d error(s)" % errorcount)
+            self.sync.UpdateProgress(toPercent, line2=kodiUtilities.getString(
+                32105) % utilities.countEpisodes(traktShowsAdd))
 
     def __deleteEpisodesFromTraktCollection(self, traktShows, kodiShows, fromPercent, toPercent):
         if kodiUtilities.getSettingAsBool('clean_trakt_episodes') and not self.sync.IsCanceled():
@@ -284,24 +334,31 @@ class SyncEpisodes:
             utilities.sanitizeShows(traktShowsRemove)
 
             if len(traktShowsRemove['shows']) == 0:
-                self.sync.UpdateProgress(toPercent, line1=kodiUtilities.getString(32077), line2=kodiUtilities.getString(32110))
-                logger.debug('[Episodes Sync] Trakt.tv episode collection is clean, no episodes to remove.')
+                self.sync.UpdateProgress(toPercent, line1=kodiUtilities.getString(
+                    32077), line2=kodiUtilities.getString(32110))
+                logger.debug(
+                    '[Episodes Sync] Trakt.tv episode collection is clean, no episodes to remove.')
                 return
 
-            logger.debug("[Episodes Sync] %i show(s) will have episodes removed from Trakt.tv collection." % len(traktShowsRemove['shows']))
+            logger.debug("[Episodes Sync] %i show(s) will have episodes removed from Trakt.tv collection." % len(
+                traktShowsRemove['shows']))
             for show in traktShowsRemove['shows']:
-                logger.debug("[Episodes Sync] Episodes removed: %s" % self.__getShowAsString(show, short=True))
+                logger.debug("[Episodes Sync] Episodes removed: %s" %
+                             self.__getShowAsString(show, short=True))
 
-            self.sync.UpdateProgress(fromPercent, line1=kodiUtilities.getString(32077), line2=kodiUtilities.getString(32111) % utilities.countEpisodes(traktShowsRemove))
+            self.sync.UpdateProgress(fromPercent, line1=kodiUtilities.getString(
+                32077), line2=kodiUtilities.getString(32111) % utilities.countEpisodes(traktShowsRemove))
 
-            logger.debug("[traktRemoveEpisodes] Shows to remove %s" % traktShowsRemove)
+            logger.debug("[traktRemoveEpisodes] Shows to remove %s" %
+                         traktShowsRemove)
             try:
                 self.sync.traktapi.removeFromCollection(traktShowsRemove)
             except Exception as ex:
                 message = utilities.createError(ex)
                 logging.fatal(message)
 
-            self.sync.UpdateProgress(toPercent, line2=kodiUtilities.getString(32112) % utilities.countEpisodes(traktShowsRemove))
+            self.sync.UpdateProgress(toPercent, line2=kodiUtilities.getString(
+                32112) % utilities.countEpisodes(traktShowsRemove))
 
     def __addEpisodesToTraktWatched(self, kodiShows, traktShows, fromPercent, toPercent):
         if kodiUtilities.getSettingAsBool('trakt_episode_playcount') and not self.sync.IsCanceled():
@@ -314,15 +371,20 @@ class SyncEpisodes:
             # logger.debug("traktShowsUpdate %s" % traktShowsUpdate)
 
             if len(traktShowsUpdate['shows']) == 0:
-                self.sync.UpdateProgress(toPercent, line1=kodiUtilities.getString(32071), line2=kodiUtilities.getString(32106))
-                logger.debug("[Episodes Sync] Trakt.tv episode playcounts are up to date.")
+                self.sync.UpdateProgress(toPercent, line1=kodiUtilities.getString(
+                    32071), line2=kodiUtilities.getString(32106))
+                logger.debug(
+                    "[Episodes Sync] Trakt.tv episode playcounts are up to date.")
                 return
 
-            logger.debug("[Episodes Sync] %i show(s) are missing playcounts on Trakt.tv" % len(traktShowsUpdate['shows']))
+            logger.debug("[Episodes Sync] %i show(s) are missing playcounts on Trakt.tv" % len(
+                traktShowsUpdate['shows']))
             for show in traktShowsUpdate['shows']:
-                logger.debug("[Episodes Sync] Episodes updated: %s" % self.__getShowAsString(show, short=True))
+                logger.debug("[Episodes Sync] Episodes updated: %s" %
+                             self.__getShowAsString(show, short=True))
 
-            self.sync.UpdateProgress(fromPercent, line1=kodiUtilities.getString(32071), line2=kodiUtilities.getString(32070) % (len(traktShowsUpdate['shows'])))
+            self.sync.UpdateProgress(fromPercent, line1=kodiUtilities.getString(
+                32071), line2=kodiUtilities.getString(32070) % (len(traktShowsUpdate['shows'])))
             errorcount = 0
             i = 0
             x = float(len(traktShowsUpdate['shows']))
@@ -333,7 +395,8 @@ class SyncEpisodes:
                 title = show['title']
                 i += 1
                 y = ((i / x) * (toPercent-fromPercent)) + fromPercent
-                self.sync.UpdateProgress(int(y), line2=title, line3=kodiUtilities.getString(32073) % epCount)
+                self.sync.UpdateProgress(
+                    int(y), line2=title, line3=kodiUtilities.getString(32073) % epCount)
 
                 s = {'shows': [show]}
                 logger.debug("[traktUpdateEpisodes] Shows to update %s" % s)
@@ -344,22 +407,28 @@ class SyncEpisodes:
                     logging.fatal(message)
                     errorcount += 1
 
-            logger.debug("[traktUpdateEpisodes] Finished with %d error(s)" % errorcount)
-            self.sync.UpdateProgress(toPercent, line2=kodiUtilities.getString(32072) % (len(traktShowsUpdate['shows'])), line3=" ")
+            logger.debug(
+                "[traktUpdateEpisodes] Finished with %d error(s)" % errorcount)
+            self.sync.UpdateProgress(toPercent, line2=kodiUtilities.getString(
+                32072) % (len(traktShowsUpdate['shows'])), line3=" ")
 
     def __addEpisodesToKodiWatched(self, traktShows, kodiShows, kodiShowsCollected, fromPercent, toPercent):
         if kodiUtilities.getSettingAsBool('kodi_episode_playcount') and not self.sync.IsCanceled():
             updateKodiTraktShows = copy.deepcopy(traktShows)
             updateKodiKodiShows = copy.deepcopy(kodiShows)
 
-            kodiShowsUpdate = utilities.compareEpisodes(updateKodiTraktShows, updateKodiKodiShows, kodiUtilities.getSettingAsBool("scrobble_fallback"), watched=True, restrict=True, collected=kodiShowsCollected)
+            kodiShowsUpdate = utilities.compareEpisodes(updateKodiTraktShows, updateKodiKodiShows, kodiUtilities.getSettingAsBool(
+                "scrobble_fallback"), watched=True, restrict=True, collected=kodiShowsCollected)
 
             if len(kodiShowsUpdate['shows']) == 0:
-                self.sync.UpdateProgress(toPercent, line1=kodiUtilities.getString(32074), line2=kodiUtilities.getString(32107))
-                logger.debug("[Episodes Sync] Kodi episode playcounts are up to date.")
+                self.sync.UpdateProgress(toPercent, line1=kodiUtilities.getString(
+                    32074), line2=kodiUtilities.getString(32107))
+                logger.debug(
+                    "[Episodes Sync] Kodi episode playcounts are up to date.")
                 return
 
-            logger.debug("[Episodes Sync] %i show(s) shows are missing playcounts on Kodi" % len(kodiShowsUpdate['shows']))
+            logger.debug("[Episodes Sync] %i show(s) shows are missing playcounts on Kodi" % len(
+                kodiShowsUpdate['shows']))
             for s in ["%s" % self.__getShowAsString(s, short=True) for s in kodiShowsUpdate['shows']]:
                 logger.debug("[Episodes Sync] Episodes updated: %s" % s)
 
@@ -368,11 +437,13 @@ class SyncEpisodes:
             for show in kodiShowsUpdate['shows']:
                 for season in show['seasons']:
                     for episode in season['episodes']:
-                        episodes.append({'episodeid': episode['ids']['episodeid'], 'playcount': episode['plays'], "lastplayed": utilities.convertUtcToDateTime(episode['last_watched_at'])})
+                        episodes.append({'episodeid': episode['ids']['episodeid'], 'playcount': episode['plays'],
+                                         "lastplayed": utilities.convertUtcToDateTime(episode['last_watched_at'])})
 
             # split episode list into chunks of 50
             chunksize = 50
-            chunked_episodes = utilities.chunks([{"jsonrpc": "2.0", "method": "VideoLibrary.SetEpisodeDetails", "params": episodes[i], "id": i} for i in range(len(episodes))], chunksize)
+            chunked_episodes = utilities.chunks(
+                [{"jsonrpc": "2.0", "method": "VideoLibrary.SetEpisodeDetails", "params": episodes[i], "id": i} for i in range(len(episodes))], chunksize)
             i = 0
             x = float(len(episodes))
             for chunk in chunked_episodes:
@@ -380,13 +451,15 @@ class SyncEpisodes:
                     return
                 i += 1
                 y = ((i / x) * (toPercent-fromPercent)) + fromPercent
-                self.sync.UpdateProgress(int(y), line2=kodiUtilities.getString(32108) % ((i) * chunksize if (i) * chunksize < x else x, x))
+                self.sync.UpdateProgress(int(y), line2=kodiUtilities.getString(
+                    32108) % ((i) * chunksize if (i) * chunksize < x else x, x))
 
                 logger.debug("[Episodes Sync] chunk %s" % str(chunk))
                 result = kodiUtilities.kodiJsonRequest(chunk)
                 logger.debug("[Episodes Sync] result %s" % str(result))
 
-            self.sync.UpdateProgress(toPercent, line2=kodiUtilities.getString(32109) % len(episodes))
+            self.sync.UpdateProgress(
+                toPercent, line2=kodiUtilities.getString(32109) % len(episodes))
 
     def __addEpisodeProgressToKodi(self, traktShows, kodiShows, fromPercent, toPercent):
         if kodiUtilities.getSettingAsBool('trakt_episode_playback') and traktShows and not self.sync.IsCanceled():
@@ -396,11 +469,14 @@ class SyncEpisodes:
                 "scrobble_fallback"), restrict=True, playback=True)
 
             if len(kodiShowsUpdate['shows']) == 0:
-                self.sync.UpdateProgress(toPercent, line1=kodiUtilities.getString(1441), line2=kodiUtilities.getString(32129))
-                logger.debug("[Episodes Sync] Kodi episode playbacks are up to date.")
+                self.sync.UpdateProgress(toPercent, line1=kodiUtilities.getString(
+                    1441), line2=kodiUtilities.getString(32129))
+                logger.debug(
+                    "[Episodes Sync] Kodi episode playbacks are up to date.")
                 return
 
-            logger.debug("[Episodes Sync] %i show(s) shows are missing playbacks on Kodi" % len(kodiShowsUpdate['shows']))
+            logger.debug("[Episodes Sync] %i show(s) shows are missing playbacks on Kodi" % len(
+                kodiShowsUpdate['shows']))
             for s in ["%s" % self.__getShowAsString(s, short=True) for s in kodiShowsUpdate['shows']]:
                 logger.debug("[Episodes Sync] Episodes updated: %s" % s)
 
@@ -411,13 +487,16 @@ class SyncEpisodes:
                         # If library item doesn't have a runtime set get it from
                         # Trakt to avoid later using 0 in runtime * progress_pct.
                         if not episode['runtime']:
-                            episode['runtime'] = self.sync.traktapi.getEpisodeSummary(show['ids']['trakt'], season['number'], episode['number'], extended='full').runtime
-                        episodes.append({'episodeid': episode['ids']['episodeid'], 'progress': episode['progress'], 'runtime': episode['runtime']})
+                            episode['runtime'] = self.sync.traktapi.getEpisodeSummary(
+                                show['ids']['trakt'], season['number'], episode['number'], extended='full').runtime
+                        episodes.append(
+                            {'episodeid': episode['ids']['episodeid'], 'progress': episode['progress'], 'runtime': episode['runtime']})
 
             # need to calculate the progress in int from progress in percent from Trakt
             # split episode list into chunks of 50
             chunksize = 50
-            chunked_episodes = utilities.chunks([{"jsonrpc": "2.0", "id": i, "method": "VideoLibrary.SetEpisodeDetails", "params": {"episodeid":episodes[i]['episodeid'], "resume": {"position": episodes[i]['runtime'] / 100.0 * episodes[i]['progress'], "total": episodes[i]['runtime']}}} for i in range(len(episodes))], chunksize)
+            chunked_episodes = utilities.chunks([{"jsonrpc": "2.0", "id": i, "method": "VideoLibrary.SetEpisodeDetails", "params": {"episodeid": episodes[i]['episodeid'], "resume": {
+                                                "position": episodes[i]['runtime'] / 100.0 * episodes[i]['progress'], "total": episodes[i]['runtime']}}} for i in range(len(episodes))], chunksize)
             i = 0
             x = float(len(episodes))
             for chunk in chunked_episodes:
@@ -425,47 +504,59 @@ class SyncEpisodes:
                     return
                 i += 1
                 y = ((i / x) * (toPercent-fromPercent)) + fromPercent
-                self.sync.UpdateProgress(int(y), line2=kodiUtilities.getString(32130) % ((i) * chunksize if (i) * chunksize < x else x, x))
+                self.sync.UpdateProgress(int(y), line2=kodiUtilities.getString(
+                    32130) % ((i) * chunksize if (i) * chunksize < x else x, x))
 
                 kodiUtilities.kodiJsonRequest(chunk)
 
-            self.sync.UpdateProgress(toPercent, line2=kodiUtilities.getString(32131) % len(episodes))
+            self.sync.UpdateProgress(
+                toPercent, line2=kodiUtilities.getString(32131) % len(episodes))
 
     def __syncShowsRatings(self, traktShows, kodiShows, fromPercent, toPercent):
         if kodiUtilities.getSettingAsBool('trakt_sync_ratings') and traktShows and not self.sync.IsCanceled():
             updateKodiTraktShows = copy.deepcopy(traktShows)
             updateKodiKodiShows = copy.deepcopy(kodiShows)
 
-            traktShowsToUpdate = utilities.compareShows(updateKodiKodiShows, updateKodiTraktShows, kodiUtilities.getSettingAsBool("scrobble_fallback"), rating=True)
+            traktShowsToUpdate = utilities.compareShows(
+                updateKodiKodiShows, updateKodiTraktShows, kodiUtilities.getSettingAsBool("scrobble_fallback"), rating=True)
             if len(traktShowsToUpdate['shows']) == 0:
-                self.sync.UpdateProgress(toPercent, line1='', line2=kodiUtilities.getString(32181))
-                logger.debug("[Episodes Sync] Trakt show ratings are up to date.")
+                self.sync.UpdateProgress(
+                    toPercent, line1='', line2=kodiUtilities.getString(32181))
+                logger.debug(
+                    "[Episodes Sync] Trakt show ratings are up to date.")
             else:
-                logger.debug("[Episodes Sync] %i show(s) will have show ratings added on Trakt" % len(traktShowsToUpdate['shows']))
+                logger.debug("[Episodes Sync] %i show(s) will have show ratings added on Trakt" % len(
+                    traktShowsToUpdate['shows']))
 
-                self.sync.UpdateProgress(fromPercent, line1='', line2=kodiUtilities.getString(32182) % len(traktShowsToUpdate['shows']))
+                self.sync.UpdateProgress(fromPercent, line1='', line2=kodiUtilities.getString(
+                    32182) % len(traktShowsToUpdate['shows']))
 
                 self.sync.traktapi.addRating(traktShowsToUpdate)
 
             # needs to be restricted, because we can't add a rating to an episode which is not in our Kodi collection
-            kodiShowsUpdate = utilities.compareShows(updateKodiTraktShows, updateKodiKodiShows, kodiUtilities.getSettingAsBool("scrobble_fallback"), rating=True, restrict=True)
+            kodiShowsUpdate = utilities.compareShows(updateKodiTraktShows, updateKodiKodiShows, kodiUtilities.getSettingAsBool(
+                "scrobble_fallback"), rating=True, restrict=True)
 
             if len(kodiShowsUpdate['shows']) == 0:
-                self.sync.UpdateProgress(toPercent, line1='', line2=kodiUtilities.getString(32176))
-                logger.debug("[Episodes Sync] Kodi show ratings are up to date.")
+                self.sync.UpdateProgress(
+                    toPercent, line1='', line2=kodiUtilities.getString(32176))
+                logger.debug(
+                    "[Episodes Sync] Kodi show ratings are up to date.")
             else:
-                logger.debug("[Episodes Sync] %i show(s) will have show ratings added in Kodi" % len(kodiShowsUpdate['shows']))
+                logger.debug("[Episodes Sync] %i show(s) will have show ratings added in Kodi" % len(
+                    kodiShowsUpdate['shows']))
 
                 shows = []
                 for show in kodiShowsUpdate['shows']:
-                    shows.append({'tvshowid': show['tvshowid'], 'rating': show['rating']})
+                    shows.append(
+                        {'tvshowid': show['tvshowid'], 'rating': show['rating']})
 
                 # split episode list into chunks of 50
                 chunksize = 50
                 chunked_episodes = utilities.chunks([{"jsonrpc": "2.0", "id": i, "method": "VideoLibrary.SetTVShowDetails",
-                                        "params": {"tvshowid": shows[i]['tvshowid'],
-                                                   "userrating": shows[i]['rating']}} for i in range(len(shows))],
-                                        chunksize)
+                                                      "params": {"tvshowid": shows[i]['tvshowid'],
+                                                                 "userrating": shows[i]['rating']}} for i in range(len(shows))],
+                                                    chunksize)
                 i = 0
                 x = float(len(shows))
                 for chunk in chunked_episodes:
@@ -473,12 +564,13 @@ class SyncEpisodes:
                         return
                     i += 1
                     y = ((i / x) * (toPercent-fromPercent)) + fromPercent
-                    self.sync.UpdateProgress(int(y), line1='', line2=kodiUtilities.getString(32177) % ((i) * chunksize if (i) * chunksize < x else x, x))
+                    self.sync.UpdateProgress(int(y), line1='', line2=kodiUtilities.getString(
+                        32177) % ((i) * chunksize if (i) * chunksize < x else x, x))
 
                     kodiUtilities.kodiJsonRequest(chunk)
 
-                self.sync.UpdateProgress(toPercent, line2=kodiUtilities.getString(32178) % len(shows))
-
+                self.sync.UpdateProgress(
+                    toPercent, line2=kodiUtilities.getString(32178) % len(shows))
 
     def __syncEpisodeRatings(self, traktShows, kodiShows, fromPercent, toPercent):
         if kodiUtilities.getSettingAsBool('trakt_sync_ratings') and traktShows and not self.sync.IsCanceled():
@@ -488,21 +580,28 @@ class SyncEpisodes:
             traktShowsToUpdate = utilities.compareEpisodes(
                 updateKodiKodiShows, updateKodiTraktShows, kodiUtilities.getSettingAsBool("scrobble_fallback"), rating=True)
             if len(traktShowsToUpdate['shows']) == 0:
-                self.sync.UpdateProgress(toPercent, line1='', line2=kodiUtilities.getString(32181))
-                logger.debug("[Episodes Sync] Trakt episode ratings are up to date.")
+                self.sync.UpdateProgress(
+                    toPercent, line1='', line2=kodiUtilities.getString(32181))
+                logger.debug(
+                    "[Episodes Sync] Trakt episode ratings are up to date.")
             else:
-                logger.debug("[Episodes Sync] %i show(s) will have episode ratings added on Trakt" % len(traktShowsToUpdate['shows']))
+                logger.debug("[Episodes Sync] %i show(s) will have episode ratings added on Trakt" % len(
+                    traktShowsToUpdate['shows']))
 
-                self.sync.UpdateProgress(fromPercent, line1='', line2=kodiUtilities.getString(32182) % len(traktShowsToUpdate['shows']))
+                self.sync.UpdateProgress(fromPercent, line1='', line2=kodiUtilities.getString(
+                    32182) % len(traktShowsToUpdate['shows']))
                 self.sync.traktapi.addRating(traktShowsToUpdate)
 
             kodiShowsUpdate = utilities.compareEpisodes(updateKodiTraktShows, updateKodiKodiShows, kodiUtilities.getSettingAsBool(
                 "scrobble_fallback"), restrict=True, rating=True)
             if len(kodiShowsUpdate['shows']) == 0:
-                self.sync.UpdateProgress(toPercent, line1='', line2=kodiUtilities.getString(32173))
-                logger.debug("[Episodes Sync] Kodi episode ratings are up to date.")
+                self.sync.UpdateProgress(
+                    toPercent, line1='', line2=kodiUtilities.getString(32173))
+                logger.debug(
+                    "[Episodes Sync] Kodi episode ratings are up to date.")
             else:
-                logger.debug("[Episodes Sync] %i show(s) will have episode ratings added in Kodi" % len(kodiShowsUpdate['shows']))
+                logger.debug("[Episodes Sync] %i show(s) will have episode ratings added in Kodi" % len(
+                    kodiShowsUpdate['shows']))
                 for s in ["%s" % self.__getShowAsString(s, short=True) for s in kodiShowsUpdate['shows']]:
                     logger.debug("[Episodes Sync] Episodes updated: %s" % s)
 
@@ -510,14 +609,15 @@ class SyncEpisodes:
                 for show in kodiShowsUpdate['shows']:
                     for season in show['seasons']:
                         for episode in season['episodes']:
-                            episodes.append({'episodeid': episode['ids']['episodeid'], 'rating': episode['rating']})
+                            episodes.append(
+                                {'episodeid': episode['ids']['episodeid'], 'rating': episode['rating']})
 
                 # split episode list into chunks of 50
                 chunksize = 50
                 chunked_episodes = utilities.chunks([{"jsonrpc": "2.0", "id": i, "method": "VideoLibrary.SetEpisodeDetails",
-                                        "params": {"episodeid": episodes[i]['episodeid'],
-                                                   "userrating": episodes[i]['rating']}} for i in range(len(episodes))],
-                                        chunksize)
+                                                      "params": {"episodeid": episodes[i]['episodeid'],
+                                                                 "userrating": episodes[i]['rating']}} for i in range(len(episodes))],
+                                                    chunksize)
                 i = 0
                 x = float(len(episodes))
                 for chunk in chunked_episodes:
@@ -525,12 +625,13 @@ class SyncEpisodes:
                         return
                     i += 1
                     y = ((i / x) * (toPercent-fromPercent)) + fromPercent
-                    self.sync.UpdateProgress(int(y), line1='', line2=kodiUtilities.getString(32174) % ((i) * chunksize if (i) * chunksize < x else x, x))
+                    self.sync.UpdateProgress(int(y), line1='', line2=kodiUtilities.getString(
+                        32174) % ((i) * chunksize if (i) * chunksize < x else x, x))
 
                     kodiUtilities.kodiJsonRequest(chunk)
 
-                self.sync.UpdateProgress(toPercent, line2=kodiUtilities.getString(32175) % len(episodes))
-
+                self.sync.UpdateProgress(
+                    toPercent, line2=kodiUtilities.getString(32175) % len(episodes))
 
     def __getShowAsString(self, show, short=False):
         p = []
@@ -538,9 +639,11 @@ class SyncEpisodes:
             for season in show['seasons']:
                 s = ""
                 if short:
-                    s = ", ".join(["S%02dE%02d" % (season['number'], i['number']) for i in season['episodes']])
+                    s = ", ".join(
+                        ["S%02dE%02d" % (season['number'], i['number']) for i in season['episodes']])
                 else:
-                    episodes = ", ".join([str(i) for i in show['shows']['seasons'][season]])
+                    episodes = ", ".join(
+                        [str(i) for i in show['shows']['seasons'][season]])
                     s = "Season: %d, Episodes: %s" % (season, episodes)
                 p.append(s)
         else:
@@ -549,4 +652,3 @@ class SyncEpisodes:
             return "%s [tvdb: %s] - %s" % (show['title'], show['ids']['tvdb'], ", ".join(p))
         else:
             return "%s [tvdb: No id] - %s" % (show['title'], ", ".join(p))
-

--- a/script.trakt/resources/lib/syncMovies.py
+++ b/script.trakt/resources/lib/syncMovies.py
@@ -1,30 +1,35 @@
 # -*- coding: utf-8 -*-
 
 import copy
-from resources.lib import utilities
-from resources.lib import kodiUtilities
 import logging
 
+from resources.lib import kodiUtilities, utilities
+
 logger = logging.getLogger(__name__)
+
 
 class SyncMovies():
     def __init__(self, sync, progress):
         self.sync = sync
         if not self.sync.show_progress and sync.sync_on_update and sync.notify and self.sync.notify_during_playback:
-            kodiUtilities.notification('%s %s' % (kodiUtilities.getString(32045), kodiUtilities.getString(32046)), kodiUtilities.getString(32061))  # Sync started
+            kodiUtilities.notification('%s %s' % (kodiUtilities.getString(
+                32045), kodiUtilities.getString(32046)), kodiUtilities.getString(32061))  # Sync started
         if sync.show_progress and not sync.run_silent:
-            progress.create("%s %s" % (kodiUtilities.getString(32045), kodiUtilities.getString(32046)), line1=" ", line2=" ", line3=" ")
+            progress.create("%s %s" % (kodiUtilities.getString(
+                32045), kodiUtilities.getString(32046)), "")
 
         kodiMovies = self.__kodiLoadMovies()
         if not isinstance(kodiMovies, list) and not kodiMovies:
-            logger.debug("[Movies Sync] Kodi movie list is empty, aborting movie Sync.")
+            logger.debug(
+                "[Movies Sync] Kodi movie list is empty, aborting movie Sync.")
             if sync.show_progress and not sync.run_silent:
                 progress.close()
             return
         try:
             traktMovies = self.__traktLoadMovies()
         except Exception:
-            logger.debug("[Movies Sync] Error getting Trakt.tv movie list, aborting movie Sync.")
+            logger.debug(
+                "[Movies Sync] Error getting Trakt.tv movie list, aborting movie Sync.")
             if sync.show_progress and not sync.run_silent:
                 progress.close()
             return
@@ -44,21 +49,24 @@ class SyncMovies():
         self.__syncMovieRatings(traktMovies, kodiMovies, 92, 99)
 
         if sync.show_progress and not sync.run_silent:
-            self.sync.UpdateProgress(100, line1=kodiUtilities.getString(32066), line2=" ", line3=" ")
+            self.sync.UpdateProgress(
+                100, line1=kodiUtilities.getString(32066), line2=" ", line3=" ")
             progress.close()
 
         if not sync.show_progress and sync.sync_on_update and sync.notify and sync.notify_during_playback:
-            kodiUtilities.notification('%s %s' % (kodiUtilities.getString(32045), kodiUtilities.getString(32046)), kodiUtilities.getString(32062))  # Sync complete
+            kodiUtilities.notification('%s %s' % (kodiUtilities.getString(
+                32045), kodiUtilities.getString(32046)), kodiUtilities.getString(32062))  # Sync complete
 
-        logger.debug("[Movies Sync] Movies on Trakt.tv (%d), movies in Kodi (%d)." % (len(traktMovies), len(kodiMovies)))
+        logger.debug("[Movies Sync] Movies on Trakt.tv (%d), movies in Kodi (%d)." % (
+            len(traktMovies), len(kodiMovies)))
         logger.debug("[Movies Sync] Complete.")
-
 
     def __kodiLoadMovies(self):
         self.sync.UpdateProgress(1, line2=kodiUtilities.getString(32079))
 
         logger.debug("[Movies Sync] Getting movie data from Kodi")
-        data = kodiUtilities.kodiJsonRequest({'jsonrpc': '2.0', 'id': 0, 'method': 'VideoLibrary.GetMovies', 'params': {'properties': ['title', 'imdbnumber', 'uniqueid', 'year', 'playcount', 'lastplayed', 'file', 'dateadded', 'runtime', 'userrating']}})
+        data = kodiUtilities.kodiJsonRequest({'jsonrpc': '2.0', 'id': 0, 'method': 'VideoLibrary.GetMovies', 'params': {'properties': [
+                                             'title', 'imdbnumber', 'uniqueid', 'year', 'playcount', 'lastplayed', 'file', 'dateadded', 'runtime', 'userrating']}})
         if data['limits']['total'] == 0:
             logger.debug("[Movies Sync] Kodi JSON request was empty.")
             return
@@ -70,7 +78,8 @@ class SyncMovies():
         return kodi_movies
 
     def __traktLoadMovies(self):
-        self.sync.UpdateProgress(10, line1=kodiUtilities.getString(32079), line2=kodiUtilities.getString(32081))
+        self.sync.UpdateProgress(10, line1=kodiUtilities.getString(
+            32079), line2=kodiUtilities.getString(32081))
 
         logger.debug("[Movies Sync] Getting movie collection from Trakt.tv")
 
@@ -93,13 +102,16 @@ class SyncMovies():
 
     def __traktLoadMoviesPlaybackProgress(self, fromPercent, toPercent):
         if kodiUtilities.getSettingAsBool('trakt_movie_playback') and not self.sync.IsCanceled():
-            self.sync.UpdateProgress(fromPercent, line2=kodiUtilities.getString(32122))
+            self.sync.UpdateProgress(
+                fromPercent, line2=kodiUtilities.getString(32122))
 
-            logger.debug('[Movies Sync] Getting playback progress from Trakt.tv')
+            logger.debug(
+                '[Movies Sync] Getting playback progress from Trakt.tv')
             try:
                 traktProgressMovies = self.sync.traktapi.getMoviePlaybackProgress()
             except Exception:
-                logger.debug("[Movies Sync] Invalid Trakt.tv playback progress list, possible error getting data from Trakt, aborting Trakt.tv playback update.")
+                logger.debug(
+                    "[Movies Sync] Invalid Trakt.tv playback progress list, possible error getting data from Trakt, aborting Trakt.tv playback update.")
                 return False
 
             i = 0
@@ -108,14 +120,16 @@ class SyncMovies():
             for movie in traktProgressMovies:
                 i += 1
                 y = ((i / x) * (toPercent-fromPercent)) + fromPercent
-                self.sync.UpdateProgress(int(y), line2=kodiUtilities.getString(32123) % (i, x))
+                self.sync.UpdateProgress(
+                    int(y), line2=kodiUtilities.getString(32123) % (i, x))
 
                 # will keep the data in python structures - just like the KODI response
                 movie = movie.to_dict()
 
                 moviesProgress['movies'].append(movie)
 
-            self.sync.UpdateProgress(toPercent, line2=kodiUtilities.getString(32124))
+            self.sync.UpdateProgress(
+                toPercent, line2=kodiUtilities.getString(32124))
 
             return moviesProgress
 
@@ -127,18 +141,23 @@ class SyncMovies():
             traktMoviesToAdd = utilities.compareMovies(
                 addKodiMovies, addTraktMovies, kodiUtilities.getSettingAsBool("scrobble_fallback"))
             utilities.sanitizeMovies(traktMoviesToAdd)
-            logger.debug("[Movies Sync] Compared movies, found %s to add." % len(traktMoviesToAdd))
+            logger.debug(
+                "[Movies Sync] Compared movies, found %s to add." % len(traktMoviesToAdd))
 
             if len(traktMoviesToAdd) == 0:
-                self.sync.UpdateProgress(toPercent, line2=kodiUtilities.getString(32084))
-                logger.debug("[Movies Sync] Trakt.tv movie collection is up to date.")
+                self.sync.UpdateProgress(
+                    toPercent, line2=kodiUtilities.getString(32084))
+                logger.debug(
+                    "[Movies Sync] Trakt.tv movie collection is up to date.")
                 return
 
             titles = ", ".join(["%s" % (m['title']) for m in traktMoviesToAdd])
-            logger.debug("[Movies Sync] %i movie(s) will be added to Trakt.tv collection." % len(traktMoviesToAdd))
+            logger.debug("[Movies Sync] %i movie(s) will be added to Trakt.tv collection." % len(
+                traktMoviesToAdd))
             logger.debug("[Movies Sync] Movies to add : %s" % titles)
 
-            self.sync.UpdateProgress(fromPercent, line2=kodiUtilities.getString(32063) % len(traktMoviesToAdd))
+            self.sync.UpdateProgress(
+                fromPercent, line2=kodiUtilities.getString(32063) % len(traktMoviesToAdd))
 
             moviesToAdd = {'movies': traktMoviesToAdd}
             # logger.debug("Movies to add: %s" % moviesToAdd)
@@ -148,7 +167,8 @@ class SyncMovies():
                 message = utilities.createError(ex)
                 logging.fatal(message)
 
-            self.sync.UpdateProgress(toPercent, line2=kodiUtilities.getString(32085) % len(traktMoviesToAdd))
+            self.sync.UpdateProgress(
+                toPercent, line2=kodiUtilities.getString(32085) % len(traktMoviesToAdd))
 
     def __deleteMoviesFromTraktCollection(self, traktMovies, kodiMovies, fromPercent, toPercent):
 
@@ -160,18 +180,24 @@ class SyncMovies():
             traktMoviesToRemove = utilities.compareMovies(
                 removeTraktMovies, removeKodiMovies, kodiUtilities.getSettingAsBool("scrobble_fallback"))
             utilities.sanitizeMovies(traktMoviesToRemove)
-            logger.debug("[Movies Sync] Compared movies, found %s to remove." % len(traktMoviesToRemove))
+            logger.debug("[Movies Sync] Compared movies, found %s to remove." % len(
+                traktMoviesToRemove))
 
             if len(traktMoviesToRemove) == 0:
-                self.sync.UpdateProgress(toPercent, line2=kodiUtilities.getString(32091))
-                logger.debug("[Movies Sync] Trakt.tv movie collection is clean, no movies to remove.")
+                self.sync.UpdateProgress(
+                    toPercent, line2=kodiUtilities.getString(32091))
+                logger.debug(
+                    "[Movies Sync] Trakt.tv movie collection is clean, no movies to remove.")
                 return
 
-            titles = ", ".join(["%s" % (m['title']) for m in traktMoviesToRemove])
-            logger.debug("[Movies Sync] %i movie(s) will be removed from Trakt.tv collection." % len(traktMoviesToRemove))
+            titles = ", ".join(["%s" % (m['title'])
+                                for m in traktMoviesToRemove])
+            logger.debug("[Movies Sync] %i movie(s) will be removed from Trakt.tv collection." % len(
+                traktMoviesToRemove))
             logger.debug("[Movies Sync] Movies removed: %s" % titles)
 
-            self.sync.UpdateProgress(fromPercent, line2=kodiUtilities.getString(32076) % len(traktMoviesToRemove))
+            self.sync.UpdateProgress(fromPercent, line2=kodiUtilities.getString(
+                32076) % len(traktMoviesToRemove))
 
             moviesToRemove = {'movies': traktMoviesToRemove}
             try:
@@ -180,29 +206,37 @@ class SyncMovies():
                 message = utilities.createError(ex)
                 logging.fatal(message)
 
-            self.sync.UpdateProgress(toPercent, line2=kodiUtilities.getString(32092) % len(traktMoviesToRemove))
+            self.sync.UpdateProgress(toPercent, line2=kodiUtilities.getString(
+                32092) % len(traktMoviesToRemove))
 
     def __addMoviesToTraktWatched(self, kodiMovies, traktMovies, fromPercent, toPercent):
         if kodiUtilities.getSettingAsBool('trakt_movie_playcount') and not self.sync.IsCanceled():
             updateTraktTraktMovies = copy.deepcopy(traktMovies)
             updateTraktKodiMovies = copy.deepcopy(kodiMovies)
 
-            traktMoviesToUpdate = utilities.compareMovies(updateTraktKodiMovies, updateTraktTraktMovies, kodiUtilities.getSettingAsBool("scrobble_fallback"), watched=True)
+            traktMoviesToUpdate = utilities.compareMovies(
+                updateTraktKodiMovies, updateTraktTraktMovies, kodiUtilities.getSettingAsBool("scrobble_fallback"), watched=True)
             utilities.sanitizeMovies(traktMoviesToUpdate)
 
             if len(traktMoviesToUpdate) == 0:
-                self.sync.UpdateProgress(toPercent, line2=kodiUtilities.getString(32086))
-                logger.debug("[Movies Sync] Trakt.tv movie playcount is up to date")
+                self.sync.UpdateProgress(
+                    toPercent, line2=kodiUtilities.getString(32086))
+                logger.debug(
+                    "[Movies Sync] Trakt.tv movie playcount is up to date")
                 return
 
-            titles = ", ".join(["%s" % (m['title']) for m in traktMoviesToUpdate])
-            logger.debug("[Movies Sync] %i movie(s) playcount will be updated on Trakt.tv" % len(traktMoviesToUpdate))
+            titles = ", ".join(["%s" % (m['title'])
+                                for m in traktMoviesToUpdate])
+            logger.debug("[Movies Sync] %i movie(s) playcount will be updated on Trakt.tv" % len(
+                traktMoviesToUpdate))
             logger.debug("[Movies Sync] Movies updated: %s" % titles)
 
-            self.sync.UpdateProgress(fromPercent, line2=kodiUtilities.getString(32064) % len(traktMoviesToUpdate))
+            self.sync.UpdateProgress(fromPercent, line2=kodiUtilities.getString(
+                32064) % len(traktMoviesToUpdate))
             # Send request to update playcounts on Trakt.tv
             chunksize = 200
-            chunked_movies = utilities.chunks([movie for movie in traktMoviesToUpdate], chunksize)
+            chunked_movies = utilities.chunks(
+                [movie for movie in traktMoviesToUpdate], chunksize)
             errorcount = 0
             i = 0
             x = float(len(traktMoviesToUpdate))
@@ -211,7 +245,8 @@ class SyncMovies():
                     return
                 i += 1
                 y = ((i / x) * (toPercent-fromPercent)) + fromPercent
-                self.sync.UpdateProgress(int(y), line2=kodiUtilities.getString(32093) % ((i) * chunksize if (i) * chunksize < x else x, x))
+                self.sync.UpdateProgress(int(y), line2=kodiUtilities.getString(
+                    32093) % ((i) * chunksize if (i) * chunksize < x else x, x))
 
                 params = {'movies': chunk}
                 # logger.debug("moviechunk: %s" % params)
@@ -222,8 +257,10 @@ class SyncMovies():
                     logging.fatal(message)
                     errorcount += 1
 
-            logger.debug("[Movies Sync] Movies updated: %d error(s)" % errorcount)
-            self.sync.UpdateProgress(toPercent, line2=kodiUtilities.getString(32087) % len(traktMoviesToUpdate))
+            logger.debug(
+                "[Movies Sync] Movies updated: %d error(s)" % errorcount)
+            self.sync.UpdateProgress(toPercent, line2=kodiUtilities.getString(
+                32087) % len(traktMoviesToUpdate))
 
     def __addMoviesToKodiWatched(self, traktMovies, kodiMovies, fromPercent, toPercent):
 
@@ -235,19 +272,25 @@ class SyncMovies():
                 "scrobble_fallback"), watched=True, restrict=True)
 
             if len(kodiMoviesToUpdate) == 0:
-                self.sync.UpdateProgress(toPercent, line2=kodiUtilities.getString(32088))
-                logger.debug("[Movies Sync] Kodi movie playcount is up to date.")
+                self.sync.UpdateProgress(
+                    toPercent, line2=kodiUtilities.getString(32088))
+                logger.debug(
+                    "[Movies Sync] Kodi movie playcount is up to date.")
                 return
 
-            titles = ", ".join(["%s" % (m['title']) for m in kodiMoviesToUpdate])
-            logger.debug("[Movies Sync] %i movie(s) playcount will be updated in Kodi" % len(kodiMoviesToUpdate))
+            titles = ", ".join(["%s" % (m['title'])
+                                for m in kodiMoviesToUpdate])
+            logger.debug("[Movies Sync] %i movie(s) playcount will be updated in Kodi" % len(
+                kodiMoviesToUpdate))
             logger.debug("[Movies Sync] Movies to add: %s" % titles)
 
-            self.sync.UpdateProgress(fromPercent, line2=kodiUtilities.getString(32065) % len(kodiMoviesToUpdate))
+            self.sync.UpdateProgress(fromPercent, line2=kodiUtilities.getString(
+                32065) % len(kodiMoviesToUpdate))
 
             # split movie list into chunks of 50
             chunksize = 50
-            chunked_movies = utilities.chunks([{"jsonrpc": "2.0", "method": "VideoLibrary.SetMovieDetails", "params": {"movieid": kodiMoviesToUpdate[i]['movieid'], "playcount": kodiMoviesToUpdate[i]['plays'], "lastplayed": utilities.convertUtcToDateTime(kodiMoviesToUpdate[i]['last_watched_at'])}, "id": i} for i in range(len(kodiMoviesToUpdate))], chunksize)
+            chunked_movies = utilities.chunks([{"jsonrpc": "2.0", "method": "VideoLibrary.SetMovieDetails", "params": {"movieid": kodiMoviesToUpdate[i]['movieid'], "playcount": kodiMoviesToUpdate[i]
+                                                                                                                       ['plays'], "lastplayed": utilities.convertUtcToDateTime(kodiMoviesToUpdate[i]['last_watched_at'])}, "id": i} for i in range(len(kodiMoviesToUpdate))], chunksize)
             i = 0
             x = float(len(kodiMoviesToUpdate))
             for chunk in chunked_movies:
@@ -255,11 +298,13 @@ class SyncMovies():
                     return
                 i += 1
                 y = ((i / x) * (toPercent-fromPercent)) + fromPercent
-                self.sync.UpdateProgress(int(y), line2=kodiUtilities.getString(32089) % ((i) * chunksize if (i) * chunksize < x else x, x))
+                self.sync.UpdateProgress(int(y), line2=kodiUtilities.getString(
+                    32089) % ((i) * chunksize if (i) * chunksize < x else x, x))
 
                 kodiUtilities.kodiJsonRequest(chunk)
 
-            self.sync.UpdateProgress(toPercent, line2=kodiUtilities.getString(32090) % len(kodiMoviesToUpdate))
+            self.sync.UpdateProgress(toPercent, line2=kodiUtilities.getString(
+                32090) % len(kodiMoviesToUpdate))
 
     def __addMovieProgressToKodi(self, traktMovies, kodiMovies, fromPercent, toPercent):
 
@@ -267,19 +312,25 @@ class SyncMovies():
             updateKodiTraktMovies = copy.deepcopy(traktMovies)
             updateKodiKodiMovies = copy.deepcopy(kodiMovies)
 
-            kodiMoviesToUpdate = utilities.compareMovies(updateKodiTraktMovies['movies'], updateKodiKodiMovies, kodiUtilities.getSettingAsBool("scrobble_fallback"), restrict=True, playback=True)
+            kodiMoviesToUpdate = utilities.compareMovies(updateKodiTraktMovies['movies'], updateKodiKodiMovies, kodiUtilities.getSettingAsBool(
+                "scrobble_fallback"), restrict=True, playback=True)
             if len(kodiMoviesToUpdate) == 0:
-                self.sync.UpdateProgress(toPercent, line1='', line2=kodiUtilities.getString(32125))
-                logger.debug("[Movies Sync] Kodi movie playbacks are up to date.")
+                self.sync.UpdateProgress(
+                    toPercent, line1='', line2=kodiUtilities.getString(32125))
+                logger.debug(
+                    "[Movies Sync] Kodi movie playbacks are up to date.")
                 return
 
-            logger.debug("[Movies Sync] %i movie(s) playbacks will be updated in Kodi" % len(kodiMoviesToUpdate))
+            logger.debug("[Movies Sync] %i movie(s) playbacks will be updated in Kodi" % len(
+                kodiMoviesToUpdate))
 
-            self.sync.UpdateProgress(fromPercent, line1='', line2=kodiUtilities.getString(32126) % len(kodiMoviesToUpdate))
+            self.sync.UpdateProgress(fromPercent, line1='', line2=kodiUtilities.getString(
+                32126) % len(kodiMoviesToUpdate))
             # need to calculate the progress in int from progress in percent from Trakt
             # split movie list into chunks of 50
             chunksize = 50
-            chunked_movies = utilities.chunks([{"jsonrpc": "2.0", "id": i, "method": "VideoLibrary.SetMovieDetails", "params": {"movieid": kodiMoviesToUpdate[i]['movieid'], "resume": {"position": kodiMoviesToUpdate[i]['runtime'] / 100.0 * kodiMoviesToUpdate[i]['progress'], "total": kodiMoviesToUpdate[i]['runtime']}}} for i in range(len(kodiMoviesToUpdate))], chunksize)
+            chunked_movies = utilities.chunks([{"jsonrpc": "2.0", "id": i, "method": "VideoLibrary.SetMovieDetails", "params": {"movieid": kodiMoviesToUpdate[i]['movieid'], "resume": {
+                                              "position": kodiMoviesToUpdate[i]['runtime'] / 100.0 * kodiMoviesToUpdate[i]['progress'], "total": kodiMoviesToUpdate[i]['runtime']}}} for i in range(len(kodiMoviesToUpdate))], chunksize)
             i = 0
             x = float(len(kodiMoviesToUpdate))
             for chunk in chunked_movies:
@@ -287,10 +338,12 @@ class SyncMovies():
                     return
                 i += 1
                 y = ((i / x) * (toPercent-fromPercent)) + fromPercent
-                self.sync.UpdateProgress(int(y), line2=kodiUtilities.getString(32127) % ((i) * chunksize if (i) * chunksize < x else x, x))
+                self.sync.UpdateProgress(int(y), line2=kodiUtilities.getString(
+                    32127) % ((i) * chunksize if (i) * chunksize < x else x, x))
                 kodiUtilities.kodiJsonRequest(chunk)
 
-            self.sync.UpdateProgress(toPercent, line2=kodiUtilities.getString(32128) % len(kodiMoviesToUpdate))
+            self.sync.UpdateProgress(toPercent, line2=kodiUtilities.getString(
+                32128) % len(kodiMoviesToUpdate))
 
     def __syncMovieRatings(self, traktMovies, kodiMovies, fromPercent, toPercent):
 
@@ -298,14 +351,19 @@ class SyncMovies():
             updateKodiTraktMovies = copy.deepcopy(traktMovies)
             updateKodiKodiMovies = copy.deepcopy(kodiMovies)
 
-            traktMoviesToUpdate = utilities.compareMovies(updateKodiKodiMovies, updateKodiTraktMovies, kodiUtilities.getSettingAsBool("scrobble_fallback"), rating=True)
+            traktMoviesToUpdate = utilities.compareMovies(
+                updateKodiKodiMovies, updateKodiTraktMovies, kodiUtilities.getSettingAsBool("scrobble_fallback"), rating=True)
             if len(traktMoviesToUpdate) == 0:
-                self.sync.UpdateProgress(toPercent, line1='', line2=kodiUtilities.getString(32179))
-                logger.debug("[Movies Sync] Trakt movie ratings are up to date.")
+                self.sync.UpdateProgress(
+                    toPercent, line1='', line2=kodiUtilities.getString(32179))
+                logger.debug(
+                    "[Movies Sync] Trakt movie ratings are up to date.")
             else:
-                logger.debug("[Movies Sync] %i movie(s) ratings will be updated on Trakt" % len(traktMoviesToUpdate))
+                logger.debug("[Movies Sync] %i movie(s) ratings will be updated on Trakt" % len(
+                    traktMoviesToUpdate))
 
-                self.sync.UpdateProgress(fromPercent, line1='', line2=kodiUtilities.getString(32180) % len(traktMoviesToUpdate))
+                self.sync.UpdateProgress(fromPercent, line1='', line2=kodiUtilities.getString(
+                    32180) % len(traktMoviesToUpdate))
 
                 moviesRatings = {'movies': traktMoviesToUpdate}
 
@@ -314,12 +372,16 @@ class SyncMovies():
             kodiMoviesToUpdate = utilities.compareMovies(updateKodiTraktMovies, updateKodiKodiMovies, kodiUtilities.getSettingAsBool(
                 "scrobble_fallback"), restrict=True, rating=True)
             if len(kodiMoviesToUpdate) == 0:
-                self.sync.UpdateProgress(toPercent, line1='', line2=kodiUtilities.getString(32169))
-                logger.debug("[Movies Sync] Kodi movie ratings are up to date.")
+                self.sync.UpdateProgress(
+                    toPercent, line1='', line2=kodiUtilities.getString(32169))
+                logger.debug(
+                    "[Movies Sync] Kodi movie ratings are up to date.")
             else:
-                logger.debug("[Movies Sync] %i movie(s) ratings will be updated in Kodi" % len(kodiMoviesToUpdate))
+                logger.debug("[Movies Sync] %i movie(s) ratings will be updated in Kodi" % len(
+                    kodiMoviesToUpdate))
 
-                self.sync.UpdateProgress(fromPercent, line1='', line2=kodiUtilities.getString(32170) % len(kodiMoviesToUpdate))
+                self.sync.UpdateProgress(fromPercent, line1='', line2=kodiUtilities.getString(
+                    32170) % len(kodiMoviesToUpdate))
                 # split movie list into chunks of 50
                 chunksize = 50
                 chunked_movies = utilities.chunks([{"jsonrpc": "2.0", "id": i, "method": "VideoLibrary.SetMovieDetails",
@@ -333,8 +395,9 @@ class SyncMovies():
                         return
                     i += 1
                     y = ((i / x) * (toPercent-fromPercent)) + fromPercent
-                    self.sync.UpdateProgress(int(y), line2=kodiUtilities.getString(32171) % ((i) * chunksize if (i) * chunksize < x else x, x))
+                    self.sync.UpdateProgress(int(y), line2=kodiUtilities.getString(
+                        32171) % ((i) * chunksize if (i) * chunksize < x else x, x))
                     kodiUtilities.kodiJsonRequest(chunk)
 
-                self.sync.UpdateProgress(toPercent, line2=kodiUtilities.getString(32172) % len(kodiMoviesToUpdate))
-
+                self.sync.UpdateProgress(toPercent, line2=kodiUtilities.getString(
+                    32172) % len(kodiMoviesToUpdate))

--- a/script.trakt/resources/lib/traktapi.py
+++ b/script.trakt/resources/lib/traktapi.py
@@ -143,49 +143,45 @@ class traktAPI(object):
         result = None
 
         with Trakt.configuration.oauth.from_response(self.authorization):
-            if status == 'start':
-                with Trakt.configuration.http(retry=True):
+            with Trakt.configuration.http(retry=True):
+                if status == 'start':
                     result = Trakt['scrobble'].start(
                         show=show,
                         episode=episode,
                         progress=percent)
-            elif status == 'pause':
-                with Trakt.configuration.http(retry=True):
+                elif status == 'pause':
                     result = Trakt['scrobble'].pause(
                         show=show,
                         episode=episode,
                         progress=percent)
-            elif status == 'stop':
-                # don't retry on stop, this will cause multiple scrobbles
-                result = Trakt['scrobble'].stop(
-                    show=show,
-                    episode=episode,
-                    progress=percent)
-            else:
-                logger.debug("scrobble() Bad scrobble status")
+                elif status == 'stop':
+                    result = Trakt['scrobble'].stop(
+                        show=show,
+                        episode=episode,
+                        progress=percent)
+                else:
+                    logger.debug("scrobble() Bad scrobble status")
         return result
 
     def scrobbleMovie(self, movie, percent, status):
         result = None
 
         with Trakt.configuration.oauth.from_response(self.authorization):
-            if status == 'start':
-                with Trakt.configuration.http(retry=True):
+            with Trakt.configuration.http(retry=True):
+                if status == 'start':
                     result = Trakt['scrobble'].start(
                         movie=movie,
                         progress=percent)
-            elif status == 'pause':
-                with Trakt.configuration.http(retry=True):
+                elif status == 'pause':
                     result = Trakt['scrobble'].pause(
                         movie=movie,
                         progress=percent)
-            elif status == 'stop':
-                # don't retry on stop, this will cause multiple scrobbles
-                result = Trakt['scrobble'].stop(
-                    movie=movie,
-                    progress=percent)
-            else:
-                logger.debug("scrobble() Bad scrobble status")
+                elif status == 'stop':
+                    result = Trakt['scrobble'].stop(
+                        movie=movie,
+                        progress=percent)
+                else:
+                    logger.debug("scrobble() Bad scrobble status")
         return result
 
     def getShowsCollected(self, shows):


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: Trakt
  - Add-on ID: script.trakt
  - Version number: 3.3.2
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/trakt/script.trakt
  
Automatically scrobble all TV episodes and movies you are watching to Trakt.tv! Keep a comprehensive history of everything you've watched and be part of a global community of TV and movie enthusiasts. Sign up for a free account at http://trakt.tv and get a ton of features:

- Automatically scrobble what you're watching
- Mobile apps for iPhone, iPad, Android, and Windows Phone
- Share what you're watching (in real time) and rating to facebook and twitter
- Personalized calendar so you never miss a TV show
- Follow your friends and people you're interesed in
- Use watchlists so you don't forget to what to watch
- Track your media collections and impress your friends
- Create custom lists around any topics you choose
- Easily track your TV show progress across all seasons and episodes
- Track your progress against industry lists such as the IMDb Top 250
- Discover new shows and movies based on your viewing habits
- Widgets for your forum signature

What can this addon do?

- Automatically scrobble all TV episodes and movies you are watching
- Sync your TV episode and movie collections to Trakt (triggered after a library update)
- Auto clean your Trakt collection so that it matches up with Kodi
- Keep watched statuses synced between Kodi and Trakt
- Rate movies and episode after watching them

Special thanks to all who contributed to this plugin! Check the commit history and changelog to see these talented developers.

### Description of changes:

  - Fixes for matrix changed apis

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
