### PR TITLE
[service.subtitles.rvm.addic7ed@krypton] 3.1.4

### DIFF
--- a/service.subtitles.rvm.addic7ed/addic7ed/core.py
+++ b/service.subtitles.rvm.addic7ed/addic7ed/core.py
@@ -118,9 +118,9 @@ def download_subs(link, referrer, filename):
         label - the download location for subs.
     """
     # Re-create a download location in a temporary folder
-    if xbmcvfs.exists(temp_dir):
+    if os.path.exists(temp_dir):
         shutil.rmtree(temp_dir)
-    xbmcvfs.mkdirs(temp_dir)
+    os.mkdir(temp_dir)
     # Combine a path where to download the subs
     filename = os.path.splitext(filename)[0] + '.srt'
     subspath = os.path.join(temp_dir, filename)

--- a/service.subtitles.rvm.addic7ed/addic7ed/parser.py
+++ b/service.subtitles.rvm.addic7ed/addic7ed/parser.py
@@ -51,7 +51,7 @@ def search_episode(query, languages=None):
     """
     if languages is None:
         languages = [LanguageData('English', 'English')]
-    webpage = session.load_page('/srch.php',
+    webpage = session.load_page('/search.php',
                                 params={'search': query, 'Submit': 'Search'})
     soup = BeautifulSoup(webpage, 'html5lib')
     table = soup.find('table',

--- a/service.subtitles.rvm.addic7ed/addic7ed/webclient.py
+++ b/service.subtitles.rvm.addic7ed/addic7ed/webclient.py
@@ -9,8 +9,8 @@ __all__ = ['Session']
 
 SITE = 'https://www.addic7ed.com'
 HEADERS = {
-    'User-Agent': 'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:67.0) '
-                  'Gecko/20100101 Firefox/67.0',
+    'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 '
+                  '(KHTML, like Gecko) Chrome/87.0.4280.88 Safari/537.36',
     'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
     'Host': SITE[8:],
     'Accept-Charset': 'UTF-8',

--- a/service.subtitles.rvm.addic7ed/addon.xml
+++ b/service.subtitles.rvm.addic7ed/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon id="service.subtitles.rvm.addic7ed"
   name="Addic7ed.com"
-  version="3.1.3"
+  version="3.1.4"
   provider-name="Roman V.M.">
 <requires>
   <import addon="xbmc.python" version="2.25.0"/>
@@ -32,8 +32,8 @@
     <icon>icon.png</icon>
     <fanart>fanart.jpg</fanart>
   </assets>
-  <news>v.3.1.3:
-- Internal changes.</news>
+  <news>v.3.1.4:
+- Fix cleaning a temp download directory.</news>
   <reuselanguageinvoker>false</reuselanguageinvoker>
 </extension>
 </addon>


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: Addic7ed.com
  - Add-on ID: service.subtitles.rvm.addic7ed
  - Version number: 3.1.4
  - Kodi/repository version: krypton

- **Code location**
  - URL: https://github.com/romanvm/service.addic7ed
  
Subtitles service for Addic7ed.com. It supports only TV shows.

### Description of changes:

v.3.1.4:
- Fix cleaning a temp download directory.

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
