### PR TITLE
[script.module.inputstreamhelper@krypton] 0.5.2

### DIFF
--- a/script.module.inputstreamhelper/README.md
+++ b/script.module.inputstreamhelper/README.md
@@ -90,6 +90,9 @@ Please report any issues or bug reports on the [GitHub Issues](https://github.co
 This module is licensed under the **The MIT License**. Please see the [LICENSE.txt](LICENSE.txt) file for details.
 
 ## Releases
+### v0.5.2 (2020-12-13)
+- Update Chrome OS ARM hardware id's (@mediaminister)
+
 ### v0.5.1 (2020-10-02)
 - Fix incorrect ARM HWIDs: PHASER and PHASER360 (@dagwieers)
 - Added Hebrew translations (@haggaie)

--- a/script.module.inputstreamhelper/addon.xml
+++ b/script.module.inputstreamhelper/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.module.inputstreamhelper" name="InputStream Helper" version="0.5.1" provider-name="emilsvennesson, dagwieers, mediaminister, horstle">
+<addon id="script.module.inputstreamhelper" name="InputStream Helper" version="0.5.2" provider-name="emilsvennesson, dagwieers, mediaminister, horstle">
   <requires>
     <!--py3 compliant-->
     <import addon="xbmc.python" version="2.25.0"/>
@@ -23,6 +23,9 @@
     <description lang="fr_FR">Un simple module Kodi qui simplifie la vie des développeurs de modules complémentaires en s’appuyant sur des modules complémentaires basés sur InputStream et sur la lecture de DRM.</description>
     <description lang="es_ES">Un módulo Kodi simple que hace la vida más fácil para los desarrolladores de complementos que dependen de complementos basados en InputStream y reproducción de DRM.</description>
     <news>
+v0.5.2 (2020-12-13)
+- Update Chrome OS ARM hardware id's
+
 v0.5.1 (2020-10-02)
 - Fix incorrect ARM HWIDs: PHASER and PHASER360
 - Added Hebrew translations

--- a/script.module.inputstreamhelper/lib/inputstreamhelper/config.py
+++ b/script.module.inputstreamhelper/lib/inputstreamhelper/config.py
@@ -79,36 +79,24 @@ WIDEVINE_CONFIG_NAME = 'manifest.json'
 
 CHROMEOS_RECOVERY_URL = 'https://dl.google.com/dl/edgedl/chromeos/recovery/recovery.json'
 
-# Last updated: 2019-08-20 (version 12239.67.0)
+# To keep the Chrome OS ARM hardware ID list up to date, the following resources can be used:
+# https://www.chromium.org/chromium-os/developer-information-for-chrome-os-devices
+# https://cros-updates-serving.appspot.com/
+# Last updated: 2020-10-05
 CHROMEOS_RECOVERY_ARM_HWIDS = [
-    # 'ARKHAM',
-    'BIG',
-    'BLAZE',
     'BOB',
-    # 'DAISY',
     'DRUWL',
     'DUMO',
     'ELM',
-    'EXPRESSO',
     'FIEVEL',
     'HANA',
-    'JAQ',
-    'JERRY',
+    'JUNIPER-HVPU',
     'KEVIN',
-    'KITTY',
+    'KODAMA',
+    'KRANE-ZDKS',
     'MICKEY',
-    'MIGHTY',
-    'MINNIE',
-    'PI',
-    'PIT',
-    'RELM',
     'SCARLET',
-    'SKATE',
-    'SNOW',
-    'SPEEDY',
-    'SPRING',
     'TIGER',
-    # 'WHIRLWIND',
 ]
 
 CHROMEOS_BLOCK_SIZE = 512

--- a/script.module.inputstreamhelper/lib/inputstreamhelper/kodiutils.py
+++ b/script.module.inputstreamhelper/lib/inputstreamhelper/kodiutils.py
@@ -7,6 +7,13 @@ from contextlib import contextmanager
 import xbmc
 import xbmcaddon
 from xbmcgui import DialogProgress, DialogProgressBG
+
+try:  # Kodi v19 or newer
+    from xbmcvfs import translatePath
+except ImportError:  # Kodi v18 and older
+    # pylint: disable=ungrouped-imports
+    from xbmc import translatePath
+
 from .unicodes import from_unicode, to_unicode
 
 # NOTE: We need to explicitly add the add-on id here!
@@ -60,7 +67,7 @@ def kodi_version_major():
 
 def translate_path(path):
     """Translate special xbmc paths"""
-    return to_unicode(xbmc.translatePath(from_unicode(path)))
+    return to_unicode(translatePath(from_unicode(path)))
 
 
 def get_addon_info(key):
@@ -186,14 +193,11 @@ def get_setting_int(key, default=None):
 
 def get_setting_float(key, default=None):
     """Get an add-on setting as float"""
+    value = get_setting(key, default)
     try:
-        return ADDON.getSettingNumber(key)
-    except (AttributeError, TypeError):  # On Krypton or older, or when not a float
-        value = get_setting(key, default)
-        try:
-            return float(value)
-        except ValueError:
-            return default
+        return float(value)
+    except ValueError:
+        return default
     except RuntimeError:  # Occurs when the add-on is disabled
         return default
 

--- a/script.module.inputstreamhelper/lib/inputstreamhelper/widevine/arm.py
+++ b/script.module.inputstreamhelper/lib/inputstreamhelper/widevine/arm.py
@@ -147,6 +147,7 @@ def install_widevine_arm(backup_path):
                       localize(30018, diskspace=sizeof_fmt(required_diskspace)))
             return False
 
+        log(2, 'Downloading best ChromeOS image for Widevine: {hwid} ({version})'.format(**arm_device))
         url = arm_device['url']
         downloaded = http_download(url, message=localize(30022), checksum=arm_device['sha1'], hash_alg='sha1',
                                    dl_size=int(arm_device['zipfilesize']))  # Downloading the recovery image

--- a/script.module.inputstreamhelper/resources/settings.xml
+++ b/script.module.inputstreamhelper/resources/settings.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <settings>
-    <setting id="last_modified" value="0.0" visible="false"/>
-    <setting id="last_check" value="0.0" visible="false"/>
-    <setting id="version" value="" visible="false"/>
     <category label="30900"> <!-- Expert -->
+        <setting id="last_modified" default="0.0" visible="false"/>
+        <setting id="last_check" default="0.0" visible="false"/>
+        <setting id="version" default="" visible="false"/>
         <setting label="30901" help="30902" type="action" action="RunScript(script.module.inputstreamhelper, info)"/>
         <setting type="sep"/>
         <setting label="30903" help="30904" type="bool" id="disabled" default="false"/>


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: InputStream Helper
  - Add-on ID: script.module.inputstreamhelper
  - Version number: 0.5.2
  - Kodi/repository version: krypton

- **Code location**
  - URL: https://github.com/emilsvennesson/script.module.inputstreamhelper
  
A simple Kodi module that makes life easier for add-on developers relying on InputStream based add-ons and DRM playback.

### Description of changes:


v0.5.2 (2020-12-13)
- Update Chrome OS ARM hardware id's

v0.5.1 (2020-10-02)
- Fix incorrect ARM HWIDs: PHASER and PHASER360
- Added Hebrew translations
- Updated Dutch, Japanese and Korean translations

v0.5.0 (2020-06-25)
- Extract Widevine CDM directly from Chrome OS, minimizing disk space usage and eliminating the need for root access
- Improve progress dialog while extracting Widevine CDM on ARM devices
- Support resuming interrupted downloads on unreliable internet connections
- Reshape InputStream Helper information dialog
- Updated Dutch, English, French, German, Greek, Hungarian, Romanian, Russian, Spanish and Swedish translations
    

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
