### PR TITLE
[script.module.kodiswift] 0.0.12

### DIFF
--- a/script.module.kodiswift/addon.xml
+++ b/script.module.kodiswift/addon.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.module.kodiswift" name="kodiswift" provider-name="Aaron Frase (Sinap); TJ Jiang" version="0.0.11">
+<addon id="script.module.kodiswift" name="kodiswift" provider-name="Aaron Frase (Sinap); TJ Jiang" version="0.0.12">
   <requires>
     <import addon="xbmc.python" version="2.24.0"/>
     <import addon="script.module.six" version="1.13.0"/>
   </requires>
   <extension library="lib" point="xbmc.python.module"/>
   <extension point="xbmc.addon.metadata">
-    <summary lang="en">A fork of the xbmcswift2 project</summary>
-    <description lang="en">A micro framework to enable rapid development of Kodi plugins. TJ Jiang is responsible for modifications in 0.0.9, 0.0.10 and 0.0.11.</description>
+    <summary lang="en_GB">A fork of the xbmcswift2 project</summary>
+    <description lang="en_GB">A micro framework to enable rapid development of Kodi plugins. TJ Jiang is responsible for modifications in 0.0.9, 0.0.10 and 0.0.11.</description>
     <platform>all</platform>
     <license>GNU General Public License v3 (GPL-3)</license>
     <source>https://github.com/afrase/kodiswift</source>

--- a/script.module.kodiswift/changelog.txt
+++ b/script.module.kodiswift/changelog.txt
@@ -1,3 +1,8 @@
+0.0.12
+=====
+
+- improves python 2,3 compatibility by replacing instance compare functions with six.type.objects.
+
 0.0.11
 =====
 

--- a/script.module.kodiswift/lib/kodiswift/common.py
+++ b/script.module.kodiswift/lib/kodiswift/common.py
@@ -71,7 +71,7 @@ def pickle_dict(items):
     ret = {}
     pickled_keys = []
     for k, v in items.items():
-        if isinstance(v, basestring):
+        if isinstance(v, six.string_types):
             ret[k] = v
         else:
             pickled_keys.append(k)

--- a/script.module.kodiswift/lib/kodiswift/listitem.py
+++ b/script.module.kodiswift/lib/kodiswift/listitem.py
@@ -51,8 +51,8 @@ class ListItem(object):
         previous context menu items will be removed.
         """
         for label, action in items:
-            assert isinstance(label, basestring)
-            assert isinstance(action, basestring)
+            assert isinstance(label, six.string_types)
+            assert isinstance(action, six.string_types)
         if replace_items:
             self._context_menu_items = []
         self._context_menu_items.extend(items)

--- a/script.module.kodiswift/lib/kodiswift/urls.py
+++ b/script.module.kodiswift/lib/kodiswift/urls.py
@@ -122,7 +122,7 @@ class UrlRule(object):
         with the appropriate value from the items dict.
         """
         for key, val in items.items():
-            if not isinstance(val, basestring):
+            if not isinstance(val, six.string_types):
                 raise TypeError('Value "%s" for key "%s" must be an instance'
                                 ' of basestring' % (val, key))
             items[key] = six.moves.urllib.parse.quote_plus(val)
@@ -163,7 +163,7 @@ class UrlRule(object):
         """
         # Convert any ints and longs to strings
         for key, val in items.items():
-            if isinstance(val, (int, long)):
+            if isinstance(val, six.integer_types):
                 items[key] = str(val)
 
         # First use our defaults passed when registering the rule

--- a/script.module.kodiswift/lib/kodiswift/xbmcmixin.py
+++ b/script.module.kodiswift/lib/kodiswift/xbmcmixin.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
 
-import os
+import os,six
 import warnings
 from datetime import timedelta
 from functools import wraps
@@ -215,8 +215,8 @@ class XBMCMixin(object):
         value = self.addon.getSetting(key)
         if converter is str:
             return value
-        elif converter is unicode:
-            return value.decode('utf-8')
+        elif converter is six.text_type: #unicode
+            return six.ensure_text(value, 'utf-8') #value.decode('utf-8')
         elif converter is bool:
             return value == 'true'
         elif converter is int:
@@ -337,7 +337,7 @@ class XBMCMixin(object):
             item = {}
             succeeded = False
 
-        if isinstance(item, basestring):
+        if isinstance(item, six.string_types):
             # caller is passing a url instead of an item dict
             item = {'path': item}
 


### PR DESCRIPTION
### Description
Improves python 2,3 compatibility by replacing instance compare functions with six.type.objects.
### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [X] Each add-on submission should be a single commit with using the following style: [script.foo.bar] 1.0.0

Additional information :
- Import the six library in lib script files to make them compatible with python 3.
- It's for jarvis. And there are only minor differences in addon.xml compared to [[script.module.kodiswift] 0.0.12+matrix.1](https://github.com/xbmc/repo-scripts/pull/1884).
