### PR TITLE
[script.trakt@matrix] 3.3.5

### DIFF
--- a/script.trakt/addon.xml
+++ b/script.trakt/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.trakt" name="Trakt" version="3.3.4" provider-name="Trakt.tv, Razzeee">
+<addon id="script.trakt" name="Trakt" version="3.3.5" provider-name="Trakt.tv, Razzeee">
     <requires>
         <import addon="xbmc.python" version="3.0.0"/>
         <import addon="script.module.trakt" version="4.1.0"/>
@@ -58,12 +58,12 @@
         <website>https://trakt.tv</website>
         <source>https://github.com/trakt/script.trakt</source>
         <news>- Fix variable reference error</news>
-    <assets>
-        <icon>icon.png</icon>
-        <fanart>fanart.jpg</fanart>
-        <screenshot>resources/image-01.png</screenshot>
-        <screenshot>resources/image-02.png</screenshot>
-        <screenshot>resources/image-03.png</screenshot>
-    </assets>
+        <assets>
+            <icon>icon.png</icon>
+            <fanart>fanart.jpg</fanart>
+            <screenshot>resources/image-01.png</screenshot>
+            <screenshot>resources/image-02.png</screenshot>
+            <screenshot>resources/image-03.png</screenshot>
+        </assets>
     </extension>
 </addon>

--- a/script.trakt/resources/lib/syncMovies.py
+++ b/script.trakt/resources/lib/syncMovies.py
@@ -329,8 +329,8 @@ class SyncMovies():
             # need to calculate the progress in int from progress in percent from Trakt
             # split movie list into chunks of 50
             chunksize = 50
-            chunked_movies = utilities.chunks([{"jsonrpc": "2.0", "id": i, "method": "VideoLibrary.SetMovieDetails", "params": {"movieid": movies[i]['movieid'], "resume": {
-                                              "position": movies[i]['runtime'] / 100.0 * movies[i]['progress'], "total": movies[i]['runtime']}}} for i in range(len(kodiMoviesToUpdate)) if movies[i]['runtime'] > 0], chunksize)
+            chunked_movies = utilities.chunks([{"jsonrpc": "2.0", "id": i, "method": "VideoLibrary.SetMovieDetails", "params": {"movieid": kodiMoviesToUpdate[i]['movieid'], "resume": {
+                                              "position": kodiMoviesToUpdate[i]['runtime'] / 100.0 * kodiMoviesToUpdate[i]['progress'], "total": kodiMoviesToUpdate[i]['runtime']}}} for i in range(len(kodiMoviesToUpdate)) if kodiMoviesToUpdate[i]['runtime'] > 0], chunksize)
             i = 0
             x = float(len(kodiMoviesToUpdate))
             for chunk in chunked_movies:


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: Trakt
  - Add-on ID: script.trakt
  - Version number: 3.3.5
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/trakt/script.trakt
  
Automatically scrobble all TV episodes and movies you are watching to Trakt.tv! Keep a comprehensive history of everything you've watched and be part of a global community of TV and movie enthusiasts. Sign up for a free account at http://trakt.tv and get a ton of features:

- Automatically scrobble what you're watching
- Mobile apps for iPhone, iPad, Android, and Windows Phone
- Share what you're watching (in real time) and rating to facebook and twitter
- Personalized calendar so you never miss a TV show
- Follow your friends and people you're interesed in
- Use watchlists so you don't forget to what to watch
- Track your media collections and impress your friends
- Create custom lists around any topics you choose
- Easily track your TV show progress across all seasons and episodes
- Track your progress against industry lists such as the IMDb Top 250
- Discover new shows and movies based on your viewing habits
- Widgets for your forum signature

What can this addon do?

- Automatically scrobble all TV episodes and movies you are watching
- Sync your TV episode and movie collections to Trakt (triggered after a library update)
- Auto clean your Trakt collection so that it matches up with Kodi
- Keep watched statuses synced between Kodi and Trakt
- Rate movies and episode after watching them

Special thanks to all who contributed to this plugin! Check the commit history and changelog to see these talented developers.

### Description of changes:

- Fix variable reference error

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
