### PR TITLE
[script.service.next-episode@matrix] 1.2.2+matrix.1

### DIFF
--- a/script.service.next-episode/addon.xml
+++ b/script.service.next-episode/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon id="script.service.next-episode"
    name="Next Episode (next-episode.net)"
-   version="1.2.1+matrix.1"
+   version="1.2.2+matrix.1"
    provider-name="next-episode.net">
   <requires>
     <import addon="xbmc.python" version="3.0.0" />
@@ -22,17 +22,18 @@
     <description lang="ru_RU">Служба next-episode.net для Kodi позволяет добавлять фильмы и сериалы из меедиатеки в ваш список на next-episode.net. Служба также отслеживает проигрывание видео и обновляет состояние "просмотрено" на next-episode.net.[CR][B]Внимание![/B] Дополнение работает только с медиатекой Kodi.</description>
     <summary lang="uk_UA">Служба для сайта Next Episode (next-episode.net).</summary>
     <description lang="uk_UA">Служба next-episode.net для Kodi дозволяє додавати фільми та серіали з медіатеки у ваш список на next-episode.net. Служба також відстежує перегляд відео та оновлює статус "переглянуто" на next-episode.net.[CR][B]Увага![/B] Надбудова працює лише з медіатекою Kodi.</description>
-    <license>GNU GPL v.3</license>
+    <license>GPL-3.0-or-later</license>
     <website>http://next-episode.net</website>
     <email>roman1972@gmail.com</email>
     <source>https://github.com/santah/next-episode-kodi</source>
     <assets>
       <icon>icon.png</icon>
     </assets>
-    <news>1.2.1:
+    <news>1.2.2:
+- Replaced deprecated logging level.
+
+1.2.1:
 - Fixed library sync when TMDB is used as a TV shows scraper.
-- Fixed UI dialogs in Kodi 19 &quot;Matrix&quot;.
-1.2.0:
-- Added compatibility with Python 3 for the future Kodi 19 &quot;Matrix&quot; version.</news>
+- Fixed UI dialogs in Kodi 19 &quot;Matrix&quot;.</news>
   </extension>
 </addon>

--- a/script.service.next-episode/libs/logger.py
+++ b/script.service.next-episode/libs/logger.py
@@ -9,7 +9,7 @@ from inspect import currentframe
 from kodi_six import xbmc
 from .addon import ADDON_ID, ADDON_VERSION
 
-__all__ = ['log_debug', 'log_error', 'log_notice', 'log_warning']
+__all__ = ['log_debug', 'log_error', 'log_info', 'log_warning']
 
 FORMAT = '{id} [v.{version}] - {filename}:{lineno} - {message}'
 
@@ -28,8 +28,8 @@ def log_message(msg, level=xbmc.LOGDEBUG):
     )
 
 
-def log_notice(msg):
-    log_message(msg, xbmc.LOGNOTICE)
+def log_info(msg):
+    log_message(msg, xbmc.LOGINFO)
 
 
 def log_warning(msg):


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: Next Episode (next-episode.net)
  - Add-on ID: script.service.next-episode
  - Version number: 1.2.2+matrix.1
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/santah/next-episode-kodi
  
The next-episode.net service for Kodi allows to add your movies and TV episodes from media library to your inventory on next-episode.net. The service also monitors video playback and updates 'watched' status of your movies and episodes on next-episode.net.[CR][B]Note:[/B] The addon works only with Kodi medialibrary!

### Description of changes:

1.2.2:
- Replaced deprecated logging level.

1.2.1:
- Fixed library sync when TMDB is used as a TV shows scraper.
- Fixed UI dialogs in Kodi 19 "Matrix".

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
