### PR TITLE
[script.tvmaze.scrobbler@matrix] 1.1.0+matrix.1

### DIFF
--- a/script.tvmaze.scrobbler/addon.xml
+++ b/script.tvmaze.scrobbler/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon id="script.tvmaze.scrobbler"
    name="TVmaze Scrobbler/Tracker"
-   version="1.0.1+matrix.1"
+   version="1.1.0+matrix.1"
    provider-name="Roman V.M.">
   <requires>
     <import addon="xbmc.python" version="3.0.0" />
@@ -38,7 +38,11 @@ What this addon does:
       <icon>resources/images/icon.png</icon>
       <fanart>resources/images/background.jpg</fanart>
     </assets>
-    <news>1.0.1:
+    <news>1.1.0:
+- Added periodic pulling of episode watched statuses from TVmaze.
+- Improved error logging.
+
+1.0.1:
 - Fixed crashes because of malformed JSON responses from TVmaze.
 - Fixed crashes because of invalid SSL certificates.</news>
   </extension>

--- a/script.tvmaze.scrobbler/libs/exception_logger.py
+++ b/script.tvmaze.scrobbler/libs/exception_logger.py
@@ -1,0 +1,157 @@
+# coding: utf-8
+# (c) Roman Miroshnychenko <roman1972@gmail.com> 2020
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""Exception logger with extended diagnostic info"""
+from __future__ import absolute_import, unicode_literals
+
+import inspect
+import sys
+from contextlib import contextmanager
+from platform import uname
+from pprint import pformat
+
+import six
+from kodi_six import xbmc
+
+from .kodi_service import logger
+
+try:
+    from typing import Text, Dict, List, Callable, Generator  # pylint: disable=unused-import
+except ImportError:
+    pass
+
+
+def _format_vars(variables):
+    # type: (dict) -> Text
+    """
+    Format variables dictionary
+
+    :param variables: variables dict
+    :return: formatted string with sorted ``var = val`` pairs
+    """
+    var_list = [(var, val) for var, val in six.iteritems(variables)
+                if not (var.startswith('__') or var.endswith('__'))]
+    var_list.sort(key=lambda i: i[0])
+    lines = []
+    for var, val in var_list:
+        lines.append('{} = {}'.format(var, pformat(val)))
+    return '\n'.join(lines)
+
+
+def _format_code_context(code_context, lineno, index):
+    # type: (List[Text], int, int) -> Text
+    context = ''
+    if code_context is not None:
+        for i, line in enumerate(code_context, lineno - index):
+            if i == lineno:
+                context += '{}:>{}'.format(six.text_type(i).rjust(5), line)
+            else:
+                context += '{}: {}'.format(six.text_type(i).rjust(5), line)
+    return context
+
+
+FRAME_INFO_TEMPLATE = """File:
+{file_path}:{lineno}
+----------------------------------------------------------------------------------------------------
+Code context:
+{code_context}
+----------------------------------------------------------------------------------------------------
+Local variables:
+{local_vars}
+====================================================================================================
+"""
+
+
+def _format_frame_info(frame_info):
+    # type: (tuple) -> Text
+    return FRAME_INFO_TEMPLATE.format(
+        file_path=frame_info[1],
+        lineno=frame_info[2],
+        code_context=_format_code_context(frame_info[4], frame_info[2],
+                                          frame_info[5]),
+        local_vars=_format_vars(frame_info[0].f_locals)
+    )
+
+
+EXCEPTION_TEMPLATE = """
+*********************************** Unhandled exception detected ***********************************
+####################################################################################################
+                                           Diagnostic info
+----------------------------------------------------------------------------------------------------
+Exception type  : {exc_type}
+Exception value : {exc}
+System info     : {system_info}
+Python version  : {python_version}
+Kodi version    : {kodi_version}
+sys.argv        : {sys_argv}
+----------------------------------------------------------------------------------------------------
+sys.path:
+{sys_path}
+####################################################################################################
+                                            Stack Trace
+====================================================================================================
+{stack_trace}
+************************************* End of diagnostic info ***************************************
+"""
+
+
+@contextmanager
+def log_exception(logger_func=logger.error):
+    # type: (Callable[[Text], None]) -> Generator[None, None, None]
+    """
+    Diagnostic helper context manager
+
+    It controls execution within its context and writes extended
+    diagnostic info to the Kodi log if an unhandled exception
+    happens within the context. The info includes the following items:
+
+    - System info
+    - Python version
+    - Kodi version
+    - Module path.
+    - Stack trace including:
+        * File path and line number where the exception happened
+        * Code fragment where the exception has happened.
+        * Local variables at the moment of the exception.
+
+    After logging the diagnostic info the exception is re-raised.
+
+    Example::
+
+        with debug_exception():
+            # Some risky code
+            raise RuntimeError('Fatal error!')
+
+    :param logger_func: logger function that accepts a single argument
+        that is a log message.
+    """
+    try:
+        yield
+    except Exception as exc:
+        stack_trace = ''
+        for frame_info in inspect.trace(5):
+            stack_trace += _format_frame_info(frame_info)
+        message = EXCEPTION_TEMPLATE.format(
+            exc_type=exc.__class__.__name__,
+            exc=exc,
+            system_info=uname(),
+            python_version=sys.version.replace('\n', ' '),
+            kodi_version=xbmc.getInfoLabel('System.BuildVersion'),
+            sys_argv=pformat(sys.argv),
+            sys_path=pformat(sys.path),
+            stack_trace=stack_trace
+        )
+        logger_func(message)
+        raise exc

--- a/script.tvmaze.scrobbler/libs/gui.py
+++ b/script.tvmaze.scrobbler/libs/gui.py
@@ -71,7 +71,7 @@ class ConfirmationLoop(threading.Thread):
         self._parent_window.close()
 
 
-class ConfirmationDialog(pyxbmct.AddonDialogWindow):
+class ConfirmationDialog(pyxbmct.AddonDialogWindow):  # pylint: disable=too-many-ancestors
     def __init__(self, email, token, confirm_url, qrcode_path):
         # type: (Text, Text, Text, Text) -> None
         super(ConfirmationDialog, self).__init__(_('Confirm Addon Authorization'))

--- a/script.tvmaze.scrobbler/libs/kodi_monitor.py
+++ b/script.tvmaze.scrobbler/libs/kodi_monitor.py
@@ -32,7 +32,7 @@ except ImportError:
     pass
 
 
-class UpdateMonitor(xbmc.Monitor):  # pylint: disable=missing-docstring
+class KodiMonitor(xbmc.Monitor):  # pylint: disable=missing-docstring
 
     def onNotification(self, sender, method, data):
         # type: (Text, Text, Text) -> None

--- a/script.tvmaze.scrobbler/libs/kodi_service.py
+++ b/script.tvmaze.scrobbler/libs/kodi_service.py
@@ -22,15 +22,10 @@ import hashlib
 import inspect
 import os
 import re
-import sys
-from contextlib import contextmanager
-from platform import uname
-from pprint import pformat
 
-import six
-from six.moves import cPickle as pickle
 from kodi_six import xbmc
 from kodi_six.xbmcaddon import Addon
+from six.moves import cPickle as pickle
 
 try:
     from typing import Text, Dict, Callable, Generator  # pylint: disable=unused-import
@@ -168,114 +163,3 @@ class LocalizationService(object):
 
 
 GETTEXT = LocalizationService().gettext
-
-
-def _format_vars(variables):
-    # type: (dict) -> Text
-    """
-    Format variables dictionary
-
-    :param variables: variables dict
-    :return: formatted string with sorted ``var = val`` pairs
-    """
-    var_list = [(var, val) for var, val in six.iteritems(variables)
-                if not (var.startswith('__') or var.endswith('__'))]
-    var_list.sort(key=lambda i: i[0])
-    lines = []
-    for var, val in var_list:
-        lines.append('{} = {}'.format(var, pformat(val)))
-    return '\n'.join(lines)
-
-
-def _format_code_context(frame_info):
-    # type: (tuple) -> Text
-    context = ''
-    if frame_info[4] is not None:
-        for i, line in enumerate(frame_info[4], frame_info[2] - frame_info[5]):
-            if i == frame_info[2]:
-                context += '{}:>{}'.format(six.text_type(i).rjust(5), line)
-            else:
-                context += '{}: {}'.format(six.text_type(i).rjust(5), line)
-    return context
-
-
-EXCEPTION_TEMPLATE = """
-*********************************** Unhandled exception detected ***********************************
-====================================================================================================
-                                           Diagnostic info
-----------------------------------------------------------------------------------------------------
-Exception type  : {exc_type}
-Exception value : {exc}
-System info     : {system_info}
-Python version  : {python_version}
-OS info         : {os_info}
-Kodi version    : {kodi_version}
-File            : {file_path}:{lineno}
-sys.argv        : {sys_argv}
-----------------------------------------------------------------------------------------------------
-sys.path:
-{sys_path}
-----------------------------------------------------------------------------------------------------
-Code context:
-{code_context}
-----------------------------------------------------------------------------------------------------
-Global variables:
-{global_vars}
-----------------------------------------------------------------------------------------------------
-Local variables:
-{local_vars}
-====================================================================================================
-**************************************** End diagnostic info ***************************************
-"""
-
-
-@contextmanager
-def debug_exception(logger_func=logger.error):
-    # type: (Callable[[Text], None]) -> Generator[None, None, None]
-    """
-    Diagnostic helper context manager
-
-    It controls execution within its context and writes extended
-    diagnostic info to the Kodi log if an unhandled exception
-    happens within the context. The info includes the following items:
-
-    - System info
-    - Python version
-    - Kodi version
-    - Module path.
-    - Code fragment where the exception has happened.
-    - Global variables.
-    - Local variables.
-
-    After logging the diagnostic info the exception is re-raised.
-
-    Example::
-
-        with debug_exception():
-            # Some risky code
-            raise RuntimeError('Fatal error!')
-
-    :param logger_func: logger function that accepts a single argument
-        that is a log message.
-    """
-    try:
-        yield
-    except Exception as exc:
-        frame_info = inspect.trace(5)[-1]
-        message = EXCEPTION_TEMPLATE.format(
-            exc_type=type(exc),
-            exc=exc,
-            system_info=uname(),
-            python_version=sys.version.replace('\n', ' '),
-            os_info=xbmc.getInfoLabel('System.OSVersionInfo'),
-            kodi_version=xbmc.getInfoLabel('System.BuildVersion'),
-            file_path=frame_info[1],
-            lineno=frame_info[2],
-            sys_argv=pformat(sys.argv),
-            sys_path=pformat(sys.path),
-            code_context=_format_code_context(frame_info),
-            global_vars=_format_vars(frame_info[0].f_globals),
-            local_vars=_format_vars(frame_info[0].f_locals)
-        )
-        logger_func(message)
-        raise exc

--- a/script.tvmaze.scrobbler/libs/scheduled_tasks.py
+++ b/script.tvmaze.scrobbler/libs/scheduled_tasks.py
@@ -1,0 +1,53 @@
+# coding: utf-8
+# (c) Roman Miroshnychenko <roman1972@gmail.com> 2021
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Periodic tasks"""
+
+from __future__ import absolute_import, unicode_literals
+
+from datetime import datetime, timedelta
+
+import xbmc
+
+from .kodi_service import ADDON, logger
+from .scrobbling_service import pull_watched_episodes
+
+TIME_FORMAT = '%Y-%m-%d %H:%M:%S'
+
+
+def _should_pull():
+    pull_enabled = ADDON.getSettingBool('periodic_pull')
+    pull_during_playback = ADDON.getSettingBool('pull_during_playback')
+    player_has_media = xbmc.getCondVisibility('Player.HasMedia')
+    return pull_enabled and (not player_has_media or pull_during_playback)
+
+
+def periodic_pull():
+    if _should_pull():
+        now = datetime.now()
+        pull_interval_hours_str = ADDON.getSettingString('pull_interval_hours')
+        if not pull_interval_hours_str:
+            logger.error('Pulling interval is not set')
+            return
+        pull_interval_hours = int(pull_interval_hours_str)
+        time_last_pulled_str = ADDON.getSettingString('time_last_pulled')
+        time_last_pulled = (datetime.strptime(time_last_pulled_str, TIME_FORMAT)
+                            if time_last_pulled_str else None)
+        if (time_last_pulled is None
+                or now - timedelta(hours=pull_interval_hours) > time_last_pulled):
+            pull_watched_episodes()
+            ADDON.setSettingString('time_last_pulled', now.strftime(TIME_FORMAT))
+            logger.info('Pulled watched episodes from TVmaze')

--- a/script.tvmaze.scrobbler/libs/time_utils.py
+++ b/script.tvmaze.scrobbler/libs/time_utils.py
@@ -13,6 +13,10 @@ except ImportError:
 
 DATETIME_FORMAT = '%Y-%m-%d %H:%M:%S'
 
+# Dummy call to overcome this bug:
+# https://stackoverflow.com/questions/16309650/python-importerror-for-strptime-in-spyder-for-windows-7
+_ = time.strptime('2021-01-01 00:00:00', DATETIME_FORMAT)
+
 
 class proxydt(datetime.datetime):  # pylint: disable=invalid-name
     """

--- a/script.tvmaze.scrobbler/resources/language/resource.language.en_gb/strings.po
+++ b/script.tvmaze.scrobbler/resources/language/resource.language.en_gb/strings.po
@@ -104,7 +104,7 @@ msgid "Show update notifications"
 msgstr ""
 
 msgctxt "#32024"
-msgid "Automatically pull watched episodes from TVmaze"
+msgid "Pull watched episodes from TVmaze before push"
 msgstr ""
 
 msgctxt "#32025"
@@ -133,4 +133,16 @@ msgstr ""
 
 msgctxt "#32031"
 msgid "Updating TV shows in Kodi: {} of {}"
+msgstr ""
+
+msgctxt "#32032"
+msgid "Periodically pull watched episodes from TVmaze"
+msgstr ""
+
+msgctxt "#32033"
+msgid "Pulling interval (hours)"
+msgstr ""
+
+msgctxt "#32034"
+msgid "Pull during playback"
 msgstr ""

--- a/script.tvmaze.scrobbler/resources/settings.xml
+++ b/script.tvmaze.scrobbler/resources/settings.xml
@@ -2,6 +2,13 @@
 <settings>
     <setting label="32024" type="bool" id="pull_from_tvmaze" default="true" />
     <setting label="32023" type="bool" id="show_notifications" default="true" />
+    <setting label="32032" type="bool" id="periodic_pull" default="false" />
+    <setting label="32033" type="labelenum" id="pull_interval_hours" values="1|3|6|12|24"
+             enable="eq(-1,true)" />
+    <setting label="32034" type="bool" id="pull_during_playback" default="false"
+             enable="eq(-2,true)" />
+    <!-- Hidden settings -->
     <setting label="" type="text" id="username" default="" visible="false"/>
     <setting label="" type="text" id="apikey" default="" visible="false"/>
+    <setting label="" type="text" id="time_last_pulled" default="" visible="false"/>
 </settings>

--- a/script.tvmaze.scrobbler/script.py
+++ b/script.tvmaze.scrobbler/script.py
@@ -18,8 +18,9 @@
 
 from __future__ import absolute_import, unicode_literals
 
+from libs.exception_logger import log_exception
 from libs.gui import DIALOG
-from libs.kodi_service import debug_exception, GETTEXT
+from libs.kodi_service import GETTEXT
 from libs.scrobbling_service import get_menu_actions
 
 _ = GETTEXT
@@ -36,5 +37,5 @@ def main():
 
 
 if __name__ == '__main__':
-    with debug_exception():
+    with log_exception():
         main()

--- a/script.tvmaze.scrobbler/service.py
+++ b/script.tvmaze.scrobbler/service.py
@@ -18,10 +18,13 @@
 
 from __future__ import absolute_import, unicode_literals
 
-from libs.kodi_monitor import UpdateMonitor
+from libs.exception_logger import log_exception
+from libs.kodi_monitor import KodiMonitor
 from libs.kodi_service import logger
+from libs.scheduled_tasks import periodic_pull
 
-MONITOR = UpdateMonitor()
-logger.info('Service started')
-MONITOR.waitForAbort()
-logger.info('Service stopped')
+with log_exception():
+    monitor = KodiMonitor()
+    while not monitor.waitForAbort(3.0):
+        periodic_pull()
+    logger.info('Service stopped')


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: TVmaze Scrobbler/Tracker
  - Add-on ID: script.tvmaze.scrobbler
  - Version number: 1.1.0+matrix.1
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/romanvm/kodi.tvmaze.scrobbler
  
Automatically track all TV episodes you are watching to TVmaze. A must have if you want to sync your watch history between various applications.
Sign up for a free account at https://tvmaze.com for more features.

This Kodi TV episode Tracker uses the TVmaze.com user API's scrobbler endpoints(https://static.tvmaze.com/apidoc/)

What this addon does:
- Performs an initial sync between Kodi and TVmaze for the episodes you've watched.
- If you add an episode to the Kodi library it marks it as "acquired" on TVmaze.
- If you watch an episode in Kodi it marks it as "watched" in TVmaze.
- If you mark an episode as watched in TVmaze it marks it as watched in Kodi.

### Description of changes:

1.1.0:
- Added periodic pulling of episode watched statuses from TVmaze.
- Improved error logging.

1.0.1:
- Fixed crashes because of malformed JSON responses from TVmaze.
- Fixed crashes because of invalid SSL certificates.

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
