### PR TITLE
[script.embuary.info@leia] 1.2.7

### DIFF
--- a/script.embuary.info/addon.xml
+++ b/script.embuary.info/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.embuary.info" name="Embuary Info" version="1.2.6" provider-name="sualfred">
+<addon id="script.embuary.info" name="Embuary Info" version="1.2.7" provider-name="sualfred">
     <requires>
         <import addon="xbmc.python" version="2.26.0"/>
         <import addon="script.module.requests" version="2.9.1"/>

--- a/script.embuary.info/resources/lib/tmdb.py
+++ b/script.embuary.info/resources/lib/tmdb.py
@@ -505,7 +505,11 @@ def tmdb_handle_season(item,tvshow_details,full_info=False):
 
 def tmdb_fallback_info(item,key):
     if FALLBACK_LANGUAGE == DEFAULT_LANGUAGE:
-        key_value = item.get(key, '').replace('&amp;', '&').strip()
+        try:
+            key_value = item.get(key, '').replace('&amp;', '&').strip()
+        except Exception:
+            key_value = ''
+
     else:
         key_value = tmdb_get_translation(item, key, DEFAULT_LANGUAGE)
 
@@ -526,7 +530,7 @@ def tmdb_get_translation(item,key,language):
                     key_value = translation['data'][key]
 
                     if key_value:
-                            return key_value.replace('&amp;', '&').strip()
+                        return key_value.replace('&amp;', '&').strip()
     except Exception:
         pass
 


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: Embuary Info
  - Add-on ID: script.embuary.info
  - Version number: 1.2.7
  - Kodi/repository version: leia

- **Code location**
  - URL: https://github.com/sualfred/script.embuary.info
  
Helper script to provide The Movie DB informations for persons, shows and movies. Works best with a skin integration.

### Description of changes:



### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
