### PR TITLE
[service.libraryautoupdate] 1.2.2

### DIFF
--- a/service.libraryautoupdate/addon.xml
+++ b/service.libraryautoupdate/addon.xml
@@ -1,13 +1,13 @@
 ﻿<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="service.libraryautoupdate"
-    name="Library Auto Update" version="1.2.1" provider-name="robweber">
+    name="Library Auto Update" version="1.2.2" provider-name="robweber">
   <requires>
     <import addon="xbmc.python" version="3.0.0"/>
     <import addon="script.module.dateutil" version="2.7.3" />
     <import addon="script.module.kodi-six" version="0.1.0"/>
     <import addon="script.module.future" version="0.16.0.4"/>
   </requires>
-  <extension point="xbmc.python.script" library="manual.py" /> 
+  <extension point="xbmc.python.script" library="manual.py" />
   <extension point="xbmc.service" library="default.py" />
   <extension point="xbmc.addon.metadata">
     <summary lang="be_BY">Update your Kodi Video and Music Libraries on a timer. Timer runs as an Kodi service so you never miss an update.</summary>
@@ -78,7 +78,8 @@
 	<assets>
 		<icon>resources/media/icon.png</icon>
 	</assets>
-	<news>Version 1.2.1
-- fixes for deprecated Python module calls</news>
+	<news>Version 1.2.2
+- updated settings.xml to new format, added support for levels
+- xbmcgui.Dialog and xbmcvfs.translatePath fixes</news>
   </extension>
 </addon>

--- a/service.libraryautoupdate/edit_custom_paths.py
+++ b/service.libraryautoupdate/edit_custom_paths.py
@@ -5,7 +5,7 @@ from resources.lib.cronclasses import CustomPathFile
 dialog = xbmcgui.Dialog()
 
 # show the disclaimer - do this every time
-dialog.ok(utils.getString(30031), "", utils.getString(30032), utils.getString(30033))
+dialog.ok(utils.getString(30031), "%s\n%s" % (utils.getString(30032), utils.getString(30033)))
 
 
 def selectPath(contentType):
@@ -47,7 +47,7 @@ def showMainScreen(contentType):
                     customPaths.addPath(path)
             else:
                 # delete?
-                if(dialog.yesno(heading=utils.getString(30021), line1=utils.getString(30022))):
+                if(dialog.yesno(heading=utils.getString(30021), message=utils.getString(30022))):
                     # get the id of the selected item
                     aPath = customPaths.getPaths()[exitCondition - 1]
                     # delete that id

--- a/service.libraryautoupdate/resources/language/resource.language.en_gb/strings.po
+++ b/service.libraryautoupdate/resources/language/resource.language.en_gb/strings.po
@@ -67,16 +67,16 @@ msgid "Run during playback"
 msgstr "Run during playback"
 
 msgctxt "#30008"
-msgid "Startup Delay (minutes)"
-msgstr "Startup Delay (minutes)"
+msgid "Startup Delay"
+msgstr "Startup Delay"
 
 msgctxt "#30009"
 msgid "Used Advanced Timer"
 msgstr "Used Advanced Timer"
 
 msgctxt "#30010"
-msgid "Amount of time between updates (hours)"
-msgstr "Amount of time between updates (hours)"
+msgid "Amount of time between updates"
+msgstr "Amount of time between updates"
 
 msgctxt "#30011"
 msgid "Cron Expression"
@@ -217,3 +217,95 @@ msgstr "Update will run again "
 msgctxt "#30061"
 msgid "Do you wish to manually run an update?"
 msgstr "Do you wish to manually run an update?"
+
+msgctxt "#30062"
+msgid "No Delay"
+msgstr "No Delay"
+
+msgctxt "#30063"
+msgid "1 Minute"
+msgstr "1 Minute"
+
+msgctxt "#30064"
+msgid "2 Minutes"
+msgstr "2 Minutes"
+
+msgctxt "#30065"
+msgid "3 Minutes"
+msgstr "3 Minutes"
+
+msgctxt "#30066"
+msgid "4 Minutes"
+msgstr "4 Minutes"
+
+msgctxt "#30067"
+msgid "5 Minutes"
+msgstr "5 Minutes"
+
+msgctxt "#30068"
+msgid "1 Hour"
+msgstr "1 Hour"
+
+msgctxt "#30069"
+msgid "2 Hours"
+msgstr "2 Hours"
+
+msgctxt "#30070"
+msgid "4 Hours"
+msgstr "4 Hours"
+
+msgctxt "#30071"
+msgid "6 Hours"
+msgstr "6 Hours"
+
+msgctxt "#30072"
+msgid "12 Hours"
+msgstr "12 Hours"
+
+msgctxt "#30073"
+msgid "24 Hours"
+msgstr "24 Hours"
+
+msgctxt "#30074"
+msgid "How long to delay missed scan after system startup"
+msgstr "How long to delay missed scan after system startup"
+
+msgctxt "#30075"
+msgid "Allow library scans when media is playing"
+msgstr "Allow library scans when media is playing"
+
+msgctxt "#30076"
+msgid "Only allow scans to start when system is idle (screensaver active)"
+msgstr "Only allow scans to start when system is idle (screensaver active)"
+
+msgctxt "#30077"
+msgid "Disables the dialog box when starting a Manual Run"
+msgstr "Disables the dialog box when starting a Manual Run"
+
+msgctxt "#30078"
+msgid "Toggle use a cron timer instead of the simple timer"
+msgstr "Toggle use a cron timer instead of the simple timer"
+
+msgctxt "#30079"
+msgid "Select how often to start library scans"
+msgstr "Select how often to start library scans"
+
+msgctxt "#30080"
+msgid "Set a custom interval using cron syntax - example is '15 */5 * * *' for quarter past the hour every 5 hours every day"
+msgstr "Set a custom interval using cron syntax - example is '15 */5 * * *' for quarter past the hour every 5 hours every day"
+
+msgctxt "#30081"
+msgid "Launch the custom paths editor to select specific scan directories instead of the entire library"
+msgstr "Launch the custom paths editor to select specific scan directories instead of the entire library"
+
+msgctxt "#30082"
+msgid "Run the Kodi library clean process to remove deleted media"
+msgstr "Run the Kodi library clean process to remove deleted media"
+
+msgctxt "#30083"
+msgid "Adds additional confirmation prompt before clean process runs"
+msgstr "Adds additional confirmation prompt before clean process runs"
+
+msgctxt "#30084"
+msgid "Set how often to run the clean process. After each update, once a day, once a week, once a month, or custom"
+msgstr "Set how often to run the clean process. After each update, once a day, once a week, once a month, or custom"

--- a/service.libraryautoupdate/resources/settings.xml
+++ b/service.libraryautoupdate/resources/settings.xml
@@ -1,38 +1,296 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<settings>
-	<category id="general" label="30001">
-		<setting id="startup_delay" type="enum" values="0|1|2|3|4|5" label="30008" default="0"  />
-		<setting id="notify_next_run" type="bool" label="30006" default="true" />
-		<setting id="run_during_playback" type="bool" label="30007" default="false" />
-		<setting id="run_on_idle" type="bool" label="30014" default="false" />
-		<setting id="check_sources" type="bool" label="30017" default="false" />
-		<setting id="disable_manual_prompt" type="bool" label="30015" default="false" />
-		<setting id="upgrade_notes" type="number" label="upgrade_notes" visible="false" default="1" />
-	</category>
-	<category id="video_timer" label="30002">
-		<setting id="update_video" type="bool" label="30004" default="true" />
-		<setting id="video_advanced_timer" type="bool" label="30009" default="false" enable="eq(-1,true)"/>
-		<setting id="video_timer" type="enum" values="1|2|4|6|12|24" label="30010" default="2" enable="!eq(-1,true) + eq(-2,true)" visible="!eq(-1,true)" />
-		<setting id="video_cron_expression" type="text" label="30011" visible="eq(-2,true)" enable="eq(-2,true) + eq(-3,true)" default="0 * * * *" />
-		<setting type="sep" />
-		<!-- custom paths -->
-		<setting id="run_custom_paths" type="action" action="RunScript(special://home/addons/service.libraryautoupdate/edit_custom_paths.py,type=video)" label="30020" />
-	</category>
-	<category id="music_timer" label="30003">
-		<setting id="update_music" type="bool" label="30005" default="false" />
-		<setting id="music_advanced_timer" type="bool" label="30009" default="false" enable="eq(-1,true)" />
-		<setting id="music_timer" type="enum" values="1|2|4|6|12|24" label="30010" default="2" enable="!eq(-1,true) + eq(-2,true)" visible="!eq(-1,true)" />
-		<setting id="music_cron_expression" type="text" label="30011" enable="eq(-2,true) + eq(-3,true)" default="0 * * * *" visible="eq(-2,true)" />
-		<setting type="sep" />
-		<!-- custom paths -->
-		<setting id="run_custom_paths_music" type="action" action="RunScript(special://home/addons/service.libraryautoupdate/edit_custom_paths.py,type=music)" label="30020" />
-	</category>
-	<category id="clean_timer" label="30040">
-		<setting id="clean_libraries" type="bool" label="30041" default="false" />
-		<setting id="library_to_clean" type="enum" lvalues="30055|30002|30003" label="30054" default="0" enable="eq(-1,true)" />
-		<setting id="user_confirm_clean" type="bool" label="30051" default="false" enable="eq(-2,true) + !eq(1,0)" />
-		<setting id="clean_timer" type="enum" lvalues="30044|30045|30046|30047|30011" label="30043" default="0" enable="eq(-3,true)" />
-		<setting id="clean_video_cron_expression" type="text" label="30056" default="0 0 * * *" enable="eq(-4,true)" visible="eq(-1,4)" />
-		<setting id="clean_music_cron_expression" type="text" label="30057" default="0 2 * * *" enable="eq(-5,true)" visible="eq(-2,4)" />
-	</category>
+<?xml version="1.0"?>
+<settings version="1">
+  <section id="service.libraryautoupdate">
+    <category id="general" label="30001" help="">
+      <group id="1" label="">
+        <!-- startup delay 0 to 5 min -->
+        <setting id="startup_delay" type="integer" label="30008" help="30074">
+          <level>1</level>
+          <default>0</default>
+          <constraints>
+            <options>
+              <option label="30062">0</option>
+              <option label="30063">1</option>
+              <option label="30064">2</option>
+              <option label="30065">3</option>
+              <option label="30066">4</option>
+              <option label="30067">5</option>
+            </options>
+          </constraints>
+          <control type="spinner" format="string" />
+        </setting>
+        <setting id="notify_next_run" type="boolean" label="30006" help="">
+          <level>0</level>
+          <default>true</default>
+          <control type="toggle" />
+        </setting>
+    		<setting id="run_during_playback" type="boolean" label="30007" help="30075">
+          <level>1</level>
+          <default>false</default>
+          <control type="toggle" />
+        </setting>
+    		<setting id="run_on_idle" type="boolean" label="30014" help="30076">
+          <level>1</level>
+          <default>false</default>
+          <control type="toggle" />
+        </setting>
+    		<setting id="check_sources" type="boolean" label="30017" help="">
+          <level>2</level>
+          <default>false</default>
+          <control type="toggle" />
+        </setting>
+        <setting id="disable_manual_prompt" type="boolean" label="30015" help="30077">
+          <level>2</level>
+          <default>false</default>
+          <control type="toggle" />
+        </setting>
+        <!-- upgrade notes not visible to users -->
+        <setting id="upgrade_notes" type="integer" label="upgrade_notes" help="">
+          <level>4</level>
+          <default>1</default>
+          <visible>false</visible>
+          <control type="edit" format="integer">
+            <heading>upgrade_notes</heading>
+          </control>
+        </setting>
+      </group>
+    </category>
+    <category id="video_timer" label="30002">
+      <group id="1" label="">
+    		<setting id="update_video" type="boolean" label="30004" help="">
+          <level>0</level>
+          <default>true</default>
+          <control type="toggle" />
+        </setting>
+    		<setting id="video_advanced_timer" type="boolean" label="30009" help="30078">
+          <level>2</level>
+          <default>false</default>
+          <dependencies>
+            <dependency type="enable" setting="update_video">true</dependency>
+          </dependencies>
+          <control type="toggle" />
+        </setting>
+        <!-- timer options 1 hr, 2 hr, 4 hr, 6 hr, 12 hr, 24 hr -->
+    		<setting id="video_timer" type="integer" label="30010" help="30079">
+          <level>0</level>
+          <default>2</default>
+          <constraints>
+            <options>
+              <option label="30068">1</option>
+              <option label="30069">2</option>
+              <option label="30070">4</option>
+              <option label="30071">6</option>
+              <option label="30072">12</option>
+              <option label="30073">24</option>
+            </options>
+          </constraints>
+          <dependencies>
+            <dependency type="enable">
+              <and>
+                <condition setting="update_video">true</condition>
+                <condition setting="video_advanced_timer" operator="!is">true</condition>
+              </and>
+            </dependency>
+            <dependency type="visible" setting="video_advanced_timer" operator="!is">true</dependency>
+          </dependencies>
+          <control type="spinner" format="string"/>
+        </setting>
+    		<setting id="video_cron_expression" type="string" label="30011" help="30080">
+          <level>2</level>
+          <default>0 * * * *</default>
+          <constraints>
+            <allowempty>false</allowempty>
+          </constraints>
+          <dependencies>
+            <dependency type="enable">
+              <and>
+                <condition setting="update_video">true</condition>
+                <condition setting="video_advanced_timer">true</condition>
+              </and>
+            </dependency>
+            <dependency type="visible" setting="video_advanced_timer">true</dependency>
+          </dependencies>
+          <control type="edit" format="string">
+            <heading>30011</heading>
+          </control>
+        </setting>
+      </group>
+      <group id="2" label="">
+        <!-- custom paths editor -->
+    		<setting id="run_custom_paths" type="action" label="30020" help="30081">
+          <level>3</level>
+          <default />
+          <control type="button" format="action">
+            <data>RunScript(special://home/addons/service.libraryautoupdate/edit_custom_paths.py,type=video)</data>
+          </control>
+        </setting>
+      </group>
+  	</category>
+    <category id="music_timer" label="30003">
+      <group id="1" label="">
+        <setting id="update_music" type="boolean" label="30005" help="">
+          <level>0</level>
+          <default>false</default>
+          <control type="toggle" />
+        </setting>
+        <setting id="music_advanced_timer" type="boolean" label="30009" help="30078">
+          <level>2</level>
+          <default>false</default>
+          <dependencies>
+            <dependency type="enable" setting="update_music">true</dependency>
+          </dependencies>
+          <control type="toggle" />
+        </setting>
+        <!-- timer options 1 hr, 2 hr, 4 hr, 6 hr, 12 hr, 24 hr -->
+        <setting id="music_timer" type="integer" label="30010" help="30079">
+          <level>0</level>
+          <default>2</default>
+          <constraints>
+            <options>
+              <option label="30068">1</option>
+              <option label="30069">2</option>
+              <option label="30070">4</option>
+              <option label="30071">6</option>
+              <option label="30072">12</option>
+              <option label="30073">24</option>
+            </options>
+          </constraints>
+          <dependencies>
+            <dependency type="enable">
+              <and>
+                <condition setting="update_music">true</condition>
+                <condition setting="music_advanced_timer" operator="!is">true</condition>
+              </and>
+            </dependency>
+            <dependency type="visible" setting="music_advanced_timer" operator="!is">true</dependency>
+          </dependencies>
+          <control type="spinner" format="string"/>
+        </setting>
+        <setting id="music_cron_expression" type="string" label="30011" help="30080">
+          <level>2</level>
+          <default>0 * * * *</default>
+          <constraints>
+            <allowempty>false</allowempty>
+          </constraints>
+          <dependencies>
+            <dependency type="enable">
+              <and>
+                <condition setting="update_music">true</condition>
+                <condition setting="music_advanced_timer">true</condition>
+              </and>
+            </dependency>
+            <dependency type="visible" setting="music_advanced_timer">true</dependency>
+          </dependencies>
+          <control type="edit" format="string">
+            <heading>30011</heading>
+          </control>
+        </setting>
+      </group>
+      <group id="2" label="">
+        <!-- custom paths editor -->
+    		<setting id="run_custom_paths_music" type="action" label="30020" help="30081">
+          <level>3</level>
+          <default />
+          <control type="button" format="action">
+            <data>RunScript(special://home/addons/service.libraryautoupdate/edit_custom_paths.py,type=music)</data>
+          </control>
+        </setting>
+      </group>
+  	</category>
+    <category id="clean_timer" label="30040">
+      <group id="1" label="">
+        <setting id="clean_libraries" type="boolean" label="30041" help="30082">
+          <level>1</level>
+          <default>false</default>
+          <control type="toggle" />
+        </setting>
+        <!-- options are both, video and music -->
+        <setting id="library_to_clean" type="integer" label="30054" help="">
+          <level>1</level>
+          <default>30055</default>
+          <constraints>
+            <options>
+              <option label="30055">0</option>
+              <option label="30002">1</option>
+              <option label="30003">2</option>
+            </options>
+          </constraints>
+          <dependencies>
+            <dependency type="enable" setting="clean_libraries">true</dependency>
+          </dependencies>
+          <control type="spinner" format="string"/>
+        </setting>
+        <!-- can only check this when not on the both setting above -->
+        <setting id="user_confirm_clean" type="boolean" label="30051" help="30083">
+          <level>2</level>
+          <default>false</default>
+          <dependencies>
+            <dependency type="enable">
+              <and>
+                <condition setting="clean_libraries">true</condition>
+                <condition setting="library_to_clean" operator="!is">0</condition>
+              </and>
+            </dependency>
+          </dependencies>
+          <control type="toggle" />
+        </setting>
+        <!-- clean options are after update, daily, weekly, monthly, and custom cron -->
+        <setting id="clean_timer" type="integer" label="30043" help="30084">
+          <level>1</level>
+          <default>0</default>
+          <constraints>
+            <options>
+              <option label="30044">0</option>
+              <option label="30045">1</option>
+              <option label="30046">2</option>
+              <option label="30047">3</option>
+              <option label="30011">4</option>
+            </options>
+          </constraints>
+          <dependencies>
+            <dependency type="enable" setting="clean_libraries">true</dependency>
+          </dependencies>
+          <control type="spinner" format="string"/>
+        </setting>
+        <setting id="clean_video_cron_expression" type="string" label="30056" help="30080">
+          <level>1</level>
+          <default>0 0 * * *</default>
+          <constraints>
+            <allowempty>false</allowempty>
+          </constraints>
+          <dependencies>
+            <dependency type="enable" setting="clean_libraries">true</dependency>
+            <dependency type="visible">
+              <and>
+                <condition setting="library_to_clean" operator="!is">2</condition>
+                <condition type="visible" setting="clean_timer">4</condition>
+              </and>
+            </dependency>
+          </dependencies>
+          <control type="edit" format="string">
+            <heading>30056</heading>
+          </control>
+        </setting>
+        <setting id="clean_music_cron_expression" type="string" label="30057" help="30080">
+          <level>1</level>
+          <default>0 2 * * *</default>
+          <constraints>
+            <allowempty>false</allowempty>
+          </constraints>
+          <dependencies>
+            <dependency type="enable" setting="clean_libraries">true</dependency>
+            <dependency type="visible">
+              <and>
+                <condition setting="library_to_clean" operator="!is">1</condition>
+                <condition type="visible" setting="clean_timer">4</condition>
+              </and>
+            </dependency>
+          </dependencies>
+          <control type="edit" format="string">
+            <heading>30057</heading>
+          </control>
+        </setting>
+      </group>
+  	</category>
+  </section>
 </settings>


### PR DESCRIPTION
### Description
Updated the ```settings.xml``` to the new format. Also fixed issues with ```xbmcgui.Dialog()``` calls that used the old line1, line2 arguments. 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [script.foo.bar] 1.0.0

Additional information :
- Submitting your add-on to this specific branch makes it available to any Kodi version equal or higher than the branch name with the applicable Kodi dependencies limits.
- [add-on development](http://kodi.wiki/view/Add-on_development) wiki page.
- Kodi [pydocs](http://kodi.wiki/view/PyDocs) provide information about the Python API
- [PEP8](https://www.python.org/dev/peps/pep-0008/) codingstyle which is considered best practise but not mandatory.
- This add-on repository has automated code guideline check which could help you improve your coding. You can find the results of these check at [Codacy](https://www.codacy.com/app/Kodi/repo-scripts/dashboard). You can create your own account as well to continuously monitor your python coding before submitting to repo.
- Development questions can be asked in the [add-on development](http://forum.kodi.tv/forumdisplay.php?fid=26) section on the Kodi forum.
