### PR TITLE
[service.iptv.manager@leia] 0.2.2

### DIFF
--- a/service.iptv.manager/CHANGELOG.md
+++ b/service.iptv.manager/CHANGELOG.md
@@ -1,8 +1,28 @@
 # Changelog
 
+## [v0.2.2](https://github.com/add-ons/service.iptv.manager/tree/v0.2.2) (2020-12-07)
+
+[Full Changelog](https://github.com/add-ons/service.iptv.manager/compare/v0.2.1...v0.2.2)
+
+**Implemented enhancements:**
+
+- Allow passing credits with the EPG data [\#54](https://github.com/add-ons/service.iptv.manager/pull/54) ([michaelarnauts](https://github.com/michaelarnauts))
+
+**Fixed bugs:**
+
+- Rollback pvr.iptvsimple to 3.8.8 [\#57](https://github.com/add-ons/service.iptv.manager/pull/57) ([MPParsley](https://github.com/MPParsley))
+
+**Merged pull requests:**
+
+- Run tests on Python 3.9 [\#55](https://github.com/add-ons/service.iptv.manager/pull/55) ([michaelarnauts](https://github.com/michaelarnauts))
+
 ## [v0.2.1](https://github.com/add-ons/service.iptv.manager/tree/v0.2.1) (2020-11-03)
 
 [Full Changelog](https://github.com/add-ons/service.iptv.manager/compare/v0.2.0...v0.2.1)
+
+**Implemented enhancements:**
+
+- Cleanup code by removing play by airdate [\#49](https://github.com/add-ons/service.iptv.manager/pull/49) ([michaelarnauts](https://github.com/michaelarnauts))
 
 **Fixed bugs:**
 
@@ -10,7 +30,6 @@
 
 **Merged pull requests:**
 
-- Cleanup code by removing play by airdate [\#49](https://github.com/add-ons/service.iptv.manager/pull/49) ([michaelarnauts](https://github.com/michaelarnauts))
 - Add a release workflow [\#45](https://github.com/add-ons/service.iptv.manager/pull/45) ([dagwieers](https://github.com/dagwieers))
 
 ## [v0.2.0](https://github.com/add-ons/service.iptv.manager/tree/v0.2.0) (2020-10-09)

--- a/service.iptv.manager/addon.xml
+++ b/service.iptv.manager/addon.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="service.iptv.manager" name="IPTV Manager" version="0.2.1" provider-name="Michaël Arnauts">
+<addon id="service.iptv.manager" name="IPTV Manager" version="0.2.2" provider-name="Michaël Arnauts">
     <requires>
         <import addon="xbmc.python" version="2.26.0"/>
         <import addon="script.module.dateutil" version="2.6.0"/>
-        <import addon="pvr.iptvsimple" version="3.9.8"/>
+        <import addon="pvr.iptvsimple" version="3.8.8"/>
     </requires>
     <!-- This is needed to get an add-on icon -->
     <extension point="xbmc.python.script" library="default.py">
@@ -26,9 +26,9 @@
         <description lang="ru_RU">Это дополнение интегрирует IPTV каналы из других дополнений в Kodi PVR.</description>
         <platform>all</platform>
         <license>GPL-3.0-only</license>
-        <news>v0.2.1 (2020-11-03)
-- Code cleanup
-- Bugfix when no supported Addons are installed.</news>
+        <news>v0.2.2 (2020-12-07)
+- Relax version restriction for IPTV Simple.
+- Process credits.</news>
         <source>https://github.com/add-ons/service.iptv.manager</source>
         <assets>
             <icon>resources/icon.png</icon>


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: IPTV Manager
  - Add-on ID: service.iptv.manager
  - Version number: 0.2.2
  - Kodi/repository version: leia

- **Code location**
  - URL: https://github.com/add-ons/service.iptv.manager
  
This add-on integrates IPTV Channels from other Add-ons in the Kodi PVR.

### Description of changes:

v0.2.2 (2020-12-07)
- Relax version restriction for IPTV Simple.
- Process credits.

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
