### PR TITLE
[script.module.codequick] 0.9.13

### DIFF
--- a/script.module.codequick/addon.xml
+++ b/script.module.codequick/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.module.codequick" name="CodeQuick" provider-name="willforde" version="0.9.12">
+<addon id="script.module.codequick" name="CodeQuick" provider-name="willforde" version="0.9.13">
     <requires>
         <import addon="xbmc.python" version="2.25.0"/>
         <import addon="script.module.youtube.dl" version="18.0.0"/>

--- a/script.module.codequick/lib/codequick/__init__.py
+++ b/script.module.codequick/lib/codequick/__init__.py
@@ -40,4 +40,12 @@ from codequick.script import Script
 from codequick.route import Route
 from codequick import utils, storage
 
-__all__ = ["run", "Script", "Route", "Resolver", "Listitem", "utils", "storage"]
+__all__ = [
+    "run",
+    "Script",
+    "Route",
+    "Resolver",
+    "Listitem",
+    "utils",
+    "storage",
+]

--- a/script.module.codequick/lib/codequick/script.py
+++ b/script.module.codequick/lib/codequick/script.py
@@ -12,7 +12,7 @@ import xbmc
 
 # Package imports
 from codequick.utils import ensure_unicode, ensure_native_str, unicode_type, string_map
-from codequick.support import dispatcher, script_data, addon_data, logger_id
+from codequick.support import dispatcher, script_data, addon_data, logger_id, CallbackRef
 
 __all__ = ["Script", "Settings"]
 
@@ -158,6 +158,39 @@ class Script(object):
     def __init__(self):
         self._title = self.params.get(u"_title_", u"")
         self.handle = dispatcher.handle
+
+    @classmethod
+    def ref(cls, path):
+        """
+        When given a path to a callback function, will return a reference to that callback function.
+
+        This is used as a way to link to a callback without the need to import it first.
+        With this only the required module containing the callback is imported when callback is executed.
+        This can be used to improve performance when dealing with lots of different callback functions.
+
+        .. note:
+
+            This method needs to be called from the same callback object type of
+            the referenced callback. e.g. Script/Route/Resolver.
+
+        The path structure is '/<package>/<module>:function' where 'package' is the full package path.
+        'module' is the name of the modules containing the callback.
+        And 'function' is the name of the callback function.
+
+        :example:
+            >>> from codequick import Route, Resolver, Listitem
+            >>> item = Listitem()
+            >>>
+            >>> # Example of referencing a Route callback
+            >>> item.set_callback(Route.ref("/resources/lib/videos:video_list"))
+            >>>
+            >>> # Example of referencing a Resolver callback
+            >>> item.set_callback(Resolver.ref("/resources/lib/resolvers:play_video"))
+
+        :param str path: The path to a callback function.
+        :return: A callback reference object.
+        """
+        return CallbackRef(path, cls)
 
     @classmethod
     def register(cls, callback):

--- a/script.module.codequick/lib/codequick/search.py
+++ b/script.module.codequick/lib/codequick/search.py
@@ -3,14 +3,19 @@ from __future__ import absolute_import
 
 # Standard Library Imports
 from hashlib import sha1
-import pickle
 
 # Package imports
 from codequick.storage import PersistentDict
 from codequick.support import dispatcher
 from codequick.listing import Listitem
-from codequick.utils import keyboard, ensure_unicode, unicode_type
+from codequick.utils import keyboard, ensure_unicode
 from codequick.route import Route, validate_listitems
+
+try:
+    # noinspection PyPep8Naming
+    import cPickle as pickle
+except ImportError:  # pragma: no cover
+    import pickle
 
 # Localized string Constants
 ENTER_SEARCH_STRING = 16017
@@ -21,135 +26,157 @@ SEARCH = 137
 SEARCH_DB = u"_new_searches.pickle"
 
 
-def hash_params(data):
-    # type: (dict) -> unicode_type
+class Search(object):
+    def __init__(self, plugin, extra_params):
+        # The saved search persistent storage
+        self.db = search_db = PersistentDict(SEARCH_DB)
+        plugin.register_delayed(search_db.close)
 
-    # Convert dict of params into a sorted list of key, value pairs
-    sorted_dict = sorted(data.items())
+        # Fetch saved data specific to this session
+        session_hash = self.hash_params(extra_params)
+        self.data = search_db.setdefault(session_hash, [])
 
-    # Pickle the sorted dict so we can hash the contents
-    content = pickle.dumps(sorted_dict, protocol=2)
-    return ensure_unicode(sha1(content).hexdigest())
+    def __iter__(self):
+        return iter(self.data)
+
+    def __contains__(self, item):
+        return item in self.data
+
+    def __bool__(self):
+        return bool(self.data)
+
+    def __nonzero__(self):
+        return bool(self.data)
+
+    def remove(self, item):  # type: (str) -> None
+        self.data.remove(item)
+        self.db.flush()
+
+    def append(self, item):  # type: (str) -> None
+        self.data.append(item)
+        self.db.flush()
+
+    @staticmethod
+    def hash_params(data):
+        # Convert dict of params into a sorted list of key, value pairs
+        sorted_dict = sorted(data.items())
+
+        # Pickle the sorted dict so we can hash the contents
+        content = pickle.dumps(sorted_dict, protocol=2)
+        return ensure_unicode(sha1(content).hexdigest())
 
 
 @Route.register
-class SavedSearches(Route):
+def saved_searches(plugin, remove_entry=None, search=False, first_load=False, **extras):
     """
-    Class used to list all saved searches for the addon that called it.
+    Callback used to list all saved searches for the addon that called it.
 
-    Useful to add search support to addon that will also keep track of previous searches.
+    Useful to add search support to addon and will also keep track of previous searches.
     Also contains option via context menu to remove old search terms.
+
+    :param Route plugin: Tools related to Route callbacks.
+    :param remove_entry: [opt] Search term to remove from history.
+    :param search: [opt] When set to True the search input box will appear.
+    :param first_load: Only True when callback is called for the first time, allowes for search box to appear on load.
+    :param extras: Any extra params to farward on to the next callback
+    :returns: A list of search terms or the search results if loaded for the first time.
     """
+    searchdb = Search(plugin, extras)
 
-    def __init__(self):
-        super(SavedSearches, self).__init__()
+    # Remove search term from saved searches
+    if remove_entry and remove_entry in searchdb:
+        searchdb.remove(remove_entry)
+        plugin.update_listing = True
 
-        # Persistent list of currently saved searches
-        self.search_db = PersistentDict(SEARCH_DB)
-        self.register_delayed(self.close)
-        self.session_data = None  # type: list
-
-    def run(self, remove_entry=None, search=False, first_load=False, **extras):
-        """List all saved searches."""
-
-        # Create session hash from givin arguments
-        session_hash = hash_params(extras)
-        self.session_data = session_data = self.search_db.setdefault(session_hash, [])
-
-        # Remove search term from saved searches
-        if remove_entry and remove_entry in session_data:
-            session_data.remove(remove_entry)
-            self.update_listing = True
-            self.search_db.flush()
-
-        # Show search dialog if search argument is True, or if there is no search term saved
-        # First load is used to only allow auto search to work when first loading the saved search container.
-        # Fixes an issue when there is no saved searches left after removing them.
-        elif search or (first_load is True and not session_data):
-            search_term = keyboard(self.localize(ENTER_SEARCH_STRING))
-            if search_term:
-                return self.redirect_search(search_term, extras)
-            elif not session_data:
-                return False
-            else:
-                self.update_listing = True
-
-        # List all saved search terms
-        return self.list_terms(extras)
-
-    def redirect_search(self, search_term, extras):
-        """
-        Checks if searh term returns valid results before adding to saved searches.
-        Then directly farward the results to kodi.
-
-        :param str search_term: The serch term used to search for results.
-        :param dict extras: Extra parameters that will be farwarded on to the callback function.
-        :return: List if valid search results
-        """
-        self.params[u"_title_"] = search_term.title()
-        self.category = self.params[u"_title_"]
-        callback_params = extras.copy()
-        callback_params["search_query"] = search_term
-
-        # We switch selector to redirected callback to allow next page to work properly
-        route = callback_params.pop("_route")
-        dispatcher.selector = route
-
-        # Fetch search results from callback
-        func = dispatcher.get_route().function
-        listitems = func(self, **callback_params)
-
-        # Check that we have valid listitems
-        valid_listitems = validate_listitems(listitems)
-
-        # Add the search term to database and return the list of results
-        if valid_listitems:
-            if search_term not in self.session_data:  # pragma: no branch
-                self.session_data.append(search_term)
-                self.search_db.flush()
-
-            return valid_listitems
-        else:
-            # Return False to indicate failure
+    # Show search dialog if search argument is True, or if there is no search term saved
+    # First load is used to only allow auto search to work when first loading the saved search container.
+    # Fixes an issue when there is no saved searches left after removing them.
+    elif search or (first_load and not searchdb):
+        search_term = keyboard(plugin.localize(ENTER_SEARCH_STRING))
+        if search_term:
+            return redirect_search(plugin, searchdb, search_term, extras)
+        elif not searchdb:
             return False
+        else:
+            plugin.update_listing = True
 
-    def list_terms(self, extras):
-        """
-        List all saved searches.
+    # List all saved search terms
+    return list_terms(plugin, searchdb, extras)
 
-        :param dict extras: Extra parameters that will be farwarded on to the context.container.
 
-        :returns: A generator of listitems.
-        :rtype: :class:`types.GeneratorType`
-        """
-        # Add listitem for adding new search terms
-        search_item = Listitem()
-        search_item.label = u"[B]%s[/B]" % self.localize(SEARCH)
-        search_item.set_callback(self, search=True, **extras)
-        search_item.art.global_thumb("search_new.png")
-        yield search_item
+def redirect_search(plugin, searchdb, search_term, extras):
+    """
+    Checks if searh term returns valid results before adding to saved searches.
+    Then directly farward the results to kodi.
 
-        # Set the callback function to the route that was given
-        callback_params = extras.copy()
-        route = callback_params.pop("_route")
-        callback = dispatcher.get_route(route).callback
+    :param Route plugin: Tools related to Route callbacks.
+    :param Search searchdb: Search DB
+    :param str search_term: The serch term used to search for results.
+    :param dict extras: Extra parameters that will be farwarded on to the callback function.
+    :return: List if valid search results
+    """
+    plugin.params[u"_title_"] = title = search_term.title()
+    plugin.category = title
+    callback_params = extras.copy()
+    callback_params["search_query"] = search_term
 
-        # Prefetch the localized string for the context menu lable
-        str_remove = self.localize(REMOVE)
+    # We switch selector to redirected callback to allow next page to work properly
+    route = callback_params.pop("_route")
+    dispatcher.selector = route
 
-        # List all saved searches
-        for search_term in self.session_data:
-            item = Listitem()
-            item.label = search_term.title()
+    # Fetch search results from callback
+    func = dispatcher.get_route().function
+    listitems = func(plugin, **callback_params)
 
-            # Creatre Context Menu item for removing search term
-            item.context.container(self, str_remove, remove_entry=search_term, **extras)
+    # Check that we have valid listitems
+    valid_listitems = validate_listitems(listitems)
 
-            # Update params with full url and set the callback
-            item.params.update(callback_params, search_query=search_term)
-            item.set_callback(callback)
-            yield item
+    # Add the search term to database and return the list of results
+    if valid_listitems:
+        if search_term not in searchdb:  # pragma: no branch
+            searchdb.append(search_term)
 
-    def close(self):
-        """Close the connection to the search database."""
-        self.search_db.close()
+        return valid_listitems
+    else:
+        # Return False to indicate failure
+        return False
+
+
+def list_terms(plugin, searchdb, extras):
+    """
+    List all saved searches.
+
+    :param Route plugin: Tools related to Route callbacks.
+    :param Search searchdb: Search DB
+    :param dict extras: Extra parameters that will be farwarded on to the context.container.
+
+    :returns: A generator of listitems.
+    :rtype: :class:`types.GeneratorType`
+    """
+    # Add listitem for adding new search terms
+    search_item = Listitem()
+    search_item.label = u"[B]%s[/B]" % plugin.localize(SEARCH)
+    search_item.set_callback(saved_searches, search=True, **extras)
+    search_item.art.global_thumb("search_new.png")
+    yield search_item
+
+    # Set the callback function to the route that was given
+    callback_params = extras.copy()
+    route = callback_params.pop("_route")
+    callback = dispatcher.get_route(route).callback
+
+    # Prefetch the localized string for the context menu lable
+    str_remove = plugin.localize(REMOVE)
+
+    # List all saved searches
+    for search_term in searchdb:
+        item = Listitem()
+        item.label = search_term.title()
+
+        # Creatre Context Menu item for removing search term
+        item.context.container(saved_searches, str_remove, remove_entry=search_term, **extras)
+
+        # Update params with full url and set the callback
+        item.params.update(callback_params, search_query=search_term)
+        item.set_callback(callback)
+        yield item

--- a/script.module.codequick/lib/codequick/support.py
+++ b/script.module.codequick/lib/codequick/support.py
@@ -3,10 +3,10 @@ from __future__ import absolute_import
 
 # Standard Library Imports
 import importlib
+import warnings
 import binascii
 import inspect
 import logging
-import pickle
 import time
 import sys
 import re
@@ -19,11 +19,19 @@ import xbmc
 # Package imports
 from codequick.utils import parse_qs, ensure_native_str, urlparse, PY3, unicode_type
 
+try:
+    # noinspection PyPep8Naming
+    import cPickle as pickle
+except ImportError:  # pragma: no cover
+    import pickle
+
 if PY3:
     from inspect import getfullargspec
+    PICKLE_PROTOCOL = 4
 else:
     # noinspection PyDeprecation
     from inspect import getargspec as getfullargspec
+    PICKLE_PROTOCOL = 2
 
 script_data = xbmcaddon.Addon("script.module.codequick")
 addon_data = xbmcaddon.Addon()
@@ -96,7 +104,20 @@ class KodiLogHandler(logging.Handler):
             xbmc.log("###### debug ######", xbmc.LOGWARNING)
 
 
-class Route(object):
+class CallbackRef(object):
+    __slots__ = ("path", "parent", "is_playable", "is_folder")
+
+    def __init__(self, path, parent):
+        self.path = path.rstrip("/").replace(":", "/")
+        self.is_playable = parent.is_playable
+        self.is_folder = parent.is_folder
+        self.parent = parent
+
+    def __eq__(self, other):
+        return self.path == other.path
+
+
+class Route(CallbackRef):
     """
     Handle callback route data.
 
@@ -111,40 +132,26 @@ class Route(object):
     :ivar parent: The parent class that will handle the response from callback.
     :ivar str path: The route path to func/class.
     """
-    __slots__ = ("parent", "function", "callback", "path", "is_playable", "is_folder")
-
-    def __eq__(self, other):
-        return self.path == other.path
+    __slots__ = ("function", "callback")
 
     def __init__(self, callback, parent, path):
         # Register a class callback
         if inspect.isclass(callback):
+            msg = "Use of class based callbacks are Deprecated, please use function callbacks"
+            warnings.warn(msg, DeprecationWarning)
             if hasattr(callback, "run"):
-                self.parent = parent = callback
+                parent = callback
                 self.function = callback.run
                 callback.test = staticmethod(self.unittest_caller)
             else:
                 raise NameError("missing required 'run' method for class: '{}'".format(callback.__name__))
         else:
             # Register a function callback
-            self.parent = parent
             self.function = callback
             callback.test = self.unittest_caller
 
-        self.is_playable = parent.is_playable
-        self.is_folder = parent.is_folder
+        super(Route, self).__init__(path, parent)
         self.callback = callback
-        self.path = path
-
-    def args_to_kwargs(self, args, kwargs):  # type: (tuple, dict) -> None
-        """Convert positional arguments to keyword arguments and merge into callback parameters."""
-        callback_args = self.arg_names()[1:]
-        arg_map = zip(callback_args, args)
-        kwargs.update(arg_map)
-
-    def arg_names(self):  # type: () -> list
-        """Return a list of argument names, positional and keyword arguments."""
-        return getfullargspec(self.function).args
 
     def unittest_caller(self, *args, **kwargs):
         """
@@ -168,7 +175,7 @@ class Route(object):
         # Update support params with the params
         # that are to be passed to callback
         if args:
-            self.args_to_kwargs(args, dispatcher.params)
+            dispatcher.params["_args_"] = args
 
         if kwargs:
             dispatcher.params.update(kwargs)
@@ -239,7 +246,7 @@ class Dispatcher(object):
 
     def get_route(self, path=None):  # type: (str) -> Route
         """Return the given route object."""
-        path = path if path else self.selector
+        path = path.rstrip("/") if path else self.selector
 
         # Attempt to import the module where the route
         # is located if it's not already registered
@@ -266,7 +273,7 @@ class Dispatcher(object):
         # Construct route path
         path = callback.__name__.lower()
         if path != "root":
-            path = "/{}/{}/".format(callback.__module__.strip("_").replace(".", "/"), callback.__name__).lower()
+            path = "/{}/{}".format(callback.__module__.strip("_").replace(".", "/"), callback.__name__).lower()
 
         # Register callback
         if path in self.registered_routes:
@@ -311,7 +318,8 @@ class Dispatcher(object):
 
             # Initialize controller and execute callback
             parent_ins = route.parent()
-            results = route.function(parent_ins, **self.callback_params)
+            arg_params = self.params.get("_args_", [])
+            results = route.function(parent_ins, *arg_params, **self.callback_params)
             if hasattr(parent_ins, "_process_results"):
                 # noinspection PyProtectedMember
                 redirect = parent_ins._process_results(results)
@@ -332,7 +340,7 @@ class Dispatcher(object):
                 msg = unicode_type(e).encode("utf8")
 
             # Log the error in both the gui and the kodi log file
-            logger.critical(msg, exc_info=1)
+            logger.exception(msg)
             dialog = xbmcgui.Dialog()
             dialog.notification(e.__class__.__name__, msg, addon_data.getAddonInfo("icon"))
             return e
@@ -382,12 +390,18 @@ def build_path(callback=None, args=None, query=None, **extra_query):
     # Set callback to current callback if not given
     if callback and hasattr(callback, "route"):
         route = callback.route
-    else:
+    elif isinstance(callback, CallbackRef):
+        route = callback
+    elif callback:
+        msg = "passing in callback path is deprecated, use callback reference 'Route.ref' instead"
+        warnings.warn(msg, DeprecationWarning)
         route = dispatcher.get_route(callback)
+    else:
+        route = dispatcher.get_route()
 
     # Convert args to keyword args if required
     if args:
-        route.args_to_kwargs(args, query)
+        query["_args_"] = args
 
     # If extra querys are given then append the
     # extra querys to the current set of querys
@@ -397,7 +411,7 @@ def build_path(callback=None, args=None, query=None, **extra_query):
 
     # Encode the query parameters using json
     if query:
-        pickled = binascii.hexlify(pickle.dumps(query, protocol=pickle.HIGHEST_PROTOCOL))
+        pickled = binascii.hexlify(pickle.dumps(query, protocol=PICKLE_PROTOCOL))
         query = "_pickle_={}".format(pickled.decode("ascii") if PY3 else pickled)
 
     # Build kodi url with new path and query parameters


### PR DESCRIPTION
### Description
#### Changed
- Deprecate the use of class based callbacks.
- Deprecate ability to pass playable url to listitem.set_callback(), use listitem.set_path() instead.
- Deprecate ability to pass a path to a callback when calling listitem.set_callback(), use a callback reference instead.
- Functions that except callbacks can now except a callback reference object. Better for performance.
- Some small performance tweaks.

#### Added
- Ability to get and set listitem params as attributes, e.g. item.info.genre = "Science Fiction".
- Listitem objects are now fully pickable.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [script.foo.bar] 1.0.0
