### PR TITLE
[service.sleeptimer] 2.0.7

### DIFF
--- a/service.sleeptimer/addon.xml
+++ b/service.sleeptimer/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="service.sleeptimer"
        name="Sleep Timer"
-      version="2.0.5"
+      version="2.0.7"
       provider-name="enen92, Solo0815">
     <requires>
 		<import addon="xbmc.addon" version="14.0.0"/>
@@ -16,6 +16,6 @@
          <forum>http://forum.kodi.tv/showthread.php?tid=211971</forum>
     	    <source>https://github.com/enen92/service.sleeptimer</source>
          <platform>all</platform>
-         <license>GNU GENERAL PUBLIC LICENSE. Version 2, June 1991</license>
+         <license>GPL-2.0-only</license>
     </extension>
 </addon>

--- a/service.sleeptimer/changelog.txt
+++ b/service.sleeptimer/changelog.txt
@@ -1,3 +1,6 @@
+2.0.6 - 27/6/2016
+-Updated settings
+
 2.0.5 - 19/12/2015
 -Bug fixing - thanks joshjowen
 

--- a/service.sleeptimer/resources/language/English/strings.po
+++ b/service.sleeptimer/resources/language/English/strings.po
@@ -16,108 +16,116 @@ msgstr ""
 
 msgctxt "#30000"
 msgid "Sleep Timer"
-""
+msgstr ""
 
 msgctxt "#30001"
 msgid "Cancel to continue playing"
-""
+msgstr ""
 
 msgctxt "#30002"
 msgid "Service check time (minutes)"
-""
+msgstr ""
 
 msgctxt "#30003"
 msgid "Waiting time for the dialog (before stop) (seconds)"
-""
+msgstr ""
 
 msgctxt "#30004"
 msgid "Slow mute audio before stop playing"
-""
+msgstr ""
 
 msgctxt "#30005"
 msgid "General"
-""
+msgstr ""
 
 msgctxt "#30006"
 msgid "Time between 1% volume change  (millisec)"
-""
+msgstr ""
 
 msgctxt "#30007"
 msgid "Next check time if dialog is cancelled (minutes)"
-""
+msgstr ""
 
 msgctxt "#30008"
 msgid "Enable Screensaver after stopping"
-""
+msgstr ""
 
 msgctxt "#30009"
 msgid "Audio/Video Supervision settings"
-""
+msgstr ""
 
 msgctxt "#30010"
 msgid "Enable Video Supervision"
-""
+msgstr ""
 
 msgctxt "#30011"
 msgid "Enable Audio Supervision"
-""
+msgstr ""
 
 msgctxt "#30012"
 msgid "Maximum Playing time (minutes) before asking to stop"
-""
+msgstr ""
 
 msgctxt "#30013"
 msgid "Video Playbacktime"
-""
+msgstr ""
 
 msgctxt "#30014"
 msgid "Audio Playbacktime"
-""
+msgstr ""
 
 msgctxt "#30015"
 msgid "Debug"
-""
+msgstr ""
 
 msgctxt "#30016"
 msgid "Debug mode"
-""
+msgstr ""
 
 msgctxt "#30017"
 msgid "'Enable' debugging sets:"
-""
+msgstr ""
 
 msgctxt "#30018"
 msgid "Audio and Video-Check enabled"
-""
+msgstr ""
 
 msgctxt "#30019"
 msgid "Service check time (minutes): '1'"
-""
+msgstr ""
 
 msgctxt "#30020"
 msgid "Waiting time for the dialog (before stop) (seconds): '30'"
-""
+msgstr ""
 
 msgctxt "#30021"
 msgid "It doesn't matter, what you set in the other Tabs!"
-""
+msgstr ""
 
 msgctxt "#30022"
 msgid "Execute custom cmd after playback stop"
-""
+msgstr ""
 
 msgctxt "#30023"
 msgid "Custom CMD"
-""
+msgstr ""
 
 msgctxt "#30024"
 msgid "Supervision Mode"
-""
+msgstr ""
 
 msgctxt "#30025"
 msgid "Hour start (eg. 23:00)"
-""
+msgstr ""
 
 msgctxt "#30026"
 msgid "Hour supervision end (eg. 03:20)"
-""
+msgstr ""
+
+msgctxt "#30027"
+msgid "Always"
+msgstr ""
+
+msgctxt "#30028"
+msgid "Specific Time"
+msgstr ""

--- a/service.sleeptimer/resources/language/Portuguese/strings.po
+++ b/service.sleeptimer/resources/language/Portuguese/strings.po
@@ -120,3 +120,11 @@ msgstr "Hora de inicio (ex. 23:00)"
 msgctxt "#30026"
 msgid "Hour supervision end (eg. 03:20)"
 msgstr "Hora de fim (ex. 03:20)"
+
+msgctxt "#30027"
+msgid "Always"
+msgstr "Sempre"
+
+msgctxt "#30028"
+msgid "Specific Time"
+msgstr "Tempo especifico"

--- a/service.sleeptimer/resources/settings.xml
+++ b/service.sleeptimer/resources/settings.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <settings>
 	<category label="30005">
-		<setting id="check_time" label="30002" default="5" type="labelenum" values="1|3|5|10|15|20|25|30"/>
-		<setting id="waiting_time_dialog" label="30003" type="labelenum" default="60" values="30|45|60|90|120|150|180"/>
+		<setting id="check_time" label="30002" default="5" type="slider" range="1,5,120" option="int"/>
+		<setting id="waiting_time_dialog" label="30003" type="slider" default="60" range="30,5,180" option="int"/>
 		<setting id="audio_change" label="30004" type="bool" default="true" visible="true"/>
 		<setting id="audio_change_rate" label="30006" enable="eq(-1,true)" type="slider" default="500" range="50,50,3000" option="int"/>
-		<setting id="check_time_next" label="30007" default="30" type="labelenum" values="15|30|45|60|90|120"/>
+		<setting id="check_time_next" label="30007" type="slider" default="30" range="15,10,120" option="int"/>
 		<setting id="enable_screensaver" label="30008" type="bool" default="false" visible="true"/>
 	     <setting id="custom_cmd" label="30022" type="bool" default="false" visible="true"/>
 	     <setting id="cmd" type="text" label="30023" default="" visible="eq(-1,true)"/>
@@ -14,10 +14,10 @@
 		<setting id="video_enable" label="30010" type="bool" default="true" visible="true"/>
 		<setting id="audio_enable" label="30011" type="bool" default="true" visible="true"/>
 		<setting label="30012" type="lsep"/>
-		<setting id="max_time_video" label="30013" type="labelenum" default="150" enable="eq(-3,true)" values="30|60|90|120|150|180|210|240|270|300|330|360|390|420"/>
-		<setting id="max_time_audio" label="30014" type="labelenum" default="150" enable="eq(-3,true)" values="30|60|90|120|150|180|210|240|270|300|330|360|390|420"/>
+		<setting id="max_time_video" label="30013" default="150" enable="eq(-3,true)" type="slider" range="30,5,420" option="int"/>
+		<setting id="max_time_audio" label="30014" default="150" enable="eq(-3,true)" type="slider" range="30,5,420" option="int"/>
 		<setting label="30024" type="lsep"/>
-		<setting id="supervision_mode" label="30024" type="enum" default="0" values="Always|Specific Time"/>
+		<setting id="supervision_mode" label="30024" type="enum" default="0" values="30027|30028"/>
 		<setting label="30025" type="text" id="hour_start_sup" visible="eq(-1,1)" default="00:00"/>
 		<setting label="30026" type="text" id="hour_end_sup" visible="eq(-2,1)" default="00:00"/>
 	</category>


### PR DESCRIPTION
- Sync with upstream
- fix high cpu usage
- avoid using xbmc.sleep for high sleep values
- fix translations