### PR TITLE
[script.xbmc.unpausejumpback@matrix] 3.0.1

### DIFF
--- a/script.xbmc.unpausejumpback/README.md
+++ b/script.xbmc.unpausejumpback/README.md
@@ -1,8 +1,7 @@
-
 Kodi Unpause Jumpback
 ===================================
 
-_script.xbmc.unpausejumpback_
+`script.xbmc.unpausejumpback`
 
 Simple Kodi Service to jump back a configurable number of seconds after pause, or rewind/fast-forward events.
 

--- a/script.xbmc.unpausejumpback/addon.xml
+++ b/script.xbmc.unpausejumpback/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.xbmc.unpausejumpback" name="Unpause Jumpback" version="3.0.0" provider-name="bossanova808,Memphiz,Lucleonhart,schumi2004,dkadioglu">
+<addon id="script.xbmc.unpausejumpback" name="Unpause Jumpback" version="3.0.1" provider-name="bossanova808,Memphiz,Lucleonhart,schumi2004,dkadioglu">
   <requires>
     <import addon="xbmc.python" version="3.0.0"/>
   </requires>
@@ -24,7 +24,9 @@
     <source>https://github.com/bossanova808/script.xbmc.unpausejumpback/</source>
     <forum>http://forum.xbmc.org/showthread.php?tid=134837</forum>
     <email>bossonav808@gmail.com</email>
-    <news>v3.0.0
+    <news>v3.0.1
+        [fix] minor bugfix for http/s sources (plugins)
+        v3.0.0
         [new] Update for Kodi Matrix / Python 3, make unpause on resume vs. pause a choice, bugfixes and tidy up.
     </news>
     <assets>

--- a/script.xbmc.unpausejumpback/changelog.txt
+++ b/script.xbmc.unpausejumpback/changelog.txt
@@ -1,3 +1,6 @@
+3.0.1
+- Minor bugfix with http/s sources (plugins)
+
 3.0.0
 - Update for Matrix / Python3 (work borrowed from https://github.com/dkadioglu/script.xbmc.unpausejumpback)
 - Add setting for jump back occurring at time of un-pause vs. at time of pause

--- a/script.xbmc.unpausejumpback/resources/lib/common.py
+++ b/script.xbmc.unpausejumpback/resources/lib/common.py
@@ -3,10 +3,12 @@
 # Handy utility functions for Kodi Addons
 # By bossanova808
 # Free in all senses....
-# VERSION 0.1.2
-# (Matrix on)
+# VERSION 0.1.4 2020-10-18
+# (For Kodi Matrix & later)
 
 import xbmc
+import xbmcvfs
+import xbmcgui
 import xbmcaddon
 import sys
 import traceback
@@ -20,9 +22,10 @@ ADDON_VERSION = ADDON.getAddonInfo('version')
 ADDON_ARGUMENTS = str(sys.argv)
 CWD = ADDON.getAddonInfo('path')
 LANGUAGE = ADDON.getLocalizedString
-PROFILE = xbmc.translatePath(ADDON.getAddonInfo('profile'))
+PROFILE = xbmcvfs.translatePath(ADDON.getAddonInfo('profile'))
 KODI_VERSION = xbmc.getInfoLabel('System.BuildVersion')
 USER_AGENT = "Mozilla/5.0 (Windows; U; Windows NT 5.1; fr; rv:1.9.0.1) Gecko/2008070208 Firefox/3.6"
+WEATHER_WINDOW = xbmcgui.Window(12600)
 
 
 def log(message, exception_instance=None, level=xbmc.LOGDEBUG):
@@ -43,6 +46,17 @@ def log(message, exception_instance=None, level=xbmc.LOGDEBUG):
         xbmc.log(message_with_exception, level)
 
 
+def log_info(message, exception_instance=None):
+    """
+    Log a message at the LOGINFO level, i.e. even if Kodi debugging is not turned on. Use sparingly.
+
+    :param message: required, the message to log
+    :param exception_instance: optional, an instance of some Exception
+    """
+
+    log(message, exception_instance, level=xbmc.LOGINFO)
+
+
 def footprints(startup=True):
     """
     Log the startup of an addon, and key Kodi details that are helpful for debugging
@@ -50,11 +64,11 @@ def footprints(startup=True):
     :param startup: optional, default True.  If true, log the startup of an addon, otherwise log the exit.
     """
     if startup:
-        log('Starting...')
-        log(f'Kodi Version: {KODI_VERSION}')
-        log(f'Addon arguments: {ADDON_ARGUMENTS}')
+        log_info(f'Starting...')
+        log_info(f'Kodi Version: {KODI_VERSION}')
+        log_info(f'Addon arguments: {ADDON_ARGUMENTS}')
     else:
-        log('Exiting...')
+        log_info(f'Exiting...')
 
 
 def set_property(window, name, value=""):

--- a/script.xbmc.unpausejumpback/resources/lib/unpause_jumpback.py
+++ b/script.xbmc.unpausejumpback/resources/lib/unpause_jumpback.py
@@ -110,7 +110,7 @@ class MyPlayer(xbmc.Player):
             log("Video is playing via Live TV, which is set as an excluded location.")
             return True
 
-        if (full_path.find("http://") > -1) and (full_path.find("https://") > -1) and self.exclude_http:
+        if (full_path.find("http://") > -1) or (full_path.find("https://") > -1) and self.exclude_http:
             log("Video is playing via HTTP source, which is set as an excluded location.")
             return True
 


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: Unpause Jumpback
  - Add-on ID: script.xbmc.unpausejumpback
  - Version number: 3.0.1
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/bossanova808/script.xbmc.unpausejumpback/
  

        This addon will jump back a number of seconds whenever a video is un-paused - to make sure you don't miss anything.
        You can set the amount of seconds to jump back, and the minimum duration of the pause before the addon will trigger a jump back.
        It also allows to jump back or forward after rewind or fast-forward of a specified amount of seconds to compensate for over-shooting.
        (Originally created by Memphiz, up-keep taken over by bossanova808 in 2020 for Kodi Matrix and beyond).
    

### Description of changes:

v3.0.1
        [fix] minor bugfix for http/s sources (plugins)
        v3.0.0
        [new] Update for Kodi Matrix / Python 3, make unpause on resume vs. pause a choice, bugfixes and tidy up.
    

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
