### PR TITLE
[script.service.checkpreviousepisode@matrix] 0.4.2

### DIFF
--- a/script.service.checkpreviousepisode/README.md
+++ b/script.service.checkpreviousepisode/README.md
@@ -10,5 +10,7 @@ You can mark shows where episode order doesn't matter as show to be ignored (and
 
 If it detects you've started playback of an episode you probably shouldn't have, the video will be paused, and you'll get a pop up window with options to stop playback, carry on on this occasion, or carry on and also mark the show as one to ignore from now on.
 
+Forum thread: <https://forum.kodi.tv/showthread.php?tid=355464>
+
 Available in the main Kodi repository (legacy Python 2 version for Kodi Leia and below, Python 3 version for Kodi Matrix and the on).
 

--- a/script.service.checkpreviousepisode/addon.xml
+++ b/script.service.checkpreviousepisode/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.service.checkpreviousepisode" name="Kodi Check Previous Episode" provider-name="bossanova808, Razzeee, Lucleonhart" version="0.4.1">
+<addon id="script.service.checkpreviousepisode" version="0.4.2" name="Kodi Check Previous Episode" provider-name="bossanova808, Razzeee, Lucleonhart" >
   <requires>
     <import addon="xbmc.python" version="3.0.0" />
     <import addon="script.module.yaml" version="3.11.0" />
@@ -13,7 +13,7 @@
     <description lang="bg_BG">Когато пускате епизод от даден сериал скриптът проверява предходния и предупреждава ако той отсъства от библиотеката или не е изгледан.</description>
     <platform>all</platform>
     <license>GPL-2.0-only</license>
-    <forum>https://forum.kodi.tv/showthread.php?tid=151531</forum>
+    <forum>https://forum.kodi.tv/showthread.php?tid=355464</forum>
     <website>https://kodi.wiki/view/Add-on:XBMC_Check_Previous_Episode</website>
     <source>https://github.com/bossanova808/script.service.checkpreviousepisode</source>
   <assets>

--- a/script.service.checkpreviousepisode/changelog.txt
+++ b/script.service.checkpreviousepisode/changelog.txt
@@ -1,34 +1,37 @@
-v0.4
-* Updated (by Razzeee) to Python 3 / Kodi Matrix - thanks Razzeee!!
+v0.4.2
+- Update for changes to Kodi Matrix logging functions
+
+v0.4.1
+- Updated (by Razzeee) to Python 3 / Kodi Matrix - thanks Razzeee!!
 
 v0.3.5 
-* (N.B. this is the last version for Kodi Leia and below)
-* Fixed error with non ascii chars in show title
-* Better addon profile path handling, create profile directory if doesn't exists
+- (N.B. this is the last version for Kodi Leia and below)
+- Fixed error with non ascii chars in show title
+- Better addon profile path handling, create profile directory if doesn't exists
 
 v0.3.4
-* Add new option to ignore particular shows
-* Move 'browse show episodes' to a setting rather than on every interaction, which felt janky to me
-* Improve language across the board
+- Add new option to ignore particular shows
+- Move 'browse show episodes' to a setting rather than on every interaction, which felt janky to me
+- Improve language across the board
 
 v0.3.3
-* Krypton fixes for previous
+- Krypton fixes for previous
 
 v0.3.2
-* Maintenance by bossanova08 - Updated for Kodi Leia
-* Add new setting to ignore if the previous episode is not in library at all
+- Maintenance by bossanova08 - Updated for Kodi Leia
+- Add new setting to ignore if the previous episode is not in library at all
 
 v0.3.1
-* Use builtin json module instead of simplejson (Thanks tamland)
+- Use builtin json module instead of simplejson (Thanks tamland)
 
 v0.3.0
-* Added option to show a "browse this show" dialog
+- Added option to show a "browse this show" dialog
 
 v0.2.1
-* Stupid bug fixed
+- Stupid bug fixed
 
 v0.2.0
-* Added transifex language support
+- Added transifex language support
 
 v0.1.0
-* Initial release
+- Initial release

--- a/script.service.checkpreviousepisode/default.py
+++ b/script.service.checkpreviousepisode/default.py
@@ -230,7 +230,7 @@ if len(sys.argv) > 1:
 # DEFAULT - RUN AS A SERVICE & WATCH PLAYBACK EVENTS
 else:
     log('Kodi ' + str(__kodiversion__) +
-        ', listen to onAVStarted', xbmc.LOGNOTICE)
+        ', listen to onAVStarted', xbmc.LOGINFO)
 
     monitor = xbmc.Monitor()
     player_monitor = MyPlayer()


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: Kodi Check Previous Episode
  - Add-on ID: script.service.checkpreviousepisode
  - Version number: 0.4.2
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/bossanova808/script.service.checkpreviousepisode
  
This service helps prevent spoilers by checking if the previous episode in a series has been watched. If not, it will pause playback and warn you.  Specific shows can be marked to be ignored if episode order does not matter.

### Description of changes:

Updated for Matrix logging changes (LOGNOTICE -> LOGINFO)

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
