### PR TITLE
[weather.ozweather@matrix] 1.2.2

### DIFF
--- a/weather.ozweather/addon.xml
+++ b/weather.ozweather/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="weather.ozweather" name="Oz Weather" version="1.2.1" provider-name="Bossanova808">
+<addon id="weather.ozweather" name="Oz Weather" version="1.2.2" provider-name="Bossanova808">
 	<requires>
 		<import addon="xbmc.python" version="3.0.0"/>
     	<import addon="script.module.requests" version="2.22.0+matrix.1"/>
@@ -21,7 +21,9 @@
        		<icon>icon.png</icon>
        		<fanart>fanart.jpg</fanart>
 		</assets>
-		<news>V1.2.1
+		<news>V1.2.2
+			- Fix for setting of new locations
+			V1.2.1
 			- Updated for change in Kodi logging functions (LOGNOTICE -> LOGINFO)
 			v1.2.0
 			- Updated for Kodi Matrix and Python 3

--- a/weather.ozweather/changelog.txt
+++ b/weather.ozweather/changelog.txt
@@ -1,4 +1,9 @@
-v1.2 
+
+v1.2.2
+ - Change xbmc.translatePath (deprecated) to xbmcvfs.translatePath
+ - Fix missing import in locations.py that broke setting new locations
+
+v1.2.1
  - Submit to Kodi Matrx repo
  - Add github workflows for addon checking & submission
 

--- a/weather.ozweather/resources/lib/common.py
+++ b/weather.ozweather/resources/lib/common.py
@@ -7,6 +7,7 @@
 # (For Kodi Matrix & later)
 
 import xbmc
+import xbmcvfs
 import xbmcgui
 import xbmcaddon
 import sys
@@ -21,7 +22,7 @@ ADDON_VERSION = ADDON.getAddonInfo('version')
 ADDON_ARGUMENTS = str(sys.argv)
 CWD = ADDON.getAddonInfo('path')
 LANGUAGE = ADDON.getLocalizedString
-PROFILE = xbmc.translatePath(ADDON.getAddonInfo('profile'))
+PROFILE = xbmcvfs.translatePath(ADDON.getAddonInfo('profile'))
 KODI_VERSION = xbmc.getInfoLabel('System.BuildVersion')
 USER_AGENT = "Mozilla/5.0 (Windows; U; Windows NT 5.1; fr; rv:1.9.0.1) Gecko/2008070208 Firefox/3.6"
 WEATHER_WINDOW = xbmcgui.Window(12600)

--- a/weather.ozweather/resources/lib/forecast.py
+++ b/weather.ozweather/resources/lib/forecast.py
@@ -1,4 +1,5 @@
 import xbmc
+import xbmcvfs
 import xbmcgui
 
 from resources.lib.common import *
@@ -118,9 +119,9 @@ def forecast(urlPath, radarCode):
     if extended_features == "true":
         log("Getting radar images for " + radarCode)
 
-        backgroundsPath = xbmc.translatePath(
+        backgroundsPath = xbmcvfs.translatePath(
             "special://profile/addon_data/weather.ozweather/radarbackgrounds/" + radarCode + "/");
-        overlayLoopPath = xbmc.translatePath(
+        overlayLoopPath = xbmcvfs.translatePath(
             "special://profile/addon_data/weather.ozweather/currentloop/" + radarCode + "/");
 
         updateRadarBackgrounds = ADDON.getSetting('BGDownloadToggle')
@@ -157,7 +158,7 @@ def get_forecast():
     clear_properties()
 
     # Set basic properties/'brand'
-    set_property(WEATHER_WINDOW, 'WeatherProviderLogo', xbmc.translatePath(os.path.join(CWD, 'resources', 'banner.png')))
+    set_property(WEATHER_WINDOW, 'WeatherProviderLogo', xbmcvfs.translatePath(os.path.join(CWD, 'resources', 'banner.png')))
     set_property(WEATHER_WINDOW, 'WeatherProvider', 'Bureau of Meteorology Australia (via WeatherZone)')
     set_property(WEATHER_WINDOW, 'WeatherVersion', ADDON_NAME + "-" + ADDON_VERSION)
 

--- a/weather.ozweather/resources/lib/locations.py
+++ b/weather.ozweather/resources/lib/locations.py
@@ -2,6 +2,7 @@ import xbmc
 import xbmcgui
 
 from resources.lib.common import *
+from resources.lib.weatherzone import *
 
 
 def refresh_locations():


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: Oz Weather
  - Add-on ID: weather.ozweather
  - Version number: 1.2.2
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/bossanova808/weather.ozweather
  
Weather forecast data scraped from the Australian Bureau of Meteorology via WeatherZone - www.bom.gov.au and www.weatherzone.com.au.  For full features (e.g. radar) make sure you install the replacement skin files found via the addon wiki (https://kodi.wiki/index.php?title=Add-on:Oz_Weather).

### Description of changes:

V1.2.2
			- Fix for setting of new locations
			V1.2.1
			- Updated for change in Kodi logging functions (LOGNOTICE -> LOGINFO)
			v1.2.0
			- Updated for Kodi Matrix and Python 3
    	

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
