### PR TITLE
[script.module.codequick] 0.9.13

### DIFF
--- a/script.module.codequick/addon.xml
+++ b/script.module.codequick/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.module.codequick" name="CodeQuick" provider-name="willforde" version="0.9.12">
+<addon id="script.module.codequick" name="CodeQuick" provider-name="willforde" version="0.9.13">
     <requires>
         <import addon="xbmc.python" version="2.25.0"/>
         <import addon="script.module.youtube.dl" version="18.0.0"/>

--- a/script.module.codequick/lib/codequick/__init__.py
+++ b/script.module.codequick/lib/codequick/__init__.py
@@ -33,11 +33,19 @@ Codacy: https://app.codacy.com/app/willforde/script.module.codequick/dashboard
 from __future__ import absolute_import
 
 # Package imports
-from codequick.support import run
+from codequick.support import run, get_route
 from codequick.resolver import Resolver
 from codequick.listing import Listitem
 from codequick.script import Script
 from codequick.route import Route
 from codequick import utils, storage
 
-__all__ = ["run", "Script", "Route", "Resolver", "Listitem", "utils", "storage"]
+__all__ = [
+    "run",
+    "Script",
+    "Route",
+    "Resolver",
+    "Listitem",
+    "utils",
+    "storage",
+]

--- a/script.module.codequick/lib/codequick/listing.py
+++ b/script.module.codequick/lib/codequick/listing.py
@@ -15,8 +15,9 @@ import xbmcplugin
 import xbmcgui
 
 # Package imports
+from codequick.route import Route
 from codequick.script import Script
-from codequick.support import auto_sort, build_path, logger_id, dispatcher, Route
+from codequick.support import auto_sort, build_path, logger_id, dispatcher, CallbackRef
 from codequick.utils import ensure_unicode, ensure_native_str, unicode_type, PY3, bold
 
 if PY3:
@@ -98,12 +99,20 @@ SEARCH = 137
 
 
 class Params(MutableMapping):
-    def __init__(self):
-        self.raw_dict = {}
+    def __setstate__(self, state):
+        self.__dict__.update(state)
 
-    def __getitem__(self, key):
-        value = self.raw_dict[key]
-        return value.decode("utf8") if isinstance(value, bytes) else value
+    def __init__(self):
+        self.__dict__["raw_dict"] = {}
+
+    def __setattr__(self, name, value):
+        self[name] = value
+
+    def __getattr__(self, name):
+        try:
+            return self[name]
+        except KeyError:
+            raise AttributeError("'{0}' object has no attribute '{1}'".format(self.__class__.__name__, name))
 
     def __setitem__(self, key, value):
         if isinstance(value, bytes):
@@ -111,8 +120,18 @@ class Params(MutableMapping):
         else:
             self.raw_dict[key] = value
 
+    def __getitem__(self, key):
+        value = self.raw_dict[key]
+        return value.decode("utf8") if isinstance(value, bytes) else value
+
     def __delitem__(self, key):  # type: (str) -> None
         del self.raw_dict[key]
+
+    def __delattr__(self, name):
+        if name in self.raw_dict:
+            del self.raw_dict[name]
+        else:
+            raise AttributeError("'{0}' object has no attribute '{1}'".format(self.__class__.__name__, name))
 
     def __contains__(self, key):  # type: (str) -> bool
         return key in self.raw_dict
@@ -162,15 +181,10 @@ class Art(Params):
 
     :example:
         >>> item = Listitem()
-        >>> item.art["icon"] = "http://www.example.ie/icon.png"
+        >>> item.art.icon = "http://www.example.ie/icon.png"
         >>> item.art["fanart"] = "http://www.example.ie/fanart.jpg"
         >>> item.art.local_thumb("thumbnail.png")
     """
-
-    def __init__(self, listitem):  # type: (xbmcgui.ListItem) -> None
-        super(Art, self).__init__()
-        self._listitem = listitem
-
     def __setitem__(self, key, value):  # type: (str, str) -> None
         self.raw_dict[key] = ensure_native_str(value)
 
@@ -201,7 +215,7 @@ class Art(Params):
         # So there is no neeed to use ensure_native_str
         self.raw_dict["thumb"] = global_image.format(image)
 
-    def _close(self, isfolder):
+    def _close(self, listitem, isfolder):  # type: (xbmcgui.ListItem, bool) -> None
         if fanart and "fanart" not in self.raw_dict:  # pragma: no branch
             self.raw_dict["fanart"] = fanart
         if "thumb" not in self.raw_dict:  # pragma: no branch
@@ -210,7 +224,7 @@ class Art(Params):
             self.raw_dict["icon"] = "DefaultFolder.png" if isfolder else "DefaultVideo.png"
 
         self.clean()  # Remove all None values
-        self._listitem.setArt(self.raw_dict)
+        listitem.setArt(self.raw_dict)
 
 
 class Info(Params):
@@ -239,14 +253,9 @@ class Info(Params):
 
     :examples:
         >>> item = Listitem()
-        >>> item.info['genre'] = 'Science Fiction'
-        >>> item.info['size'] = 256816
+        >>> item.info.genre = "Science Fiction"
+        >>> item.info["size"] = 256816
     """
-
-    def __init__(self, listitem):  # type: (xbmcgui.ListItem) -> None
-        super(Info, self).__init__()
-        self._listitem = listitem
-
     def __setitem__(self, key, value):
         if value is None or value == "":
             logger.debug("Ignoring empty infolable: '%s'", key)
@@ -311,10 +320,10 @@ class Info(Params):
     def _duration(duration):
         """Converts duration from a string of 'hh:mm:ss' into seconds."""
         if isinstance(duration, (str, unicode_type)):
-            duration = duration.strip(";").strip(":")
-            if ":" in duration or ";" in duration:
+            duration = duration.replace(";", ":").strip(":")
+            if ":" in duration:
                 # Split Time By Marker and Convert to Integer
-                time_parts = duration.replace(";", ":").split(":")
+                time_parts = duration.split(":")
                 time_parts.reverse()
                 duration = 0
                 counter = 1
@@ -329,29 +338,25 @@ class Info(Params):
 
         return duration
 
-    def _close(self, content_type):
+    def _close(self, listitem, content_type):  # type: (xbmcgui.ListItem, str) -> None
         raw_dict = self.raw_dict
         # Add label as plot if no plot is found
         if "plot" not in raw_dict:  # pragma: no branch
             raw_dict["plot"] = raw_dict["title"]
 
-        self._listitem.setInfo(content_type, raw_dict)
+        listitem.setInfo(content_type, raw_dict)
 
 
 class Property(Params):
-    def __init__(self, listitem):  # type: (xbmcgui.ListItem) -> None
-        super(Property, self).__init__()
-        self._listitem = listitem
-
     def __setitem__(self, key, value):  # type: (str, str) -> None
         if value:
             self.raw_dict[key] = ensure_unicode(value)
         else:
             logger.debug("Ignoring empty property: '%s'", key)
 
-    def _close(self):
+    def _close(self, listitem):  # type: (xbmcgui.ListItem) -> None
         for key, value in self.raw_dict.items():
-            self._listitem.setProperty(key, value)
+            listitem.setProperty(key, value)
 
 
 class Stream(Params):
@@ -374,14 +379,9 @@ class Stream(Params):
 
     :example:
         >>> item = Listitem()
-        >>> item.stream['video_codec'] = 'h264'
-        >>> item.stream['audio_codec'] = 'aac'
+        >>> item.stream.video_codec = "h264"
+        >>> item.stream["audio_codec"] = "aac"
     """
-
-    def __init__(self, listitem):  # type: (xbmcgui.ListItem) -> None
-        super(Stream, self).__init__()
-        self._listitem = listitem
-
     def __setitem__(self, key, value):
         if not value:
             logger.debug("Ignoring empty stream detail value for: '%s'", key)
@@ -436,7 +436,7 @@ class Stream(Params):
         elif self.raw_dict["height"] >= 720:
             self.raw_dict["aspect"] = 1.78
 
-    def _close(self):
+    def _close(self, listitem):  # type: (xbmcgui.ListItem) -> None
         video = {}
         subtitle = {}
         audio = {"channels": 2}
@@ -453,11 +453,11 @@ class Stream(Params):
                 raise KeyError("unknown stream detail key: '{}'".format(key))
 
         # Now we are ready to send the stream info to kodi
-        self._listitem.addStreamInfo("audio", audio)
+        listitem.addStreamInfo("audio", audio)
         if video:
-            self._listitem.addStreamInfo("video", video)
+            listitem.addStreamInfo("video", video)
         if subtitle:
-            self._listitem.addStreamInfo("subtitle", subtitle)
+            listitem.addStreamInfo("subtitle", subtitle)
 
 
 class Context(list):
@@ -472,23 +472,19 @@ class Context(list):
 
                  http://kodi.wiki/view/List_of_Built_In_Functions
     """
-
-    def __init__(self, listitem):  # type: (xbmcgui.ListItem) -> None
-        super(Context, self).__init__()
-        self._listitem = listitem
-
     def related(self, callback, *args, **kwargs):
         """
         Convenient method to add a "Related Videos" context menu item.
 
         All this really does is to call "context.container" and sets "label" for you.
 
-        :param callback: The function that will be called when menu item is activated.
+        :param Callback callback: The function that will be called when menu item is activated.
         :param args: [opt] "Positional" arguments that will be passed to the callback.
         :param kwargs: [opt] "Keyword" arguments that will be passed to the callback.
         """
         # Add '_updatelisting_ = True' to callback params if called from the same callback as is given here
-        if callback.route == dispatcher.get_route():
+        path = callback.path if isinstance(callback, CallbackRef) else callback.route.path
+        if path == dispatcher.get_route().path:
             kwargs["_updatelisting_"] = True
 
         related_videos_text = Script.localize(RELATED_VIDEOS)
@@ -499,9 +495,10 @@ class Context(list):
         """
         Convenient method to add a context menu item that links to a "container".
 
-        :type label: str
-        :param callback: The function that will be called when menu item is activated.
+        :param Callback callback: The function that will be called when menu item is activated.
         :param label: The label of the context menu item.
+        :type label: str
+
         :param args: [opt] "Positional" arguments that will be passed to the callback.
         :param kwargs: [opt] "Keyword" arguments that will be passed to the callback.
         """
@@ -512,7 +509,7 @@ class Context(list):
         """
         Convenient method to add a context menu item that links to a "script".
 
-        :param callback: The function that will be called when menu item is activated.
+        :param Callback callback: The function that will be called when menu item is activated.
         :type label: str or unicode
         :param label: The label of the context menu item.
         :param args: [opt] "Positional" arguments that will be passed to the callback.
@@ -521,9 +518,9 @@ class Context(list):
         command = "XBMC.RunPlugin(%s)" % build_path(callback, args, kwargs)
         self.append((label, command))
 
-    def _close(self):
+    def _close(self, listitem):  # type: (xbmcgui.ListItem) -> None
         if self:
-            self._listitem.addContextMenuItems(self)
+            listitem.addContextMenuItems(self)
 
 
 class Listitem(object):
@@ -532,39 +529,50 @@ class Listitem(object):
 
     :param str content_type: [opt] Type of content been listed. e.g. "video", "music", "pictures".
     """
+    def __getstate__(self):
+        state = self.__dict__.copy()
+        state["label"] = self.label
+        del state["listitem"]
+        return state
+
+    def __setstate__(self, state):
+        label = state.pop("label")
+        self.__dict__.update(state)
+        self.listitem = xbmcgui.ListItem()
+        self.label = label
 
     def __init__(self, content_type="video"):
         self._content_type = content_type
-        self.is_playable = True
-        self.is_folder = False
+        self._is_playable = False
+        self._is_folder = False
         self._args = None
-        self.path = ""
+        self._path = ""
 
         #: The underlining kodi listitem object, for advanced use.
-        self.listitem = listitem = xbmcgui.ListItem()
+        self.listitem = xbmcgui.ListItem()
 
         #: List of paths to subtitle files.
         self.subtitles = []
 
-        self.info = Info(listitem)
+        self.info = Info()
         """
         Dictionary like object for adding "infoLabels".
         See :class:`listing.Info<codequick.listing.Info>` for more details.
         """
 
-        self.art = Art(listitem)
+        self.art = Art()
         """
         Dictionary like object for adding "listitem art".
         See :class:`listing.Art<codequick.listing.Art>` for more details.
         """
 
-        self.stream = Stream(listitem)
+        self.stream = Stream()
         """
         Dictionary like object for adding "stream details".
         See :class:`listing.Stream<codequick.listing.Stream>` for more details.
         """
 
-        self.context = Context(listitem)
+        self.context = Context()
         """
         List object for "context menu" items.
         See :class:`listing.Context<codequick.listing.Context>` for more details.
@@ -579,7 +587,7 @@ class Listitem(object):
             >>> item.params['videoid'] = 'kqmdIV_gBfo'
         """
 
-        self.property = Property(listitem)
+        self.property = Property()
         """
         Dictionary like object that allows you to add "listitem properties". e.g. "StartOffset".
 
@@ -611,67 +619,86 @@ class Listitem(object):
         self.params["_title_"] = unformatted_label
         self.info["title"] = unformatted_label
 
+    @property
+    def path(self):
+        return self._path
+
+    @path.setter
+    def path(self, value):
+        # For backwards compatibility
+        self._path = value
+        self._is_playable = True
+
+    def set_path(self, path, is_folder=False, is_playable=True):
+        """
+        Set the listitem's path.
+
+        The path can be any of the following:
+            * Any kodi path, e.g. "plugin://" or "script://"
+            * Directly playable URL or filepath.
+
+        .. note::
+
+            When specifying a external 'plugin' or 'script' as the path, Kodi will treat it as a playable item.
+            To override this behavior, you can set the ``is_playable`` and ``is_folder`` parameters.
+
+        :param path: A playable URL or plugin/script path.
+        :param is_folder: Tells kodi if path is a folder (default -> ``False``).
+        :param is_playable: Tells kodi if path is a playable item (default -> ``True``).
+        """
+        self._path = path
+        self._is_folder = is_folder
+        self._is_playable = False if path.startswith("script://") else is_playable
+
     def set_callback(self, callback, *args, **kwargs):
         """
-        Set the "callback" object.
+        Set the "callback" function for this listitem.
 
         The "callback" parameter can be any of the following:
             * :class:`codequick.Script<codequick.script.Script>` callback.
             * :class:`codequick.Route<codequick.route.Route>` callback.
             * :class:`codequick.Resolver<codequick.resolver.Resolver>` callback.
-            * The path to a callback function. i.e. "/resources/lib/main/video_list/"
-            * Any kodi path, e.g. "plugin://" or "script://"
-            * Directly playable URL.
+            * A callback reference object :func:`Script.ref<codequick.script.Script.ref>`.
 
-        .. note::
-
-            When specifying a external plugin / script path as a callback, Kodi treats it as a playable item by default.
-            To override this behavior, you can pass in the ``is_playable`` and ``is_folder`` parameters.
-            If only ``is_folder`` is given, then ``is_playable`` will default to ``not is_folder``.
-
-        .. note::
-
-            If callback is a file path, use listitem.path instead of set_callback()
-
-        :param callback: The "callback" or playable URL.
+        :param callback: The "callback" function or reference object.
         :param args: "Positional" arguments that will be passed to the callback.
         :param kwargs: "Keyword" arguments that will be passed to the callback.
         """
-        if not hasattr(callback, "route"):
-            # Only used for external plugin / script paths, ignored otherwise
-            self.is_folder = is_folder = kwargs.pop("is_folder", self.is_folder)
-            self.is_playable = kwargs.pop("is_playable", not is_folder)
-
+        if hasattr(callback, "route"):
+            callback = callback.route
+        elif not isinstance(callback, CallbackRef):
             # We don't have a plugin / http path,
             # So we should then have a callback path
             if "://" not in callback:
-                callback = dispatcher.get_route(callback).callback
+                msg = "passing callback path to 'set_callback' is deprecated, " \
+                      "use callback reference 'Route.ref' instead"
+                logger.warning("DeprecationWarning: " + msg)
+                callback = dispatcher.get_route(callback)
+            else:
+                msg = "passing a playable / plugin path to 'set_callback' is deprecated, use 'set_path' instead"
+                logger.warning("DeprecationWarning: " + msg)
+                is_folder = kwargs.pop("is_folder", False)
+                is_playable = kwargs.pop("is_playable", not is_folder)
+                self.set_path(callback, is_folder, is_playable)
+                return
 
-        self.path = callback
+        self.params.update(kwargs)
+        self._is_playable = callback.is_playable
+        self._is_folder = callback.is_folder
+        self._path = callback
         self._args = args
-        if kwargs:
-            self.params.update(kwargs)
 
     # noinspection PyProtectedMember
     def _close(self):
-        path = self.path
         listitem = self.listitem
-        # When we have a callback function
-        if hasattr(path, "route"):
-            isfolder = path.route.is_folder
-            listitem.setProperty("isplayable", str(path.route.is_playable).lower())
-            listitem.setProperty("folder", str(path.route.is_folder).lower())
-            path = build_path(path, self._args, self.params.raw_dict)
-        # When we have a blank listitem that does nothing
-        elif not path:
-            listitem.setProperty("isplayable", "false")
-            listitem.setProperty("folder", "false")
-            isfolder = False
+        isfolder = self._is_folder
+        listitem.setProperty("folder", str(isfolder).lower())
+        listitem.setProperty("isplayable", str(self._is_playable).lower())
+
+        if isinstance(self._path, CallbackRef):
+            path = build_path(self._path, self._args, self.params.raw_dict)
         else:
-            # Directly playable item or plugin path that calls another addon.
-            listitem.setProperty("isplayable", str(self.is_playable).lower())
-            listitem.setProperty("folder", str(self.is_folder).lower())
-            isfolder = self.is_folder
+            path = self._path
 
         if not isfolder:
             # Add mediatype if not already set
@@ -687,7 +714,7 @@ class Listitem(object):
             self.context.append(("$LOCALIZE[13350]", "XBMC.ActivateWindow(videoplaylist)"))
 
             # Close video related datasets
-            self.stream._close()
+            self.stream._close(listitem)
 
         # Set label to UNKNOWN if unset
         if not self.label:  # pragma: no branch
@@ -695,10 +722,10 @@ class Listitem(object):
 
         # Close common datasets
         listitem.setPath(path)
-        self.property._close()
-        self.context._close()
-        self.info._close(self._content_type)
-        self.art._close(isfolder)
+        self.property._close(listitem)
+        self.context._close(listitem)
+        self.info._close(listitem, self._content_type)
+        self.art._close(listitem, isfolder)
 
         # Return a tuple compatible with 'xbmcplugin.addDirectoryItems'
         return path, listitem, isfolder
@@ -721,9 +748,8 @@ class Listitem(object):
 
         This method will create and populate a listitem from a set of given values.
 
-        :type label: str
-        :param callback: The "callback" function or playable URL.
-        :param label: The listitem's label.
+        :param Callback callback: The "callback" function or playable URL.
+        :param str label: The listitem's label.
         :param dict art: Dictionary of listitem art.
         :param dict info: Dictionary of infoLabels.
         :param dict stream: Dictionary of stream details.
@@ -741,8 +767,16 @@ class Listitem(object):
             >>> listitem = Listitem.from_dict(**item)
         """
         item = cls()
-        item.set_callback(callback)
         item.label = label
+
+        if isinstance(callback, str):
+            if "://" in callback:
+                item.set_path(callback)
+            else:
+                # noinspection PyTypeChecker
+                item.set_callback(callback)
+        else:
+            item.set_callback(callback)
 
         if params:  # pragma: no branch
             item.params.update(params)
@@ -766,8 +800,8 @@ class Listitem(object):
         """
         Constructor for adding link to "Next Page" of content.
 
-        The current running "callback" will be called with all of the parameters that are given here.
-        You can also specify which "callback" will be called by setting a keywork only argument called 'callback'.
+        By default the current running "callback" will be called with all of the parameters that are given here.
+        You can specify which "callback" will be called by setting a keyword only argument called 'callback'.
 
         :param args: "Positional" arguments that will be passed to the callback.
         :param kwargs: "Keyword" arguments that will be passed to the callback.
@@ -777,8 +811,7 @@ class Listitem(object):
             >>> item.next_page(url="http://example.com/videos?page2")
         """
         # Current running callback
-        callback = dispatcher.get_route().callback
-        callback = kwargs.pop("callback", callback)
+        callback = kwargs.pop("callback") if "callback" in kwargs else dispatcher.get_route().callback
 
         # Add support params to callback params
         kwargs["_updatelisting_"] = True if u"_nextpagecount_" in dispatcher.params else False
@@ -801,7 +834,7 @@ class Listitem(object):
 
         This is a convenience method that creates the listitem with "name", "thumbnail" and "plot", already preset.
 
-        :param callback: The "callback" function.
+        :param Callback callback: The "callback" function.
         :param args: "Positional" arguments that will be passed to the callback.
         :param kwargs: "Keyword" arguments that will be passed to the callback.
         """
@@ -823,29 +856,25 @@ class Listitem(object):
         that was given will be executed with all parameters forwarded on. Except with one extra
         parameter, ``search_query``, which is the "search term" that was selected.
 
-        :param callback: Function that will be called when the "listitem" is activated.
+        :param Callback callback: Function that will be called when the "listitem" is activated.
         :param args: "Positional" arguments that will be passed to the callback.
         :param kwargs: "Keyword" arguments that will be passed to the callback.
-        :raises ValueError: If the given "callback" function does not have a ``search_query`` parameter.
         """
         if hasattr(callback, "route"):
             route = callback.route
+        elif isinstance(callback, CallbackRef):
+            route = callback
         else:
             route = dispatcher.get_route(callback)
 
-        # Check that callback function has required parameter(search_query)
-        if "search_query" not in route.arg_names():
-            raise ValueError("callback function is missing required argument: 'search_query'")
-
-        if args:
-            # Convert positional arguments to keyword arguments
-            route.args_to_kwargs(args, kwargs)
+        kwargs["first_load"] = True
+        kwargs["_route"] = route.path
 
         item = cls()
         item.label = bold(Script.localize(SEARCH))
         item.art.global_thumb("search.png")
         item.info["plot"] = Script.localize(SEARCH_PLOT)
-        item.set_callback("/codequick/search/savedsearches/", _route=route.path, first_load=True, **kwargs)
+        item.set_callback(Route.ref("/codequick/search:saved_searches"), *args, **kwargs)
         return item
 
     @classmethod
@@ -866,15 +895,13 @@ class Listitem(object):
             >>> item = Listitem()
             >>> item.youtube("UC4QZ_LsYcvcq7qOsOhpAX4A")
         """
-        from codequick.youtube import Playlist
-
         # Youtube exists, Creating listitem link
         item = cls()
         item.label = label if label else bold(Script.localize(ALLVIDEOS))
         item.art.global_thumb("videos.png")
         item.params["contentid"] = content_id
         item.params["enable_playlists"] = False if content_id.startswith("PL") else enable_playlists
-        item.set_callback(Playlist)
+        item.set_callback(Route.ref("/codequick/youtube:playlist"))
         return item
 
     def __repr__(self):

--- a/script.module.codequick/lib/codequick/resolver.py
+++ b/script.module.codequick/lib/codequick/resolver.py
@@ -2,7 +2,6 @@
 from __future__ import absolute_import
 
 # Standard Library Imports
-import warnings
 import logging
 import inspect
 import re
@@ -217,7 +216,8 @@ class Resolver(Script):
 
     @staticmethod
     def extract_youtube(source):  # pragma: no cover
-        warnings.warn("This method was only temporary and will be removed in future release.", DeprecationWarning)
+        msg = "This method was only temporary and will be removed in future release."
+        logger.warning("DeprecationWarning: " + msg)
         # TODO: Remove this method now that youtube.dl works on kodi for Xbox
         # noinspection PyPackageRequirements
         import htmlement

--- a/script.module.codequick/lib/codequick/script.py
+++ b/script.module.codequick/lib/codequick/script.py
@@ -12,7 +12,7 @@ import xbmc
 
 # Package imports
 from codequick.utils import ensure_unicode, ensure_native_str, unicode_type, string_map
-from codequick.support import dispatcher, script_data, addon_data, logger_id
+from codequick.support import dispatcher, script_data, addon_data, logger_id, CallbackRef
 
 __all__ = ["Script", "Settings"]
 
@@ -158,6 +158,39 @@ class Script(object):
     def __init__(self):
         self._title = self.params.get(u"_title_", u"")
         self.handle = dispatcher.handle
+
+    @classmethod
+    def ref(cls, path):
+        """
+        When given a path to a callback function, will return a reference to that callback function.
+
+        This is used as a way to link to a callback without the need to import it first.
+        With this only the required module containing the callback is imported when callback is executed.
+        This can be used to improve performance when dealing with lots of different callback functions.
+
+        .. note:
+
+            This method needs to be called from the same callback object type of
+            the referenced callback. e.g. Script/Route/Resolver.
+
+        The path structure is '/<package>/<module>:function' where 'package' is the full package path.
+        'module' is the name of the modules containing the callback.
+        And 'function' is the name of the callback function.
+
+        :example:
+            >>> from codequick import Route, Resolver, Listitem
+            >>> item = Listitem()
+            >>>
+            >>> # Example of referencing a Route callback
+            >>> item.set_callback(Route.ref("/resources/lib/videos:video_list"))
+            >>>
+            >>> # Example of referencing a Resolver callback
+            >>> item.set_callback(Resolver.ref("/resources/lib/resolvers:play_video"))
+
+        :param str path: The path to a callback function.
+        :return: A callback reference object.
+        """
+        return CallbackRef(path, cls)
 
     @classmethod
     def register(cls, callback):

--- a/script.module.codequick/lib/codequick/search.py
+++ b/script.module.codequick/lib/codequick/search.py
@@ -3,14 +3,19 @@ from __future__ import absolute_import
 
 # Standard Library Imports
 from hashlib import sha1
-import pickle
 
 # Package imports
 from codequick.storage import PersistentDict
 from codequick.support import dispatcher
 from codequick.listing import Listitem
-from codequick.utils import keyboard, ensure_unicode, unicode_type
+from codequick.utils import keyboard, ensure_unicode
 from codequick.route import Route, validate_listitems
+
+try:
+    # noinspection PyPep8Naming
+    import cPickle as pickle
+except ImportError:  # pragma: no cover
+    import pickle
 
 # Localized string Constants
 ENTER_SEARCH_STRING = 16017
@@ -21,135 +26,157 @@ SEARCH = 137
 SEARCH_DB = u"_new_searches.pickle"
 
 
-def hash_params(data):
-    # type: (dict) -> unicode_type
+class Search(object):
+    def __init__(self, plugin, extra_params):
+        # The saved search persistent storage
+        self.db = search_db = PersistentDict(SEARCH_DB)
+        plugin.register_delayed(search_db.close)
 
-    # Convert dict of params into a sorted list of key, value pairs
-    sorted_dict = sorted(data.items())
+        # Fetch saved data specific to this session
+        session_hash = self.hash_params(extra_params)
+        self.data = search_db.setdefault(session_hash, [])
 
-    # Pickle the sorted dict so we can hash the contents
-    content = pickle.dumps(sorted_dict, protocol=2)
-    return ensure_unicode(sha1(content).hexdigest())
+    def __iter__(self):
+        return iter(self.data)
+
+    def __contains__(self, item):
+        return item in self.data
+
+    def __bool__(self):
+        return bool(self.data)
+
+    def __nonzero__(self):
+        return bool(self.data)
+
+    def remove(self, item):  # type: (str) -> None
+        self.data.remove(item)
+        self.db.flush()
+
+    def append(self, item):  # type: (str) -> None
+        self.data.append(item)
+        self.db.flush()
+
+    @staticmethod
+    def hash_params(data):
+        # Convert dict of params into a sorted list of key, value pairs
+        sorted_dict = sorted(data.items())
+
+        # Pickle the sorted dict so we can hash the contents
+        content = pickle.dumps(sorted_dict, protocol=2)
+        return ensure_unicode(sha1(content).hexdigest())
 
 
 @Route.register
-class SavedSearches(Route):
+def saved_searches(plugin, remove_entry=None, search=False, first_load=False, **extras):
     """
-    Class used to list all saved searches for the addon that called it.
+    Callback used to list all saved searches for the addon that called it.
 
-    Useful to add search support to addon that will also keep track of previous searches.
+    Useful to add search support to addon and will also keep track of previous searches.
     Also contains option via context menu to remove old search terms.
+
+    :param Route plugin: Tools related to Route callbacks.
+    :param remove_entry: [opt] Search term to remove from history.
+    :param search: [opt] When set to True the search input box will appear.
+    :param first_load: Only True when callback is called for the first time, allowes for search box to appear on load.
+    :param extras: Any extra params to farward on to the next callback
+    :returns: A list of search terms or the search results if loaded for the first time.
     """
+    searchdb = Search(plugin, extras)
 
-    def __init__(self):
-        super(SavedSearches, self).__init__()
+    # Remove search term from saved searches
+    if remove_entry and remove_entry in searchdb:
+        searchdb.remove(remove_entry)
+        plugin.update_listing = True
 
-        # Persistent list of currently saved searches
-        self.search_db = PersistentDict(SEARCH_DB)
-        self.register_delayed(self.close)
-        self.session_data = None  # type: list
-
-    def run(self, remove_entry=None, search=False, first_load=False, **extras):
-        """List all saved searches."""
-
-        # Create session hash from givin arguments
-        session_hash = hash_params(extras)
-        self.session_data = session_data = self.search_db.setdefault(session_hash, [])
-
-        # Remove search term from saved searches
-        if remove_entry and remove_entry in session_data:
-            session_data.remove(remove_entry)
-            self.update_listing = True
-            self.search_db.flush()
-
-        # Show search dialog if search argument is True, or if there is no search term saved
-        # First load is used to only allow auto search to work when first loading the saved search container.
-        # Fixes an issue when there is no saved searches left after removing them.
-        elif search or (first_load is True and not session_data):
-            search_term = keyboard(self.localize(ENTER_SEARCH_STRING))
-            if search_term:
-                return self.redirect_search(search_term, extras)
-            elif not session_data:
-                return False
-            else:
-                self.update_listing = True
-
-        # List all saved search terms
-        return self.list_terms(extras)
-
-    def redirect_search(self, search_term, extras):
-        """
-        Checks if searh term returns valid results before adding to saved searches.
-        Then directly farward the results to kodi.
-
-        :param str search_term: The serch term used to search for results.
-        :param dict extras: Extra parameters that will be farwarded on to the callback function.
-        :return: List if valid search results
-        """
-        self.params[u"_title_"] = search_term.title()
-        self.category = self.params[u"_title_"]
-        callback_params = extras.copy()
-        callback_params["search_query"] = search_term
-
-        # We switch selector to redirected callback to allow next page to work properly
-        route = callback_params.pop("_route")
-        dispatcher.selector = route
-
-        # Fetch search results from callback
-        func = dispatcher.get_route().function
-        listitems = func(self, **callback_params)
-
-        # Check that we have valid listitems
-        valid_listitems = validate_listitems(listitems)
-
-        # Add the search term to database and return the list of results
-        if valid_listitems:
-            if search_term not in self.session_data:  # pragma: no branch
-                self.session_data.append(search_term)
-                self.search_db.flush()
-
-            return valid_listitems
-        else:
-            # Return False to indicate failure
+    # Show search dialog if search argument is True, or if there is no search term saved
+    # First load is used to only allow auto search to work when first loading the saved search container.
+    # Fixes an issue when there is no saved searches left after removing them.
+    elif search or (first_load and not searchdb):
+        search_term = keyboard(plugin.localize(ENTER_SEARCH_STRING))
+        if search_term:
+            return redirect_search(plugin, searchdb, search_term, extras)
+        elif not searchdb:
             return False
+        else:
+            plugin.update_listing = True
 
-    def list_terms(self, extras):
-        """
-        List all saved searches.
+    # List all saved search terms
+    return list_terms(plugin, searchdb, extras)
 
-        :param dict extras: Extra parameters that will be farwarded on to the context.container.
 
-        :returns: A generator of listitems.
-        :rtype: :class:`types.GeneratorType`
-        """
-        # Add listitem for adding new search terms
-        search_item = Listitem()
-        search_item.label = u"[B]%s[/B]" % self.localize(SEARCH)
-        search_item.set_callback(self, search=True, **extras)
-        search_item.art.global_thumb("search_new.png")
-        yield search_item
+def redirect_search(plugin, searchdb, search_term, extras):
+    """
+    Checks if searh term returns valid results before adding to saved searches.
+    Then directly farward the results to kodi.
 
-        # Set the callback function to the route that was given
-        callback_params = extras.copy()
-        route = callback_params.pop("_route")
-        callback = dispatcher.get_route(route).callback
+    :param Route plugin: Tools related to Route callbacks.
+    :param Search searchdb: Search DB
+    :param str search_term: The serch term used to search for results.
+    :param dict extras: Extra parameters that will be farwarded on to the callback function.
+    :return: List if valid search results
+    """
+    plugin.params[u"_title_"] = title = search_term.title()
+    plugin.category = title
+    callback_params = extras.copy()
+    callback_params["search_query"] = search_term
 
-        # Prefetch the localized string for the context menu lable
-        str_remove = self.localize(REMOVE)
+    # We switch selector to redirected callback to allow next page to work properly
+    route = callback_params.pop("_route")
+    dispatcher.selector = route
 
-        # List all saved searches
-        for search_term in self.session_data:
-            item = Listitem()
-            item.label = search_term.title()
+    # Fetch search results from callback
+    func = dispatcher.get_route().function
+    listitems = func(plugin, **callback_params)
 
-            # Creatre Context Menu item for removing search term
-            item.context.container(self, str_remove, remove_entry=search_term, **extras)
+    # Check that we have valid listitems
+    valid_listitems = validate_listitems(listitems)
 
-            # Update params with full url and set the callback
-            item.params.update(callback_params, search_query=search_term)
-            item.set_callback(callback)
-            yield item
+    # Add the search term to database and return the list of results
+    if valid_listitems:
+        if search_term not in searchdb:  # pragma: no branch
+            searchdb.append(search_term)
 
-    def close(self):
-        """Close the connection to the search database."""
-        self.search_db.close()
+        return valid_listitems
+    else:
+        # Return False to indicate failure
+        return False
+
+
+def list_terms(plugin, searchdb, extras):
+    """
+    List all saved searches.
+
+    :param Route plugin: Tools related to Route callbacks.
+    :param Search searchdb: Search DB
+    :param dict extras: Extra parameters that will be farwarded on to the context.container.
+
+    :returns: A generator of listitems.
+    :rtype: :class:`types.GeneratorType`
+    """
+    # Add listitem for adding new search terms
+    search_item = Listitem()
+    search_item.label = u"[B]%s[/B]" % plugin.localize(SEARCH)
+    search_item.set_callback(saved_searches, search=True, **extras)
+    search_item.art.global_thumb("search_new.png")
+    yield search_item
+
+    # Set the callback function to the route that was given
+    callback_params = extras.copy()
+    route = callback_params.pop("_route")
+    callback = dispatcher.get_route(route).callback
+
+    # Prefetch the localized string for the context menu lable
+    str_remove = plugin.localize(REMOVE)
+
+    # List all saved searches
+    for search_term in searchdb:
+        item = Listitem()
+        item.label = search_term.title()
+
+        # Creatre Context Menu item for removing search term
+        item.context.container(saved_searches, str_remove, remove_entry=search_term, **extras)
+
+        # Update params with full url and set the callback
+        item.params.update(callback_params, search_query=search_term)
+        item.set_callback(callback)
+        yield item


### PR DESCRIPTION
### Description
Mostly prep work for version 1.0.0

#### Changed
- Deprecate the use of class based callbacks.
- Deprecate ability to pass playable url to listitem.set_callback(), use listitem.set_path() instead.
- Deprecate ability to pass a path to a callback when calling listitem.set_callback(), use a callback reference instead.
- Functions that except callbacks can also except a callback reference object. Better for performance.

#### Added
- Ability to get and set listitem params as attributes, e.g. item.info.genre = "Science Fiction".
- Listitem objects are now fully pickable.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [script.foo.bar] 1.0.0