### PR TITLE
[service.upnext@leia] 1.1.3

### DIFF
--- a/service.upnext/README.md
+++ b/service.upnext/README.md
@@ -15,7 +15,7 @@ The add-on has various settings to fine-tune the experience, however the default
 
   * Simple or fancy mode (defaults to fancy mode, but a more simple interface is possible)
   * The notification time can be adjusted (defaults to 30 seconds before the end)
-  * The default action can be confnigured, i.e. should it advance to the next episode (default) when the user does not respond, or stop
+  * The default action can be configured, i.e. should it advance to the next episode (default) when the user does not respond, or stop
   * The number of episodes to play automatically before asking the user if he is still there (defaults to 3 episodes)
 
 > NOTE: The add-on settings are found in the Kodi add-ons section, in the *Services* category.
@@ -23,6 +23,16 @@ The add-on has various settings to fine-tune the experience, however the default
 For [Addon Integration](https://github.com/im85288/service.upnext/wiki/Addon-Integration) and [Skinners](https://github.com/im85288/service.upnext/wiki/Skinners) see the [wiki](https://github.com/im85288/service.upnext/wiki)
 
 ## Releases
+### v1.1.3 (2020-10-14)
+- Enable customPlayTime by default (@dagwieers)
+- Do not seek to the end before playing next episode (@dagwieers)
+- Add Kodi v17 compatibility (@dagwieers)
+- Fix logging on Kodi v19 (Matrix) after recent breakage (@MoojMidge)
+- Enqueue the next episode in the playlist (@MoojMidge)
+
+### v1.1.2 (2020-06-22)
+- Small bugfix release (@im85288)
+
 ### v1.1.1 (2020-06-21)
 - Avoid conflict with external players (@BrutuZ)
 - Restore "Ignore Playlist" option (@BrutuZ)
@@ -40,3 +50,40 @@ For [Addon Integration](https://github.com/im85288/service.upnext/wiki/Addon-Int
 - New translations for Brazilian, Czech, Greek, Japanese, Korean (@mediabrasiltv, @svetlemodry, @Twilight0, @Thunderbird2086)
 - New translations for Russian, Slovak, Spanish, Swedish (@vlmaksime, @matejmosko, @sagatxxx, @Sopor)
 - Translation updates to Croatian, French, German, Hungarian, Italian, Polish (@arvvoid, @zecakeh, @tweimer, @frodo19, @EffeF, @notoco)
+
+### v1.0.7 (2019-12-03)
+- Add Up Next in the program add-on section (@dagwieers)
+- Update add-on icon to use black background (@dagwieers)
+- Fix 24-hour format based on Kodi setting (@dagwieers)
+- New translations for Croatian (@arvvoid)
+- Translation updates to French, Hungarian, Italian and Polish (@mediaminister, @frodo19, @EffeF, @notoco)
+
+### v1.0.6 (2019-11-26)
+- Implement base64 encoding to support newer AddonSignals (@dagwieers)
+- Fixes to Python 3.5 support (@anxdpanic)
+- Add SPDX identifier for license (@dagwieers)
+- Translation updates to German (@tweimer)
+
+### v1.0.5 (2019-11-19)
+- Translation fixes (@dagwieers)
+
+### v1.0.4 (2019-11-19)
+- Automatic stop playing as option (@notoco)
+- Fix exception when add-on is exited (@dagwieers)
+- Fix playlist logic (@mediaminister)
+- Add support for Python 3 and Kodi v19 (@mediaminister)
+- Introduce "Close" button when configured in settings (@dagwieers)
+- Add support for a Back-button action to dismiss Up Next pop-up (@dagwieers)
+- Always reset state when playback finishes (@mediaminister)
+- Various code improvements and fixes (@dagwieers, @mediaminister)
+- New translations for Dutch (@dagwieers)
+- Translation updates to German (@semool, @beatmasterRS)
+
+### v1.0.3 (2019-07-30)
+- Disable tracking for non episode (@angelblue05)
+
+### v1.0.2 (2019-07-24)
+- Add JSONRPC method (@angelblue05)
+- Add priority to existing playlist (@angelblue05)
+- Add endtime prop (@angelblue05)
+- Remove enablePlaylist setting (@angelblue05)

--- a/service.upnext/addon.xml
+++ b/service.upnext/addon.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='yes'?>
-<addon id="service.upnext" name="Up Next" version="1.1.2" provider-name="im85288">
+<addon id="service.upnext" name="Up Next" version="1.1.3" provider-name="im85288">
     <requires>
         <import addon="xbmc.python" version="2.26.0"/>
     </requires>
@@ -40,6 +40,12 @@ Många befintliga tillägg integreras redan med den här utanför lådan-tjänst
         <platform>all</platform>
         <license>GPL-2.0-only</license>
         <news>
+### v1.1.3 (2020-10-14)
+- Enable customPlayTime by default
+- Do not seek to the end before playing next episode
+- Add Kodi v17 compatibility
+- Fix logging on Kodi v19 (Matrix) after recent breakage
+- Enqueue the next episode in the playlist
 
 ### v1.1.2 (2020-06-22)
 - Bug fix for change from sleep to waitForAbort using seconds and not ms

--- a/service.upnext/resources/language/resource.language.cs_cz/strings.po
+++ b/service.upnext/resources/language/resource.language.cs_cz/strings.po
@@ -94,6 +94,14 @@ msgctxt "#30049"
 msgid "Next Episode"
 msgstr "Další epizoda"
 
+msgctxt "#30060"
+msgid "[B]UP NEXT DEMO MODE ENABLED[/B]"
+msgstr ""
+
+msgctxt "#30061"
+msgid "[I]Episodes automatically skip to end.[/I]"
+msgstr ""
+
 
 ### SETTINGS
 msgctxt "#30500"
@@ -183,6 +191,10 @@ msgstr "Vývojář"
 msgctxt "#30801"
 msgid "Test how the user interface looks"
 msgstr "Otestovat vzhled uživatelského rozhraní"
+
+msgctxt "#30803"
+msgid "Enable DEMO mode"
+msgstr ""
 
 msgctxt "#30805"
 msgid "Show an UpNext pop-up…"

--- a/service.upnext/resources/language/resource.language.de_de/strings.po
+++ b/service.upnext/resources/language/resource.language.de_de/strings.po
@@ -95,6 +95,14 @@ msgctxt "#30049"
 msgid "Next Episode"
 msgstr "Nächste Episode"
 
+msgctxt "#30060"
+msgid "[B]UP NEXT DEMO MODE ENABLED[/B]"
+msgstr "[B]UP NEXT DEMOMODUS AKTIVIERT[/B]"
+
+msgctxt "#30061"
+msgid "[I]Episodes automatically skip to end.[/I]"
+msgstr "[I]Episoden springen automatisch zum Ende.[/I]"
+
 
 ### SETTINGS
 msgctxt "#30500"
@@ -111,7 +119,7 @@ msgstr "Anzeigemodus der Benachrichtigung"
 
 msgctxt "#30505"
 msgid "Show a \"Stop\" button instead of a \"Close\" button"
-msgstr "Wiedergabe nach dem Schließen des Dialogs stoppen"
+msgstr "\"Stopp\"-Button statt \"Schließen\"-Button anzeigen"
 
 msgctxt "#30600"
 msgid "Behaviour"
@@ -185,18 +193,22 @@ msgctxt "#30801"
 msgid "Test how the user interface looks"
 msgstr "Testen, wie die Benutzeroberfläche aussieht"
 
+msgctxt "#30803"
+msgid "Enable DEMO mode"
+msgstr "DEMO-Modus aktivieren"
+
 msgctxt "#30805"
 msgid "Show an UpNext pop-up…"
-msgstr "UpNext-Popup anzeigen"
+msgstr "UpNext-Popup anzeigen…"
 
 msgctxt "#30807"
 msgid "Show an UpNextSimple pop-up…"
-msgstr "UpNextSimple-Popup anzeigen"
+msgstr "UpNextSimple-Popup anzeigen…"
 
 msgctxt "#30809"
 msgid "Show a StillWatching pop-up…"
-msgstr "StillWatching-Popup anzeigen"
+msgstr "StillWatching-Popup anzeigen…"
 
 msgctxt "#30811"
 msgid "Show a StillWatchingSimple pop-up…"
-msgstr "StillWatchingSimple-Popup anzeigen"
+msgstr "StillWatchingSimple-Popup anzeigen…"

--- a/service.upnext/resources/language/resource.language.el_gr/strings.po
+++ b/service.upnext/resources/language/resource.language.el_gr/strings.po
@@ -94,6 +94,14 @@ msgctxt "#30049"
 msgid "Next Episode"
 msgstr "Επόμενο επεισόδιο"
 
+msgctxt "#30060"
+msgid "[B]UP NEXT DEMO MODE ENABLED[/B]"
+msgstr ""
+
+msgctxt "#30061"
+msgid "[I]Episodes automatically skip to end.[/I]"
+msgstr ""
+
 
 ### SETTINGS
 msgctxt "#30500"
@@ -183,6 +191,10 @@ msgstr "Προγραμματιστής"
 msgctxt "#30801"
 msgid "Test how the user interface looks"
 msgstr "Δοκιμή του πως μοιάζει το περιβάλλον"
+
+msgctxt "#30803"
+msgid "Enable DEMO mode"
+msgstr ""
 
 msgctxt "#30805"
 msgid "Show an UpNext pop-up…"

--- a/service.upnext/resources/language/resource.language.en_gb/strings.po
+++ b/service.upnext/resources/language/resource.language.en_gb/strings.po
@@ -94,6 +94,14 @@ msgctxt "#30049"
 msgid "Next Episode"
 msgstr ""
 
+msgctxt "#30060"
+msgid "[B]UP NEXT DEMO MODE ENABLED[/B]"
+msgstr ""
+
+msgctxt "#30061"
+msgid "[I]Episodes automatically skip to end.[/I]"
+msgstr ""
+
 
 ### SETTINGS
 msgctxt "#30500"
@@ -182,6 +190,10 @@ msgstr ""
 
 msgctxt "#30801"
 msgid "Test how the user interface looks"
+msgstr ""
+
+msgctxt "#30803"
+msgid "Enable DEMO mode"
 msgstr ""
 
 msgctxt "#30805"

--- a/service.upnext/resources/language/resource.language.es_es/strings.po
+++ b/service.upnext/resources/language/resource.language.es_es/strings.po
@@ -94,6 +94,15 @@ msgctxt "#30049"
 msgid "Next Episode"
 msgstr "Siguiente episodio"
 
+msgctxt "#30060"
+msgid "[B]UP NEXT DEMO MODE ENABLED[/B]"
+msgstr ""
+
+msgctxt "#30061"
+msgid "[I]Episodes automatically skip to end.[/I]"
+msgstr ""
+
+
 # ## SETTINGS
 msgctxt "#30500"
 msgid "Interface"
@@ -182,6 +191,10 @@ msgstr "Desarrollador"
 msgctxt "#30801"
 msgid "Test how the user interface looks"
 msgstr "Prueba cómo se ve la interfaz de usuario"
+
+msgctxt "#30803"
+msgid "Enable DEMO mode"
+msgstr ""
 
 msgctxt "#30805"
 msgid "Show an UpNext pop-up…"

--- a/service.upnext/resources/language/resource.language.fr_fr/strings.po
+++ b/service.upnext/resources/language/resource.language.fr_fr/strings.po
@@ -96,6 +96,14 @@ msgctxt "#30049"
 msgid "Next Episode"
 msgstr "Prochain épisode"
 
+msgctxt "#30060"
+msgid "[B]UP NEXT DEMO MODE ENABLED[/B]"
+msgstr ""
+
+msgctxt "#30061"
+msgid "[I]Episodes automatically skip to end.[/I]"
+msgstr ""
+
 
 ### SETTINGS
 msgctxt "#30500"
@@ -185,6 +193,10 @@ msgstr "Développeur"
 msgctxt "#30801"
 msgid "Test how the user interface looks"
 msgstr "Tester l’apparence de l’interface utilisateur"
+
+msgctxt "#30803"
+msgid "Enable DEMO mode"
+msgstr ""
 
 msgctxt "#30805"
 msgid "Show an UpNext pop-up…"

--- a/service.upnext/resources/language/resource.language.hr_hr/strings.po
+++ b/service.upnext/resources/language/resource.language.hr_hr/strings.po
@@ -94,6 +94,15 @@ msgctxt "#30049"
 msgid "Next Episode"
 msgstr "Sljedeća epizoda"
 
+msgctxt "#30060"
+msgid "[B]UP NEXT DEMO MODE ENABLED[/B]"
+msgstr ""
+
+msgctxt "#30061"
+msgid "[I]Episodes automatically skip to end.[/I]"
+msgstr ""
+
+
 # ## SETTINGS
 msgctxt "#30500"
 msgid "Interface"
@@ -182,6 +191,10 @@ msgstr "Developer"
 msgctxt "#30801"
 msgid "Test how the user interface looks"
 msgstr "Testirajte kako izgleda korisničko sučelje"
+
+msgctxt "#30803"
+msgid "Enable DEMO mode"
+msgstr ""
 
 msgctxt "#30805"
 msgid "Show an UpNext pop-up…"

--- a/service.upnext/resources/language/resource.language.hu_hu/strings.po
+++ b/service.upnext/resources/language/resource.language.hu_hu/strings.po
@@ -93,6 +93,14 @@ msgctxt "#30049"
 msgid "Next Episode"
 msgstr "Következő rész"
 
+msgctxt "#30060"
+msgid "[B]UP NEXT DEMO MODE ENABLED[/B]"
+msgstr ""
+
+msgctxt "#30061"
+msgid "[I]Episodes automatically skip to end.[/I]"
+msgstr ""
+
 
 ### SETTINGS
 msgctxt "#30500"
@@ -182,6 +190,10 @@ msgstr "Fejlesztő"
 msgctxt "#30801"
 msgid "Test how the user interface looks"
 msgstr "Felhasználói felület kinézet tesztelése"
+
+msgctxt "#30803"
+msgid "Enable DEMO mode"
+msgstr ""
 
 msgctxt "#30805"
 msgid "Show an UpNext pop-up…"

--- a/service.upnext/resources/language/resource.language.in_hi/strings.po
+++ b/service.upnext/resources/language/resource.language.in_hi/strings.po
@@ -94,6 +94,14 @@ msgctxt "#30049"
 msgid "Next Episode"
 msgstr "अगला एपिसोड"
 
+msgctxt "#30060"
+msgid "[B]UP NEXT DEMO MODE ENABLED[/B]"
+msgstr ""
+
+msgctxt "#30061"
+msgid "[I]Episodes automatically skip to end.[/I]"
+msgstr ""
+
 
 ### SETTINGS
 msgctxt "#30500"
@@ -183,6 +191,10 @@ msgstr "विकासक"
 msgctxt "#30801"
 msgid "Test how the user interface looks"
 msgstr "परीक्षण करें कि उपयोगकर्ता इंटरफ़ेस कैसा दिखता है"
+
+msgctxt "#30803"
+msgid "Enable DEMO mode"
+msgstr ""
 
 msgctxt "#30805"
 msgid "Show an UpNext pop-up…"

--- a/service.upnext/resources/language/resource.language.it_it/strings.po
+++ b/service.upnext/resources/language/resource.language.it_it/strings.po
@@ -94,6 +94,15 @@ msgctxt "#30049"
 msgid "Next Episode"
 msgstr "Prossimo Episodio"
 
+msgctxt "#30060"
+msgid "[B]UP NEXT DEMO MODE ENABLED[/B]"
+msgstr ""
+
+msgctxt "#30061"
+msgid "[I]Episodes automatically skip to end.[/I]"
+msgstr ""
+
+
 # SETTINGS
 msgctxt "#30500"
 msgid "Interface"
@@ -182,6 +191,10 @@ msgstr "Sviluppatore"
 msgctxt "#30801"
 msgid "Test how the user interface looks"
 msgstr "Testa come l'interfaccia utente appare"
+
+msgctxt "#30803"
+msgid "Enable DEMO mode"
+msgstr ""
 
 msgctxt "#30805"
 msgid "Show an UpNext pop-up…"

--- a/service.upnext/resources/language/resource.language.ja_jp/strings.po
+++ b/service.upnext/resources/language/resource.language.ja_jp/strings.po
@@ -40,7 +40,7 @@ msgstr "まだ観るの。"
 
 msgctxt "#30032"
 msgid "Enable on playlists"
-msgstr ""
+msgstr "プレイリストに有効"
 
 msgctxt "#30033"
 msgid "Stop"
@@ -93,6 +93,14 @@ msgstr "Debug"
 msgctxt "#30049"
 msgid "Next Episode"
 msgstr "次のエピソード"
+
+msgctxt "#30060"
+msgid "[B]UP NEXT DEMO MODE ENABLED[/B]"
+msgstr ""
+
+msgctxt "#30061"
+msgid "[I]Episodes automatically skip to end.[/I]"
+msgstr ""
 
 
 ### SETTINGS
@@ -183,6 +191,10 @@ msgstr "デベロッパーモード"
 msgctxt "#30801"
 msgid "Test how the user interface looks"
 msgstr "テストしたい通知ウィンドウ"
+
+msgctxt "#30803"
+msgid "Enable DEMO mode"
+msgstr ""
 
 msgctxt "#30805"
 msgid "Show an UpNext pop-up…"

--- a/service.upnext/resources/language/resource.language.ko_kr/strings.po
+++ b/service.upnext/resources/language/resource.language.ko_kr/strings.po
@@ -40,7 +40,7 @@ msgstr "계속 보시렵니까?"
 
 msgctxt "#30032"
 msgid "Enable on playlists"
-msgstr ""
+msgstr "재생목록에 사용"
 
 msgctxt "#30033"
 msgid "Stop"
@@ -93,6 +93,14 @@ msgstr "Debug"
 msgctxt "#30049"
 msgid "Next Episode"
 msgstr "다음 에피소드"
+
+msgctxt "#30060"
+msgid "[B]UP NEXT DEMO MODE ENABLED[/B]"
+msgstr ""
+
+msgctxt "#30061"
+msgid "[I]Episodes automatically skip to end.[/I]"
+msgstr ""
 
 
 ### SETTINGS
@@ -183,6 +191,10 @@ msgstr "개발자모드"
 msgctxt "#30801"
 msgid "Test how the user interface looks"
 msgstr "어떤 알림창을 테스트하시렵니까?"
+
+msgctxt "#30803"
+msgid "Enable DEMO mode"
+msgstr ""
 
 msgctxt "#30805"
 msgid "Show an UpNext pop-up…"

--- a/service.upnext/resources/language/resource.language.nl_nl/strings.po
+++ b/service.upnext/resources/language/resource.language.nl_nl/strings.po
@@ -93,6 +93,14 @@ msgctxt "#30049"
 msgid "Next Episode"
 msgstr "Volgende aflevering"
 
+msgctxt "#30060"
+msgid "[B]UP NEXT DEMO MODE ENABLED[/B]"
+msgstr "[B]UP NEXT DEMO MODUS IS GEACTIVEERD[/B]"
+
+msgctxt "#30061"
+msgid "[I]Episodes automatically skip to end.[/I]"
+msgstr "[I]Afleveringen springen automatisch naar het einde.[/I]"
+
 
 ### SETTINGS
 msgctxt "#30500"
@@ -183,9 +191,13 @@ msgctxt "#30801"
 msgid "Test how the user interface looks"
 msgstr "Test hoe de gebruikersinterface er uit ziet"
 
+msgctxt "#30803"
+msgid "Enable DEMO mode"
+msgstr "Activeer DEMO modus"
+
 msgctxt "#30805"
 msgid "Show an UpNext pop-up…"
-msgstr "Toon een upNext pop-up…"
+msgstr "Toon een UpNext pop-up…"
 
 msgctxt "#30807"
 msgid "Show an UpNextSimple pop-up…"

--- a/service.upnext/resources/language/resource.language.pl_pl/strings.po
+++ b/service.upnext/resources/language/resource.language.pl_pl/strings.po
@@ -93,6 +93,14 @@ msgctxt "#30049"
 msgid "Next Episode"
 msgstr "Następny odcinek"
 
+msgctxt "#30060"
+msgid "[B]UP NEXT DEMO MODE ENABLED[/B]"
+msgstr ""
+
+msgctxt "#30061"
+msgid "[I]Episodes automatically skip to end.[/I]"
+msgstr ""
+
 
 ### SETTINGS
 msgctxt "#30500"
@@ -182,6 +190,10 @@ msgstr "Deweloper"
 msgctxt "#30801"
 msgid "Test how the user interface looks"
 msgstr "Testuj wygląd interfejsu"
+
+msgctxt "#30803"
+msgid "Enable DEMO mode"
+msgstr ""
 
 msgctxt "#30805"
 msgid "Show an UpNext pop-up…"

--- a/service.upnext/resources/language/resource.language.pt_br/strings.po
+++ b/service.upnext/resources/language/resource.language.pt_br/strings.po
@@ -94,6 +94,14 @@ msgctxt "#30049"
 msgid "Next Episode"
 msgstr "Próximo Episódio"
 
+msgctxt "#30060"
+msgid "[B]UP NEXT DEMO MODE ENABLED[/B]"
+msgstr ""
+
+msgctxt "#30061"
+msgid "[I]Episodes automatically skip to end.[/I]"
+msgstr ""
+
 
 ### SETTINGS
 msgctxt "#30500"
@@ -183,6 +191,10 @@ msgstr "Desenvolvedor"
 msgctxt "#30801"
 msgid "Test how the user interface looks"
 msgstr "Teste a aparência da interface do usuário"
+
+msgctxt "#30803"
+msgid "Enable DEMO mode"
+msgstr ""
 
 msgctxt "#30805"
 msgid "Show an UpNext pop-up…"

--- a/service.upnext/resources/language/resource.language.ro_ro/strings.po
+++ b/service.upnext/resources/language/resource.language.ro_ro/strings.po
@@ -95,6 +95,14 @@ msgctxt "#30049"
 msgid "Next Episode"
 msgstr "Următorul episod"
 
+msgctxt "#30060"
+msgid "[B]UP NEXT DEMO MODE ENABLED[/B]"
+msgstr ""
+
+msgctxt "#30061"
+msgid "[I]Episodes automatically skip to end.[/I]"
+msgstr ""
+
 
 ### SETTINGS
 msgctxt "#30500"
@@ -184,6 +192,10 @@ msgstr "Dezvoltator"
 msgctxt "#30801"
 msgid "Test how the user interface looks"
 msgstr "Testează cum arată interfața utilizator"
+
+msgctxt "#30803"
+msgid "Enable DEMO mode"
+msgstr ""
 
 msgctxt "#30805"
 msgid "Show an UpNext pop-up…"

--- a/service.upnext/resources/language/resource.language.ru_ru/strings.po
+++ b/service.upnext/resources/language/resource.language.ru_ru/strings.po
@@ -94,6 +94,14 @@ msgctxt "#30049"
 msgid "Next Episode"
 msgstr "Следующая серия"
 
+msgctxt "#30060"
+msgid "[B]UP NEXT DEMO MODE ENABLED[/B]"
+msgstr ""
+
+msgctxt "#30061"
+msgid "[I]Episodes automatically skip to end.[/I]"
+msgstr ""
+
 
 ### SETTINGS
 msgctxt "#30500"
@@ -183,6 +191,10 @@ msgstr "Для разработчика"
 msgctxt "#30801"
 msgid "Test how the user interface looks"
 msgstr "Проверьте, как выглядит пользовательский интерфейс"
+
+msgctxt "#30803"
+msgid "Enable DEMO mode"
+msgstr ""
 
 msgctxt "#30805"
 msgid "Show an UpNext pop-up…"

--- a/service.upnext/resources/language/resource.language.sk_sk/strings.po
+++ b/service.upnext/resources/language/resource.language.sk_sk/strings.po
@@ -17,7 +17,7 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n>=2 && n<=4 ? 1 : 2);\n"
 "X-Generator: Poedit 2.2.4\n"
 
-# ## APPLICATION
+### APPLICATION
 msgctxt "#30006"
 msgid "Watch Now"
 msgstr "Pozerať teraz"
@@ -94,7 +94,16 @@ msgctxt "#30049"
 msgid "Next Episode"
 msgstr "Ďalšia epizóda"
 
-# ## SETTINGS
+msgctxt "#30060"
+msgid "[B]UP NEXT DEMO MODE ENABLED[/B]"
+msgstr ""
+
+msgctxt "#30061"
+msgid "[I]Episodes automatically skip to end.[/I]"
+msgstr ""
+
+
+### SETTINGS
 msgctxt "#30500"
 msgid "Interface"
 msgstr "Rozhranie"
@@ -182,6 +191,10 @@ msgstr "Vývojár"
 msgctxt "#30801"
 msgid "Test how the user interface looks"
 msgstr "Otestuj ako vyzerá rozhranie"
+
+msgctxt "#30803"
+msgid "Enable DEMO mode"
+msgstr ""
 
 msgctxt "#30805"
 msgid "Show an UpNext pop-up…"

--- a/service.upnext/resources/language/resource.language.sv_se/strings.po
+++ b/service.upnext/resources/language/resource.language.sv_se/strings.po
@@ -94,6 +94,14 @@ msgctxt "#30049"
 msgid "Next Episode"
 msgstr "Nästa avsnitt"
 
+msgctxt "#30060"
+msgid "[B]UP NEXT DEMO MODE ENABLED[/B]"
+msgstr ""
+
+msgctxt "#30061"
+msgid "[I]Episodes automatically skip to end.[/I]"
+msgstr ""
+
 
 ### SETTINGS
 msgctxt "#30500"
@@ -183,6 +191,10 @@ msgstr "Utvecklare"
 msgctxt "#30801"
 msgid "Test how the user interface looks"
 msgstr "Testa hur användargränssnittet ser ut"
+
+msgctxt "#30803"
+msgid "Enable DEMO mode"
+msgstr ""
 
 msgctxt "#30805"
 msgid "Show an UpNext pop-up…"

--- a/service.upnext/resources/lib/api.py
+++ b/service.upnext/resources/lib/api.py
@@ -35,6 +35,22 @@ class Api:
     def play_kodi_item(episode):
         jsonrpc(method='Player.Open', id=0, params=dict(item=dict(episodeid=episode.get('episodeid'))))
 
+    def queue_next_item(self, episode):
+        next_item = {}
+        if not self.data:
+            next_item.update(episodeid=episode.get('episodeid'))
+        elif self.data.get('play_url'):
+            next_item.update(file=self.data.get('play_url'))
+
+        if next_item:
+            jsonrpc(method='Playlist.Add', id=0, params=dict(playlistid=1, item=next_item))
+
+        return bool(next_item)
+
+    @staticmethod
+    def reset_queue():
+        jsonrpc(method='Playlist.Remove', id=0, params=dict(playlistid=1, position=0))
+
     def get_next_in_playlist(self, position):
         result = jsonrpc(method='Playlist.GetItems', params=dict(
             playlistid=1,

--- a/service.upnext/resources/lib/demo.py
+++ b/service.upnext/resources/lib/demo.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+# GNU General Public License v2.0 (see COPYING or https://www.gnu.org/licenses/gpl-2.0.txt)
+
+from __future__ import absolute_import, division, unicode_literals
+from xbmcgui import ControlLabel, getScreenHeight, getScreenWidth, Window
+from utils import localize, log as ulog
+
+
+class DemoOverlay():
+    def __init__(self, windowid):
+        self.window = Window(windowid)
+        self._demolabel = None
+        self.log('initialized')
+
+    def log(self, msg, level=2):
+        ulog(msg, name=self.__class__.__name__, level=level)
+
+    def show(self):
+        if self._demolabel is not None:
+            return
+        # FIXME: Using a different font does not seem to have much of an impact
+        self._demolabel = ControlLabel(0, getScreenHeight() // 4, getScreenWidth(), 100, localize(30060) + '\n' + localize(30061), font='font36_title', textColor='0xddee9922', alignment=0x00000002)
+        self.window.addControl(self._demolabel)
+        self.log('show', 0)
+
+    def hide(self):
+        if self._demolabel is None:
+            return
+        self.window.removeControl(self._demolabel)
+        self._demolabel = None
+        self.log('hide', 0)
+
+    def _close(self):
+        self.hide()
+        self.log('closed', 0)
+
+    def __del__(self):
+        self.hide()
+        self.log('destroy', 0)

--- a/service.upnext/resources/lib/player.py
+++ b/service.upnext/resources/lib/player.py
@@ -30,13 +30,18 @@ class UpNextPlayer(Player):
     def disable_tracking(self):
         self.state.track = False
 
+    def reset_queue(self):
+        if self.state.queued:
+            self.api.reset_queue()
+            self.state.queued = False
+
     def onPlayBackStarted(self):  # pylint: disable=invalid-name
         """Will be called when kodi starts playing a file"""
-        self.monitor.waitForAbort(5)
+        self.monitor.waitForAbort(2)
         if not getCondVisibility('videoplayer.content(episodes)'):
             return
         self.state.track = True
-
+        self.reset_queue()
 
     def onPlayBackPaused(self):  # pylint: disable=invalid-name
         self.state.pause = True
@@ -46,15 +51,18 @@ class UpNextPlayer(Player):
 
     def onPlayBackStopped(self):  # pylint: disable=invalid-name
         """Will be called when user stops playing a file"""
+        self.reset_queue()
         self.api.reset_addon_data()
         self.state = State()  # Reset state
 
     def onPlayBackEnded(self):  # pylint: disable=invalid-name
         """Will be called when Kodi has ended playing a file"""
+        self.reset_queue()
         self.api.reset_addon_data()
         self.state = State()  # Reset state
 
     def onPlayBackError(self):  # pylint: disable=invalid-name
         """Will be called when when playback stops due to an error"""
+        self.reset_queue()
         self.api.reset_addon_data()
         self.state = State()  # Reset state

--- a/service.upnext/resources/lib/playitem.py
+++ b/service.upnext/resources/lib/playitem.py
@@ -36,6 +36,7 @@ class PlayItem:
             current_episode = self.api.handle_addon_lookup_of_current_episode()
             self.state.current_episode_id = current_episode.get('episodeid')
             if self.state.current_tv_show_id != current_episode.get('tvshowid'):
+                self.log('Change in TV show ID: last: %s / current: %s' % (self.state.current_tv_show_id, current_episode.get('tvshowid')), 2)
                 self.state.current_tv_show_id = current_episode.get('tvshowid')
                 self.state.played_in_a_row = 1
         return episode
@@ -53,10 +54,10 @@ class PlayItem:
             return
 
         item = result.get('result').get('item')
-        self.state.tv_show_id = item.get('tvshowid')
         if item.get('type') != 'episode':
             return
 
+        self.state.tv_show_id = item.get('tvshowid')
         if int(self.state.tv_show_id) == -1:
             current_show_title = item.get('showtitle').encode('utf-8')
             self.state.tv_show_id = self.api.showtitle_to_id(title=current_show_title)
@@ -72,5 +73,6 @@ class PlayItem:
         )
         self.state.current_episode_id = current_episode_id
         if self.state.current_tv_show_id != self.state.tv_show_id:
+            self.log('Change in TV show ID: last: %s / current: %s' % (self.state.current_tv_show_id, self.state.tv_show_id), 2)
             self.state.current_tv_show_id = self.state.tv_show_id
             self.state.played_in_a_row = 1

--- a/service.upnext/resources/lib/script.py
+++ b/service.upnext/resources/lib/script.py
@@ -5,7 +5,7 @@
 from __future__ import absolute_import, division, unicode_literals
 from datetime import datetime, timedelta
 from math import ceil
-from xbmc import Monitor, sleep
+from xbmc import Monitor
 from xbmcgui import WindowXMLDialog
 from statichelper import from_unicode
 from utils import addon_path, get_setting_bool, localize, localize_time
@@ -88,12 +88,13 @@ def test_popup(window):
     popup.show()
     step = 0
     wait = 100
+    wait_s = wait / 1000
     timeout = 10000
     monitor = Monitor()
     while popup and step < timeout and not monitor.abortRequested():
         if popup.pause:
             continue
-        sleep(wait)
+        monitor.waitForAbort(wait_s)
         popup.update_progress_control(timeout, wait)
         step += wait
 

--- a/service.upnext/resources/lib/state.py
+++ b/service.upnext/resources/lib/state.py
@@ -20,3 +20,4 @@ class State:
         self.last_file = None
         self.track = False
         self.pause = False
+        self.queued = False

--- a/service.upnext/resources/lib/stillwatching.py
+++ b/service.upnext/resources/lib/stillwatching.py
@@ -34,7 +34,7 @@ class StillWatching(WindowXMLDialog):
         self.prepare_progress_control()
 
     def set_info(self):
-        episode_info = '%(season)sx%(episode)s.' % self.item
+        episode_info = '{season}x{episode}.'.format(**self.item)
         if self.item.get('rating') is None:
             rating = ''
         else:

--- a/service.upnext/resources/lib/upnext.py
+++ b/service.upnext/resources/lib/upnext.py
@@ -39,7 +39,7 @@ class UpNext(WindowXMLDialog):
             self.getControl(3013).setLabel(localize(30034))  # Close
 
     def set_info(self):
-        episode_info = '%(season)sx%(episode)s.' % self.item
+        episode_info = '{season}x{episode}.'.format(**self.item)
         if self.item.get('rating') is None:
             rating = ''
         else:

--- a/service.upnext/resources/lib/utils.py
+++ b/service.upnext/resources/lib/utils.py
@@ -4,7 +4,7 @@
 from __future__ import absolute_import, division, unicode_literals
 import sys
 import json
-from xbmc import executeJSONRPC, getRegion, log as xlog, LOGDEBUG, LOGNOTICE
+from xbmc import executeJSONRPC, getInfoLabel, getRegion, log as xlog, LOGDEBUG, LOGINFO
 from xbmcaddon import Addon
 from xbmcgui import Window
 from statichelper import from_unicode, to_unicode
@@ -25,6 +25,12 @@ def addon_id():
 def addon_path():
     """Return add-on path"""
     return get_addon_info('path')
+
+
+def get_kodi_version():
+    """Return Kodi version number as float"""
+    build = getInfoLabel("System.BuildVersion")
+    return float(build[:4])
 
 
 def get_property(key, window_id=10000):
@@ -143,7 +149,12 @@ def log(msg, name=None, level=1):
     set_property('logLevel', log_level)
     if not debug_logging and log_level < level:
         return
-    level = LOGDEBUG if debug_logging else LOGNOTICE
+    if debug_logging:
+        level = LOGDEBUG
+    elif get_kodi_version() >= 19:
+        level = LOGINFO
+    else:
+        level = LOGINFO + 1
     xlog('[%s] %s -> %s' % (addon_id(), name, from_unicode(msg)), level=level)
 
 
@@ -187,3 +198,13 @@ def localize_time(time):
     time_format = time_format.replace(':%S', '')
 
     return time.strftime(time_format)
+
+
+def kodi_version():
+    """Returns full Kodi version as string"""
+    return getInfoLabel('System.BuildVersion').split(' ')[0]
+
+
+def kodi_version_major():
+    """Returns major Kodi version as integer"""
+    return int(kodi_version().split('.')[0])

--- a/service.upnext/resources/settings.xml
+++ b/service.upnext/resources/settings.xml
@@ -10,7 +10,7 @@
         <setting label="30605" type="bool" id="includeWatched" default="false"/>
         <setting label="30607" type="slider" id="playedInARow" default="3" range="0,1,15" option="int"/>
         <setting label="30609" type="lsep"/> <!-- Autoplay duration -->
-        <setting label="30611" type="bool" id="customAutoPlayTime" default="false"/>
+        <setting label="30611" type="bool" id="customAutoPlayTime" default="true"/>
         <setting label="30613" type="slider" id="autoPlaySeasonTime" default="30" range="0,5,120" option="int" subsetting="true" visible="eq(-1,false)"/>
         <setting label="30615" type="slider" id="autoPlayTimeXS" default="15" range="0,5,120" option="int" subsetting="true" visible="eq(-2,true)"/>
         <setting label="30617" type="slider" id="autoPlayTimeS" default="30" range="0,5,120" option="int" subsetting="true" visible="eq(-3,true)"/>
@@ -24,6 +24,7 @@
     </category>
     <category label="30800"> <!-- Developer -->
         <setting label="30801" type="lsep"/> <!-- Test the GUI -->
+        <setting label="30803" type="bool" id="enableDemoMode" default="false"/>
         <setting label="30805" type="action" action="RunScript(service.upnext,test_window,script-upnext-upnext.xml)"/>
         <setting label="30807" type="action" action="RunScript(service.upnext,test_window,script-upnext-upnext-simple.xml)"/>
         <setting label="30809" type="action" action="RunScript(service.upnext,test_window,script-upnext-stillwatching.xml)"/>


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: Up Next
  - Add-on ID: service.upnext
  - Version number: 1.1.3
  - Kodi/repository version: leia

- **Code location**
  - URL: https://github.com/im85288/service.upnext
  
A service add-on that shows a Netflix-style notification for watching the next episode. After a few automatic iterations it asks the user if he is still there watching.

A lot of existing add-ons already integrate with this service out-of-the-box.

### Description of changes:


### v1.1.3 (2020-10-14)
- Enable customPlayTime by default
- Do not seek to the end before playing next episode
- Add Kodi v17 compatibility
- Fix logging on Kodi v19 (Matrix) after recent breakage
- Enqueue the next episode in the playlist

### v1.1.2 (2020-06-22)
- Bug fix for change from sleep to waitForAbort using seconds and not ms

### v1.1.1 (2020-06-21)
- Avoid conflict with external players
- Restore "Ignore Playlist" option
- Fix a known Kodi bug related to displaying hours
- Improvements to endtime visualization
- New translations for Hindi and Romanian
- Translation updates to Hungarian and Spanish

### v1.1.0 (2020-01-17)
- Add notification_offset for Netflix add-on
- Fix various runtime exceptions
- Implement new settings
- Implement new developer mode
- Show current time and next endtime in notification
- New translations for Brazilian, Czech, Greek, Japanese, Korean
- New translations for Russian, Slovak, Spanish, Swedish
- Translation updates to Croatian, French, German, Hungarian, Italian, Polish
        

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
