### PR TITLE
[script.trakt@matrix] 3.3.2

### DIFF
--- a/script.trakt/resources/lib/service.py
+++ b/script.trakt/resources/lib/service.py
@@ -68,7 +68,7 @@ class traktService:
                 del data['action']
                 self.doAddToWatchlist(data)
             elif action == 'manualSync':
-                if not self.syncThread.isAlive():
+                if not self.syncThread.is_alive():
                     logger.debug("Performing a manual sync.")
                     self.doSync(
                         manual=True, silent=data['silent'], library=data['library'])
@@ -132,7 +132,7 @@ class traktService:
         del self.Monitor
 
         # check if sync thread is running, if so, join it.
-        if self.syncThread.isAlive():
+        if self.syncThread.is_alive():
             self.syncThread.join()
 
     def doManualRating(self, data):

--- a/script.trakt/resources/lib/syncEpisodes.py
+++ b/script.trakt/resources/lib/syncEpisodes.py
@@ -472,10 +472,10 @@ class SyncEpisodes:
                 self.sync.UpdateProgress(toPercent, line1=kodiUtilities.getString(
                     1441), line2=kodiUtilities.getString(32129))
                 logger.debug(
-                    "[Episodes Sync] Kodi episode playbacks are up to date.")
+                    "[Episodes Sync] Kodi episode progress is up to date.")
                 return
 
-            logger.debug("[Episodes Sync] %i show(s) shows are missing playbacks on Kodi" % len(
+            logger.debug("[Episodes Sync] %i show(s) shows are missing progress in Kodi" % len(
                 kodiShowsUpdate['shows']))
             for s in ["%s" % self.__getShowAsString(s, short=True) for s in kodiShowsUpdate['shows']]:
                 logger.debug("[Episodes Sync] Episodes updated: %s" % s)
@@ -495,8 +495,8 @@ class SyncEpisodes:
             # need to calculate the progress in int from progress in percent from Trakt
             # split episode list into chunks of 50
             chunksize = 50
-            chunked_episodes = utilities.chunks([{"jsonrpc": "2.0", "id": i, "method": "VideoLibrary.SetEpisodeDetails", "params": {"episodeid": episodes[i]['episodeid'], "resume": {
-                                                "position": episodes[i]['runtime'] / 100.0 * episodes[i]['progress'], "total": episodes[i]['runtime']}}} for i in range(len(episodes))], chunksize)
+            chunked_episodes = utilities.chunks([{"jsonrpc": "2.0", "id": i, "method": "VideoLibrary.SetEpisodeDetails", "params": {"episodeid": episode['episodeid'], "resume": {
+                                                "position": episode['runtime'] / 100.0 * episode['progress'], "total": episode['runtime']}}} for episode in episodes if episode['runtime'] > 0], chunksize)
             i = 0
             x = float(len(episodes))
             for chunk in chunked_episodes:

--- a/script.trakt/resources/lib/syncMovies.py
+++ b/script.trakt/resources/lib/syncMovies.py
@@ -318,10 +318,10 @@ class SyncMovies():
                 self.sync.UpdateProgress(
                     toPercent, line1='', line2=kodiUtilities.getString(32125))
                 logger.debug(
-                    "[Movies Sync] Kodi movie playbacks are up to date.")
+                    "[Movies Sync] Kodi movie progress is up to date.")
                 return
 
-            logger.debug("[Movies Sync] %i movie(s) playbacks will be updated in Kodi" % len(
+            logger.debug("[Movies Sync] %i movie(s) progress will be updated in Kodi" % len(
                 kodiMoviesToUpdate))
 
             self.sync.UpdateProgress(fromPercent, line1='', line2=kodiUtilities.getString(
@@ -329,8 +329,8 @@ class SyncMovies():
             # need to calculate the progress in int from progress in percent from Trakt
             # split movie list into chunks of 50
             chunksize = 50
-            chunked_movies = utilities.chunks([{"jsonrpc": "2.0", "id": i, "method": "VideoLibrary.SetMovieDetails", "params": {"movieid": kodiMoviesToUpdate[i]['movieid'], "resume": {
-                                              "position": kodiMoviesToUpdate[i]['runtime'] / 100.0 * kodiMoviesToUpdate[i]['progress'], "total": kodiMoviesToUpdate[i]['runtime']}}} for i in range(len(kodiMoviesToUpdate))], chunksize)
+            chunked_movies = utilities.chunks([{"jsonrpc": "2.0", "id": i, "method": "VideoLibrary.SetMovieDetails", "params": {"movieid": movie['movieid'], "resume": {
+                                              "position": movie['runtime'] / 100.0 * movie['progress'], "total": movie['runtime']}}} for movie in kodiMoviesToUpdate if movie['runtime'] > 0], chunksize)
             i = 0
             x = float(len(kodiMoviesToUpdate))
             for chunk in chunked_movies:


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: Trakt
  - Add-on ID: script.trakt
  - Version number: 3.3.2
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/trakt/script.trakt
  
Automatically scrobble all TV episodes and movies you are watching to Trakt.tv! Keep a comprehensive history of everything you've watched and be part of a global community of TV and movie enthusiasts. Sign up for a free account at http://trakt.tv and get a ton of features:

- Automatically scrobble what you're watching
- Mobile apps for iPhone, iPad, Android, and Windows Phone
- Share what you're watching (in real time) and rating to facebook and twitter
- Personalized calendar so you never miss a TV show
- Follow your friends and people you're interesed in
- Use watchlists so you don't forget to what to watch
- Track your media collections and impress your friends
- Create custom lists around any topics you choose
- Easily track your TV show progress across all seasons and episodes
- Track your progress against industry lists such as the IMDb Top 250
- Discover new shows and movies based on your viewing habits
- Widgets for your forum signature

What can this addon do?

- Automatically scrobble all TV episodes and movies you are watching
- Sync your TV episode and movie collections to Trakt (triggered after a library update)
- Auto clean your Trakt collection so that it matches up with Kodi
- Keep watched statuses synced between Kodi and Trakt
- Rate movies and episode after watching them

Special thanks to all who contributed to this plugin! Check the commit history and changelog to see these talented developers.

### Description of changes:

  - Fixes for matrix changed apis

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
