### PR TITLE
[screensaver.kaster@matrix] 1.3.5+matrix.1

### DIFF
--- a/screensaver.kaster/addon.xml
+++ b/screensaver.kaster/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="screensaver.kaster" name="Kaster" version="1.3.4+matrix.1" provider-name="enen92">
+<addon id="screensaver.kaster" name="Kaster" version="1.3.5+matrix.1" provider-name="enen92">
 	<requires>
 		<import addon="xbmc.python" version="3.0.0"/>
 		<import addon="script.module.requests" version="2.22.0"/>
@@ -20,9 +20,8 @@
 		<description lang="es_ES">Muestra bellas imágenes como las del protector de pantalla de chromecast. También puede mostrar sus propias fotos junto con su respectiva información.</description>
 		<description lang="nl_NL">Toon prachtige afbeeldingen afkomstig van de Chromecast screensaver. Je kunt ook je eigen foto's tonen met al hun informatie.</description>
 		<description lang="fr_FR">Affichez de jolies images provenant de l’écran de veille de Chromecast. Vous pouvez aussi afficher vos propres images avec leurs informations respectives.</description>
-		<news>v1.3.4 (18/12/2020)
-			[fix] New scrapped pictures (tks delboy711)
-			[new] Add new source for higher resolution pictures (tks delboy711)
+		<news>v1.3.5 (23/12/2020)
+			[fix] Unicode fixes for python3 (tks @roidy)
 		</news>
 		<assets>
 			<icon>resources/images/icon.png</icon>

--- a/screensaver.kaster/changelog.txt
+++ b/screensaver.kaster/changelog.txt
@@ -1,3 +1,6 @@
+v1.3.5 (23/12/2020)
+- [fix] Unicode fixes for python3 (tks @roidy)
+
 v1.3.4 (18/12/2020)
 - [fix] New scrapped pictures (tks delboy711)
 - [new] Add new source for higher resolution pictures (tks delboy711)

--- a/screensaver.kaster/resources/lib/screensaver.py
+++ b/screensaver.kaster/resources/lib/screensaver.py
@@ -116,8 +116,12 @@ class Kaster(xbmcgui.WindowXMLDialog):
         # Read google images from json file
         self.images = []
         if kodiutils.get_setting_as_int("screensaver-mode") == 0 or kodiutils.get_setting_as_int("screensaver-mode") == 2 or override:
-            with open(IMAGE_FILE, "r") as f:
-                images = f.read()
+            try:
+                with open(IMAGE_FILE, "r") as f:
+                    images = f.read()
+            except:
+                with open(IMAGE_FILE, "r", encoding="utf-8") as f:
+                    images = f.read()
             self.images = json.loads(images)
         # Check if we have images to append
         if kodiutils.get_setting_as_int("screensaver-mode") == 1 or kodiutils.get_setting_as_int("screensaver-mode") == 2 and not override:


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: Kaster
  - Add-on ID: screensaver.kaster
  - Version number: 1.3.5+matrix.1
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/enen92/screensaver.kaster
  
Display beautiful pictures originally from the chromecast screensaver. You can also display your own photos along with its respective information.

### Description of changes:

v1.3.5 (23/12/2020)
			[fix] Unicode fixes for python3 (tks @roidy)
		

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
