### PR TITLE
[script.xbmcbackup] 1.6.6

### DIFF
--- a/script.xbmcbackup/addon.xml
+++ b/script.xbmcbackup/addon.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="script.xbmcbackup"
-    name="Backup" version="1.6.5" provider-name="robweber">
+    name="Backup" version="1.6.6" provider-name="robweber">
   <requires>
     <import addon="xbmc.python" version="3.0.0"/>
     <import addon="script.module.dateutil" version="2.8.0" />
@@ -89,10 +89,8 @@
 		<screenshot>resources/images/screenshot3.jpg</screenshot>
 		<screenshot>resources/images/screenshot4.jpg</screenshot>
     </assets>
-    <news>Version 1.6.5
- - updated to new settings format with levels
- - added ability to change path where temp zip file is built
- - fixed issues with xbmcgui Dialogs
+    <news>Version 1.6.6
+ - fixed issue with backup rotations not working properly
 </news>
   </extension>
 </addon>

--- a/script.xbmcbackup/resources/lib/backup.py
+++ b/script.xbmcbackup/resources/lib/backup.py
@@ -57,15 +57,14 @@ class XbmcBackup:
 
     def configureRemote(self):
         if(utils.getSetting('remote_selection') == '1'):
-            self.remote_base_path = utils.getSetting('remote_path_2')
             self.remote_vfs = XBMCFileSystem(utils.getSetting('remote_path_2'))
             utils.setSetting("remote_path", "")
         elif(utils.getSetting('remote_selection') == '0'):
-            self.remote_base_path = utils.getSetting('remote_path')
             self.remote_vfs = XBMCFileSystem(utils.getSetting("remote_path"))
         elif(utils.getSetting('remote_selection') == '2'):
-            self.remote_base_path = "/"
             self.remote_vfs = DropboxFileSystem("/")
+
+        self.remote_base_path = self.remote_vfs.root_path
 
     def remoteConfigured(self):
         result = True

--- a/script.xbmcbackup/resources/lib/vfs.py
+++ b/script.xbmcbackup/resources/lib/vfs.py
@@ -73,7 +73,7 @@ class XBMCFileSystem(Vfs):
         return xbmcvfs.copy(xbmcvfs.translatePath(source), xbmcvfs.translatePath(dest))
 
     def rmdir(self, directory):
-        return xbmcvfs.rmdir(directory)
+        return xbmcvfs.rmdir(directory, force=True)  # use force=True to make sure it works recursively
 
     def rmfile(self, aFile):
         return xbmcvfs.delete(aFile)


### PR DESCRIPTION
### Description
Fixed issue major issue where backup rotation setting wasn't working with Matrix, needed to add ```force=True``` flag to ```rmdir()``` call. 
### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [script.foo.bar] 1.0.0

Additional information :
- Submitting your add-on to this specific branch makes it available to any Kodi version equal or higher than the branch name with the applicable Kodi dependencies limits.
- [add-on development](http://kodi.wiki/view/Add-on_development) wiki page.
- Kodi [pydocs](http://kodi.wiki/view/PyDocs) provide information about the Python API
- [PEP8](https://www.python.org/dev/peps/pep-0008/) codingstyle which is considered best practise but not mandatory.
- This add-on repository has automated code guideline check which could help you improve your coding. You can find the results of these check at [Codacy](https://www.codacy.com/app/Kodi/repo-scripts/dashboard). You can create your own account as well to continuously monitor your python coding before submitting to repo.
- Development questions can be asked in the [add-on development](http://forum.kodi.tv/forumdisplay.php?fid=26) section on the Kodi forum.
