### PR TITLE
[script.service.playbackresumer@matrix] 2.0.1

### DIFF
--- a/script.service.playbackresumer/README.md
+++ b/script.service.playbackresumer/README.md
@@ -6,8 +6,7 @@ A simple addon to periodically update the resume point of the currently playing 
 
 Optionally, automatically resume playback automatically when Kodi is restarted after a crash, or trigger playback of a random video.
 
-Main Kodi forum thread here:
-https://forum.kodi.tv/showthread.php?tid=183084
+Kodi forum thread: <https://forum.kodi.tv/showthread.php?tid=355383>
 
 (Original code by bradvido88 recovered from the Kodi forum, and from May 2019 updated & maintained in this repo by bossanova808).
 

--- a/script.service.playbackresumer/addon.xml
+++ b/script.service.playbackresumer/addon.xml
@@ -13,7 +13,7 @@
 	<license>GPL-3.0-only</license>
     <website>https://github.com/bossanova808/script.service.playbackresumer</website>
     <source>https://github.com/bossanova808/script.service.playbackresumer</source>
-    <forum>https://forum.kodi.tv/showthread.php?tid=183084</forum>
+    <forum>https://forum.kodi.tv/showthread.php?tid=355383</forum>
     <email>bossanova808@gmail.com</email>
     <assets>
       <icon>icon.png</icon>

--- a/script.service.playbackresumer/changelog.txt
+++ b/script.service.playbackresumer/changelog.txt
@@ -1,8 +1,27 @@
-2.0.1 - Update settings to Matrix format
-2.0.0 - Port to Python 3 and prepare for submission to Matrix repo
-1.2.0 - Updated for Kodi Leia.  Dev taken over by bossanova808@gmail.com.
-1.1.0 - added ability to Auto-Play a random video if nothing is playing
-1.0.3 - converted strings.xml to strings.po, updated license to be GPL v3, updated startup type to login
-1.0.2 - changed startup type and updated links to forum/source
-1.0.1 - updated descriptions in addon xml
-1.0.0 - initial commit for frodo
+v2.0.2
+- Update for Matrix logging changes
+
+v2.0.1 
+- Update settings to Matrix format
+
+v2.0.0 
+- Port to Python 3 and prepare for submission to Matrix repo
+
+v1.2.0 
+- Updated for Kodi Leia.  Dev taken over by bossanova808.
+
+v1.1.0 
+- added ability to Auto-Play a random video if nothing is playing
+
+v1.0.3 
+- converted strings.xml to strings.po
+- updated startup type to login
+
+v1.0.2 
+- changed startup type and updated links to forum/source
+
+v1.0.1 
+- updated descriptions in addon xml
+
+v1.0.0 
+- initial commit for frodo


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: Kodi Playback Resumer
  - Add-on ID: script.service.playbackresumer
  - Version number: 2.0.1
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/bossanova808/script.service.playbackresumer
  

        Runs as a service and will periodically update the resume point while videos are playing, so you can re-start from where you were in the event of a crash.  It can also automatically resume a video if Kodi was shutdown while playing it. See setting to configure how often the resume point is set, and whether to automatically resume.
    

### Description of changes:



### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
