### PR TITLE
[script.service.next-episode@matrix] 1.2.3+matrix.1

### DIFF
--- a/script.service.next-episode/addon.xml
+++ b/script.service.next-episode/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon id="script.service.next-episode"
    name="Next Episode (next-episode.net)"
-   version="1.2.2+matrix.1"
+   version="1.2.3+matrix.1"
    provider-name="next-episode.net">
   <requires>
     <import addon="xbmc.python" version="3.0.0" />
@@ -29,11 +29,7 @@
     <assets>
       <icon>icon.png</icon>
     </assets>
-    <news>1.2.2:
-- Replaced deprecated logging level.
-
-1.2.1:
-- Fixed library sync when TMDB is used as a TV shows scraper.
-- Fixed UI dialogs in Kodi 19 &quot;Matrix&quot;.</news>
+    <news>1.2.3:
+- Fix broken service.</news>
   </extension>
 </addon>

--- a/script.service.next-episode/service.py
+++ b/script.service.next-episode/service.py
@@ -4,11 +4,11 @@
 # License: GPL v. 3 <http://www.gnu.org/licenses/gpl-3.0.en.html>
 
 from __future__ import unicode_literals
-from libs.logger import log_notice
+from libs.logger import log_info
 from libs.monitoring import UpdateMonitor, initial_prompt
 
 initial_prompt()
 update_monitor = UpdateMonitor()
-log_notice('Service started')
+log_info('Service started')
 update_monitor.waitForAbort()
-log_notice('Service stopped')
+log_info('Service stopped')


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: Next Episode (next-episode.net)
  - Add-on ID: script.service.next-episode
  - Version number: 1.2.3+matrix.1
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/santah/next-episode-kodi
  
The next-episode.net service for Kodi allows to add your movies and TV episodes from media library to your inventory on next-episode.net. The service also monitors video playback and updates 'watched' status of your movies and episodes on next-episode.net.[CR][B]Note:[/B] The addon works only with Kodi medialibrary!

### Description of changes:

1.2.3:
- Fix broken service.

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
