### PR TITLE
[service.upnext@matrix] 1.1.4+matrix.1

### DIFF
--- a/service.upnext/README.md
+++ b/service.upnext/README.md
@@ -23,15 +23,21 @@ The add-on has various settings to fine-tune the experience, however the default
 For [Addon Integration](https://github.com/im85288/service.upnext/wiki/Addon-Integration) and [Skinners](https://github.com/im85288/service.upnext/wiki/Skinners) see the [wiki](https://github.com/im85288/service.upnext/wiki)
 
 ## Releases
+### v1.1.4 (2020-12-03)
+- Fix problem causing pop-up to not appear (@MoojMidge)
+- Translation updates to Romanian, Russian and Spanish (@tmihai20, @vlmaksime, @roliverosc)
+
 ### v1.1.3 (2020-10-14)
 - Enable customPlayTime by default (@dagwieers)
 - Do not seek to the end before playing next episode (@dagwieers)
 - Add Kodi v17 compatibility (@dagwieers)
 - Fix logging on Kodi v19 (Matrix) after recent breakage (@MoojMidge)
 - Enqueue the next episode in the playlist (@MoojMidge)
+- Translation updates to German (@tweimer)
 
 ### v1.1.2 (2020-06-22)
 - Small bugfix release (@im85288)
+- Translation updates to Japanese and Korean (@Thunderbird2086)
 
 ### v1.1.1 (2020-06-21)
 - Avoid conflict with external players (@BrutuZ)

--- a/service.upnext/addon.xml
+++ b/service.upnext/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="service.upnext" name="Up Next" version="1.1.3+matrix.1" provider-name="im85288">
+<addon id="service.upnext" name="Up Next" version="1.1.4+matrix.1" provider-name="im85288">
     <requires>
         <import addon="xbmc.python" version="3.0.0"/>
     </requires>
@@ -40,15 +40,21 @@ Många befintliga tillägg integreras redan med den här utanför lådan-tjänst
         <platform>all</platform>
         <license>GPL-2.0-only</license>
         <news>
+### v1.1.4 (2020-12-03)
+- Fix problem causing pop-up to not appear
+- Translation updates to Romanian, Russian and Spanish
+
 ### v1.1.3 (2020-10-14)
 - Enable customPlayTime by default
 - Do not seek to the end before playing next episode
 - Add Kodi v17 compatibility
 - Fix logging on Kodi v19 (Matrix) after recent breakage
 - Enqueue the next episode in the playlist
+- Translation updates to German
 
 ### v1.1.2 (2020-06-22)
 - Bug fix for change from sleep to waitForAbort using seconds and not ms
+- Translation updates to Japanese and Korean
 
 ### v1.1.1 (2020-06-21)
 - Avoid conflict with external players

--- a/service.upnext/resources/language/resource.language.es_es/strings.po
+++ b/service.upnext/resources/language/resource.language.es_es/strings.po
@@ -96,11 +96,11 @@ msgstr "Siguiente episodio"
 
 msgctxt "#30060"
 msgid "[B]UP NEXT DEMO MODE ENABLED[/B]"
-msgstr ""
+msgstr "[B]UP NEXT MODO DE DEMOSTRACIÓN HABILITADO[/B]"
 
 msgctxt "#30061"
 msgid "[I]Episodes automatically skip to end.[/I]"
-msgstr ""
+msgstr "[I]Los episodios saltan automáticamente al final.[/I]"
 
 
 # ## SETTINGS
@@ -194,7 +194,7 @@ msgstr "Prueba cómo se ve la interfaz de usuario"
 
 msgctxt "#30803"
 msgid "Enable DEMO mode"
-msgstr ""
+msgstr "Habilitar modo DEMO"
 
 msgctxt "#30805"
 msgid "Show an UpNext pop-up…"

--- a/service.upnext/resources/language/resource.language.ro_ro/strings.po
+++ b/service.upnext/resources/language/resource.language.ro_ro/strings.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: service.upnext\n"
 "Report-Msgid-Bugs-To: https://github.com/im85288/service.upnext\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"PO-Revision-Date: 2020-03-29 16:59+0000\n"
+"PO-Revision-Date: 2020-11-29 22:22+0000\n"
 "Last-Translator: tmihai20\n"
 "Language-Team: Română\n"
 "MIME-Version: 1.0\n"
@@ -97,11 +97,11 @@ msgstr "Următorul episod"
 
 msgctxt "#30060"
 msgid "[B]UP NEXT DEMO MODE ENABLED[/B]"
-msgstr ""
+msgstr "[B]MOD DEMO ACTIVAT UP NEXT"
 
 msgctxt "#30061"
 msgid "[I]Episodes automatically skip to end.[/I]"
-msgstr ""
+msgstr "[I]Episoadele se derulează automat către sfârșit"
 
 
 ### SETTINGS
@@ -195,7 +195,7 @@ msgstr "Testează cum arată interfața utilizator"
 
 msgctxt "#30803"
 msgid "Enable DEMO mode"
-msgstr ""
+msgstr "Activează mod DEMO"
 
 msgctxt "#30805"
 msgid "Show an UpNext pop-up…"

--- a/service.upnext/resources/language/resource.language.ru_ru/strings.po
+++ b/service.upnext/resources/language/resource.language.ru_ru/strings.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: service.upnext\n"
 "Report-Msgid-Bugs-To: https://github.com/im85288/service.upnext\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"PO-Revision-Date: 2018-02-26 13:31+0000\n"
+"PO-Revision-Date: 202020-12-02 00:00+0000\n"
 "Last-Translator: vl_maksime\n"
 "Language-Team: Russian\n"
 "MIME-Version: 1.0\n"
@@ -96,11 +96,11 @@ msgstr "Следующая серия"
 
 msgctxt "#30060"
 msgid "[B]UP NEXT DEMO MODE ENABLED[/B]"
-msgstr ""
+msgstr "[B]ДЕМО-РЕЖИМ UP NEXT ВКЛЮЧЕН[/B]"
 
 msgctxt "#30061"
 msgid "[I]Episodes automatically skip to end.[/I]"
-msgstr ""
+msgstr "[I]Серии автоматически переходят на конец.[/I]"
 
 
 ### SETTINGS
@@ -194,7 +194,7 @@ msgstr "Проверьте, как выглядит пользовательск
 
 msgctxt "#30803"
 msgid "Enable DEMO mode"
-msgstr ""
+msgstr "Включить ДЕМО-режим"
 
 msgctxt "#30805"
 msgid "Show an UpNext pop-up…"

--- a/service.upnext/resources/lib/player.py
+++ b/service.upnext/resources/lib/player.py
@@ -37,7 +37,7 @@ class UpNextPlayer(Player):
 
     def onPlayBackStarted(self):  # pylint: disable=invalid-name
         """Will be called when kodi starts playing a file"""
-        self.monitor.waitForAbort(2)
+        self.monitor.waitForAbort(5)
         if not getCondVisibility('videoplayer.content(episodes)'):
             return
         self.state.track = True


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: Up Next
  - Add-on ID: service.upnext
  - Version number: 1.1.4+matrix.1
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/im85288/service.upnext
  
A service add-on that shows a Netflix-style notification for watching the next episode. After a few automatic iterations it asks the user if he is still there watching.

A lot of existing add-ons already integrate with this service out-of-the-box.

### Description of changes:


### v1.1.4 (2020-12-03)
- Fix problem causing pop-up to not appear
- Translation updates to Romanian, Russian and Spanish

### v1.1.3 (2020-10-14)
- Enable customPlayTime by default
- Do not seek to the end before playing next episode
- Add Kodi v17 compatibility
- Fix logging on Kodi v19 (Matrix) after recent breakage
- Enqueue the next episode in the playlist
- Translation updates to German

### v1.1.2 (2020-06-22)
- Bug fix for change from sleep to waitForAbort using seconds and not ms
- Translation updates to Japanese and Korean

### v1.1.1 (2020-06-21)
- Avoid conflict with external players
- Restore "Ignore Playlist" option
- Fix a known Kodi bug related to displaying hours
- Improvements to endtime visualization
- New translations for Hindi and Romanian
- Translation updates to Hungarian and Spanish

### v1.1.0 (2020-01-17)
- Add notification_offset for Netflix add-on
- Fix various runtime exceptions
- Implement new settings
- Implement new developer mode
- Show current time and next endtime in notification
- New translations for Brazilian, Czech, Greek, Japanese, Korean
- New translations for Russian, Slovak, Spanish, Swedish
- Translation updates to Croatian, French, German, Hungarian, Italian, Polish
        

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
