### PR TITLE
[script.tvmaze.scrobbler@matrix] 1.1.1+matrix.1

### DIFF
--- a/script.tvmaze.scrobbler/addon.xml
+++ b/script.tvmaze.scrobbler/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon id="script.tvmaze.scrobbler"
    name="TVmaze Scrobbler/Tracker"
-   version="1.1.0+matrix.1"
+   version="1.1.1+matrix.1"
    provider-name="Roman V.M.">
   <requires>
     <import addon="xbmc.python" version="3.0.0" />
@@ -38,12 +38,11 @@ What this addon does:
       <icon>resources/images/icon.png</icon>
       <fanart>resources/images/background.jpg</fanart>
     </assets>
-    <news>1.1.0:
-- Added periodic pulling of episode watched statuses from TVmaze.
-- Improved error logging.
+    <news>1.1.1:
+- Fixed special episodes handling.
 
-1.0.1:
-- Fixed crashes because of malformed JSON responses from TVmaze.
-- Fixed crashes because of invalid SSL certificates.</news>
+1.1.0:
+- Added periodic pulling of episode watched statuses from TVmaze.
+- Improved error logging.</news>
   </extension>
 </addon>

--- a/script.tvmaze.scrobbler/libs/exception_logger.py
+++ b/script.tvmaze.scrobbler/libs/exception_logger.py
@@ -46,7 +46,7 @@ def _format_vars(variables):
     var_list.sort(key=lambda i: i[0])
     lines = []
     for var, val in var_list:
-        lines.append('{} = {}'.format(var, pformat(val)))
+        lines.append('{} = {}'.format(var, pformat(val, indent=4)))
     return '\n'.join(lines)
 
 
@@ -149,7 +149,7 @@ def log_exception(logger_func=logger.error):
             system_info=uname(),
             python_version=sys.version.replace('\n', ' '),
             kodi_version=xbmc.getInfoLabel('System.BuildVersion'),
-            sys_argv=pformat(sys.argv),
+            sys_argv=six.text_type(sys.argv),
             sys_path=pformat(sys.path),
             stack_trace=stack_trace
         )

--- a/script.tvmaze.scrobbler/libs/medialibrary_api.py
+++ b/script.tvmaze.scrobbler/libs/medialibrary_api.py
@@ -95,8 +95,8 @@ def get_episodes(tvshowid, filter_=None):
     """
     params = {
         'tvshowid': tvshowid,
-        'properties': ['season', 'episode', 'playcount', 'tvshowid',
-                       'dateadded', 'lastplayed']
+        'properties': ['season', 'episode', 'playcount', 'tvshowid', 'uniqueid',
+                       'dateadded', 'lastplayed', 'firstaired']
     }
     if filter_ is not None:
         params['filter'] = filter_
@@ -116,7 +116,7 @@ def get_recent_episodes():
     """
     params = {
         'properties': ['playcount', 'tvshowid', 'season', 'episode', 'uniqueid',
-                       'dateadded', 'lastplayed']
+                       'dateadded', 'lastplayed', 'firstaired']
     }
     result = send_json_rpc('VideoLibrary.GetRecentlyAddedEpisodes', params)
     if not result.get('episodes'):
@@ -152,7 +152,7 @@ def get_episode_details(episode_id):
     params = {
         'episodeid': episode_id,
         'properties': ['playcount', 'tvshowid', 'season', 'episode', 'uniqueid',
-                       'dateadded', 'lastplayed']
+                       'dateadded', 'lastplayed', 'firstaired']
     }
     return send_json_rpc(method, params)['episodedetails']
 

--- a/script.tvmaze.scrobbler/libs/pulled_episodes_db.py
+++ b/script.tvmaze.scrobbler/libs/pulled_episodes_db.py
@@ -37,8 +37,8 @@ class PulledEpisodesDb(object):
 
     def __init__(self):
         self._connection = sqlite3.connect(self.DB)
-        self._cursor = None  # type: Optional[sqlite3.Cursor]
-        self._connection.execute("""
+        self._cursor = self._connection.cursor()  # type: sqlite3.Cursor
+        self._cursor.execute("""
             CREATE TABLE IF NOT EXISTS pulled_episodes(
                 episode_id INTEGER PRIMARY KEY,
                 timestamp INTEGER NOT NULL
@@ -46,7 +46,6 @@ class PulledEpisodesDb(object):
         """)
 
     def __enter__(self):
-        self._cursor = self._connection.cursor()
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: TVmaze Scrobbler/Tracker
  - Add-on ID: script.tvmaze.scrobbler
  - Version number: 1.1.1+matrix.1
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/romanvm/kodi.tvmaze.scrobbler
  
Automatically track all TV episodes you are watching to TVmaze. A must have if you want to sync your watch history between various applications.
Sign up for a free account at https://tvmaze.com for more features.

This Kodi TV episode Tracker uses the TVmaze.com user API's scrobbler endpoints(https://static.tvmaze.com/apidoc/)

What this addon does:
- Performs an initial sync between Kodi and TVmaze for the episodes you've watched.
- If you add an episode to the Kodi library it marks it as "acquired" on TVmaze.
- If you watch an episode in Kodi it marks it as "watched" in TVmaze.
- If you mark an episode as watched in TVmaze it marks it as watched in Kodi.

### Description of changes:

1.1.1:
- Fixed special episodes handling.

1.1.0:
- Added periodic pulling of episode watched statuses from TVmaze.
- Improved error logging.

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
