### PR TITLE
[script.tubecast@matrix] 1.4.6+matrix.0

### DIFF
--- a/script.tubecast/README.md
+++ b/script.tubecast/README.md
@@ -6,7 +6,7 @@
 ![License](http://img.shields.io/:license-mit-blue.svg?style=flat)
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/767abb2a497c4f608c36e3db0ec6e39e)](https://www.codacy.com/app/92enen/script.tubecast?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=enen92/script.tubecast&amp;utm_campaign=Badge_Grade)
 
-![fanart](https://github.com/enen92/script.tubecast/blob/master/resources/img/fanart.jpg?raw=true)
+![fanart](https://github.com/enen92/script.tubecast/blob/matrix/resources/img/fanart.jpg?raw=true)
 
 ### What is TubeCast?
 

--- a/script.tubecast/addon.xml
+++ b/script.tubecast/addon.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.tubecast" name="TubeCast" version="1.4.5+matrix.1" provider-name="enen92">
+<addon id="script.tubecast" name="TubeCast" version="1.4.6+matrix.0" provider-name="enen92">
     <requires>
         <import addon="xbmc.python" version="3.0.0"/>
         <import addon="script.module.bottle" version="0.12.0"/>
         <import addon="script.module.requests" version="2.12.4"/>
-        <import addon="plugin.video.youtube" version="5.5.1"/>
+        <import addon="plugin.video.tubed" version="1.0.1+matrix.1"/>
     </requires>
     <extension point="xbmc.python.script" library="script.py" />
     <extension point="xbmc.service" library="main.py"/>
@@ -21,8 +21,9 @@
         <email>enen92@kodi.tv</email>
         <source>https://github.com/enen92/script.tubecast</source>
         <news>
-            [fix] missing ctt key (tks romainreignier)
-            [fix] add default id if friendlyname is missing
+            [new] use tubed instead of youtube
+            [new] branch based CI strategy
+            [del] python2 support
         </news>
         <disclaimer lang="en_GB">This is not a full chromecast implementation nor will it ever be. It will only work as long as Google keep backwards compatibility with the cast v1 protocol in the Youtube application. Deeply inspired by Leapcast and gotubecast projects</disclaimer>
         <disclaimer lang="pt_PT">Este addon não é uma implementação completa do protocolo cast nem nunca será. Apenas funcionará enquanto a Google mantiver a retrocompatibilidade com o protocolo cast v1 na aplicação móvel do youtube. Inspirado no Leapcast e gotubecast</disclaimer>

--- a/script.tubecast/resources/__init__.py
+++ b/script.tubecast/resources/__init__.py
@@ -1,2 +1,0 @@
-# -*- coding: utf-8 -*-
-__author__ = "enen92"

--- a/script.tubecast/resources/lib/__init__.py
+++ b/script.tubecast/resources/lib/__init__.py
@@ -1,2 +1,0 @@
-# -*- coding: utf-8 -*-
-__author__ = "enen92"

--- a/script.tubecast/resources/lib/kodi/__init__.py
+++ b/script.tubecast/resources/lib/kodi/__init__.py
@@ -1,1 +1,0 @@
-__author__ = "enen92"

--- a/script.tubecast/resources/lib/kodi/kodilogging.py
+++ b/script.tubecast/resources/lib/kodi/kodilogging.py
@@ -8,7 +8,6 @@ import xbmc
 
 import xbmcaddon
 
-from resources.lib.tubecast.utils import PY3
 
 LEVEL_MAP = {
     logging.CRITICAL: xbmc.LOGFATAL,
@@ -25,8 +24,6 @@ class KodiLogHandler(logging.StreamHandler):
     def __init__(self):
         logging.StreamHandler.__init__(self)
         addon_id = xbmcaddon.Addon().getAddonInfo('id')
-        if not PY3:
-            addon_id = addon_id.decode('utf-8')
         prefix = "[%s] " % addon_id
         formatter = logging.Formatter(prefix + '%(name)s: %(message)s')
         self.setFormatter(formatter)

--- a/script.tubecast/resources/lib/kodi/utils.py
+++ b/script.tubecast/resources/lib/kodi/utils.py
@@ -3,7 +3,6 @@
 import json
 
 from resources.lib.kodi import kodilogging
-from resources.lib.tubecast.utils import PY3
 
 import xbmc
 
@@ -18,15 +17,9 @@ ADDON = xbmcaddon.Addon()
 logger = kodilogging.get_logger()
 
 
-def yes_no(line1, line2=None, line3=None, nolabel=None, yeslabel=None):
-    if PY3:
-        return xbmcgui.Dialog().yesno(heading=ADDON.getAddonInfo('name'),
-                                  message="{} {}".format(line1, line2),
-                                  nolabel=nolabel,
-                                  yeslabel=yeslabel)
-    else:
-        return xbmcgui.Dialog().yesno(heading=ADDON.getAddonInfo('name'),
-                                  line1=line1, line2=line2,
+def yes_no(message, nolabel=None, yeslabel=None):
+    return xbmcgui.Dialog().yesno(heading=ADDON.getAddonInfo('name'),
+                                  message=message,
                                   nolabel=nolabel,
                                   yeslabel=yeslabel)
 
@@ -41,9 +34,7 @@ def show_settings():
 
 
 def get_setting(setting):
-    if PY3:
-        return ADDON.getSetting(setting).strip()
-    return ADDON.getSetting(setting).strip().decode('utf-8')
+    return ADDON.getSetting(setting).strip()
 
 
 def set_setting(setting, value):
@@ -76,9 +67,7 @@ def get_setting_as_int(setting):
 
 
 def get_string(string_id):
-    if PY3:
-        return ADDON.getLocalizedString(string_id)
-    return ADDON.getLocalizedString(string_id).encode('utf-8', 'ignore')
+    return ADDON.getLocalizedString(string_id)
 
 
 def kodi_json_request(params):

--- a/script.tubecast/resources/lib/tubecast/__init__.py
+++ b/script.tubecast/resources/lib/tubecast/__init__.py
@@ -1,2 +1,0 @@
-# -*- coding: utf-8 -*-
-__author__ = "enen92"

--- a/script.tubecast/resources/lib/tubecast/kodicast.py
+++ b/script.tubecast/resources/lib/tubecast/kodicast.py
@@ -2,7 +2,6 @@
 import uuid
 
 from resources.lib.kodi.utils import get_device_id
-from resources.lib.tubecast.utils import PY3
 
 
 class Kodicast(object):
@@ -17,8 +16,6 @@ class Kodicast(object):
 
 def generate_uuid():
     friendly_name = 'device.tubecast.{}'.format(Kodicast.friendlyName)
-    if not PY3:
-        friendly_name = friendly_name.encode('utf8')
     Kodicast.uuid = str(uuid.uuid5(
         uuid.NAMESPACE_DNS,
         friendly_name))

--- a/script.tubecast/resources/lib/tubecast/ssdp.py
+++ b/script.tubecast/resources/lib/tubecast/ssdp.py
@@ -8,12 +8,9 @@ import threading
 from resources.lib.kodi import kodilogging
 from resources.lib.kodi.utils import get_setting_as_bool
 from resources.lib.tubecast.kodicast import Kodicast
-from resources.lib.tubecast.utils import build_template, str_to_bytes, PY3
+from resources.lib.tubecast.utils import build_template
 
-if PY3:
-    from socketserver import DatagramRequestHandler, ThreadingUDPServer
-else:
-    from SocketServer import DatagramRequestHandler, ThreadingUDPServer
+from socketserver import DatagramRequestHandler, ThreadingUDPServer
 
 
 logger = kodilogging.get_logger("ssdp")
@@ -127,7 +124,7 @@ ST: urn:dial-multiscreen-org:service:dial:1\r
 
     def reply(self, data, address):
         socket = self.request[1]
-        socket.sendto(str_to_bytes(data), address)
+        socket.sendto(bytes(data, 'utf-8'), address)
 
     @staticmethod
     def get_remote_ip(address):
@@ -135,7 +132,7 @@ ST: urn:dial-multiscreen-org:service:dial:1\r
         s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         s.connect(address)
         iface = s.getsockname()[0]
-        return iface if PY3 else unicode(iface)
+        return iface
 
     def datagram_received(self, datagram, address):
         if get_setting_as_bool('debug-ssdp'):

--- a/script.tubecast/resources/lib/tubecast/utils.py
+++ b/script.tubecast/resources/lib/tubecast/utils.py
@@ -6,13 +6,5 @@ from textwrap import dedent
 from bottle import SimpleTemplate
 
 
-PY3 = sys.version_info.major >= 3
-
-
 def build_template(template):
     return SimpleTemplate(dedent(template))
-
-def str_to_bytes(string):
-    if PY3:
-        return bytes(string, 'utf-8')
-    return string

--- a/script.tubecast/resources/lib/tubecast/youtube/__init__.py
+++ b/script.tubecast/resources/lib/tubecast/youtube/__init__.py
@@ -1,2 +1,0 @@
-# -*- coding: utf-8 -*-
-__author__ = "enen92"

--- a/script.tubecast/resources/lib/tubecast/youtube/app.py
+++ b/script.tubecast/resources/lib/tubecast/youtube/app.py
@@ -7,17 +7,13 @@ from bottle import request, response
 
 from resources.lib.kodi import kodilogging
 from resources.lib.kodi.utils import get_device_id, get_setting_as_bool
-from resources.lib.tubecast.utils import PY3
 from resources.lib.tubecast.youtube import kodibrigde
 from resources.lib.tubecast.youtube.player import CastPlayer, STATUS_LOADING, STATUS_STOPPED
 from resources.lib.tubecast.youtube.templates import YoutubeTemplates
 from resources.lib.tubecast.youtube.utils import CommandParser
 from resources.lib.tubecast.youtube.volume import VolumeMonitor
 
-if PY3:
-    from urllib.parse import urlencode
-else:
-    from urllib import urlencode
+from urllib.parse import urlencode
 
 import xbmc
 
@@ -512,7 +508,7 @@ class YoutubeListener(threading.Thread):
             if debug_http:
                 logger.debug("received chunk %r", chunk)
 
-            parser.write(chunk.decode("utf-8") if PY3 else chunk)
+            parser.write(chunk.decode("utf-8"))
             for cmd in parser.get_commands():
                 self.app.handle_cmd(cmd)
 

--- a/script.tubecast/resources/lib/tubecast/youtube/kodibrigde.py
+++ b/script.tubecast/resources/lib/tubecast/youtube/kodibrigde.py
@@ -17,7 +17,8 @@ def set_kodi_volume(volume):
 
 
 def get_youtube_plugin_path(videoid, seek=0):  # type: (str, str) -> str
-    return "plugin://plugin.video.youtube/play/?video_id={}&seek={}".format(videoid, seek)
+    return "plugin://plugin.video.tubed/?mode=play&video_id={}&start_offset={}".format(
+        videoid, float(seek))
 
 
 def remote_connected(name):

--- a/script.tubecast/resources/lib/tubecast/youtube/pairing.py
+++ b/script.tubecast/resources/lib/tubecast/youtube/pairing.py
@@ -4,7 +4,6 @@ import time
 from .app import YoutubeCastV1
 
 from resources.lib.kodi.utils import get_string
-from resources.lib.tubecast.utils import PY3
 
 from xbmc import Monitor
 
@@ -20,10 +19,7 @@ def generate_pairing_code():
 
     i = 0
 
-    if PY3:
-        progress.update(i, message="{} {}".format(get_string(32002), pairing_code))
-    else:
-        progress.update(i, get_string(32002), pairing_code)
+    progress.update(i, message="{} {}".format(get_string(32002), pairing_code))
 
     start_time = time.time()
     while not monitor.abortRequested() and not chromecast.has_client and not progress.iscanceled() and not (time.time() - start_time) > (60 * 1):
@@ -31,11 +27,7 @@ def generate_pairing_code():
         if i > 100:
             i = 0
 
-
-        if PY3:
-            progress.update(i, message="{} {}".format(get_string(32002), pairing_code))
-        else:
-            progress.update(i, get_string(32002), pairing_code)
+        progress.update(i, message="{} {}".format(get_string(32002), pairing_code))
 
         monitor.waitForAbort(2)
     progress.close()


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: TubeCast
  - Add-on ID: script.tubecast
  - Version number: 1.4.6+matrix.0
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/enen92/script.tubecast
  
An implementation of the Cast V1 protocol in Kodi to act as a player for the Youtube mobile application

### Description of changes:


            [new] use tubed instead of youtube
            [new] branch based CI strategy
            [del] python2 support
        

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
