### PR TITLE
[service.upnext@matrix] 1.1.5+matrix.1

### DIFF
--- a/service.upnext/README.md
+++ b/service.upnext/README.md
@@ -23,6 +23,11 @@ The add-on has various settings to fine-tune the experience, however the default
 For [Addon Integration](https://github.com/im85288/service.upnext/wiki/Addon-Integration) and [Skinners](https://github.com/im85288/service.upnext/wiki/Skinners) see the [wiki](https://github.com/im85288/service.upnext/wiki)
 
 ## Releases
+### v1.1.5 (2021-02-21)
+- Fix playlists to work with non-library content (@MoojMidge)
+- Fix to prevent unwanted playback when using playlist queueing method (@MoojMidge)
+- New translation for Finnish (@Dis90)
+
 ### v1.1.4 (2020-12-03)
 - Fix problem causing pop-up to not appear (@MoojMidge)
 - Translation updates to Romanian, Russian and Spanish (@tmihai20, @vlmaksime, @roliverosc)

--- a/service.upnext/addon.xml
+++ b/service.upnext/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="service.upnext" name="Up Next" version="1.1.4+matrix.1" provider-name="im85288">
+<addon id="service.upnext" name="Up Next" version="1.1.5+matrix.1" provider-name="im85288">
     <requires>
         <import addon="xbmc.python" version="3.0.0"/>
     </requires>
@@ -40,11 +40,16 @@ Många befintliga tillägg integreras redan med den här utanför lådan-tjänst
         <platform>all</platform>
         <license>GPL-2.0-only</license>
         <news>
-### v1.1.4 (2020-12-03)
+v1.1.5 (2021-02-21)
+- Fix playlists to work with non-library content
+- Fix to prevent unwanted playback when using playlist queueing method
+- New translation for Finnish
+
+v1.1.4 (2020-12-03)
 - Fix problem causing pop-up to not appear
 - Translation updates to Romanian, Russian and Spanish
 
-### v1.1.3 (2020-10-14)
+v1.1.3 (2020-10-14)
 - Enable customPlayTime by default
 - Do not seek to the end before playing next episode
 - Add Kodi v17 compatibility
@@ -52,11 +57,11 @@ Många befintliga tillägg integreras redan med den här utanför lådan-tjänst
 - Enqueue the next episode in the playlist
 - Translation updates to German
 
-### v1.1.2 (2020-06-22)
+v1.1.2 (2020-06-22)
 - Bug fix for change from sleep to waitForAbort using seconds and not ms
 - Translation updates to Japanese and Korean
 
-### v1.1.1 (2020-06-21)
+v1.1.1 (2020-06-21)
 - Avoid conflict with external players
 - Restore "Ignore Playlist" option
 - Fix a known Kodi bug related to displaying hours
@@ -64,7 +69,7 @@ Många befintliga tillägg integreras redan med den här utanför lådan-tjänst
 - New translations for Hindi and Romanian
 - Translation updates to Hungarian and Spanish
 
-### v1.1.0 (2020-01-17)
+v1.1.0 (2020-01-17)
 - Add notification_offset for Netflix add-on
 - Fix various runtime exceptions
 - Implement new settings

--- a/service.upnext/resources/language/resource.language.fi_fi/strings.po
+++ b/service.upnext/resources/language/resource.language.fi_fi/strings.po
@@ -1,0 +1,213 @@
+# Service Up Next language file
+# Addon Name: Up Next
+# Addon id: service.upnext
+# Addon Provider: im85288
+msgid ""
+msgstr ""
+"Project-Id-Version: service.upnext\n"
+"Report-Msgid-Bugs-To: https://github.com/im85288/service.upnext\n"
+"POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"PO-Revision-Date: 2018-02-26 13:31+0000\n"
+"Last-Translator: Dis90\n"
+"Language-Team: Finnish\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: en\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 1.8.7\n"
+
+### APPLICATION
+msgctxt "#30006"
+msgid "Watch Now"
+msgstr "Katso nyt"
+
+msgctxt "#30008"
+msgid "Up Next"
+msgstr ""
+
+msgctxt "#30009"
+msgid "Ends at: $INFO[Window.Property(endtime)]"
+msgstr "Päättyy: $INFO[Window.Property(endtime)]"
+
+msgctxt "#30010"
+msgid "Continue watching"
+msgstr "Jatka katsomista"
+
+msgctxt "#30024"
+msgid "Still there?"
+msgstr "Vielä paikalla?"
+
+msgctxt "#30032"
+msgid "Enable on playlists"
+msgstr "Ota käyttöön toistolistoissa"
+
+msgctxt "#30033"
+msgid "Stop"
+msgstr "Pysäytä"
+
+msgctxt "#30034"
+msgid "Close"
+msgstr "Sulje"
+
+msgctxt "#30035"
+msgid "Continue watching in [COLOR FFFF4081]$INFO[Window.Property(remaining)][/COLOR] seconds"
+msgstr "Jatka katsomista [COLOR FFFF4081]$INFO[Window.Property(remaining)][/COLOR] sekunnin kuluttua"
+
+msgctxt "#30036"
+msgid "Up next in [COLOR FFFF4081]$INFO[Window.Property(remaining)][/COLOR] seconds"
+msgstr "Seuraavaksi [COLOR FFFF4081]$INFO[Window.Property(remaining)][/COLOR] sekunnin kuluttua"
+
+msgctxt "#30037"
+msgid "Next episode in [COLOR FFFF4081]$INFO[Window.Property(remaining)][/COLOR] seconds"
+msgstr "Seuraava jakso [COLOR FFFF4081]$INFO[Window.Property(remaining)][/COLOR] sekunnin kuluttua"
+
+msgctxt "#30038"
+msgid "Simple"
+msgstr "Yksinkertainen"
+
+msgctxt "#30039"
+msgid "Fancy"
+msgstr "Hienostunut"
+
+msgctxt "#30040"
+msgid "Play next"
+msgstr "Toista seuraava"
+
+msgctxt "#30041"
+msgid "Stop playing"
+msgstr "Pysäytä toisto"
+
+msgctxt "#30042"
+msgid "None"
+msgstr "Ei mitään"
+
+msgctxt "#30043"
+msgid "Info"
+msgstr "Info"
+
+msgctxt "#30044"
+msgid "Debug"
+msgstr "Debug"
+
+msgctxt "#30049"
+msgid "Next Episode"
+msgstr "Seuraava jakso"
+
+msgctxt "#30060"
+msgid "[B]UP NEXT DEMO MODE ENABLED[/B]"
+msgstr "[B]UP NEXT DEMO-TILA KÄYTÖSSÄ[/B]"
+
+msgctxt "#30061"
+msgid "[I]Episodes automatically skip to end.[/I]"
+msgstr "[I]Hyppää automaattisesti jaksojen loppuun.[/I]"
+
+
+### SETTINGS
+msgctxt "#30500"
+msgid "Interface"
+msgstr "Käyttöliittymä"
+
+msgctxt "#30501"
+msgid "Features"
+msgstr "Ominaisuudet"
+
+msgctxt "#30503"
+msgid "Set the display mode for the notifications"
+msgstr "Aseta ilmoitusten esitystila"
+
+msgctxt "#30505"
+msgid "Show a \"Stop\" button instead of a \"Close\" button"
+msgstr "Näytä \"Pysäytä\"-nappi \"Sulje\"-napin sijaan"
+
+msgctxt "#30600"
+msgid "Behaviour"
+msgstr "Käyttäytyminen"
+
+msgctxt "#30601"
+msgid "Features"
+msgstr "Ominaisuudet"
+
+msgctxt "#30603"
+msgid "Default action when nothing selected"
+msgstr "Oletustoiminto, kun mitään ei ole valittu"
+
+msgctxt "#30605"
+msgid "Include already watched episodes"
+msgstr "Sisällytä katsotut jaksot"
+
+msgctxt "#30607"
+msgid "Number of episodes before \"Still there?\" query"
+msgstr "Jaksojen määrä ennen \"Vielä paikalla?\" ilmoitusta"
+
+msgctxt "#30609"
+msgid "Duration in seconds for notification to be shown"
+msgstr "Kesto sekunneissa, kuinka kauan ilmoitus näytetään"
+
+msgctxt "#30611"
+msgid "Customize autoplay duration by episode length"
+msgstr "Mukauta automaattisen toiston kesto jakson pituuden mukaan"
+
+msgctxt "#30613"
+msgid "All episodes  [COLOR gray]any length[/COLOR]"
+msgstr "Kaikki jaksot  [COLOR gray]kaikki pituudet[/COLOR]"
+
+msgctxt "#30615"
+msgid "Very short episodes  [COLOR gray]< 10 mins[/COLOR]"
+msgstr "Todella lyhyet jaksot  [COLOR gray]< 10 min[/COLOR]"
+
+msgctxt "#30617"
+msgid "Short episodes  [COLOR gray]> 10 mins[/COLOR]"
+msgstr "Lyhyet jaksot  [COLOR gray]> 10 min[/COLOR]"
+
+msgctxt "#30619"
+msgid "Medium episodes  [COLOR gray]> 20 mins[/COLOR]"
+msgstr "Keskipituiset jaksot  [COLOR gray]> 20 min[/COLOR]"
+
+msgctxt "#30621"
+msgid "Long episodes  [COLOR gray]> 40 mins[/COLOR]"
+msgstr "Pitkät jaksot  [COLOR gray]> 40 min[/COLOR]"
+
+msgctxt "#30623"
+msgid "Very long episodes  [COLOR gray]> 60 mins[/COLOR]"
+msgstr "Todella pitkät jaksot  [COLOR gray]> 60 min[/COLOR]"
+
+msgctxt "#30700"
+msgid "Expert"
+msgstr "Asiantuntija"
+
+msgctxt "#30703"
+msgid "Disable Up Next"
+msgstr "Poista käytöstä Up Next"
+
+msgctxt "#30705"
+msgid "Log level"
+msgstr "Lokitaso"
+
+msgctxt "#30800"
+msgid "Developer"
+msgstr "Kehittäjä"
+
+msgctxt "#30801"
+msgid "Test how the user interface looks"
+msgstr "Kokeile miltä käyttöliittymä näyttää"
+
+msgctxt "#30803"
+msgid "Enable DEMO mode"
+msgstr "Ota käyttöön DEMO-tila"
+
+msgctxt "#30805"
+msgid "Show an UpNext pop-up…"
+msgstr "Näytä UpNext ponnahdusikkuna"
+
+msgctxt "#30807"
+msgid "Show an UpNextSimple pop-up…"
+msgstr "Näytä UpNextSimple ponnahdusikkuna"
+
+msgctxt "#30809"
+msgid "Show a StillWatching pop-up…"
+msgstr "Näytä StillWatching ponnahdusikkuna"
+
+msgctxt "#30811"
+msgid "Show a StillWatchingSimple pop-up…"
+msgstr "Näytä StillWatchingSimple ponnahdusikkuna"

--- a/service.upnext/resources/lib/playbackmanager.py
+++ b/service.upnext/resources/lib/playbackmanager.py
@@ -40,31 +40,42 @@ class PlaybackManager:
             self.demo.hide()
 
     def launch_up_next(self):
-        playlist_item = get_setting_bool('enablePlaylist')
-        episode = self.play_item.get_next()
-        self.log('Playlist setting: %s' % playlist_item)
-        if episode and not playlist_item:
+        enable_playlist = get_setting_bool('enablePlaylist')
+        episode, source = self.play_item.get_next()
+        self.log('Playlist setting: %s' % enable_playlist)
+        if source == 'playlist' and not enable_playlist:
             self.log('Playlist integration disabled', 2)
             return
         if not episode:
-            playlist_item = False
-            episode = self.play_item.get_episode()
-            if episode is None:
-                # No episode get out of here
-                self.log('Error: no episode could be found to play next...exiting', 1)
-                return
+            # No episode get out of here
+            self.log('Error: no episode could be found to play next...exiting', 1)
+            return
         self.log('episode details %s' % episode, 2)
-        self.launch_popup(episode, playlist_item)
+        play_next, keep_playing = self.launch_popup(episode, source)
+        self.state.playing_next = play_next
+
+        # Dequeue and stop playback if not playing next file
+        if not play_next and self.state.queued:
+            self.state.queued = self.api.dequeue_next_item()
+        if not keep_playing:
+            self.log('Stopping playback', 2)
+            self.player.stop()
+
         self.api.reset_addon_data()
 
-    def launch_popup(self, episode, playlist_item):
+    def launch_popup(self, episode, source=None):
         episode_id = episode.get('episodeid')
         no_play_count = episode.get('playcount') is None or episode.get('playcount') == 0
         include_play_count = True if self.state.include_watched else no_play_count
         if not include_play_count or self.state.current_episode_id == episode_id:
-            return
+            # play_next = False
+            # keep_playing = True
+            # return play_next, keep_playing
+            # Don't play next file, but keep playing current file
+            return False, True
 
-        if not playlist_item:
+        # Add next file to playlist if existing playlist is not being used
+        if source != 'playlist':
             self.state.queued = self.api.queue_next_item(episode)
 
         # We have a next up episode choose mode
@@ -84,16 +95,30 @@ class PlaybackManager:
                                                                               still_watching_page)
         if not self.state.track:
             self.log('exit launch_popup early due to disabled tracking', 2)
-            return
+            # play_next = False
+            # keep_playing = showing_next_up_page
+            # return play_next, keep_playing
+            # Don't play next file
+            # Stop if Still Watching? popup was shown to prevent unwanted playback when using FF or skip
+            return False, showing_next_up_page
+
         play_item_option_1 = (should_play_default and self.state.play_mode == 0)
         play_item_option_2 = (should_play_non_default and self.state.play_mode == 1)
         if not play_item_option_1 and not play_item_option_2:
-            return
+            # play_next = False
+            # keep_playing = next_up_page.is_cancel() if showing_next_up_page else still_watching_page.is_cancel()
+            # keep_playing = keep_playing and not get_setting_bool('stopAfterClose')
+            # return play_next, keep_playing
+            # Don't play next file, and stop current file if no playback option selected
+            return False, (
+                (next_up_page.is_cancel() if showing_next_up_page else still_watching_page.is_cancel())
+                and not get_setting_bool('stopAfterClose')
+            )
 
         self.log('playing media episode', 2)
         # Signal to trakt previous episode watched
         event(message='NEXTUPWATCHEDSIGNAL', data=dict(episodeid=self.state.current_episode_id), encoding='base64')
-        if playlist_item or self.state.queued:
+        if source == 'playlist' or self.state.queued:
             # Play playlist media
             if should_play_non_default:
                 # Only start the next episode if the user asked for it specifically
@@ -104,6 +129,12 @@ class PlaybackManager:
         else:
             # Play local media
             self.api.play_kodi_item(episode)
+
+        # play_next = True
+        # keep_playing = True
+        # return play_next, keep_playing
+        # Play next file, and keep playing current file
+        return True, True
 
     def show_popup_and_wait(self, episode, next_up_page, still_watching_page):
         try:

--- a/service.upnext/resources/lib/player.py
+++ b/service.upnext/resources/lib/player.py
@@ -58,8 +58,10 @@ class UpNextPlayer(Player):
     def onPlayBackEnded(self):  # pylint: disable=invalid-name
         """Will be called when Kodi has ended playing a file"""
         self.reset_queue()
-        self.api.reset_addon_data()
-        self.state = State()  # Reset state
+        # Only reset state if not playing the next episode
+        if not self.state.playing_next:
+            self.api.reset_addon_data()
+            self.state = State()  # Reset state
 
     def onPlayBackError(self):  # pylint: disable=invalid-name
         """Will be called when when playback stops due to an error"""

--- a/service.upnext/resources/lib/playitem.py
+++ b/service.upnext/resources/lib/playitem.py
@@ -21,17 +21,28 @@ class PlayItem:
     def log(self, msg, level=2):
         ulog(msg, name=self.__class__.__name__, level=level)
 
-    def get_episode(self):
-        current_file = self.player.getPlayingFile()
-        if not self.api.has_addon_data():
-            # Get the active player
-            result = self.api.get_now_playing()
-            self.handle_now_playing_result(result)
-            # Get the next episode from Kodi
-            episode = (
-                self.api.handle_kodi_lookup_of_episode(
-                    self.state.tv_show_id, current_file, self.state.include_watched, self.state.current_episode_id))
-        else:
+    @staticmethod
+    def get_playlist_position():
+        """Function to get current playlist playback position"""
+
+        playlist = PlayList(PLAYLIST_VIDEO)
+        position = playlist.getposition()
+        # A playlist with only one element has no next item and PlayList().getposition() starts counting from zero
+        if playlist.size() > 1 and position < (playlist.size() - 1):
+            # Return 1 based index value
+            return position + 1
+        return False
+
+    def get_next(self):
+        """Get next episode to play, based on current video source"""
+
+        episode = None
+        source = None
+        position = self.get_playlist_position()
+        has_addon_data = self.api.has_addon_data()
+
+        # Next video from addon data
+        if has_addon_data:
             episode = self.api.handle_addon_lookup_of_next_episode()
             current_episode = self.api.handle_addon_lookup_of_current_episode()
             self.state.current_episode_id = current_episode.get('episodeid')
@@ -39,15 +50,26 @@ class PlayItem:
                 self.log('Change in TV show ID: last: %s / current: %s' % (self.state.current_tv_show_id, current_episode.get('tvshowid')), 2)
                 self.state.current_tv_show_id = current_episode.get('tvshowid')
                 self.state.played_in_a_row = 1
-        return episode
+            source = 'addon' if not position else 'playlist'
 
-    def get_next(self):
-        playlist = PlayList(PLAYLIST_VIDEO)
-        position = playlist.getposition()
-        # A playlist with only one element has no next item and PlayList().getposition() starts counting from zero
-        if playlist.size() > 1 and position < (playlist.size() - 1):
-            return self.api.get_next_in_playlist(position)
-        return False
+        # Next video from non-addon playlist
+        elif position:
+            episode = self.api.get_next_in_playlist(position)
+            source = 'playlist'
+
+        # Next video from Kodi library
+        else:
+            current_file = self.player.getPlayingFile()
+            # Get the active player
+            result = self.api.get_now_playing()
+            self.handle_now_playing_result(result)
+            # Get the next episode from Kodi
+            episode = self.api.handle_kodi_lookup_of_episode(
+                self.state.tv_show_id, current_file, self.state.include_watched, self.state.current_episode_id
+            )
+            source = 'library'
+
+        return episode, source
 
     def handle_now_playing_result(self, result):
         if not result.get('result'):

--- a/service.upnext/resources/lib/state.py
+++ b/service.upnext/resources/lib/state.py
@@ -21,3 +21,4 @@ class State:
         self.track = False
         self.pause = False
         self.queued = False
+        self.playing_next = False

--- a/service.upnext/resources/lib/utils.py
+++ b/service.upnext/resources/lib/utils.py
@@ -48,6 +48,21 @@ def clear_property(key, window_id=10000):
     return Window(window_id).clearProperty(key)
 
 
+def get_int(obj, key=None, default=-1):
+    """Returns an object or value for the given key in object, as an integer.
+       Returns default value if key or object is not available.
+       Returns value if value cannot be converted to integer."""
+
+    try:
+        val = obj.get(key, default) if key else obj
+    except (AttributeError, TypeError):
+        return default
+    try:
+        return int(val)
+    except (ValueError, TypeError):
+        return val if val else default
+
+
 def get_setting(key, default=None):
     """Get an add-on setting as string"""
     # We use Addon() here to ensure changes in settings are reflected instantly


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: Up Next
  - Add-on ID: service.upnext
  - Version number: 1.1.5+matrix.1
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/im85288/service.upnext
  
A service add-on that shows a Netflix-style notification for watching the next episode. After a few automatic iterations it asks the user if he is still there watching.

A lot of existing add-ons already integrate with this service out-of-the-box.

### Description of changes:


v1.1.5 (2021-02-21)
- Fix playlists to work with non-library content
- Fix to prevent unwanted playback when using playlist queueing method
- New translation for Finnish

v1.1.4 (2020-12-03)
- Fix problem causing pop-up to not appear
- Translation updates to Romanian, Russian and Spanish

v1.1.3 (2020-10-14)
- Enable customPlayTime by default
- Do not seek to the end before playing next episode
- Add Kodi v17 compatibility
- Fix logging on Kodi v19 (Matrix) after recent breakage
- Enqueue the next episode in the playlist
- Translation updates to German

v1.1.2 (2020-06-22)
- Bug fix for change from sleep to waitForAbort using seconds and not ms
- Translation updates to Japanese and Korean

v1.1.1 (2020-06-21)
- Avoid conflict with external players
- Restore "Ignore Playlist" option
- Fix a known Kodi bug related to displaying hours
- Improvements to endtime visualization
- New translations for Hindi and Romanian
- Translation updates to Hungarian and Spanish

v1.1.0 (2020-01-17)
- Add notification_offset for Netflix add-on
- Fix various runtime exceptions
- Implement new settings
- Implement new developer mode
- Show current time and next endtime in notification
- New translations for Brazilian, Czech, Greek, Japanese, Korean
- New translations for Russian, Slovak, Spanish, Swedish
- Translation updates to Croatian, French, German, Hungarian, Italian, Polish
        

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
