### PR TITLE
[service.iptv.manager@leia] 0.2.3

### DIFF
--- a/service.iptv.manager/CHANGELOG.md
+++ b/service.iptv.manager/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog
 
+## [v0.2.3](https://github.com/add-ons/service.iptv.manager/tree/v0.2.3) (2021-02-04)
+
+[Full Changelog](https://github.com/add-ons/service.iptv.manager/compare/v0.2.2...v0.2.3)
+
+**Implemented enhancements:**
+
+- Make JSON-STREAMS group a list [\#77](https://github.com/add-ons/service.iptv.manager/pull/77) ([dagwieers](https://github.com/dagwieers))
+- Fix logging for Kodi Matrix, allow to install script.kodi.loguploader from the settings [\#75](https://github.com/add-ons/service.iptv.manager/pull/75) ([michaelarnauts](https://github.com/michaelarnauts))
+- Add support for resource:// logos [\#74](https://github.com/add-ons/service.iptv.manager/pull/74) ([dagwieers](https://github.com/dagwieers))
+- Allow to process raw M3U8 or XMLTV data [\#69](https://github.com/add-ons/service.iptv.manager/pull/69) ([michaelarnauts](https://github.com/michaelarnauts))
+- Add support for \#KODIPROP [\#68](https://github.com/add-ons/service.iptv.manager/pull/68) ([michaelarnauts](https://github.com/michaelarnauts))
+
+**Fixed bugs:**
+
+- Fix empty space in start and stop fields when no timezone was specified [\#70](https://github.com/add-ons/service.iptv.manager/pull/70) ([michaelarnauts](https://github.com/michaelarnauts))
+
+**Merged pull requests:**
+
+- Fix/improve the add-on description and summary [\#73](https://github.com/add-ons/service.iptv.manager/pull/73) ([dagwieers](https://github.com/dagwieers))
+- Make use of git archive [\#72](https://github.com/add-ons/service.iptv.manager/pull/72) ([dagwieers](https://github.com/dagwieers))
+- Verify xmltv output against the xmltv.dtd [\#71](https://github.com/add-ons/service.iptv.manager/pull/71) ([michaelarnauts](https://github.com/michaelarnauts))
+- Testing improvements [\#66](https://github.com/add-ons/service.iptv.manager/pull/66) ([michaelarnauts](https://github.com/michaelarnauts))
+- Add Romanian strings. [\#65](https://github.com/add-ons/service.iptv.manager/pull/65) ([tmihai20](https://github.com/tmihai20))
+- Initial greek translation for IPTV Manager [\#62](https://github.com/add-ons/service.iptv.manager/pull/62) ([Twilight0](https://github.com/Twilight0))
+- Add hungarian language translation [\#59](https://github.com/add-ons/service.iptv.manager/pull/59) ([takraj](https://github.com/takraj))
+- Improve tests and run tests on Windows [\#58](https://github.com/add-ons/service.iptv.manager/pull/58) ([michaelarnauts](https://github.com/michaelarnauts))
+
 ## [v0.2.2](https://github.com/add-ons/service.iptv.manager/tree/v0.2.2) (2020-12-07)
 
 [Full Changelog](https://github.com/add-ons/service.iptv.manager/compare/v0.2.1...v0.2.2)

--- a/service.iptv.manager/addon.xml
+++ b/service.iptv.manager/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="service.iptv.manager" name="IPTV Manager" version="0.2.2" provider-name="Michaël Arnauts">
+<addon id="service.iptv.manager" name="IPTV Manager" version="0.2.3" provider-name="Michaël Arnauts">
     <requires>
         <import addon="xbmc.python" version="2.26.0"/>
         <import addon="script.module.dateutil" version="2.6.0"/>
@@ -20,15 +20,24 @@
         </menu>
     </extension>
     <extension point="xbmc.addon.metadata">
-        <summary lang="en_GB">Integrate IPTV Channels from other Add-ons in the Kodi PVR</summary>
+        <summary lang="en_GB">Integrate IPTV channels from other add-ons in the Kodi TV and Radio menus</summary>
+        <summary lang="nl_NL">Integreer IPTV kanalen van andere add-ons in de Kodi TV en Radio menu's</summary>
         <summary lang="ru_RU">Интеграция IPTV каналов из других дополнений в Kodi PVR</summary>
-        <description lang="en_GB">This add-on integrates IPTV Channels from other Add-ons in the Kodi PVR.</description>
+        <summary lang="hu_HU">Más kiegészítők által szolgáltatott IPTV csatornák integrációja a Kodi PVR felületbe</summary>
+        <summary lang="el_GR">Ενσωμάτωση καναλιών IPTV από άλλα πρόσθετα στο PVR του Kodi</summary>
+        <description lang="en_GB">IPTV Manager integrates IPTV channels from other add-ons in the Kodi TV and Radio menus.</description>
+        <description lang="nl_NL">IPTV Manager integreert IPTV kanalen van andere add-ons in de Kodi TV en Radio menu's.</description>
         <description lang="ru_RU">Это дополнение интегрирует IPTV каналы из других дополнений в Kodi PVR.</description>
+        <description lang="hu_HU">Ez a kiegészítő lehetővé teszi más kiegészítők számára, hogy saját IPTV csatornákat publikáljanak a Kodi PVR felületébe.</description>
+        <description lang="el_GR">Το πρόσθετο αυτο ενσωματώνει τα κανάλια IPTV από άλλα πρόσθετα στο PVR του Kodi.</description>
         <platform>all</platform>
         <license>GPL-3.0-only</license>
-        <news>v0.2.2 (2020-12-07)
-- Relax version restriction for IPTV Simple.
-- Process credits.</news>
+        <news>v0.2.3 (2021-02-04)
+- Allow to process raw m3u8 or xmltv data.
+- Add support for #KODIPROP.
+- Support multiple groups for a channel.
+- Improvements for Kodi Matrix.
+- Update translations.</news>
         <source>https://github.com/add-ons/service.iptv.manager</source>
         <assets>
             <icon>resources/icon.png</icon>

--- a/service.iptv.manager/resources/language/resource.language.el_gr/strings.po
+++ b/service.iptv.manager/resources/language/resource.language.el_gr/strings.po
@@ -3,7 +3,7 @@
 # Addon id: service.iptv.manager
 msgid ""
 msgstr ""
-"Language: ru\n"
+"Language: en\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
@@ -11,53 +11,53 @@ msgstr ""
 # CONTEXT MENU
 msgctxt "#30600"
 msgid "Play with IPTV Manager"
-msgstr "Воспроизвести в IPTV Manager"
+msgstr "Αναπαραγωγή με τον διαχειριστή IPTV"
 
 # MESSAGES
 msgctxt "#30700"
 msgid "Are you sure you want to setup IPTV Simple for the use with IPTV Manager? Any existing configuration of IPTV Simple will be overwritten."
-msgstr "Вы уверены, что хотите настроить IPTV Simple для работы с IPTV Manager? Существующие параметры IPTV Simple будут перезаписаны."
+msgstr "Είστε σίγουροι ότι θέλετε να ρυθμίσετε το IPTV Simple για χρήση με τον διαχειριστή IPTV; Όλες οι υπάρχουσες ρυθμίσεις του IPTV simple θα επαναγραφτούν."
 
 msgctxt "#30701"
 msgid "IPTV Simple is configured for use with IPTV Manager!"
-msgstr "IPTV Simple настроен для работы с IPTV Manager!"
+msgstr "Το IPTV Simple έχει ρυθμιστεί για χρήση με τον διαχειριστή IPTV!"
 
 msgctxt "#30702"
 msgid "The configuration of IPTV Simple has failed. Please check the log files for more information."
-msgstr "Настройка IPTV Simple не удалась. Пожалуйста, проверьте файлы журнала для получения дополнительной информации."
+msgstr "Η ρύθμιση του IPTV Simple έχει αποτύχει. Παρακαλώ ελέγξτε το αρχείο καταγραφής για περισσότερες πληροφορίες."
 
 msgctxt "#30703"
 msgid "Detecting IPTV add-ons..."
-msgstr "Обнаружение дополнений IPTV..."
+msgstr "Ανίχνευση των προσθέτων IPTV..."
 
 msgctxt "#30704"
 msgid "Fetching channels and guide of {addon}..."
-msgstr "Получение каналов и программы от {addon}..."
+msgstr "Λήψη καναλιών και οδηγού του {addon}..."
 
 msgctxt "#30705"
 msgid "Updating channels and guide..."
-msgstr "Обновление каналов и программы..."
+msgstr "Ενημέρωση καναλιών και οδηγού..."
 
 msgctxt "#30706"
 msgid "This program isn't available to play."
-msgstr ""
+msgstr "Το πρόγραμμα αυτό είναι μη διαθέσιμο για αναπαραγωγή."
 
 # SETTINGS
 msgctxt "#30800"
 msgid "Channels"
-msgstr "ТВ каналы"
+msgstr "Κανάλια"
 
 msgctxt "#30801"
 msgid "Refreshing"
-msgstr "Обновление"
+msgstr "Ανανέωση"
 
 msgctxt "#30802"
 msgid "Refresh interval [I](in hours)[/I]"
-msgstr "Интервал обновления [I](в часах)[/I]"
+msgstr "Διάστημα ανανέωσης [I](σε ώρες)[/I]"
 
 msgctxt "#30803"
 msgid "Refresh channels and guide now…"
-msgstr "Обновить каналы и программу сейчас…"
+msgstr "Ανανέωση καναλιών και οδηγού τώρα…"
 
 msgctxt "#30820"
 msgid "IPTV Simple"
@@ -65,19 +65,19 @@ msgstr "IPTV Simple"
 
 msgctxt "#30821"
 msgid "Configuration"
-msgstr "Параметры"
+msgstr "Ρυθμίσεις"
 
 msgctxt "#30822"
 msgid "Configure IPTV Simple automatically…"
-msgstr "Настроить IPTV Simple автоматически…"
+msgstr "Ρύθμιση του IPTV Simple αυτομάτως…"
 
 msgctxt "#30823"
 msgid "Open IPTV Simple settings…"
-msgstr "Открыть настройки IPTV Simple…"
+msgstr "Άνοιγμα των ρυθμίσεων του IPTV Simple"
 
 msgctxt "#30824"
 msgid "Automatically restart IPTV Simple to refresh the data"
-msgstr "Автоматически перезапускать IPTV Simple при обновлении данных"
+msgstr "Αυτόματη ανανέωση του IPTV Simple για ανανέωση των δεδομένων"
 
 msgctxt "#30880"
 msgid "Expert"

--- a/service.iptv.manager/resources/language/resource.language.en_gb/strings.po
+++ b/service.iptv.manager/resources/language/resource.language.en_gb/strings.po
@@ -1,3 +1,6 @@
+# Kodi Media Center language file
+# Addon Name: IPTV Manager
+# Addon id: service.iptv.manager
 msgid ""
 msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -5,13 +8,12 @@ msgstr ""
 "Language: en\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-### CONTEXT MENU
+# CONTEXT MENU
 msgctxt "#30600"
 msgid "Play with IPTV Manager"
 msgstr ""
 
-
-### MESSAGES
+# MESSAGES
 msgctxt "#30700"
 msgid "Are you sure you want to setup IPTV Simple for the use with IPTV Manager? Any existing configuration of IPTV Simple will be overwritten."
 msgstr ""
@@ -40,8 +42,7 @@ msgctxt "#30706"
 msgid "This program isn't available to play."
 msgstr ""
 
-
-### SETTINGS
+# SETTINGS
 msgctxt "#30800"
 msgid "Channels"
 msgstr ""
@@ -76,4 +77,24 @@ msgstr ""
 
 msgctxt "#30824"
 msgid "Automatically restart IPTV Simple to refresh the data"
+msgstr ""
+
+msgctxt "#30880"
+msgid "Expert"
+msgstr ""
+
+msgctxt "#30881"
+msgid "Logging"
+msgstr ""
+
+msgctxt "#30882"
+msgid "Enable debug logging"
+msgstr ""
+
+msgctxt "#30883"
+msgid "Install Kodi Logfile Uploader…"
+msgstr ""
+
+msgctxt "#30884"
+msgid "Open Kodi Logfile Uploader…"
 msgstr ""

--- a/service.iptv.manager/resources/language/resource.language.hu_hu/strings.po
+++ b/service.iptv.manager/resources/language/resource.language.hu_hu/strings.po
@@ -3,7 +3,7 @@
 # Addon id: service.iptv.manager
 msgid ""
 msgstr ""
-"Language: ru\n"
+"Language: hu\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
@@ -11,53 +11,53 @@ msgstr ""
 # CONTEXT MENU
 msgctxt "#30600"
 msgid "Play with IPTV Manager"
-msgstr "Воспроизвести в IPTV Manager"
+msgstr "Lejátszás ezzel: IPTV Manager"
 
 # MESSAGES
 msgctxt "#30700"
 msgid "Are you sure you want to setup IPTV Simple for the use with IPTV Manager? Any existing configuration of IPTV Simple will be overwritten."
-msgstr "Вы уверены, что хотите настроить IPTV Simple для работы с IPTV Manager? Существующие параметры IPTV Simple будут перезаписаны."
+msgstr "Biztos szeretnéd, hogy az IPTV Simple ezentúl az IPTV Manager-t használja forrásként? A teljes jelenlegi konfiguráció felülírásra kerül."
 
 msgctxt "#30701"
 msgid "IPTV Simple is configured for use with IPTV Manager!"
-msgstr "IPTV Simple настроен для работы с IPTV Manager!"
+msgstr "Az IPTV Simple mostantól az IPTV Manager-t használja forrásként!"
 
 msgctxt "#30702"
 msgid "The configuration of IPTV Simple has failed. Please check the log files for more information."
-msgstr "Настройка IPTV Simple не удалась. Пожалуйста, проверьте файлы журнала для получения дополнительной информации."
+msgstr "Az IPTV Simple konfigurációja sikertelen. Részletek a hibanaplóban."
 
 msgctxt "#30703"
 msgid "Detecting IPTV add-ons..."
-msgstr "Обнаружение дополнений IPTV..."
+msgstr "IPTV kiegészítők keresése..."
 
 msgctxt "#30704"
 msgid "Fetching channels and guide of {addon}..."
-msgstr "Получение каналов и программы от {addon}..."
+msgstr "Csatornák és műsorújság letöltése: {addon}..."
 
 msgctxt "#30705"
 msgid "Updating channels and guide..."
-msgstr "Обновление каналов и программы..."
+msgstr "Csatornák és műsorújság frissítése..."
 
 msgctxt "#30706"
 msgid "This program isn't available to play."
-msgstr ""
+msgstr "Ezt a műsort jelenleg nem lehet lejátszani."
 
 # SETTINGS
 msgctxt "#30800"
 msgid "Channels"
-msgstr "ТВ каналы"
+msgstr "Csatornák"
 
 msgctxt "#30801"
 msgid "Refreshing"
-msgstr "Обновление"
+msgstr "Frissítés"
 
 msgctxt "#30802"
 msgid "Refresh interval [I](in hours)[/I]"
-msgstr "Интервал обновления [I](в часах)[/I]"
+msgstr "Frissítési időköz [I](óra)[/I]"
 
 msgctxt "#30803"
 msgid "Refresh channels and guide now…"
-msgstr "Обновить каналы и программу сейчас…"
+msgstr "Csatornák és műsorújság frissítése most…"
 
 msgctxt "#30820"
 msgid "IPTV Simple"
@@ -65,19 +65,19 @@ msgstr "IPTV Simple"
 
 msgctxt "#30821"
 msgid "Configuration"
-msgstr "Параметры"
+msgstr "Konfiguráció"
 
 msgctxt "#30822"
 msgid "Configure IPTV Simple automatically…"
-msgstr "Настроить IPTV Simple автоматически…"
+msgstr "IPTV Simple automatikus konfigurációja…"
 
 msgctxt "#30823"
 msgid "Open IPTV Simple settings…"
-msgstr "Открыть настройки IPTV Simple…"
+msgstr "IPTV Simple beállításainak megnyitása…"
 
 msgctxt "#30824"
 msgid "Automatically restart IPTV Simple to refresh the data"
-msgstr "Автоматически перезапускать IPTV Simple при обновлении данных"
+msgstr "IPTV Simple automatikus újraindítása, frissítés után"
 
 msgctxt "#30880"
 msgid "Expert"

--- a/service.iptv.manager/resources/language/resource.language.nl_nl/strings.po
+++ b/service.iptv.manager/resources/language/resource.language.nl_nl/strings.po
@@ -1,18 +1,20 @@
+# Kodi Media Center language file
+# Addon Name: IPTV Manager
+# Addon id: service.iptv.manager
 msgid ""
 msgstr ""
+"Language: nl\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: nl\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-### CONTEXT MENU
+# CONTEXT MENU
 msgctxt "#30600"
 msgid "Play with IPTV Manager"
 msgstr "Afspelen met IPTV Manager"
 
-
-### MESSAGES
+# MESSAGES
 msgctxt "#30700"
 msgid "Are you sure you want to setup IPTV Simple for the use with IPTV Manager? Any existing configuration of IPTV Simple will be overwritten."
 msgstr "Bent u zeker om IPTV Simple in te stellen om te gebruiken met IPTV Manager? De bestaande configuratie van IPTV Simple zal worden overschreven."
@@ -41,8 +43,7 @@ msgctxt "#30706"
 msgid "This program isn't available to play."
 msgstr "Dit programma is niet beschikbaar om af te spelen."
 
-
-### SETTINGS
+# SETTINGS
 msgctxt "#30800"
 msgid "Channels"
 msgstr "Kanalen"
@@ -78,3 +79,23 @@ msgstr "Open de IPTV Simple instellingen…"
 msgctxt "#30824"
 msgid "Automatically restart IPTV Simple to refresh the data"
 msgstr "Herstart IPTV Simple automatisch om de data te vernieuwen"
+
+msgctxt "#30880"
+msgid "Expert"
+msgstr "Expert"
+
+msgctxt "#30881"
+msgid "Logging"
+msgstr "Logboek"
+
+msgctxt "#30882"
+msgid "Enable debug logging"
+msgstr "Activeer debug logging"
+
+msgctxt "#30883"
+msgid "Install Kodi Logfile Uploader…"
+msgstr "Installeer Kodi Logfile Uploader…"
+
+msgctxt "#30884"
+msgid "Open Kodi Logfile Uploader…"
+msgstr "Open Kodi Logfile Uploader…"

--- a/service.iptv.manager/resources/language/resource.language.ro_ro/strings.po
+++ b/service.iptv.manager/resources/language/resource.language.ro_ro/strings.po
@@ -3,7 +3,7 @@
 # Addon id: service.iptv.manager
 msgid ""
 msgstr ""
-"Language: ru\n"
+"Language: ro\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
@@ -11,53 +11,53 @@ msgstr ""
 # CONTEXT MENU
 msgctxt "#30600"
 msgid "Play with IPTV Manager"
-msgstr "Воспроизвести в IPTV Manager"
+msgstr "Redă cu IPTV Manager"
 
 # MESSAGES
 msgctxt "#30700"
 msgid "Are you sure you want to setup IPTV Simple for the use with IPTV Manager? Any existing configuration of IPTV Simple will be overwritten."
-msgstr "Вы уверены, что хотите настроить IPTV Simple для работы с IPTV Manager? Существующие параметры IPTV Simple будут перезаписаны."
+msgstr "Sunteți sigur/(ă) că vreți să configurați IPTV Simple pentru a fi utilizat cu IPTV Manager? Dacă există vreo configurație a IPTV Simple, aceasta va fi suprascrisă."
 
 msgctxt "#30701"
 msgid "IPTV Simple is configured for use with IPTV Manager!"
-msgstr "IPTV Simple настроен для работы с IPTV Manager!"
+msgstr "IPTV Simple este configurat să fie folosit cu IPTV Manager!"
 
 msgctxt "#30702"
 msgid "The configuration of IPTV Simple has failed. Please check the log files for more information."
-msgstr "Настройка IPTV Simple не удалась. Пожалуйста, проверьте файлы журнала для получения дополнительной информации."
+msgstr "Configurarea IPTV Manager a eșuat. Vă rugăm să verificați logurile pentru mai multe informații."
 
 msgctxt "#30703"
 msgid "Detecting IPTV add-ons..."
-msgstr "Обнаружение дополнений IPTV..."
+msgstr "Se detectează add-on-uri IPTV..."
 
 msgctxt "#30704"
 msgid "Fetching channels and guide of {addon}..."
-msgstr "Получение каналов и программы от {addon}..."
+msgstr "Se descarcă canalele și ghidul pentru {addon}..."
 
 msgctxt "#30705"
 msgid "Updating channels and guide..."
-msgstr "Обновление каналов и программы..."
+msgstr "Se actualizează canalele și ghidul..."
 
 msgctxt "#30706"
 msgid "This program isn't available to play."
-msgstr ""
+msgstr "Acest program nu este disponibil pentru redare."
 
 # SETTINGS
 msgctxt "#30800"
 msgid "Channels"
-msgstr "ТВ каналы"
+msgstr "Canale"
 
 msgctxt "#30801"
 msgid "Refreshing"
-msgstr "Обновление"
+msgstr "Se actualizează"
 
 msgctxt "#30802"
 msgid "Refresh interval [I](in hours)[/I]"
-msgstr "Интервал обновления [I](в часах)[/I]"
+msgstr "Interval de actualizare [I](în ore)[/I]"
 
 msgctxt "#30803"
 msgid "Refresh channels and guide now…"
-msgstr "Обновить каналы и программу сейчас…"
+msgstr "Actualizează canalele și ghidul acum..."
 
 msgctxt "#30820"
 msgid "IPTV Simple"
@@ -65,19 +65,19 @@ msgstr "IPTV Simple"
 
 msgctxt "#30821"
 msgid "Configuration"
-msgstr "Параметры"
+msgstr "Configurare"
 
 msgctxt "#30822"
 msgid "Configure IPTV Simple automatically…"
-msgstr "Настроить IPTV Simple автоматически…"
+msgstr "Configurează IPTV Simple în mod automat..."
 
 msgctxt "#30823"
 msgid "Open IPTV Simple settings…"
-msgstr "Открыть настройки IPTV Simple…"
+msgstr "Deschide setările IPTV Simple..."
 
 msgctxt "#30824"
 msgid "Automatically restart IPTV Simple to refresh the data"
-msgstr "Автоматически перезапускать IPTV Simple при обновлении данных"
+msgstr "Repornește automat IPTV Simple pentru a actualiza datele"
 
 msgctxt "#30880"
 msgid "Expert"

--- a/service.iptv.manager/resources/lib/functions.py
+++ b/service.iptv.manager/resources/lib/functions.py
@@ -10,7 +10,6 @@ from resources.lib.modules.addon import Addon
 from resources.lib.modules.contextmenu import ContextMenu
 from resources.lib.modules.iptvsimple import IptvSimple
 
-kodilogging.config()
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -53,6 +52,8 @@ def open_settings():
 
 def run(args):
     """Run the function"""
+    kodilogging.config()
+
     function = args[1]
     function_map = {
         'setup-iptv-simple': setup_iptv_simple,

--- a/service.iptv.manager/resources/lib/kodilogging.py
+++ b/service.iptv.manager/resources/lib/kodilogging.py
@@ -8,37 +8,51 @@ import logging
 import xbmc
 import xbmcaddon
 
+from resources.lib import kodiutils
+
+ADDON = xbmcaddon.Addon()
+
 
 class KodiLogHandler(logging.StreamHandler):
-    """A log handler for Kodi"""
+    """ A log handler for Kodi """
 
     def __init__(self):
         logging.StreamHandler.__init__(self)
-        addon_id = xbmcaddon.Addon().getAddonInfo("id")
-        formatter = logging.Formatter("[{}] [%(name)s] %(message)s".format(addon_id))
+        formatter = logging.Formatter("[{}] [%(name)s] %(message)s".format(ADDON.getAddonInfo("id")))
         self.setFormatter(formatter)
+        # xbmc.LOGNOTICE is deprecated in Kodi 19 Matrix
+        if kodiutils.kodi_version_major() > 18:
+            self.info_level = xbmc.LOGINFO
+        else:
+            self.info_level = xbmc.LOGNOTICE
 
     def emit(self, record):
-        """Emit a log message"""
+        """ Emit a log message """
         levels = {
             logging.CRITICAL: xbmc.LOGFATAL,
             logging.ERROR: xbmc.LOGERROR,
             logging.WARNING: xbmc.LOGWARNING,
-            logging.INFO: xbmc.LOGINFO,
+            logging.INFO: self.info_level,
             logging.DEBUG: xbmc.LOGDEBUG,
             logging.NOTSET: xbmc.LOGNONE,
         }
+
+        # Map DEBUG level to info_level if debug logging setting has been activated
+        # This is for troubleshooting only
+        if ADDON.getSetting('debug_logging') == 'true':
+            levels[logging.DEBUG] = self.info_level
+
         try:
             xbmc.log(self.format(record), levels[record.levelno])
         except UnicodeEncodeError:
             xbmc.log(self.format(record).encode('utf-8', 'ignore'), levels[record.levelno])
 
     def flush(self):
-        """Flush the messages"""
+        """ Flush the messages """
 
 
 def config():
-    """Setup the logger with this handler"""
+    """ Setup the logger with this handler """
     logger = logging.getLogger()
+    logger.setLevel(logging.DEBUG)  # Make sure we pass all messages, Kodi will do some filtering itself.
     logger.addHandler(KodiLogHandler())
-    logger.setLevel(logging.DEBUG)

--- a/service.iptv.manager/resources/lib/modules/iptvsimple.py
+++ b/service.iptv.manager/resources/lib/modules/iptvsimple.py
@@ -109,6 +109,13 @@ class IptvSimple:
 
             for addon in channels:
                 m3u8_data += '## {addon_name}\n'.format(**addon)
+
+                # RAW M3U8 data
+                if not isinstance(addon['channels'], list):
+                    m3u8_data += addon['channels']
+                    continue
+
+                # JSON-STREAMS format
                 for channel in addon['channels']:
                     m3u8_data += '#EXTINF:-1 tvg-name="{name}"'.format(**channel)
                     if channel.get('id'):
@@ -118,11 +125,14 @@ class IptvSimple:
                     if channel.get('preset'):
                         m3u8_data += ' tvg-chno="{preset}"'.format(**channel)
                     if channel.get('group'):
-                        m3u8_data += ' group-title="{group}"'.format(**channel)
+                        m3u8_data += ' group-title="{groups}"'.format(groups=';'.join(channel.get('group')))
                     if channel.get('radio'):
                         m3u8_data += ' radio="true"'
-
-                    m3u8_data += ' catchup="vod",{name}\n{stream}\n\n'.format(**channel)
+                    m3u8_data += ' catchup="vod",{name}\n'.format(**channel)
+                    if channel.get('kodiprops'):
+                        for key, value in channel.get('kodiprops').items():
+                            m3u8_data += '#KODIPROP:{key}={value}\n'.format(key=key, value=value)
+                    m3u8_data += '{stream}\n\n'.format(**channel)
 
             fdesc.write(m3u8_data.encode('utf-8'))
 
@@ -133,7 +143,7 @@ class IptvSimple:
         os.rename(playlist_path + '.tmp', playlist_path)
 
     @classmethod
-    def write_epg(cls, epg):
+    def write_epg(cls, epg_list, channels):
         """Write EPG data"""
         output_dir = kodiutils.addon_profile()
 
@@ -153,14 +163,27 @@ class IptvSimple:
             fdesc.write('<tv>\n'.encode('utf-8'))
 
             # Write channel info
-            for _, key in enumerate(epg):
-                fdesc.write('<channel id="{key}"></channel>\n'.format(key=cls._xml_encode(key)).encode('utf-8'))
+            for addon in channels:
+                for channel in addon.get('channels'):
+                    if isinstance(channel, dict) and channel.get('id'):
+                        fdesc.write('<channel id="{id}">\n'.format(id=cls._xml_encode(channel.get('id'))).encode('utf-8'))
+                        fdesc.write(' <display-name>{name}</display-name>\n'.format(name=cls._xml_encode(channel.get('name'))).encode('utf-8'))
+                        if channel.get('logo'):
+                            fdesc.write(' <icon src="{logo}"/>\n'.format(logo=cls._xml_encode(channel.get('logo'))).encode('utf-8'))
+                        fdesc.write('</channel>\n'.encode('utf-8'))
 
-            # Write program info
-            for _, key in enumerate(epg):
-                for item in epg[key]:
-                    program = cls._construct_epg_program_xml(item, key)
-                    fdesc.write(program.encode('utf-8'))
+            for epg in epg_list:
+                # RAW XMLTV data
+                if not isinstance(epg, dict):
+                    fdesc.write(epg.encode('utf-8'))
+                    fdesc.write('\n'.encode('utf-8'))
+                    continue
+
+                # Write program info
+                for _, key in enumerate(epg):
+                    for item in epg[key]:
+                        program = cls._construct_epg_program_xml(item, key)
+                        fdesc.write(program.encode('utf-8'))
 
             fdesc.write('</tv>\n'.encode('utf-8'))
 
@@ -174,8 +197,8 @@ class IptvSimple:
     def _construct_epg_program_xml(cls, item, channel):
         """ Generate the XML for the EPG of a program. """
         try:
-            start = dateutil.parser.parse(item.get('start')).strftime('%Y%m%d%H%M%S %z')
-            stop = dateutil.parser.parse(item.get('stop')).strftime('%Y%m%d%H%M%S %z')
+            start = dateutil.parser.parse(item.get('start')).strftime('%Y%m%d%H%M%S %z').rstrip()
+            stop = dateutil.parser.parse(item.get('stop')).strftime('%Y%m%d%H%M%S %z').rstrip()
             title = item.get('title', '')
 
             # Add an icon ourselves in Kodi 18
@@ -194,34 +217,13 @@ class IptvSimple:
             program += ' <title>{title}</title>\n'.format(
                 title=cls._xml_encode(title))
 
-            if item.get('description'):
-                program += ' <desc>{description}</desc>\n'.format(
-                    description=cls._xml_encode(item.get('description')))
-
             if item.get('subtitle'):
                 program += ' <sub-title>{subtitle}</sub-title>\n'.format(
                     subtitle=cls._xml_encode(item.get('subtitle')))
 
-            if item.get('episode'):
-                program += ' <episode-num system="onscreen">{episode}</episode-num>\n'.format(
-                    episode=cls._xml_encode(item.get('episode')))
-
-            if item.get('image'):
-                program += ' <icon src="{image}"/>\n'.format(
-                    image=cls._xml_encode(item.get('image')))
-
-            if item.get('date'):
-                program += ' <date>{date}</date>\n'.format(
-                    date=cls._xml_encode(item.get('date')))
-
-            if item.get('genre'):
-                if isinstance(item.get('genre'), list):
-                    for genre in item.get('genre'):
-                        program += ' <category>{genre}</category>\n'.format(
-                            genre=cls._xml_encode(genre))
-                else:
-                    program += ' <category>{genre}</category>\n'.format(
-                        genre=cls._xml_encode(item.get('genre')))
+            if item.get('description'):
+                program += ' <desc>{description}</desc>\n'.format(
+                    description=cls._xml_encode(item.get('description')))
 
             if item.get('credits'):
                 program += ' <credits>\n'
@@ -264,6 +266,27 @@ class IptvSimple:
                         program += '  <actor>{name}</actor>\n'.format(name=cls._xml_encode(credit.get('name')))
 
                 program += ' </credits>\n'
+
+            if item.get('date'):
+                program += ' <date>{date}</date>\n'.format(
+                    date=cls._xml_encode(item.get('date')))
+
+            if item.get('genre'):
+                if isinstance(item.get('genre'), list):
+                    for genre in item.get('genre'):
+                        program += ' <category>{genre}</category>\n'.format(
+                            genre=cls._xml_encode(genre))
+                else:
+                    program += ' <category>{genre}</category>\n'.format(
+                        genre=cls._xml_encode(item.get('genre')))
+
+            if item.get('image'):
+                program += ' <icon src="{image}"/>\n'.format(
+                    image=cls._xml_encode(item.get('image')))
+
+            if item.get('episode'):
+                program += ' <episode-num system="onscreen">{episode}</episode-num>\n'.format(
+                    episode=cls._xml_encode(item.get('episode')))
 
             program += '</programme>\n'
             return program

--- a/service.iptv.manager/resources/lib/service.py
+++ b/service.iptv.manager/resources/lib/service.py
@@ -12,7 +12,6 @@ from resources.lib import kodilogging, kodiutils
 from resources.lib.modules.addon import Addon
 from resources.lib.modules.iptvsimple import IptvSimple
 
-kodilogging.config()
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -53,4 +52,5 @@ class BackgroundService(Monitor):
 
 def run():
     """Run the BackgroundService"""
+    kodilogging.config()
     BackgroundService().run()

--- a/service.iptv.manager/resources/settings.xml
+++ b/service.iptv.manager/resources/settings.xml
@@ -12,4 +12,10 @@
         <setting label="30823" type="action" option="close" action="Addon.OpenSettings(pvr.iptvsimple)" enable="System.HasAddon(pvr.iptvsimple)"/> <!-- Open IPTV Simple settings -->
         <setting label="30824" type="bool" id="iptv_simple_restart" default="true" enable="System.HasAddon(pvr.iptvsimple)"/> <!-- Automatically restart IPTV Simple -->
     </category>
+    <category label="30880"> <!-- Expert -->
+        <setting label="30881" type="lsep"/> <!-- Logging -->
+        <setting label="30882" type="bool" id="debug_logging" default="false"/>
+        <setting label="30883" type="action" action="InstallAddon(script.kodi.loguploader)" option="close" visible="!System.HasAddon(script.kodi.loguploader)"/> <!-- Install Kodi Logfile Uploader -->
+        <setting label="30884" type="action" action="RunAddon(script.kodi.loguploader)" visible="String.StartsWith(System.BuildVersion,18) + System.HasAddon(script.kodi.loguploader) | System.AddonIsEnabled(script.kodi.loguploader)" /> <!-- Open Kodi Logfile Uploader -->
+    </category>
 </settings>


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: IPTV Manager
  - Add-on ID: service.iptv.manager
  - Version number: 0.2.3
  - Kodi/repository version: leia

- **Code location**
  - URL: https://github.com/add-ons/service.iptv.manager
  
IPTV Manager integrates IPTV channels from other add-ons in the Kodi TV and Radio menus.

### Description of changes:

v0.2.3 (2021-02-04)
- Allow to process raw m3u8 or xmltv data.
- Add support for #KODIPROP.
- Support multiple groups for a channel.
- Improvements for Kodi Matrix.
- Update translations.

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
