### PR TITLE
[service.libraryautoupdate] 1.2.1

### DIFF
--- a/service.libraryautoupdate/addon.xml
+++ b/service.libraryautoupdate/addon.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="service.libraryautoupdate"
-    name="Library Auto Update" version="1.2.0" provider-name="robweber">
+    name="Library Auto Update" version="1.2.1" provider-name="robweber">
   <requires>
     <import addon="xbmc.python" version="3.0.0"/>
     <import addon="script.module.dateutil" version="2.7.3" />
@@ -78,7 +78,7 @@
 	<assets>
 		<icon>resources/media/icon.png</icon>
 	</assets>
-	<news>Version 1.2
-- matrix compatible </news>
+	<news>Version 1.2.1
+- fixes for deprecated Python module calls</news>
   </extension>
 </addon>

--- a/service.libraryautoupdate/manual.py
+++ b/service.libraryautoupdate/manual.py
@@ -8,7 +8,7 @@ runUpdate = False
 if(not utils.getSettingBool('disable_manual_prompt')):
     nextRun = autoUpdate.showNotify(False)
     # check if we should run updates
-    runUpdate = xbmcgui.Dialog().yesno(utils.getString(30000), utils.getString(30060) + nextRun, line2=utils.getString(30061), autoclose=6000)
+    runUpdate = xbmcgui.Dialog().yesno(utils.getString(30000), "%s %s \n %s" % (utils.getString(30060), nextRun, utils.getString(30061)), autoclose=6000)
 else:
     # the user has elected to skip the prompt
     runUpdate = True

--- a/service.libraryautoupdate/resources/lib/cronclasses.py
+++ b/service.libraryautoupdate/resources/lib/cronclasses.py
@@ -29,7 +29,7 @@ class CronSchedule:
 
 
 class CustomPathFile:
-    jsonFile = xbmc.translatePath(utils.data_dir() + "custom_paths.json")
+    jsonFile = xbmcvfs.translatePath(utils.data_dir() + "custom_paths.json")
     paths = None
     contentType = 'video'  # all by default
 

--- a/service.libraryautoupdate/resources/lib/service.py
+++ b/service.libraryautoupdate/resources/lib/service.py
@@ -294,9 +294,9 @@ class AutoUpdater:
     def readLastRun(self):
         if(self.last_run == 0):
             # read it in from the settings
-            if(xbmcvfs.exists(xbmc.translatePath(utils.data_dir() + "last_run.txt"))):
+            if(xbmcvfs.exists(xbmcvfs.translatePath(utils.data_dir() + "last_run.txt"))):
 
-                runFile = xbmcvfs.File(xbmc.translatePath(utils.data_dir() + "last_run.txt"))
+                runFile = xbmcvfs.File(xbmcvfs.translatePath(utils.data_dir() + "last_run.txt"))
 
                 try:
                     # there may be an issue with this file, we'll get it the next time through
@@ -309,7 +309,7 @@ class AutoUpdater:
                 self.last_run = 0
 
     def writeLastRun(self):
-        runFile = xbmcvfs.File(xbmc.translatePath(utils.data_dir() + "last_run.txt"), 'w')
+        runFile = xbmcvfs.File(xbmcvfs.translatePath(utils.data_dir() + "last_run.txt"), 'w')
         runFile.write(str(self.last_run))
         runFile.close()
 

--- a/service.libraryautoupdate/resources/lib/utils.py
+++ b/service.libraryautoupdate/resources/lib/utils.py
@@ -5,8 +5,8 @@ __Addon = xbmcaddon.Addon(__addon_id__)
 
 
 def check_data_dir():
-    if(not xbmcvfs.exists(xbmc.translatePath(data_dir()))):
-        xbmcvfs.mkdir(xbmc.translatePath(data_dir()))
+    if(not xbmcvfs.exists(xbmcvfs.translatePath(data_dir()))):
+        xbmcvfs.mkdir(xbmcvfs.translatePath(data_dir()))
 
 
 def data_dir():
@@ -22,7 +22,7 @@ def log(message, loglevel=xbmc.LOGDEBUG):
 
 
 def showNotification(title, message):
-    xbmcgui.Dialog().notification(getString(30000), message, time=5000, icon=xbmc.translatePath(__Addon.getAddonInfo('path') + "/resources/media/icon.png"), sound=False)
+    xbmcgui.Dialog().notification(getString(30000), message, time=5000, icon=xbmcvfs.translatePath(__Addon.getAddonInfo('path') + "/resources/media/icon.png"), sound=False)
 
 
 def setSetting(name, value):


### PR DESCRIPTION
### Description
Updated to remove calls to deprecated Python library functions for both ```xbmcgui.Dialog()``` and ```xbmc.translatePath```

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [script.foo.bar] 1.0.0

Additional information :
- Submitting your add-on to this specific branch makes it available to any Kodi version equal or higher than the branch name with the applicable Kodi dependencies limits.
- [add-on development](http://kodi.wiki/view/Add-on_development) wiki page.
- Kodi [pydocs](http://kodi.wiki/view/PyDocs) provide information about the Python API
- [PEP8](https://www.python.org/dev/peps/pep-0008/) codingstyle which is considered best practise but not mandatory.
- This add-on repository has automated code guideline check which could help you improve your coding. You can find the results of these check at [Codacy](https://www.codacy.com/app/Kodi/repo-scripts/dashboard). You can create your own account as well to continuously monitor your python coding before submitting to repo.
- Development questions can be asked in the [add-on development](http://forum.kodi.tv/forumdisplay.php?fid=26) section on the Kodi forum.
