### PR TITLE
[script.module.adobepass@krypton] 2020.11.5

### DIFF
--- a/script.module.adobepass/addon.xml
+++ b/script.module.adobepass/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.module.adobepass" name="adobepass" version="2020.10.12" provider-name="eracknaphobia">
+<addon id="script.module.adobepass" name="adobepass" version="2020.11.5" provider-name="eracknaphobia">
   <requires>
     <import addon="xbmc.python" version="2.25.0"/>
     <import addon="script.module.requests"/>

--- a/script.module.adobepass/lib/adobepass/adobe.py
+++ b/script.module.adobepass/lib/adobepass/adobe.py
@@ -1,4 +1,4 @@
-import os
+import os, sys
 import uuid, hmac, hashlib, base64, time
 from kodi_six import xbmc, xbmcgui, xbmcaddon, xbmcvfs
 import requests


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: adobepass
  - Add-on ID: script.module.adobepass
  - Version number: 2020.11.5
  - Kodi/repository version: krypton

- **Code location**
  - URL: https://github.com/eracknaphobia/script.module.adobepass
  
Simplify Logins authentication services that use adobe primetime (formely adobe pass)

### Description of changes:



### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
