### PR TITLE
[script.tvmaze.scrobbler@matrix] 1.0.1+matrix.1

### DIFF
--- a/script.tvmaze.scrobbler/addon.xml
+++ b/script.tvmaze.scrobbler/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon id="script.tvmaze.scrobbler"
    name="TVmaze Scrobbler/Tracker"
-   version="1.0.0+matrix.1"
+   version="1.0.1+matrix.1"
    provider-name="Roman V.M.">
   <requires>
     <import addon="xbmc.python" version="3.0.0" />
@@ -38,7 +38,8 @@ What this addon does:
       <icon>resources/images/icon.png</icon>
       <fanart>resources/images/background.jpg</fanart>
     </assets>
-    <news>1.0.0:
-- The first public release.</news>
+    <news>1.0.1:
+- Fixed crashes because of malformed JSON responses from TVmaze.
+- Fixed crashes because of invalid SSL certificates.</news>
   </extension>
 </addon>


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: TVmaze Scrobbler/Tracker
  - Add-on ID: script.tvmaze.scrobbler
  - Version number: 1.0.1+matrix.1
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/romanvm/kodi.tvmaze.scrobbler
  
Automatically track all TV episodes you are watching to TVmaze. A must have if you want to sync your watch history between various applications.
Sign up for a free account at https://tvmaze.com for more features.

This Kodi TV episode Tracker uses the TVmaze.com user API's scrobbler endpoints(https://static.tvmaze.com/apidoc/)

What this addon does:
- Performs an initial sync between Kodi and TVmaze for the episodes you've watched.
- If you add an episode to the Kodi library it marks it as "acquired" on TVmaze.
- If you watch an episode in Kodi it marks it as "watched" in TVmaze.
- If you mark an episode as watched in TVmaze it marks it as watched in Kodi.

### Description of changes:

1.0.1:
- Fixed crashes because of malformed JSON responses from TVmaze.

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
