### PR TITLE
[script.module.inputstreamhelper@krypton] 0.5.1

### DIFF
--- a/script.module.inputstreamhelper/README.md
+++ b/script.module.inputstreamhelper/README.md
@@ -90,30 +90,35 @@ Please report any issues or bug reports on the [GitHub Issues](https://github.co
 This module is licensed under the **The MIT License**. Please see the [LICENSE.txt](LICENSE.txt) file for details.
 
 ## Releases
-## v0.5.0 (2020-06-25)
+### v0.5.1 (2020-10-02)
+- Fix incorrect ARM HWIDs: PHASER and PHASER360 (@dagwieers)
+- Added Hebrew translations (@haggaie)
+- Updated Dutch, Japanese and Korean translations (@michaelarnauts, @Thunderbird2086)
+
+### v0.5.0 (2020-06-25)
 - Extract Widevine CDM directly from Chrome OS, minimizing disk space usage and eliminating the need for root access (@horstle)
 - Improve progress dialog while extracting Widevine CDM on ARM devices (@horstle, @mediaminister)
 - Support resuming interrupted downloads on unreliable internet connections (@horstle, @mediaminister)
 - Reshape InputStream Helper information dialog (@horstle, @dagwieers)
 - Updated Dutch, English, French, German, Greek, Hungarian, Romanian, Russian, Spanish and Swedish translations (@dagwieers, @horstle, @mediaminister, @tweimer, @Twilight0, @frodo19, @tmihai20, @vlmaksime, @roliverosc, @Sopor)
 
-## v0.4.7 (2020-05-03)
+### v0.4.7 (2020-05-03)
 - Fix hardlink on Windows (@BarmonHammer)
 - Fix support for unicode chars in paths (@mediaminister)
 - Show remaining time during Widevine installation on ARM devices (@horstle)
 
-## v0.4.6 (2020-04-29)
+### v0.4.6 (2020-04-29)
 - Compatibility fixes for Kodi 19 Matrix "pre-release" builds (@mediaminister)
 - Optimize Widevine CDM detection (@dagwieers)
 - Minor fixes for Widevine installation on ARM devices (@dagwieers @mediaminister @horstle)
 
-## v0.4.5 (2020-04-07)
+### v0.4.5 (2020-04-07)
 - Added Spanish and Romanian translations (@roliverosc, @tmihai20)
 - Added support for Kodi 19 Matrix "pre-release" builds (@mediaminister)
 - Fix Widevine backups when using an external drive (@horstle)
 - Various fixes for Widevine installation on ARM devices (@horstle)
 
-## v0.4.4 (2020-03-01)
+### v0.4.4 (2020-03-01)
 - Added option to restore a previously installed Widevine version (@horstle)
 - Improve progress bar when extracting Widevine on ARM devices (@dagwieers)
 - Improve Widevine library version detection (@dagwieers, @mediaminister)
@@ -123,7 +128,7 @@ This module is licensed under the **The MIT License**. Please see the [LICENSE.t
 - Updated existing translations (@dnicolaas, @Sopor, @tweimer, @horstle, @mediaminister)
 - Various small bugfixes for Widevine installation on ARM devices (@dagwieers, @mediaminister, @Twilight0, @janhicken)
 
-## v0.4.3 (2019-09-25)
+### v0.4.3 (2019-09-25)
 - French translation (@brunoduc)
 - Updated translations (@vlmaksime, @dagwieers, @pinoelefante, @horstle, @Twilight0, @emilsvennesson)
 - Ensure Kodi 19 compatibility (@mediaminister)
@@ -132,7 +137,7 @@ This module is licensed under the **The MIT License**. Please see the [LICENSE.t
 - Fix add-on settings crashes when InputStream Adaptive is missing (@mediaminister)
 - Improve unicode character support (@mediaminister)
 
-## v0.4.2 (2019-09-03)
+### v0.4.2 (2019-09-03)
 - Move release history to readme file (@mediaminister)
 - Clean up coverage/codecov config (@dagwieers)
 - Add InputStream Helper Information to settings page (@horstle, @dagwieers)
@@ -143,14 +148,14 @@ This module is licensed under the **The MIT License**. Please see the [LICENSE.t
 - Fix unresponsive Kodi when opening add-on information pane (@dagwieers, @mediaminister)
 - Add-on structure improvements (@dagwieers)
 
-## v0.4.1 (2019-09-01)
+### v0.4.1 (2019-09-01)
 - Follow kodi-addon-checker recommended code changes (@mediaminister)
 - Implement api using runscript (@mediaminister)
 - Fix ARM processing in unittest locally (@dagwieers)
 - Add more project information (@dagwieers)
 - More coverage improvements (@dagwieers)
 
-## v0.4.0 (2019-09-01)
+### v0.4.0 (2019-09-01)
 - Use local url variable (@mediaminister)
 - Directly use Kodi CDM directory (@mediaminister)
 - Implement settings menu and API (@dagwieers)
@@ -172,12 +177,12 @@ This module is licensed under the **The MIT License**. Please see the [LICENSE.t
 - Russian translation (@vlmaksime)
 - Swedish translation (@emilsvennesson)
 
-## v0.3.5 (2019-08-15)
+### v0.3.5 (2019-08-15)
 - Auto install inputstream.adaptive (@mediaminister)
 - Fix latest Widevine version detection (@dagwieers)
 - Check for Widevine updates on new release (@mediaminister)
 
-## v0.3.4 (2019-03-23)
+### v0.3.4 (2019-03-23)
 - python2_3 compability (@mediaminister, @Rechi)
 - Option to disable inputstreamhelper in settings.xml
 - calculate disk space on the tmp folder (@dawez)
@@ -187,7 +192,7 @@ This module is licensed under the **The MIT License**. Please see the [LICENSE.t
 - Greek translation (@Twilight0)
 - Russian translation (@vlmaksime)
 
-## v0.3.3 (2018-02-21)
+### v0.3.3 (2018-02-21)
 - Load loop if it's a kernel module (@mkreisl)
 - Fix legacy Widevine CDM update detection
 - inputstream_addon is now a public variable
@@ -195,35 +200,35 @@ This module is licensed under the **The MIT License**. Please see the [LICENSE.t
 - Improve logging
 - Cosmetics
 
-## v0.3.2 (2018-01-30)
+### v0.3.2 (2018-01-30)
 - Fix OSMC arm architecture detection
 - Fix ldd permissions error
 
-## v0.3.1 (2018-01-29)
+### v0.3.1 (2018-01-29)
 - check_inputstream() return fix
 
-## v0.3.0 (2018-01-29)
+### v0.3.0 (2018-01-29)
 - Bug fix: module left xbmcaddon class in memory
 - Keep Widevine CDM up-to-date with the latest version available (Kodi 18 and higher)
 - Check for missing depending libraries by parsing the output from ldd
 - Use older Widevine binaries on Kodi Krypton (fixes nss/nspr dependency issues)
 
-## v0.2.4 (2018.01.01)
+### v0.2.4 (2018.01.01)
 - Fix ARM download on systems with sudo (OSMC etc)
 - Actually bump version in addon.xml, unlike v0.2.3...
 
-## v0.2.3 (2017-12-30)
+### v0.2.3 (2017-12-30)
 - Make sure Kodi and Widevine CDM binary architecture matches
 - Minor wording changes/fixes
 
-## v0.2.2 (2017-12-05)
+### v0.2.2 (2017-12-05)
 - Fixes for widevine download when using 64-bit Kodi (@gismo112, @asciidisco)
 
-## v0.2.1 (2017-10-15)
+### v0.2.1 (2017-10-15)
 - Update German translation (@asciidisco)
 - Improve root permissions acquisition
 
-## v0.2.0 (2017-09-29)
+### v0.2.0 (2017-09-29)
 - Automatic Widevine CDM download on ARM devices
 - Display Widevine EULA during installation procedure
 - German translation (thanks to asciidisco)
@@ -231,5 +236,5 @@ This module is licensed under the **The MIT License**. Please see the [LICENSE.t
 - Better exception handling
 - Code cleanup
 
-## v0.1.0 (2017-09-13)
+### v0.1.0 (2017-09-13)
 - Initial release

--- a/script.module.inputstreamhelper/addon.xml
+++ b/script.module.inputstreamhelper/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.module.inputstreamhelper" name="InputStream Helper" version="0.5.0" provider-name="emilsvennesson, dagwieers, mediaminister, horstle">
+<addon id="script.module.inputstreamhelper" name="InputStream Helper" version="0.5.1" provider-name="emilsvennesson, dagwieers, mediaminister, horstle">
   <requires>
     <!--py3 compliant-->
     <import addon="xbmc.python" version="2.25.0"/>
@@ -23,12 +23,17 @@
     <description lang="fr_FR">Un simple module Kodi qui simplifie la vie des développeurs de modules complémentaires en s’appuyant sur des modules complémentaires basés sur InputStream et sur la lecture de DRM.</description>
     <description lang="es_ES">Un módulo Kodi simple que hace la vida más fácil para los desarrolladores de complementos que dependen de complementos basados en InputStream y reproducción de DRM.</description>
     <news>
-     v0.5.0 (2020-06-25)
-        - Extract Widevine CDM directly from Chrome OS, minimizing disk space usage and eliminating the need for root access
-        - Improve progress dialog while extracting Widevine CDM on ARM devices
-        - Support resuming interrupted downloads on unreliable internet connections
-        - Reshape InputStream Helper information dialog
-        - Updated Dutch, English, French, German, Greek, Hungarian, Romanian, Russian, Spanish and Swedish translations
+v0.5.1 (2020-10-02)
+- Fix incorrect ARM HWIDs: PHASER and PHASER360
+- Added Hebrew translations
+- Updated Dutch, Japanese and Korean translations
+
+v0.5.0 (2020-06-25)
+- Extract Widevine CDM directly from Chrome OS, minimizing disk space usage and eliminating the need for root access
+- Improve progress dialog while extracting Widevine CDM on ARM devices
+- Support resuming interrupted downloads on unreliable internet connections
+- Reshape InputStream Helper information dialog
+- Updated Dutch, English, French, German, Greek, Hungarian, Romanian, Russian, Spanish and Swedish translations
     </news>
     <platform>all</platform>
     <license>MIT</license>

--- a/script.module.inputstreamhelper/lib/inputstreamhelper/config.py
+++ b/script.module.inputstreamhelper/lib/inputstreamhelper/config.py
@@ -99,8 +99,6 @@ CHROMEOS_RECOVERY_ARM_HWIDS = [
     'MICKEY',
     'MIGHTY',
     'MINNIE',
-    'PHASER',
-    'PHASER360',
     'PI',
     'PIT',
     'RELM',

--- a/script.module.inputstreamhelper/lib/inputstreamhelper/widevine/arm_chromeos.py
+++ b/script.module.inputstreamhelper/lib/inputstreamhelper/widevine/arm_chromeos.py
@@ -124,7 +124,7 @@ class ChromeOSImage:
 
         self.seek_stream(self.part_offset + 1024)  # superblock starts after 1024 byte
         pack = self.read_stream(fmt_len)
-        sb_dict = dict(zip(names, unpack(fmt, pack)))
+        sb_dict = dict(list(zip(names, unpack(fmt, pack))))
 
         sb_dict['s_magic'] = hex(sb_dict['s_magic'])
         assert sb_dict['s_magic'] == '0xef53'  # assuming/checking this is an ext2 fs
@@ -149,7 +149,7 @@ class ChromeOSImage:
         pack = self.read_stream(fmt_len)
         blk = unpack(fmt, pack)
 
-        blk_dict = dict(zip(names, blk))
+        blk_dict = dict(list(zip(names, blk)))
 
         return blk_dict
 
@@ -180,7 +180,7 @@ class ChromeOSImage:
         pack = self.read_stream(fmt_len)
         inode = unpack(fmt, pack)
 
-        inode_dict = dict(zip(names, inode))
+        inode_dict = dict(list(zip(names, inode)))
         inode_dict['i_mode'] = hex(inode_dict['i_mode'])
 
         blocks = inode_dict['i_size'] / self.blocksize
@@ -195,7 +195,7 @@ class ChromeOSImage:
         dir_names = ('inode', 'rec_len', 'name_len', 'file_type', 'name')
         dir_fmt = '<IHBB' + str(len(chunk) - 8) + 's'
 
-        dir_dict = dict(zip(dir_names, unpack(dir_fmt, chunk)))
+        dir_dict = dict(list(zip(dir_names, unpack(dir_fmt, chunk))))
 
         return dir_dict
 

--- a/script.module.inputstreamhelper/resources/language/resource.language.he_il/strings.po
+++ b/script.module.inputstreamhelper/resources/language/resource.language.he_il/strings.po
@@ -4,347 +4,344 @@ msgstr ""
 "Project-Id-Version: script.module.inputstreamhelper\n"
 "Report-Msgid-Bugs-To: https://github.com/emilsvennesson/script.module.inputstreamhelper\n"
 "POT-Creation-Date: 2013-11-18 16:15+0000\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: Dion Nicolaas <dion@nicolaas.net>\n"
-"Language-Team: Dutch\n"
+"PO-Revision-Date: 2020-10-01 19:22+0300\n"
+"Language-Team: Hebrew\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: nl\n"
-"Plural-Forms: nplurals=2; plural=(n != 1)\n"
+"Language: he_IL\n"
+"Plural-Forms: nplurals=4; plural=(n==1 ? 0 : n==2 ? 1 : n>10 && n%10==0 ? 2 : 3);\n"
 
 msgctxt "#30001"
 msgid "Information"
-msgstr "Informatie"
+msgstr "מידע"
 
 msgctxt "#30002"
 msgid "This add-on relies on the proprietary decryption module [B]Widevine CDM[/B] for playback."
-msgstr "Deze add-on heeft de [B]Widevine CDM[/B] decodeer-module van een derde partij nodig om af te spelen."
+msgstr "הרחבה זו תלויה במודול הפענוח הקנייני [B]Widevine CDM[/B] על מנת לנגן."
 
 msgctxt "#30004"
 msgid "Error"
-msgstr "Fout"
+msgstr "שגיאה"
 
 msgctxt "#30005"
 msgid "An error occurred while installing [B]Widevine CDM[/B]. Please enable debug logging and file a bug report at:[CR][CR]github.com/emilsvennesson/script.module.inputstreamhelper"
-msgstr "Er is een fout opgetreden bij het installeren van [B]Widevine CDM[/B]. Schakel debug logging in en dien een bug-rapport in op:[CR][CR]github.com/emilsvennesson/script.module.inputstreamhelper"
+msgstr "קרתה שגיאה במהלך התקנת [B]Widevine CDM[/B]. נא לאפשר רישום ניפוי באגים ולדווח ב-[CR][CR]github.com/emilsvennesson/script.module.inputstreamhelper"
 
 msgctxt "#30006"
 msgid "Due to distribution rights, [B]Widevine CDM[/B] has to be extracted from a Chrome OS recovery image. This process requires at least [B]{diskspace}[/B] of free disk space. Do you wish to continue?"
-msgstr "Wegens distributierechten moet [B]Widevine CDM[/B] worden uitgepakt uit een recovery-image van Chrome OS. Voor dit process is minimaal [B]{diskspace}[/B] vrije schijfruimte nodig. Wil je doorgaan?"
+msgstr "בגלל זכויות הפצה יש לחלץ את [B]Widevine CDM[/B] מתוך קובץ ההצלה של מערכת ההפעלה כרום. תהליך זה לוקח לפחות [B]{diskspace}[/B] של שטח אחסון. האם ברצונך להמשיך?"
 
 msgctxt "#30007"
 msgid "[B]Widevine CDM[/B] is unfortunately not available on this system architecture ([B]{arch}[/B])."
-msgstr "[B]Widevine CDM[/B] is helaas niet beschikbaar voor deze syteemarchitectuur ([B]{arch}[/B])."
+msgstr "לרוע המזל מודול [B]Widevine CDM[/B] אינו זמין עבור ארכיטקטורת המערכת הזו ([B]{arch}[/B])."
 
 msgctxt "#30008"
 msgid "[B]{addon}[/B] is missing on your Kodi install. This add-on is required to play this content."
-msgstr "[B]{addon}[/B] ontbreekt op deze Kodi-installatie. Deze add-on is nodig om deze video af te spelen."
+msgstr "ההרחבה [B]{addon}[/B] חסרה בהתקנת קודי שלך. הרחבה זו נדרשת כדי לנגן תוכן זה."
 
 msgctxt "#30009"
 msgid "[B]{addon}[/B] is not enabled. This add-on is required to play this content.[CR][CR]Would you like to enable [B]{addon}[/B]?"
-msgstr "[B]{addon}[/B] is niet ingeschakeld. Deze add-on is nodig om de video af te spelen.[CR][CR][B]{addon}[/B] inschakelen?"
+msgstr "ההרחבה [B]{addon}[/B] איננה מאופשרת. הרחבה זו נדרשת על מנת לנגן תוכן זה. האם ברצונך לאפשר את ההרחבה [B]{addon}[/B]?"
 
 msgctxt "#30010"
 msgid "[B]Kodi {version}[/B] or higher is required for [B]Widevine CDM[/B] content playback."
-msgstr "[B]Kodi {version}[/B] of hoger is nodig om met [B]Widevine CDM[/B] beschermde video's af te spelen."
+msgstr "גרסת קודי [B]{version}[/B] ומעלה נדרשת לניגון תוכן באמצעות [B]Widevine CDM[/B]."
 
 msgctxt "#30011"
 msgid "This operating system ([B]{os}[/B]) is not supported by [B]Widevine CDM[/B]."
-msgstr "Dit besturingssysteem ([B]{os}[/B] wordt niet ondersteund door [B]Widevine CDM[/B]."
+msgstr "מערכת ההפעלה [B]{os}[/B] איננה נתמכת על ידי [B]Widevine CDM[/B]."
 
 msgctxt "#30012"
 msgid "The Windows Store version of Kodi does not support [B]Widevine CDM[/B].[CR][CR]Please use the installer from kodi.tv instead."
-msgstr "De Windows Store versie van Kodi ondersteunt [B]Widevine CDM[/B] niet.[CR][CR]Gebruik de Windows-installer van kodi.tv."
+msgstr "גרסת חנות היישומים של חלונות (Windows Store) של קודי אינה תומכת ב-[B]Widevine CDM[/B].[CR][CR]נא להשתמש בכלי ההתקנה מאתר kodi.tv במקום זאת."
 
 msgctxt "#30013"
 msgid "Failed to retrieve [B]{filename}[/B]."
-msgstr "Het is niet gelukt om [B]{filename}[/B] op te halen."
+msgstr "שגיאה בשליפת הקובץ [B]{filename}[/B]."
 
 msgctxt "#30014"
 msgid "Download in progress..."
-msgstr "Bezig met downloaden..."
+msgstr "ההורדה מתבצעת..."
 
 msgctxt "#30015"
 msgid "Downloading [B]{filename}[/B]..."
-msgstr "[B]{filename}[/B] wordt gedownload..."
+msgstr "מוריד את הקובץ [B]{filename}[/B]..."
 
 msgctxt "#30016"
 msgid "Failed to extract [B]Widevine CDM[/B] from zip file."
-msgstr "Het uitpakken van [B]Widevine CDM[/B] uit het zip-bestand is mislukt."
+msgstr "שגיאה בחילוץ [B]Widevine CDM[/B] מקובץ zip."
 
 msgctxt "#30017"
 msgid "[B]{addon}[/B] {version} or later is required to play this content."
-msgstr "[B]{addon}[/B] {version} of later is nodig om deze video af te spelen."
+msgstr "ההרחבה [B]{addon}[/B] מגרסה {version} ומעלה נדרשת על מנת לנגן תוכן זה."
 
 msgctxt "#30018"
 msgid "You do not have enough free disk space to install [B]Widevine CDM[/B]. Free up at least [B]{diskspace}[/B] and try again."
-msgstr "Er is onvoldoende schijfruimte vrij om [B]Widevine CDM[/B] te installeren. Maak minstens [B]{diskspace}[/B] vrij en probeer het opnieuw."
+msgstr "אין מספיק שטח אחסון על מנת להתקין את  [B]Widevine CDM[/B]. יש לפנות לפחות [B]{diskspace}[/B] ולנסות שוב."
 
 msgctxt "#30019"
 msgid "This operating system ([B]{os}[/B]) is not supported by [B]Widevine CDM[/B] for ARM devices."
-msgstr "Dit besturingssysteem ([B]{os}[/B]) wordt niet ondersteund door [B]Widevine CDM[/B] voor ARM-apparaten."
+msgstr "מערכת ההפעלה הזו ([B]{os}[/B]) אינה נתמכת על ידי [B]Widevine CDM[/B] עבור התקני ARM."
 
 msgctxt "#30020"
 msgid "[B]'{command1}'[/B] or [B]'{command2}'[/B] command needs to exist on system to extract the [B]Widevine CDM[/B]."
-msgstr "Het commando [B]'{command1}'[/B] of [B]'{command2}'[/B] moet op het systeem aanwezig zijn om [B]Widevine CDM[/B] uit te pakken."
+msgstr "הפקודה [B]'{command1}'[/B] או [B]'{command2}'[/B] נדרשת כדי לחלץ את  [B]Widevine CDM[/B]."
 
 msgctxt "#30021"
 msgid "[B]'{command}'[/B] command needs to exist on system to extract the [B]Widevine CDM[/B]."
-msgstr "Het commando [B]'{command}'[/B] moet op het systeem aanwezig zijn om [B]Widevine CDM[/B] uit te pakken."
+msgstr "הפקודה [B]'{command}'[/B] נדרשת כדי לחלץ את [B]Widevine CDM[/B]."
 
 msgctxt "#30022"
 msgid "Downloading the Chrome OS recovery image..."
-msgstr "De recovery-image van Chrome OS wordt gedownload..."
+msgstr "מוריד את קובץ ההצלה של מערכת ההפעלה כרום..."
 
 msgctxt "#30023"
 msgid "Download completed!"
-msgstr "Klaar met downloaden!"
+msgstr "ההורדה הושלמה!"
 
 msgctxt "#30024"
 msgid "The installation now needs to unzip, mount and extract [B]Widevine CDM[/B] from the recovery image.[CR][CR]This process may take up to ten minutes to complete."
-msgstr "Voor de installatie moet de recovery-image worden gemount, worden gedecomprimeerd en moet [B]Widevine CDM[/B] worden uitgepakt.[CR][CR]Dit proces kan wel tien minuten duren."
+msgstr "על ההתקנה כעת לפרוש ולחלץ את [B]Widevine CDM[/B] מתוך קובץ ההצלה.[CR][CR]תהליך זה עשוי לקחת עד עשר דקות."
 
 msgctxt "#30025"
 msgid "Acquiring EULA."
-msgstr "Licentieovereenkomst wordt opgehaald"
+msgstr "מוריד הסכם רישיון למשתמש הקצה."
 
 msgctxt "#30026"
 msgid "Widevine CDM EULA"
-msgstr "Widevine CDM licentieovereenkomst"
+msgstr "הסכם רישיון למשתמש הקצה של Widevine CDM"
 
 msgctxt "#30027"
 msgid "I accept"
-msgstr "Akkoord"
+msgstr "אני מקבל/ת"
 
 msgctxt "#30028"
 msgid "Cancel"
-msgstr "Afbreken"
+msgstr "ביטול"
 
 msgctxt "#30029"
 msgid "OK"
-msgstr "OK"
+msgstr "אישור"
 
 msgctxt "#30030"
 msgid "The installation may need to run the following commands with root permissions: [B]{cmds}[/B]."
-msgstr "Voor de installatie zouden de volgende commando's met root-permissie kunnen worden uitgevoerd: [B]{cmds}[/B]."
+msgstr "ההתקנה עשויה להריץ את הפקודות הבאות בהרשאות root: [B]{cmds}[/B]."
 
 msgctxt "#30031"
 msgid "An update of [B]Widevine CDM[/B] is required to play this content."
-msgstr "Een update van [B]Widevine CDM[/B] is nodig voor het afspelen van deze video."
+msgstr "עדכון של [B]Widevine CDM[/B] נדרש על מנת לנגן תוכן זה."
 
 msgctxt "#30032"
 msgid "Your system is missing the following libraries required by Widevine CDM: [B]{libs}[/B]. Install the libraries to play this content."
-msgstr "De volgende libraries, die nodig zijn voor Widevine CDM, ontbreken op het systeem: [B]{libs}[/B]. Installeer deze libraries om deze video af te spelen."
+msgstr "במערכת שלך חסרים הספריות הבאות הנדרשות על ידי Widevine CDM: [B]{libs}[/B]. יש להתקין את הספריות על מנת לנגן תוכן זה."
 
 msgctxt "#30033"
 msgid "There is an update available for [B]Widevine CDM[/B]."
-msgstr "Er is een update voor [B]Widevine CDM[/B] beschikbaar."
+msgstr "יש עדכון זמין עבור המודול [B]Widevine CDM[/B]."
 
 msgctxt "#30034"
 msgid "Update"
-msgstr "Update"
+msgstr "לעדכן"
 
 msgctxt "#30035"
 msgid "[B]loop[/B] is still loaded"
-msgstr "[B]loop[/B] is nog steeds geladen."
+msgstr "המודול [B]loop[/B] עדיין טעון"
 
 msgctxt "#30036"
 msgid "Unload it by running [B]modprobe -r loop[/B] in the terminal."
-msgstr "Stop [B]loop[/B] door het volgende commando in een terminal te starten: [B]modprobe -r loop[/B]"
+msgstr "ניתן להסיר אותו באמצעות הפקודה [B]modprobe -r loop[/B] במסוף."
 
 msgctxt "#30037"
 msgid "Success!"
-msgstr "Gelukt!"
+msgstr "הצלחה!"
 
 msgctxt "#30038"
 msgid "Install Widevine"
-msgstr "Installeer Widevine"
+msgstr "התקנת Widevine"
 
 msgctxt "#30039"
 msgid "[B]Widevine CDM[/B] is currently not available natively on ARM64. Please switch to a 32-bit userspace for [B]Widevine CDM[/B] support."
-msgstr "[B]Widevine CDM[/B] is momenteel niet in een ARM64-versie beschikbaar. Gebruik een 32-bits omgeving om [B]Widevine CDM[/B] te kunnen gebruiken."
+msgstr "המודול [B]Widevine CDM[/B] איננו זמין עבור ARM64. יש להחליף ל-userspace של 32 סיביות עבור תמיכה ב-[B]Widevine CDM[/B]."
 
 msgctxt "#30040"
 msgid "Update available"
-msgstr "Update beschikbaar"
+msgstr "עדכון זמין"
 
 msgctxt "#30041"
 msgid "Widevine CDM is required"
-msgstr "Widevine CDM is vereist"
+msgstr "נדרש Widevine CDM"
 
 msgctxt "#30042"
 msgid "Using a SOCKS proxy requires the PySocks library (script.module.pysocks) installed."
-msgstr "Als u een SOCKS-proxy gebruikt, moet de PySocks-library (script.module.pysocks) geïnstalleerd zijn."
+msgstr "שימוש בפרוקסי מסוג SOCKS דורש התקנת ספריית PySocks (script.module.pysocks)."
 
 msgctxt "#30043"
 msgid "Extracting Widevine CDM"
-msgstr "Widevine CDM wordt uitgepakt"
+msgstr "מחלץ את Widevine CDM"
 
 msgctxt "#30044"
 msgid "Preparing downloaded image..."
-msgstr "De recovery-image wordt voorbereid..."
+msgstr "מכין את הקובץ שהורד..."
 
 msgctxt "#30045"
 msgid "Uncompressing image..."
-msgstr "De recovery-image wordt uitgepakt..."
+msgstr "פורש קובץ..."
 
 msgctxt "#30046"
 msgid "This may take several minutes."
-msgstr "Dit kan enkele minuten duren."
+msgstr "תהליך זה עשוי לקחת מספר דקות."
 
 msgctxt "#30047"
 msgid "[I]Please do not interrupt this process.[/I]"
-msgstr "[I]Onderbreek dit proces niet.[/I]"
+msgstr "[I]נא לא לעצור תהליך זה[/I]"
 
 msgctxt "#30048"
 msgid "Extracting Widevine CDM from image..."
-msgstr "Widevine CDM wordt van de recovery-image gehaald..."
+msgstr "מחלץ את Widevine CDM מתוך הקובץ..."
 
 msgctxt "#30049"
 msgid "Installing Widevine CDM..."
-msgstr "Widevine CDM wordt geïnstalleerd..."
+msgstr "מתקין את Widevine CDM..."
 
 msgctxt "#30050"
 msgid "Finishing..."
-msgstr "Beëindigen..."
+msgstr "מסיים..."
 
 msgctxt "#30051"
 msgid "[B]Widevine CDM[/B] successfully installed."
-msgstr "[B]Widevine CDM[/B] met succes geïnstalleerd."
+msgstr "מודול [B]Widevine CDM[/B] הותקן בהצלחה."
 
 msgctxt "#30052"
 msgid "[B]Widevine CDM[/B] successfully removed."
-msgstr "[B]Widevine CDM[/B] met succes verwijderd."
+msgstr "מודול [B]Widevine CDM[/B] הוסר בהצלחה."
 
 msgctxt "#30053"
 msgid "[B]Widevine CDM[/B] not found."
-msgstr "[B]Widevine CDM[/B] is niet gevonden."
+msgstr "[B]Widevine CDM[/B] לא נמצא."
 
 msgctxt "#30054"
 msgid "disabled"
-msgstr "uitgeschakeld"
+msgstr "מבוטל"
 
 msgctxt "#30055"
 msgid "There is not enough free disk space in the current temporary directory. Would you like to specify a different one to temporarily use for the Chrome OS Recovery Image (e.g. on a USB)?"
-msgstr "Er is onvoldoende vrije schijfruimte in de huidige tijdelijke map. Wilt u een andere map opgeven om tijdelijk te gebruiken voor de recovery-image van Chrome OS (bijvoorbeeld op een USB-stick)?"
+msgstr "אין מספיק שטח אחסון בתיקיה הזמנית הנוכחית. האם תרצה/י לבחור תיקיה אחרת לשימוש זמני עבור קובץ ההצלה של מערכת ההפעלה כרום (למשל על גבי USB)?"
 
 msgctxt "#30056"
 msgid "No backups found!"
-msgstr "Geen backups gevonden!"
+msgstr "לא נמצאו גיבויים!"
 
 msgctxt "#30057"
 msgid "Choose a backup to restore"
-msgstr "Kies een back-up om te herstellen"
+msgstr "בחר/י גיבוי לשחזור"
 
 msgctxt "#30058"
 msgid "Time remaining: {mins:d}:{secs:02d}"
-msgstr "Resterende tijd: {mins:d}:{secs:02d}"
+msgstr "הזמן שנותר: {mins:d}:{secs:02d}"
 
 msgctxt "#30059"
 msgid "Meanwhile, should we try extracting Widevine CDM using the legacy method?"
-msgstr "Moeten we ondertussen Widevine CDM proberen uit te pakken met de legacy-methode?"
+msgstr "בינתיים, האם לנסות לחלץ את Widevine CDM בשיטה הישנה?"
 
 msgctxt "#30060"
 msgid "Identifying wanted partition..."
-msgstr "Bezig met de gewenste partitie te identificeren..."
+msgstr "מזהה את המחיצה המבוקשת..."
 
 msgctxt "#30061"
 msgid "Scanning the filesystem for the Widevine CDM..."
-msgstr "Bezig met het bestandssysteem te scannen op Widevine CDM..."
+msgstr "סורק את מערכת הקבצים עבור Widevine CDM"
 
 msgctxt "#30062"
 msgid "Widevine CDM found, analyzing..."
-msgstr "Widevine CDM gevonden, bezig met analyseren..."
+msgstr "המודול Widevine CDM נמצא, מנתח..."
 
 msgctxt "#30063"
 msgid "Could not make the request. Your internet may be down."
-msgstr "Het verzoek kan niet verstuurd worden. Uw internetverbinding is mogelijk niet beschikbaar."
+msgstr "לא ניתן לבצע את הבקשה. האינטרנט שלך עשוי להיות מנותק."
 
 msgctxt "#30064"
 msgid "Could not finish the download."
-msgstr "Het downloaden kan niet voltooid worden."
+msgstr "לא ניתן להשלים את ההורדה."
 
 msgctxt "#30065"
 msgid "Shall we try again?"
-msgstr "Zullen we het opnieuw proberen?"
+msgstr "לנסות שוב?"
 
-
-### INFORMATION DIALOG
+# ## INFORMATION DIALOG
 msgctxt "#30800"
 msgid "[B]Kodi[/B] version [B]{version}[/B] is running on a [B]{system}[/B] system with [B]{arch}[/B] architecture."
-msgstr "[B]Kodi[/B] versie [B]{version}[/B] draait op een [B]{system}[/B] systeem met [B]{arch}[/B] architectuur."
+msgstr "[B]קודי[/B] מגרסה [B]{version}[/B] רץ על מערכת [B]{system}[/B] עם ארכיטקטורה [B]{arch}[/B]."
 
 msgctxt "#30810"
 msgid "[B]InputStream Helper[/B] is at version [B]{version}[/B] {state}"
-msgstr "[B]InputStream Helper[/B] is versie [B]{version}[/B] {state}"
+msgstr "[B]InputStream Helper[/B] בגרסה [B]{version}[/B] {state}"
 
 msgctxt "#30811"
 msgid "[B]InputStream Adaptive[/B] is at version [B]{version}[/B] {state}"
-msgstr "[B]InputStream Adaptive[/B] is versie [B]{version}[/B] {state}"
+msgstr "[B]InputStream Helper[/B] בגרסה [B]{version}[/B] {state}"
 
 msgctxt "#30820"
 msgid "[B]Widevine CDM[/B] is [B]built into Android[/B]"
-msgstr "[B]Widevine CDM[/B] is [B]ingebouwd in Android[/B]"
+msgstr "המודול [B]Widevine CDM[/B] הוא חלק [B]מובנה באנדרואיד[/B]"
 
 msgctxt "#30821"
 msgid "[B]Widevine CDM[/B] is at version [B]{version}[/B] and was installed on [B]{date}[/B]"
-msgstr "[B]Widevine CDM[/B] is versie [B]{version}[/B] en werd geïnstalleerd op [B]{date}[/B]"
+msgstr "המודול [B]Widevine CDM[/B] מגרסה [B]{version}[/B] הותקן בתאריך [B]{date}[/B]"
 
 msgctxt "#30822"
 msgid "It was extracted from Chrome OS image [B]{name}[/B] with version [B]{version}[/B]"
-msgstr "Het werd uitgepakt uit Chrome OS image [B]{name}[/B] met versie [B]{version}[/B]"
+msgstr "חולץ מתוך קובץ מערכת ההפעלה כרום [B]{name}[/B] מגרסה [B]{version}[/B]"
 
 msgctxt "#30823"
 msgid "It was last checked for updates on [B]{date}[/B]"
-msgstr "Het werd laatste gecontroleerd op [B]{date}[/B]"
+msgstr "נבדק לזמינות עדכונים בפעם האחרונה בתאריך [B]{date}[/B]"
 
 msgctxt "#30824"
 msgid "It is installed at [B]{path}[/B]"
-msgstr "Het is geïnstalleerd in [B]{path}[/B]"
+msgstr "הותקן ב-[B]{path}[/B]"
 
 msgctxt "#30830"
 msgid "Please report issues to: [COLOR yellow]{url}[/COLOR]"
-msgstr "Gelieve problemen te melden op: [COLOR yellow]{url}[/COLOR]"
+msgstr "נא לדווח על שגיאות אל: [COLOR yellow]{url}[/COLOR]"
 
-
-### SETTINGS
+# ## SETTINGS
 msgctxt "#30900"
 msgid "Expert"
-msgstr "Expert"
+msgstr "מומחה"
 
 msgctxt "#30901"
 msgid "InputStream Helper information"
-msgstr "InputStream Helper informatie"
+msgstr "מידע InputStream Helper"
 
 msgctxt "#30903"
 msgid "Disable InputStream Helper"
-msgstr "InputStream Helper uitschakelen"
+msgstr "ביטול InputStream Helper"
 
 msgctxt "#30904"
 msgid "[I]When disabled, DRM playback may fail![/I]"
-msgstr "[I]Indien uitgeschakeld kan de weergave van DRM-content mislukken![/I]"
+msgstr "[I]כאשר מבוטל, ניגון של תוכן מוגן בזכויות יוצרים (DRM) עשוי להיכשל![/I]"
 
 msgctxt "#30905"
 msgid "Update frequency in days"
-msgstr "Updatefrequentie in dagen"
+msgstr "תדירות עדכון בימים"
 
 msgctxt "#30907"
 msgid "Temporary download directory"
-msgstr "Tijdelijke download-folder"
+msgstr "תיקיית הורדה זמנית"
 
 msgctxt "#30909"
 msgid "(Re)install Widevine CDM library..."
-msgstr "Widevine CDM (her-)installeren..."
+msgstr "התקנה (מחדש) של ספריית Widevine CDM..."
 
 msgctxt "#30911"
 msgid "Remove Widevine CDM library..."
-msgstr "Widevine CDM verwijderen..."
+msgstr "הסרת ספריית Widevine CDM..."
 
 msgctxt "#30913"
 msgid "Number of backups"
-msgstr "Aantal backups"
+msgstr "מספר הגיבויים"
 
 msgctxt "#30915"
 msgid "Restore Widevine CDM library..."
-msgstr "Herstel Widevine CDM..."
+msgstr "שחזור ספריית Widevine CDM..."

--- a/script.module.inputstreamhelper/resources/language/resource.language.ja_jp/strings.po
+++ b/script.module.inputstreamhelper/resources/language/resource.language.ja_jp/strings.po
@@ -6,345 +6,345 @@ msgstr ""
 "POT-Creation-Date: 2013-11-18 16:15+0000\n"
 "PO-Revision-Date: 2019-12-07 14:00+0900\n"
 "Last-Translator: Allen Choi<37539914+Thunderbird2086@users.noreply.github.com>\n"
-"Language-Team: Korean\n"
+"Language-Team: Japanese\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: ko\n"
+"Language: ja\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
 
 msgctxt "#30001"
 msgid "Information"
-msgstr "알림"
+msgstr "情報"
 
 msgctxt "#30002"
 msgid "This add-on relies on the proprietary decryption module [B]Widevine CDM[/B] for playback."
-msgstr "이 애드온은 독점복호화 모듈인 [B]Widevine CDM[/B]을 사용합니다."
+msgstr "このアドオンは、独占復号化モデュールである[B]Widevine CDM[/B]を使います。"
 
 msgctxt "#30004"
 msgid "Error"
-msgstr "오류"
+msgstr "エラー"
 
 msgctxt "#30005"
 msgid "An error occurred while installing [B]Widevine CDM[/B]. Please enable debug logging and file a bug report at:[CR][CR]github.com/emilsvennesson/script.module.inputstreamhelper"
-msgstr "[B]Widevine CDM[/B]을 설치 중 오류가 있었습니다. 디버깅 모드로 바꾼 후 로그 화일을 보내주십시오:[CR][CR]github.com/emilsvennesson/script.module.inputstreamhelper"
+msgstr "[B]Widevine CDM[/B]をインストール中にエラー発生しました。デバッグモードにしてログと一緒に報告してください:[CR][CR]github.com/emilsvennesson/script.module.inputstreamhelper"
 
 msgctxt "#30006"
 msgid "Due to distribution rights, [B]Widevine CDM[/B] has to be extracted from a Chrome OS recovery image. This process requires at least [B]{diskspace}[/B] of free disk space. Do you wish to continue?"
-msgstr "배포권리 때문에, [B]Widevine CDM[/B]을 크롬OS리커버리 이미지로부터 뽑아내야하며, 최소 [B]{diskspace}[/B]의 여유공간이 필요합니다. 계속 하시렵니까?"
+msgstr "配給権の理由で、[B]Widevine CDM[/B]をChrome OSのリカバリイメージから抽出しなければなりません。このため[B]{diskspace}[/B]以上の空き容量が必要です。続きますか。"
 
 msgctxt "#30007"
 msgid "[B]Widevine CDM[/B] is unfortunately not available on this system architecture ([B]{arch}[/B])."
-msgstr "이 시스템에 알맞은 [B]Widevine CDM[/B]이 없습니다 ([B]{arch}[/B])."
+msgstr "このシステムにて使用可能な[B]Widevine CDM[/B]はありません。([B]{arch}[/B])"
 
 msgctxt "#30008"
 msgid "[B]{addon}[/B] is missing on your Kodi install. This add-on is required to play this content."
-msgstr "이 컨텐츠를 재생하는 데 필요한 [B]{addon}[/B]이(가) 없군요."
+msgstr "このコンテンツを再生するため必要な[B]{addon}[/B]が見つかりません。"
 
 msgctxt "#30009"
 msgid "[B]{addon}[/B] is not enabled. This add-on is required to play this content.[CR][CR]Would you like to enable [B]{addon}[/B]?"
-msgstr "이 컨텐츠를 재생하는 데 필요한 [B]{addon}[/B]이(가) 사용하지 않음으로 되어 있네요.[CR][CR][B]{addon}[/B]을(를) 사용함으로 바꿀까요?"
+msgstr "このコンテンツを再生するため必要な[B]{addon}[/B]が使えない状態です。[CR][CR][B]{addon}[/B]を使いましょうか。"
 
 msgctxt "#30010"
 msgid "[B]Kodi {version}[/B] or higher is required for [B]Widevine CDM[/B] content playback."
-msgstr "[B]Widevine CDM[/B] 컨텐츠를 재생하려면 [B]Kodi {version}[/B] 혹은 그 이상이 필요합니다."
+msgstr "[B]Widevine CDM[/B]コンテンツを再生するため、[B]Kodi {version}[/B]以後が必要です。"
 
 msgctxt "#30011"
 msgid "This operating system ([B]{os}[/B]) is not supported by [B]Widevine CDM[/B]."
-msgstr "[B]Widevine CDM[/B]은 이 운영체제([B]{os}[/B])을(를) 지원하지 않습니다."
+msgstr "[B]Widevine CDM[/B]はこのシステム([B]{os}[/B])に対応しません。"
 
 msgctxt "#30012"
 msgid "The Windows Store version of Kodi does not support [B]Widevine CDM[/B].[CR][CR]Please use the installer from kodi.tv instead."
-msgstr "마이크로소프트 스토어의 Kodi는 [B]Widevine CDM[/B]을 사용할 수 없습니다.[CR][CR]kodi.tv로부터 설치하여 주십시오."
+msgstr "MicrosoftストアのKodiは[B]Widevine CDM[/B]を対応しません。[CR][CR]kodi.tvのインストーラを使ってください。"
 
 msgctxt "#30013"
 msgid "Failed to retrieve [B]{filename}[/B]."
-msgstr "[B]{filename}[/B]을(를) 뽑아내지 못했습니다."
+msgstr "[B]{filename}[/B]の抽出を失敗しました。"
 
 msgctxt "#30014"
 msgid "Download in progress..."
-msgstr "내려받고 있는 중..."
+msgstr "ダウンロード中。。。"
 
 msgctxt "#30015"
 msgid "Downloading [B]{filename}[/B]..."
-msgstr "[B]{filename}[/B]을(를) 내려받고 있는 중..."
+msgstr "[B]{filename}[/B]をダウンロード中。。。"
 
 msgctxt "#30016"
 msgid "Failed to extract [B]Widevine CDM[/B] from zip file."
-msgstr "[B]Widevine CDM[/B]을 풀어내지 못했습니다."
+msgstr "圧縮ファイルから[B]Widevine CDM[/B]の抽出を失敗しました。"
 
 msgctxt "#30017"
 msgid "[B]{addon}[/B] {version} or later is required to play this content."
-msgstr "{version} 이상의 [B]{addon}[/B]이 필요합니다."
+msgstr "このコンテンツを再生するには{version}以後の[B]{addon}[/B]が必要です。"
 
 msgctxt "#30018"
 msgid "You do not have enough free disk space to install [B]Widevine CDM[/B]. Free up at least [B]{diskspace}[/B] and try again."
-msgstr "[B]Widevine CDM[/B]을 설치할 만한 공간이 없으니, [B]{diskspace}[/B]을 확보한 후 다시 하십시오."
+msgstr "[B]Widevine CDM[/B]をインストールする充分はスペースがありません。[B]{diskspace}[/B]以上の空き容量を確保してからやり直してください。"
 
 msgctxt "#30019"
 msgid "This operating system ([B]{os}[/B]) is not supported by [B]Widevine CDM[/B] for ARM devices."
-msgstr "[B]Widevine CDM[/B]은 이 운영체제([B]{os}[/B])을(를) 지원하지 않습니다."
+msgstr "[B]Widevine CDM[/B]は、このOS([B]{os}[/B])を対応しません。"
 
 msgctxt "#30020"
 msgid "[B]'{command1}'[/B] or [B]'{command2}'[/B] command needs to exist on system to extract the [B]Widevine CDM[/B]."
-msgstr "[B]Widevine CDM[/B]을 뽑아 내기 위해서 [B]'{command1}'[/B] 또는 [B]'{command2}'[/B] 커맨드가 있어야합니다."
+msgstr "[B]Widevine CDM[/B]を抽出するため、[B]'{command1}'[/B]又は[B]'{command2}'[/B]コマンドが必要です。"
 
 msgctxt "#30021"
 msgid "[B]'{command}'[/B] command needs to exist on system to extract the [B]Widevine CDM[/B]."
-msgstr "[B]Widevine CDM[/B]을 뽑아 내기 위해서 [B]'{command}'[/B] 커맨드가 있어야합니다."
+msgstr "[B]Widevine CDM[/B]を抽出するため、[B]'{command}'[/B]コマンドが必要です。"
 
 msgctxt "#30022"
 msgid "Downloading the Chrome OS recovery image..."
-msgstr "크롬OS복구 이미지를 다운로드 중..."
+msgstr "Chrome OSリカバリイメージをダウンロード中。。。"
 
 msgctxt "#30023"
 msgid "Download completed!"
-msgstr "다운로드 끝!"
+msgstr "ダウンロード完了！"
 
 msgctxt "#30024"
 msgid "The installation now needs to unzip, mount and extract [B]Widevine CDM[/B] from the recovery image.[CR][CR]This process may take up to ten minutes to complete."
-msgstr "설치를 위해서 압축해제를 하고, 복구 이미지를 마운트하여 [B]Widevine CDM[/B]을 뽑아냅니다.[CR][CR]약 10분 정도 걸릴 것입니다."
+msgstr "インストールのため、リカバリイメージを解凍し、マウントして[B]Widevine CDM[/B]を抽出します。[CR][CR]完了まで10分ほど掛かります。"
 
 msgctxt "#30025"
 msgid "Acquiring EULA."
-msgstr "사용자 동의서를 가져오는 중"
+msgstr "ソフトウェア利用許諾契約取得中"
 
 msgctxt "#30026"
 msgid "Widevine CDM EULA"
-msgstr "Widevine CDM 사용자 동의서"
+msgstr "Widevine CDMのソフトウェア利用許諾契約"
 
 msgctxt "#30027"
 msgid "I accept"
-msgstr "동의하오"
+msgstr "了解"
 
 msgctxt "#30028"
 msgid "Cancel"
-msgstr "싫소이다"
+msgstr "キャンセル"
 
 msgctxt "#30029"
 msgid "OK"
-msgstr "좋소"
+msgstr "オッケー"
 
 msgctxt "#30030"
 msgid "The installation may need to run the following commands with root permissions: [B]{cmds}[/B]."
-msgstr "설치를 위해 루트유저의 권한이 필요합니다: [B]{cmds}[/B]。"
+msgstr "インストールのため、スパユーザの権限が必要です: [B]{cmds}[/B]。"
 
 msgctxt "#30031"
 msgid "An update of [B]Widevine CDM[/B] is required to play this content."
-msgstr "콘텐츠를 재생하려면 [B]Widevine CDM[/B]을 업데이트 하십시오."
+msgstr "コンテンツを再生するため[B]Widevine CDM[/B]をアップデートしてください。"
 
 msgctxt "#30032"
 msgid "Your system is missing the following libraries required by Widevine CDM: [B]{libs}[/B]. Install the libraries to play this content."
-msgstr "Widevine CDM에 필요한 라이브러리가 없습니다: [B]{libs}[/B]."
+msgstr "Widevine CDMに必要なライブラリが見つかりません: [B]{libs}[/B]."
 
 msgctxt "#30033"
 msgid "There is an update available for [B]Widevine CDM[/B]."
-msgstr "[B]Widevine CDM[/B] 업데이트가 있습니다."
+msgstr "[B]Widevine CDM[/B]のアップデートが可能です。"
 
 msgctxt "#30034"
 msgid "Update"
-msgstr "업데이트"
+msgstr "アップデート"
 
 msgctxt "#30035"
 msgid "[B]loop[/B] is still loaded"
-msgstr "[B]loop[/B]이 아직 올라와 있습니다 "
+msgstr "[B]loop[/B]がまだロードされている。"
 
 msgctxt "#30036"
 msgid "Unload it by running [B]modprobe -r loop[/B] in the terminal."
-msgstr "터미널에서 [B]modprobe -r loop[/B]을 이용하여 내리십시오."
+msgstr "アンロードするには、ターミナルで[B]modprobe -r loop[/B]を実行してください。"
 
 msgctxt "#30037"
 msgid "Success!"
-msgstr "성공!"
+msgstr "成功！"
 
 msgctxt "#30038"
 msgid "Install Widevine"
-msgstr "Widevine 설치"
+msgstr "Widevineインストール"
 
 msgctxt "#30039"
 msgid "[B]Widevine CDM[/B] is currently not available natively on ARM64. Please switch to a 32-bit userspace for [B]Widevine CDM[/B] support."
-msgstr "현재 ARM64에서는 [B]Widevine CDM[/B]을 사용할 수 없습니다. [B]Widevine CDM[/B]을 사용하려면 32비트모드로 바꾸시지요."
+msgstr "現在、[B]Widevine CDM[/B]はARM64を対応しません。[B]Widevine CDM[/B]を使うには、32ビットモドに切り替えてください。"
 
 msgctxt "#30040"
 msgid "Update available"
-msgstr "업데이트가 있습니다"
+msgstr "アップデート可能"
 
 msgctxt "#30041"
 msgid "Widevine CDM is required"
-msgstr "Widevine CDM이 필요합니다"
+msgstr "Widevine CDMが必要です。"
 
 msgctxt "#30042"
 msgid "Using a SOCKS proxy requires the PySocks library (script.module.pysocks) installed."
-msgstr "SOCKS프락시를 사용하려면 PySocks라이브러리(script.module.pysocks)가 필요합니다."
+msgstr "SOCKSプロキシを使うため、PySocksライブラリ(script.module.pysocks)が必要です。"
 
 msgctxt "#30043"
 msgid "Extracting Widevine CDM"
-msgstr "Widevine CDM을 뽑아냅니다."
+msgstr "Widevine CDM抽出"
 
 msgctxt "#30044"
 msgid "Preparing downloaded image..."
-msgstr "다운로드한 이미지를 준비 중..."
+msgstr "イメージダウンロード中"
 
 msgctxt "#30045"
 msgid "Uncompressing image..."
-msgstr "이미지를 풀어 내는 중..."
+msgstr "イメージを解凍中。。。"
 
 msgctxt "#30046"
 msgid "This may take several minutes."
-msgstr "시간이 조금 걸립니다."
+msgstr "少し時間掛かります。"
 
 msgctxt "#30047"
 msgid "[I]Please do not interrupt this process.[/I]"
-msgstr "[I]가만히 두시는 것이 좋습니다.[/I]"
+msgstr "[I]このままお待ち下さい。[/I]"
 
 msgctxt "#30048"
 msgid "Extracting Widevine CDM from image..."
-msgstr "이미지로부터 Widevine CDM을 뽑아내는 중..."
+msgstr "イメージからWidevine CDMを抽出中。。。"
 
 msgctxt "#30049"
 msgid "Installing Widevine CDM..."
-msgstr "Widevine CDM 설치 중..."
+msgstr "Widevine CDMをインストール中。。。"
 
 msgctxt "#30050"
 msgid "Finishing..."
-msgstr "마무리 중..."
+msgstr "仕上げ中。。。"
 
 msgctxt "#30051"
 msgid "[B]Widevine CDM[/B] successfully installed."
-msgstr "[B]Widevine CDM[/B]을 설치했습니다."
+msgstr "[B]Widevine CDM[/B]をインストールしました。"
 
 msgctxt "#30052"
 msgid "[B]Widevine CDM[/B] successfully removed."
-msgstr "[B]Widevine CDM[/B]을 지웠습니다."
+msgstr "[B]Widevine CDM[/B]を削除しました。"
 
 msgctxt "#30053"
 msgid "[B]Widevine CDM[/B] not found."
-msgstr "[B]Widevine CDM[/B]이 없군요."
+msgstr "[B]Widevine CDM[/B]が無いようです。"
 
 msgctxt "#30054"
 msgid "disabled"
-msgstr "사용하지 않습니다."
+msgstr "使わない"
 
 msgctxt "#30055"
 msgid "There is not enough free disk space in the current temporary directory. Would you like to specify a different one to temporarily use for the Chrome OS Recovery Image (e.g. on a USB)?"
-msgstr "임시 저장소에 충분한 공간이 없습니다. 크롬OS복구 이미지를 USB 같은 다른 임시저장소에 저장하시렵니까?"
+msgstr "充分は空き容量がありません。Chrome OSリカバリイメージをUSBのような別の一時ストレジに保存ましょうか。"
 
 msgctxt "#30056"
 msgid "No backups found!"
-msgstr "저런! 백업이 없어요!"
+msgstr "バックアップがありませんよ!"
 
 msgctxt "#30057"
 msgid "Choose a backup to restore"
-msgstr "복구할 백업을 고르시지요"
+msgstr "バックアップを選んでください"
 
 msgctxt "#30058"
 msgid "Time remaining: {mins:d}:{secs:02d}"
-msgstr ""
+msgstr "残り時間: {mins:d}:{secs:02d}"
 
 msgctxt "#30059"
 msgid "Meanwhile, should we try extracting Widevine CDM using the legacy method?"
-msgstr ""
+msgstr "そしたら、Widevine CDMを既存の方法で抽出しましょうか。"
 
 msgctxt "#30060"
 msgid "Identifying wanted partition..."
-msgstr ""
+msgstr "パーティション確認中。。。"
 
 msgctxt "#30061"
 msgid "Scanning the filesystem for the Widevine CDM..."
-msgstr ""
+msgstr "Widevine CDMのためのファイルシステムをスキャン中。。。"
 
 msgctxt "#30062"
 msgid "Widevine CDM found, analyzing..."
-msgstr ""
+msgstr "Widevine CDMを見つけました、分析中。。。"
 
 msgctxt "#30063"
 msgid "Could not make the request. Your internet may be down."
-msgstr ""
+msgstr "リクエスト失敗。インタネット繋がってないかも"
 
 msgctxt "#30064"
 msgid "Could not finish the download."
-msgstr ""
+msgstr "ダウンロードを終えませんでした。"
 
 msgctxt "#30065"
 msgid "Shall we try again?"
-msgstr ""
+msgstr "もう一度やって見ましょうか。"
 
 
 ### INFORMATION DIALOG
 msgctxt "#30800"
 msgid "[B]Kodi[/B] version [B]{version}[/B] is running on a [B]{system}[/B] system with [B]{arch}[/B] architecture."
-msgstr ""
+msgstr "[B]Kodi[/B]バージョン[B]{version}[/B]がアーキテクチャ[B]{arch}[/B]のシステム[B]{system}[/B]の上で実行中です。"
 
 msgctxt "#30810"
 msgid "[B]InputStream Helper[/B] is at version [B]{version}[/B] {state}"
-msgstr ""
+msgstr "[B]InputStream Helper[/B]のバージョン [B]{version}[/B] {state}"
 
 msgctxt "#30811"
 msgid "[B]InputStream Adaptive[/B] is at version [B]{version}[/B] {state}"
-msgstr ""
+msgstr "[B]InputStream Adaptive[/B]のバージョン [B]{version}[/B] {state}"
 
 msgctxt "#30820"
 msgid "[B]Widevine CDM[/B] is [B]built into Android[/B]"
-msgstr ""
+msgstr "[B]Android[/B]に入っています。"
 
 msgctxt "#30821"
 msgid "[B]Widevine CDM[/B] is at version [B]{version}[/B] and was installed on [B]{date}[/B]"
-msgstr ""
+msgstr "[B]Widevine CDM[/B]のバージョンは[B]{version}[/B]であり、[B]{date}[/B]にインストールしました。"
 
 msgctxt "#30822"
 msgid "It was extracted from Chrome OS image [B]{name}[/B] with version [B]{version}[/B]"
-msgstr ""
+msgstr "Chrom OSのイメージ[B]{name}[/B]のバージョン[B]{version}[/B]から抽出しました。"
 
 msgctxt "#30823"
 msgid "It was last checked for updates on [B]{date}[/B]"
-msgstr ""
+msgstr "[B]{date}[/B]に最新アップデートをチェックしました。"
 
 msgctxt "#30824"
 msgid "It is installed at [B]{path}[/B]"
-msgstr ""
+msgstr "[B]{path}[/B]にインストールしました。"
 
 msgctxt "#30830"
 msgid "Please report issues to: [COLOR yellow]{url}[/COLOR]"
-msgstr "문제가 있으면 이쪽으로: [COLOR yellow]{url}[/COLOR]"
+msgstr "問題があったらここへ： [COLOR yellow]{url}[/COLOR]"
 
 
 ### SETTINGS
 msgctxt "#30900"
 msgid "Expert"
-msgstr "전문가"
+msgstr "エキスパート"
 
 msgctxt "#30901"
 msgid "InputStream Helper information"
-msgstr "InputStream Helper 정보"
+msgstr "インプットストリームヘルパー情報"
 
 msgctxt "#30903"
 msgid "Disable InputStream Helper"
-msgstr "InputStream Helper를 사용하지 않습니다."
+msgstr "インプットストリームヘルパーを使わない"
 
 msgctxt "#30904"
 msgid "[I]When disabled, DRM playback may fail![/I]"
-msgstr "[I]사용하지 않음으로 하면, DRM 재생이 안될 수도 있습니다![/I]"
+msgstr "[I]使わないと、DRM再生が出来ません！[/I]"
 
 msgctxt "#30905"
 msgid "Update frequency in days"
-msgstr "며칠에 한번씩 업데이트를 확인할까요?"
+msgstr "何日毎に更新を確認しましょうか。"
 
 msgctxt "#30907"
 msgid "Temporary download directory"
-msgstr "임시 저장소"
+msgstr "ダウンロードフォルダ"
 
 msgctxt "#30909"
 msgid "(Re)install Widevine CDM library..."
-msgstr "Widevind CDM 라이브러리를 (다시) 설치..."
+msgstr "Widevind CDMライブラリの(再)インストール"
 
 msgctxt "#30911"
 msgid "Remove Widevine CDM library..."
-msgstr "Widevine CDM 라이브러리 제거..."
+msgstr "Widevine CDMライブラリを削除。。。"
 
 msgctxt "#30913"
 msgid "Number of backups"
-msgstr "몇개를 백업할까요?"
+msgstr "バックアップ数"
 
 msgctxt "#30915"
 msgid "Restore Widevine CDM library..."
-msgstr ""
+msgstr "Widevine CDMライブラリ修復..."

--- a/script.module.inputstreamhelper/resources/language/resource.language.ko_kr/strings.po
+++ b/script.module.inputstreamhelper/resources/language/resource.language.ko_kr/strings.po
@@ -6,345 +6,345 @@ msgstr ""
 "POT-Creation-Date: 2013-11-18 16:15+0000\n"
 "PO-Revision-Date: 2019-12-07 14:00+0900\n"
 "Last-Translator: Allen Choi<37539914+Thunderbird2086@users.noreply.github.com>\n"
-"Language-Team: Japanese\n"
+"Language-Team: Korean\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: ja\n"
+"Language: ko\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
 
 msgctxt "#30001"
 msgid "Information"
-msgstr "情報"
+msgstr "알림"
 
 msgctxt "#30002"
 msgid "This add-on relies on the proprietary decryption module [B]Widevine CDM[/B] for playback."
-msgstr "このアドオンは、独占復号化モデュールである[B]Widevine CDM[/B]を使います。"
+msgstr "이 애드온은 독점복호화 모듈인 [B]Widevine CDM[/B]을 사용합니다."
 
 msgctxt "#30004"
 msgid "Error"
-msgstr "エラー"
+msgstr "오류"
 
 msgctxt "#30005"
 msgid "An error occurred while installing [B]Widevine CDM[/B]. Please enable debug logging and file a bug report at:[CR][CR]github.com/emilsvennesson/script.module.inputstreamhelper"
-msgstr "[B]Widevine CDM[/B]をインストール中にエラー発生しました。デバッグモードにしてログと一緒に報告してください:[CR][CR]github.com/emilsvennesson/script.module.inputstreamhelper"
+msgstr "[B]Widevine CDM[/B]을 설치 중 오류가 있었습니다. 디버깅 모드로 바꾼 후 로그 화일을 보내주십시오:[CR][CR]github.com/emilsvennesson/script.module.inputstreamhelper"
 
 msgctxt "#30006"
 msgid "Due to distribution rights, [B]Widevine CDM[/B] has to be extracted from a Chrome OS recovery image. This process requires at least [B]{diskspace}[/B] of free disk space. Do you wish to continue?"
-msgstr "配給権の理由で、[B]Widevine CDM[/B]をChrome OSのリカバリイメージから抽出しなければなりません。このため[B]{diskspace}[/B]以上の空き容量が必要です。続きますか。"
+msgstr "배포권리 때문에, [B]Widevine CDM[/B]을 크롬OS리커버리 이미지로부터 뽑아내야하며, 최소 [B]{diskspace}[/B]의 여유공간이 필요합니다. 계속 하시렵니까?"
 
 msgctxt "#30007"
 msgid "[B]Widevine CDM[/B] is unfortunately not available on this system architecture ([B]{arch}[/B])."
-msgstr "このシステムにて使用可能な[B]Widevine CDM[/B]はありません。([B]{arch}[/B])"
+msgstr "이 시스템에 알맞은 [B]Widevine CDM[/B]이 없습니다 ([B]{arch}[/B])."
 
 msgctxt "#30008"
 msgid "[B]{addon}[/B] is missing on your Kodi install. This add-on is required to play this content."
-msgstr "このコンテンツを再生するため必要な[B]{addon}[/B]が見つかりません。"
+msgstr "이 컨텐츠를 재생하는 데 필요한 [B]{addon}[/B]이(가) 없군요."
 
 msgctxt "#30009"
 msgid "[B]{addon}[/B] is not enabled. This add-on is required to play this content.[CR][CR]Would you like to enable [B]{addon}[/B]?"
-msgstr "このコンテンツを再生するため必要な[B]{addon}[/B]が使えない状態です。[CR][CR][B]{addon}[/B]を使いましょうか。"
+msgstr "이 컨텐츠를 재생하는 데 필요한 [B]{addon}[/B]이(가) 사용하지 않음으로 되어 있네요.[CR][CR][B]{addon}[/B]을(를) 사용함으로 바꿀까요?"
 
 msgctxt "#30010"
 msgid "[B]Kodi {version}[/B] or higher is required for [B]Widevine CDM[/B] content playback."
-msgstr "[B]Widevine CDM[/B]コンテンツを再生するため、[B]Kodi {version}[/B]以後が必要です。"
+msgstr "[B]Widevine CDM[/B] 컨텐츠를 재생하려면 [B]Kodi {version}[/B] 혹은 그 이상이 필요합니다."
 
 msgctxt "#30011"
 msgid "This operating system ([B]{os}[/B]) is not supported by [B]Widevine CDM[/B]."
-msgstr "[B]Widevine CDM[/B]はこのシステム([B]{os}[/B])に対応しません。"
+msgstr "[B]Widevine CDM[/B]은 이 운영체제([B]{os}[/B])을(를) 지원하지 않습니다."
 
 msgctxt "#30012"
 msgid "The Windows Store version of Kodi does not support [B]Widevine CDM[/B].[CR][CR]Please use the installer from kodi.tv instead."
-msgstr "MicrosoftストアのKodiは[B]Widevine CDM[/B]を対応しません。[CR][CR]kodi.tvのインストーラを使ってください。"
+msgstr "마이크로소프트 스토어의 Kodi는 [B]Widevine CDM[/B]을 사용할 수 없습니다.[CR][CR]kodi.tv로부터 설치하여 주십시오."
 
 msgctxt "#30013"
 msgid "Failed to retrieve [B]{filename}[/B]."
-msgstr "[B]{filename}[/B]の抽出を失敗しました。"
+msgstr "[B]{filename}[/B]을(를) 뽑아내지 못했습니다."
 
 msgctxt "#30014"
 msgid "Download in progress..."
-msgstr "ダウンロード中。。。"
+msgstr "내려받고 있는 중..."
 
 msgctxt "#30015"
 msgid "Downloading [B]{filename}[/B]..."
-msgstr "[B]{filename}[/B]をダウンロード中。。。"
+msgstr "[B]{filename}[/B]을(를) 내려받고 있는 중..."
 
 msgctxt "#30016"
 msgid "Failed to extract [B]Widevine CDM[/B] from zip file."
-msgstr "圧縮ファイルから[B]Widevine CDM[/B]の抽出を失敗しました。"
+msgstr "[B]Widevine CDM[/B]을 풀어내지 못했습니다."
 
 msgctxt "#30017"
 msgid "[B]{addon}[/B] {version} or later is required to play this content."
-msgstr "このコンテンツを再生するには{version}以後の[B]{addon}[/B]が必要です。"
+msgstr "{version} 이상의 [B]{addon}[/B]이 필요합니다."
 
 msgctxt "#30018"
 msgid "You do not have enough free disk space to install [B]Widevine CDM[/B]. Free up at least [B]{diskspace}[/B] and try again."
-msgstr "[B]Widevine CDM[/B]をインストールする充分はスペースがありません。[B]{diskspace}[/B]以上の空き容量を確保してからやり直してください。"
+msgstr "[B]Widevine CDM[/B]을 설치할 만한 공간이 없으니, [B]{diskspace}[/B]을 확보한 후 다시 하십시오."
 
 msgctxt "#30019"
 msgid "This operating system ([B]{os}[/B]) is not supported by [B]Widevine CDM[/B] for ARM devices."
-msgstr "[B]Widevine CDM[/B]は、このOS([B]{os}[/B])を対応しません。"
+msgstr "[B]Widevine CDM[/B]은 이 운영체제([B]{os}[/B])을(를) 지원하지 않습니다."
 
 msgctxt "#30020"
 msgid "[B]'{command1}'[/B] or [B]'{command2}'[/B] command needs to exist on system to extract the [B]Widevine CDM[/B]."
-msgstr "[B]Widevine CDM[/B]を抽出するため、[B]'{command1}'[/B]又は[B]'{command2}'[/B]コマンドが必要です。"
+msgstr "[B]Widevine CDM[/B]을 뽑아 내기 위해서 [B]'{command1}'[/B] 또는 [B]'{command2}'[/B] 커맨드가 있어야합니다."
 
 msgctxt "#30021"
 msgid "[B]'{command}'[/B] command needs to exist on system to extract the [B]Widevine CDM[/B]."
-msgstr "[B]Widevine CDM[/B]を抽出するため、[B]'{command}'[/B]コマンドが必要です。"
+msgstr "[B]Widevine CDM[/B]을 뽑아 내기 위해서 [B]'{command}'[/B] 커맨드가 있어야합니다."
 
 msgctxt "#30022"
 msgid "Downloading the Chrome OS recovery image..."
-msgstr "Chrome OSリカバリイメージをダウンロード中。。。"
+msgstr "크롬OS복구 이미지를 내려받는 중..."
 
 msgctxt "#30023"
 msgid "Download completed!"
-msgstr "ダウンロード完了！"
+msgstr "다운로드 끝!"
 
 msgctxt "#30024"
 msgid "The installation now needs to unzip, mount and extract [B]Widevine CDM[/B] from the recovery image.[CR][CR]This process may take up to ten minutes to complete."
-msgstr "インストールのため、リカバリイメージを解凍し、マウントして[B]Widevine CDM[/B]を抽出します。[CR][CR]完了まで10分ほど掛かります。"
+msgstr "설치를 위해서 압축해제를 하고, 복구 이미지를 마운트하여 [B]Widevine CDM[/B]을 뽑아냅니다.[CR][CR]약 10분 정도 걸릴 것입니다."
 
 msgctxt "#30025"
 msgid "Acquiring EULA."
-msgstr "ソフトウェア利用許諾契約取得中"
+msgstr "사용자 동의서를 가져오는 중"
 
 msgctxt "#30026"
 msgid "Widevine CDM EULA"
-msgstr "Widevine CDMのソフトウェア利用許諾契約"
+msgstr "Widevine CDM 사용자 동의서"
 
 msgctxt "#30027"
 msgid "I accept"
-msgstr "了解"
+msgstr "동의하오"
 
 msgctxt "#30028"
 msgid "Cancel"
-msgstr "キャンセル"
+msgstr "싫소이다"
 
 msgctxt "#30029"
 msgid "OK"
-msgstr "オッケー"
+msgstr "좋소"
 
 msgctxt "#30030"
 msgid "The installation may need to run the following commands with root permissions: [B]{cmds}[/B]."
-msgstr "インストールのため、スパユーザの権限が必要です: [B]{cmds}[/B]。"
+msgstr "설치를 위해 루트유저의 권한이 필요합니다: [B]{cmds}[/B]。"
 
 msgctxt "#30031"
 msgid "An update of [B]Widevine CDM[/B] is required to play this content."
-msgstr "コンテンツを再生するため[B]Widevine CDM[/B]をアップデートしてください。"
+msgstr "콘텐츠를 재생하려면 [B]Widevine CDM[/B]을 업데이트 하십시오."
 
 msgctxt "#30032"
 msgid "Your system is missing the following libraries required by Widevine CDM: [B]{libs}[/B]. Install the libraries to play this content."
-msgstr "Widevine CDMに必要なライブラリが見つかりません: [B]{libs}[/B]."
+msgstr "Widevine CDM에 필요한 라이브러리가 없습니다: [B]{libs}[/B]."
 
 msgctxt "#30033"
 msgid "There is an update available for [B]Widevine CDM[/B]."
-msgstr "[B]Widevine CDM[/B]のアップデートが可能です。"
+msgstr "[B]Widevine CDM[/B] 업데이트가 있습니다."
 
 msgctxt "#30034"
 msgid "Update"
-msgstr "アップデート"
+msgstr "업데이트"
 
 msgctxt "#30035"
 msgid "[B]loop[/B] is still loaded"
-msgstr "[B]loop[/B]がまだロードされている。"
+msgstr "[B]loop[/B]이 아직 올라와 있습니다 "
 
 msgctxt "#30036"
 msgid "Unload it by running [B]modprobe -r loop[/B] in the terminal."
-msgstr "アンロードするには、ターミナルで[B]modprobe -r loop[/B]を実行してください。"
+msgstr "터미널에서 [B]modprobe -r loop[/B]을 이용하여 내리십시오."
 
 msgctxt "#30037"
 msgid "Success!"
-msgstr "成功！"
+msgstr "성공!"
 
 msgctxt "#30038"
 msgid "Install Widevine"
-msgstr "Widevineインストール"
+msgstr "Widevine 설치"
 
 msgctxt "#30039"
 msgid "[B]Widevine CDM[/B] is currently not available natively on ARM64. Please switch to a 32-bit userspace for [B]Widevine CDM[/B] support."
-msgstr "現在、[B]Widevine CDM[/B]はARM64を対応しません。[B]Widevine CDM[/B]を使うには、32ビットモドに切り替えてください。"
+msgstr "현재 ARM64에서는 [B]Widevine CDM[/B]을 사용할 수 없습니다. [B]Widevine CDM[/B]을 사용하려면 32비트모드로 바꾸시지요."
 
 msgctxt "#30040"
 msgid "Update available"
-msgstr "アップデート可能"
+msgstr "업데이트가 있습니다"
 
 msgctxt "#30041"
 msgid "Widevine CDM is required"
-msgstr "Widevine CDMが必要です。"
+msgstr "Widevine CDM이 필요합니다"
 
 msgctxt "#30042"
 msgid "Using a SOCKS proxy requires the PySocks library (script.module.pysocks) installed."
-msgstr "SOCKSプロキシを使うため、PySocksライブラリ(script.module.pysocks)が必要です。"
+msgstr "SOCKS프락시를 사용하려면 PySocks라이브러리(script.module.pysocks)가 필요합니다."
 
 msgctxt "#30043"
 msgid "Extracting Widevine CDM"
-msgstr "Widevine CDM抽出"
+msgstr "Widevine CDM을 뽑아냅니다."
 
 msgctxt "#30044"
 msgid "Preparing downloaded image..."
-msgstr "イメージダウンロード中"
+msgstr "다운로드한 이미지를 준비 중..."
 
 msgctxt "#30045"
 msgid "Uncompressing image..."
-msgstr "イメージを解凍中。。。"
+msgstr "이미지를 풀어 내는 중..."
 
 msgctxt "#30046"
 msgid "This may take several minutes."
-msgstr "少し時間掛かります。"
+msgstr "시간이 조금 걸립니다."
 
 msgctxt "#30047"
 msgid "[I]Please do not interrupt this process.[/I]"
-msgstr "[I]このままお待ち下さい。[/I]"
+msgstr "[I]가만히 두시는 것이 좋습니다.[/I]"
 
 msgctxt "#30048"
 msgid "Extracting Widevine CDM from image..."
-msgstr "イメージからWidevine CDMを抽出中。。。"
+msgstr "이미지로부터 Widevine CDM을 뽑아내는 중..."
 
 msgctxt "#30049"
 msgid "Installing Widevine CDM..."
-msgstr "Widevine CDMをインストール中。。。"
+msgstr "Widevine CDM 설치 중..."
 
 msgctxt "#30050"
 msgid "Finishing..."
-msgstr "仕上げ中。。。"
+msgstr "마무리 중..."
 
 msgctxt "#30051"
 msgid "[B]Widevine CDM[/B] successfully installed."
-msgstr "[B]Widevine CDM[/B]をインストールしました。"
+msgstr "[B]Widevine CDM[/B]을 설치했습니다."
 
 msgctxt "#30052"
 msgid "[B]Widevine CDM[/B] successfully removed."
-msgstr "[B]Widevine CDM[/B]を削除しました。"
+msgstr "[B]Widevine CDM[/B]을 지웠습니다."
 
 msgctxt "#30053"
 msgid "[B]Widevine CDM[/B] not found."
-msgstr "[B]Widevine CDM[/B]が無いようです。"
+msgstr "[B]Widevine CDM[/B]이 없군요."
 
 msgctxt "#30054"
 msgid "disabled"
-msgstr "使わない"
+msgstr "사용하지 않습니다."
 
 msgctxt "#30055"
 msgid "There is not enough free disk space in the current temporary directory. Would you like to specify a different one to temporarily use for the Chrome OS Recovery Image (e.g. on a USB)?"
-msgstr "充分は空き容量がありません。Chrome OSリカバリイメージをUSBのような別の一時ストレジに保存ましょうか。"
+msgstr "임시 저장소에 충분한 공간이 없습니다. 크롬OS복구 이미지를 USB 같은 다른 임시저장소에 저장하시렵니까?"
 
 msgctxt "#30056"
 msgid "No backups found!"
-msgstr "バックアップがありませんよ!"
+msgstr "저런! 백업이 없어요!"
 
 msgctxt "#30057"
 msgid "Choose a backup to restore"
-msgstr "バックアップを選んでください"
+msgstr "복구할 백업을 고르시지요"
 
 msgctxt "#30058"
 msgid "Time remaining: {mins:d}:{secs:02d}"
-msgstr ""
+msgstr "남은 시간: {mins:d}:{secs:02d}"
 
 msgctxt "#30059"
 msgid "Meanwhile, should we try extracting Widevine CDM using the legacy method?"
-msgstr ""
+msgstr "그러면, Widevine CDM을 예전방식으로 풀어낼까요?"
 
 msgctxt "#30060"
 msgid "Identifying wanted partition..."
-msgstr ""
+msgstr "파티션 확인 중..."
 
 msgctxt "#30061"
 msgid "Scanning the filesystem for the Widevine CDM..."
-msgstr ""
+msgstr "Widevin CDM을 위한 파일시스템을 확인 중..."
 
 msgctxt "#30062"
 msgid "Widevine CDM found, analyzing..."
-msgstr ""
+msgstr "Widevine CDM 발견해서 분석 중..."
 
 msgctxt "#30063"
 msgid "Could not make the request. Your internet may be down."
-msgstr ""
+msgstr "연결실패. 인터넷이 죽었을 수도 있습니다."
 
 msgctxt "#30064"
 msgid "Could not finish the download."
-msgstr ""
+msgstr "내려받기를 끝내지 못 했습니다."
 
 msgctxt "#30065"
 msgid "Shall we try again?"
-msgstr ""
+msgstr "다시 할까요?"
 
 
 ### INFORMATION DIALOG
 msgctxt "#30800"
 msgid "[B]Kodi[/B] version [B]{version}[/B] is running on a [B]{system}[/B] system with [B]{arch}[/B] architecture."
-msgstr ""
+msgstr "[B]Kodi[/B] 버전 [B]{version}[/B]이 아키텍쳐 [B]{arch}[/B]의 시스템 [B]{system}[/B]에서 실행중입니다."
 
 msgctxt "#30810"
 msgid "[B]InputStream Helper[/B] is at version [B]{version}[/B] {state}"
-msgstr ""
+msgstr "[B]InputStream Helper[/B] 버전 [B]{version}[/B] {state}"
 
 msgctxt "#30811"
 msgid "[B]InputStream Adaptive[/B] is at version [B]{version}[/B] {state}"
-msgstr ""
+msgstr "[B]InputStream Adaptive[/B] 버전 [B]{version}[/B] {state}"
 
 msgctxt "#30820"
 msgid "[B]Widevine CDM[/B] is [B]built into Android[/B]"
-msgstr ""
+msgstr "[B]Android에 이미 포함[/B]되어 있습니다."
 
 msgctxt "#30821"
 msgid "[B]Widevine CDM[/B] is at version [B]{version}[/B] and was installed on [B]{date}[/B]"
-msgstr ""
+msgstr "[B]Widevine CDM[/B]의 버전은 [B]{version}[/B]이며, [B]{date}[/B]에 설치하였습니다."
 
 msgctxt "#30822"
 msgid "It was extracted from Chrome OS image [B]{name}[/B] with version [B]{version}[/B]"
-msgstr ""
+msgstr "버전 [B]{version}[/B]의 Chrom OS 이미지 [B]{name}[/B]로부터 뽑아냈습니다."
 
 msgctxt "#30823"
 msgid "It was last checked for updates on [B]{date}[/B]"
-msgstr ""
+msgstr "[B]{date}[/B]에 마지막으로 업데이트를 확인하였습니다."
 
 msgctxt "#30824"
 msgid "It is installed at [B]{path}[/B]"
-msgstr ""
+msgstr "[B]{path}[/B]에 설치하였습니다."
 
 msgctxt "#30830"
 msgid "Please report issues to: [COLOR yellow]{url}[/COLOR]"
-msgstr "問題があったらここへ： [COLOR yellow]{url}[/COLOR]"
+msgstr "문제가 있으면 이쪽으로: [COLOR yellow]{url}[/COLOR]"
 
 
 ### SETTINGS
 msgctxt "#30900"
 msgid "Expert"
-msgstr "エキスパート"
+msgstr "전문가"
 
 msgctxt "#30901"
 msgid "InputStream Helper information"
-msgstr "インプットストリームヘルパー情報"
+msgstr "InputStream Helper 정보"
 
 msgctxt "#30903"
 msgid "Disable InputStream Helper"
-msgstr "インプットストリームヘルパーを使わない"
+msgstr "InputStream Helper를 사용하지 않습니다."
 
 msgctxt "#30904"
 msgid "[I]When disabled, DRM playback may fail![/I]"
-msgstr "[I]使わないと、DRM再生が出来ません！[/I]"
+msgstr "[I]사용하지 않음으로 하면, DRM 재생이 안될 수도 있습니다![/I]"
 
 msgctxt "#30905"
 msgid "Update frequency in days"
-msgstr "何日毎に更新を確認しましょうか。"
+msgstr "며칠에 한번씩 업데이트를 확인할까요?"
 
 msgctxt "#30907"
 msgid "Temporary download directory"
-msgstr "ダウンロードフォルダ"
+msgstr "임시 저장소"
 
 msgctxt "#30909"
 msgid "(Re)install Widevine CDM library..."
-msgstr "Widevind CDMライブラリの(再)インストール"
+msgstr "Widevind CDM 라이브러리를 (다시) 설치..."
 
 msgctxt "#30911"
 msgid "Remove Widevine CDM library..."
-msgstr "Widevine CDMライブラリを削除。。。"
+msgstr "Widevine CDM 라이브러리 제거..."
 
 msgctxt "#30913"
 msgid "Number of backups"
-msgstr "バックアップ数"
+msgstr "몇개를 백업할까요?"
 
 msgctxt "#30915"
 msgid "Restore Widevine CDM library..."
-msgstr ""
+msgstr "Widevine CDM라이브러리 복구..."


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: InputStream Helper
  - Add-on ID: script.module.inputstreamhelper
  - Version number: 0.5.1
  - Kodi/repository version: krypton

- **Code location**
  - URL: https://github.com/emilsvennesson/script.module.inputstreamhelper
  
A simple Kodi module that makes life easier for add-on developers relying on InputStream based add-ons and DRM playback.

### Description of changes:


v0.5.1 (2020-10-02)
- Fix incorrect ARM HWIDs: PHASER and PHASER360
- Added Hebrew translations
- Updated Dutch, Japanese and Korean translations

v0.5.0 (2020-06-25)
- Extract Widevine CDM directly from Chrome OS, minimizing disk space usage and eliminating the need for root access
- Improve progress dialog while extracting Widevine CDM on ARM devices
- Support resuming interrupted downloads on unreliable internet connections
- Reshape InputStream Helper information dialog
- Updated Dutch, English, French, German, Greek, Hungarian, Romanian, Russian, Spanish and Swedish translations
    

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
