### PR TITLE
[script.tubecast@matrix] 1.4.5+matrix.1

### DIFF
--- a/script.tubecast/README.md
+++ b/script.tubecast/README.md
@@ -34,6 +34,10 @@ Support will only be provided via the forum thread in [Kodi's Forums](https://fo
 
 None, for now at least :)
 
+### Notes
+
+- Tubecast uses the `System.FriendlyName` infolabel to get the name to be advertised to the youtube application. In some systems this value is not available and the value defined for the setting `Kodi advertisement name (fallback)` will be used instead
+
 ### Disclaimer
 
 *This is not a full chromecast implementation nor will never be. Please refrain from suggesting it as a feature request.*

--- a/script.tubecast/addon.xml
+++ b/script.tubecast/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.tubecast" name="TubeCast" version="1.4.4+matrix.1" provider-name="enen92">
+<addon id="script.tubecast" name="TubeCast" version="1.4.5+matrix.1" provider-name="enen92">
     <requires>
         <import addon="xbmc.python" version="3.0.0"/>
         <import addon="script.module.bottle" version="0.12.0"/>
@@ -11,23 +11,23 @@
     <extension point="xbmc.addon.metadata">
         <summary lang="en_GB">Cast videos from the Youtube application to Kodi</summary>
         <summary lang="pt_PT">Cast de vídeos a partir da aplicação móvel Youtube para o Kodi</summary>
-	<summary lang="es_ES">Transmitir videos desde la aplicación de Youtube a Kodi</summary>
-	<description lang="en_GB">An implementation of the Cast V1 protocol in Kodi to act as a player for the Youtube mobile application</description>
-    <description lang="pt_PT">Uma implementação do protocolo Cast V1 no Kodi para este funcionar como player externo remotamente controlado pela aplicação móvel do YouTube</description>
-	<description lang="es_ES">Una implementación del protocolo Cast V1 en Kodi para actuar como reproductor externo para la aplicación móvil de Youtube</description>
-	<platform>all</platform>
+        <summary lang="es_ES">Transmitir videos desde la aplicación de Youtube a Kodi</summary>
+        <description lang="en_GB">An implementation of the Cast V1 protocol in Kodi to act as a player for the Youtube mobile application</description>
+        <description lang="pt_PT">Uma implementação do protocolo Cast V1 no Kodi para este funcionar como player externo remotamente controlado pela aplicação móvel do YouTube</description>
+        <description lang="es_ES">Una implementación del protocolo Cast V1 en Kodi para actuar como reproductor externo para la aplicación móvil de Youtube</description>
+        <platform>all</platform>
         <license>MIT</license>
         <forum>https://forum.kodi.tv/showthread.php?tid=329153</forum>
         <email>enen92@kodi.tv</email>
         <source>https://github.com/enen92/script.tubecast</source>
         <news>
-            [new] Add spanish translation (tks roliverosc)
-            [fix] Playlist doesn't continue after second video (tks NextLight)
+            [fix] missing ctt key (tks romainreignier)
+            [fix] add default id if friendlyname is missing
         </news>
         <disclaimer lang="en_GB">This is not a full chromecast implementation nor will it ever be. It will only work as long as Google keep backwards compatibility with the cast v1 protocol in the Youtube application. Deeply inspired by Leapcast and gotubecast projects</disclaimer>
         <disclaimer lang="pt_PT">Este addon não é uma implementação completa do protocolo cast nem nunca será. Apenas funcionará enquanto a Google mantiver a retrocompatibilidade com o protocolo cast v1 na aplicação móvel do youtube. Inspirado no Leapcast e gotubecast</disclaimer>
-	<disclaimer lang="es_ES">Esta no es una implementación completa de Chromecast ni lo será nunca. Solo funcionará mientras Google mantenga la compatibilidad con el protocolo Cast v1 en la aplicación Youtube. Profundamente inspirado por los proyectos Leapcast y gotubecast</disclaimer>
-	<assets>
+	    <disclaimer lang="es_ES">Esta no es una implementación completa de Chromecast ni lo será nunca. Solo funcionará mientras Google mantenga la compatibilidad con el protocolo Cast v1 en la aplicación Youtube. Profundamente inspirado por los proyectos Leapcast y gotubecast</disclaimer>
+        <assets>
             <icon>resources/img/icon.png</icon>
             <fanart>resources/img/fanart.jpg</fanart>
             <screenshot>resources/img/screenshot-0.jpg</screenshot>

--- a/script.tubecast/resources/language/resource.language.en_gb/strings.po
+++ b/script.tubecast/resources/language/resource.language.en_gb/strings.po
@@ -76,3 +76,7 @@ msgstr ""
 msgctxt "#32014"
 msgid "Debug HTTP requests"
 msgstr ""
+
+msgctxt "#32015"
+msgid "Kodi advertisement name (fallback)"
+msgstr ""

--- a/script.tubecast/resources/language/resource.language.pt_pt/strings.po
+++ b/script.tubecast/resources/language/resource.language.pt_pt/strings.po
@@ -72,3 +72,11 @@ msgstr "Depuração"
 msgctxt "#32013"
 msgid "Verify SSL connections"
 msgstr "Verificar ligações SSL"
+
+msgctxt "#32014"
+msgid "Debug HTTP requests"
+msgstr "Depuração de pedidos HTTP"
+
+msgctxt "#32015"
+msgid "Kodi advertisement name (fallback)"
+msgstr "Nome para o Kodi (fallback)"

--- a/script.tubecast/resources/lib/kodi/utils.py
+++ b/script.tubecast/resources/lib/kodi/utils.py
@@ -51,7 +51,10 @@ def set_setting(setting, value):
 
 
 def get_device_id():
-    return get_infolabel("System.FriendlyName")
+    friendly_name = get_infolabel("System.FriendlyName")
+    if not friendly_name:
+        friendly_name = get_setting("kodi-advertise")
+    return friendly_name
 
 
 def get_setting_as_bool(setting):

--- a/script.tubecast/resources/lib/tubecast/youtube/app.py
+++ b/script.tubecast/resources/lib/tubecast/youtube/app.py
@@ -48,7 +48,8 @@ class CastState(object):
         return bool(self.playlist)
 
     def handle_set_playlist(self, data):
-        self.ctt = data["ctt"]
+        if 'ctt' in data:
+            self.ctt = data["ctt"]
 
         self.playlist_id = data["listId"]
         self.playlist = data["videoIds"].split(",")

--- a/script.tubecast/resources/settings.xml
+++ b/script.tubecast/resources/settings.xml
@@ -3,6 +3,7 @@
 	<category label="32003">
 		<setting label="32004" type="bool" id="enable-ssdp" default="true"/>
 		<setting label="32013" type="bool" id="verify-ssl" default="true"/>
+		<setting label="32015" type="text" id="kodi-advertise" default="Kodi-TV" />
 	</category>
 	<category label="32012">
 		<setting label="32005" type="bool" id="debug-ssdp" default="false"/>


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: TubeCast
  - Add-on ID: script.tubecast
  - Version number: 1.4.5+matrix.1
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/enen92/script.tubecast
  
An implementation of the Cast V1 protocol in Kodi to act as a player for the Youtube mobile application

### Description of changes:


            [fix] missing ctt key (tks romainreignier)
            [fix] add default id if friendlyname is missing
        

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
