### PR TITLE
[script.module.kodiswift] 0.0.10

### DIFF
--- a/script.module.kodiswift/addon.xml
+++ b/script.module.kodiswift/addon.xml
@@ -1,12 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.module.kodiswift" name="kodiswift" provider-name="Aaron Frase (Sinap); TJ Jiang" version="0.0.9">
+<addon id="script.module.kodiswift" name="kodiswift" provider-name="Aaron Frase (Sinap); TJ Jiang" version="0.0.10">
   <requires>
     <import addon="xbmc.python" version="2.24.0"/>
+    <import addon="script.module.six" version="1.13.0"/>
   </requires>
   <extension library="lib" point="xbmc.python.module"/>
   <extension point="xbmc.addon.metadata">
     <summary lang="en">A fork of the xbmcswift2 project</summary>
-    <description lang="en">A micro framework to enable rapid development of Kodi plugins. TJ Jiang is responsible for modifications in 0.0.9.</description>
+    <description lang="en">A micro framework to enable rapid development of Kodi plugins. TJ Jiang is responsible for modifications in 0.0.9 and 0.0.10.</description>
     <platform>all</platform>
     <license>GNU General Public License v3 (GPL-3)</license>
     <source>https://github.com/afrase/kodiswift</source>

--- a/script.module.kodiswift/changelog.txt
+++ b/script.module.kodiswift/changelog.txt
@@ -1,5 +1,17 @@
+0.0.10
+=====
+
+- fixed the error in not importing python six library in addon.xml.
+
+0.0.9
+=====
+
+- enable script.module.kodiswift to support python 2 and python 3 by incorporating the six package.
+- add supports on subtitles.
+
 0.0.8
 =====
+
 - Set `listitem.is_folder` to `False` when setting `listitem.is_playable` to `True`.
 
 0.0.7


### PR DESCRIPTION
### Description
- Fixed the error in not importing python six library in addon.xml in version 0.0.9 (got an error report from a user).
- Give more details in changelog.
### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [X] Each add-on submission should be a single commit with using the following style: [script.foo.bar] 1.0.0
