### PR TITLE
[service.subtitles.rvm.addic7ed@matrix] 3.1.5+matrix.1

### DIFF
--- a/service.subtitles.rvm.addic7ed/addic7ed/actions.py
+++ b/service.subtitles.rvm.addic7ed/addic7ed/actions.py
@@ -10,7 +10,7 @@ import shutil
 from collections import namedtuple
 from six import PY2
 from six.moves import urllib_parse as urlparse
-from kodi_six import xbmc, xbmcplugin, xbmcgui, xbmcvfs
+from kodi_six import xbmc, xbmcplugin, xbmcgui
 from . import parser
 from .addon import addon, profile, get_ui_string, icon
 from .exceptions import DailyLimitError, ParseError, SubsSearchError, \
@@ -24,7 +24,7 @@ temp_dir = os.path.join(profile, 'temp')
 handle = int(sys.argv[1])
 
 
-VIDEOFILES = frozenset(('.avi', '.mkv', '.mp4', '.ts', '.m2ts', '.mov'))
+VIDEOFILES = {'.avi', '.mkv', '.mp4', '.ts', '.m2ts', '.mov'}
 dialog = xbmcgui.Dialog()
 release_re = re.compile(r'-(.*?)(?:\[.*?\])?\.')
 
@@ -118,6 +118,8 @@ def download_subs(link, referrer, filename):
         label - the download location for subs.
     """
     # Re-create a download location in a temporary folder
+    if not os.path.exists(profile):
+        os.mkdir(profile)
     if os.path.exists(temp_dir):
         shutil.rmtree(temp_dir)
     os.mkdir(temp_dir)

--- a/service.subtitles.rvm.addic7ed/addon.xml
+++ b/service.subtitles.rvm.addic7ed/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon id="service.subtitles.rvm.addic7ed"
   name="Addic7ed.com"
-  version="3.1.4+matrix.1"
+  version="3.1.5+matrix.1"
   provider-name="Roman V.M.">
 <requires>
   <import addon="xbmc.python" version="3.0.0"/>
@@ -32,7 +32,10 @@
     <icon>icon.png</icon>
     <fanart>fanart.jpg</fanart>
   </assets>
-  <news>v.3.1.4:
+  <news>v.3.1.5:
+- Fixed a crash when downloading subs for the first time after installing the addon.
+
+v.3.1.4:
 - Fix cleaning a temp download directory.</news>
   <reuselanguageinvoker>false</reuselanguageinvoker>
 </extension>

--- a/service.subtitles.rvm.addic7ed/main.py
+++ b/service.subtitles.rvm.addic7ed/main.py
@@ -3,7 +3,7 @@
 # The main script contains minimum code to speed up launching on slower systems
 
 import sys
-from addic7ed.core import router
+from addic7ed.actions import router
 from addic7ed.exception_logger import log_exception
 
 if __name__ == '__main__':


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: Addic7ed.com
  - Add-on ID: service.subtitles.rvm.addic7ed
  - Version number: 3.1.5+matrix.1
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/romanvm/service.addic7ed
  
Subtitles service for Addic7ed.com. It supports only TV shows.

### Description of changes:

v.3.1.5:
- Fixed a crash when downloading subs for the first time after installing the addon.

v.3.1.4:
- Fix cleaning a temp download directory.

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
