### PR TITLE
[script.trakt@matrix] 3.4.2

### DIFF
--- a/script.trakt/README.md
+++ b/script.trakt/README.md
@@ -1,86 +1,90 @@
 [![Codacy Badge](https://api.codacy.com/project/badge/grade/5302383dedf74b1fba592ba1d8f966f7)](https://www.codacy.com/app/razzeee/script-trakt)
-[![Build Status](https://travis-ci.org/trakt/script.trakt.svg?branch=master)](https://travis-ci.org/trakt/script.trakt)
+[![Build Status](https://travis-ci.org/trakt/script.trakt.svg?branch=main)](https://travis-ci.org/trakt/script.trakt)
 [![Coverage Status](https://coveralls.io/repos/github/trakt/script.trakt/badge.svg)](https://coveralls.io/github/trakt/script.trakt)
 
-Trakt.tv scrobbler and library sync
-==============================================
+# Trakt.tv scrobbler and library sync
 
 ### Table of Contents
-* [What is Trakt?](#what-is-trakt)
-* [What can this addon do?](#what-can-this-addon-do)
-* [What can be scrobbled??](#what-can-be-scrobbled)
-* [Installation](#installation)
-* [Problems?](#problems)
-  * ["I found something that doesn't work"](#i-found-something-that-doesnt-work)
-  * [Creating logfiles](#creating-logfiles)
-  * [Invoke sync via JSON-RPC](#invoke-sync-via-jsonrpc)
-* [Contribute](#contribute)
-  * [Pull requests](#pull-requests)
-  * [Translations](#translations)
-* [Thanks](#thanks)
+
+- [What is Trakt?](#what-is-trakt)
+- [What can this addon do?](#what-can-this-addon-do)
+- [What can be scrobbled??](#what-can-be-scrobbled)
+- [Installation](#installation)
+- [Problems?](#problems)
+  - ["I found something that doesn't work"](#i-found-something-that-doesnt-work)
+  - [Creating logfiles](#creating-logfiles)
+  - [Invoke sync via JSON-RPC](#invoke-sync-via-jsonrpc)
+- [Contribute](#contribute)
+  - [Pull requests](#pull-requests)
+  - [Translations](#translations)
+- [Thanks](#thanks)
 
 ### What is Trakt?
+
 Automatically scrobble all TV episodes and movies you are watching to Trakt.tv! Keep a comprehensive history of everything you've watched and be part of a global community of TV and movie enthusiasts. Sign up for a free account at [Trakt.tv](http://trakt.tv) and get a ton of features:
 
-* Automatically scrobble what you're watching
-* [Mobile apps](http://trakt.tv/downloads) for iPhone, iPad, Android, and Windows Phone
-* Share what you're watching (in real time) and rating to facebook and twitter
-* Personalized calendar so you never miss a TV show
-* Follow your friends and people you're interesed in
-* Use watchlists so you don't forget what to watch
-* Track your media collections and impress your friends
-* Create custom lists around any topics you choose
-* Easily track your TV show progress across all seasons and episodes
-* Track your progress against industry lists such as the IMDb Top 250
-* Discover new shows and movies based on your viewing habits
-* Widgets for your forum signature
+- Automatically scrobble what you're watching
+- [Mobile apps](http://trakt.tv/downloads) for iPhone, iPad, Android, and Windows Phone
+- Share what you're watching (in real time) and rating to facebook and twitter
+- Personalized calendar so you never miss a TV show
+- Follow your friends and people you're interesed in
+- Use watchlists so you don't forget what to watch
+- Track your media collections and impress your friends
+- Create custom lists around any topics you choose
+- Easily track your TV show progress across all seasons and episodes
+- Track your progress against industry lists such as the IMDb Top 250
+- Discover new shows and movies based on your viewing habits
+- Widgets for your forum signature
 
 ### What can this addon do?
-* Automatically scrobble TV episodes and movies you are watching 
-* Sync your TV episode and movie collections to Trakt (manually or triggered by a library update)
-* Keep watched statuses synced between Kodi and Trakt
-* Rate movies and episodes after watching them
-* Custom skin/keymap actions for toggling watched status, and rating (tagging and listing disabled for now)
+
+- Automatically scrobble TV episodes and movies you are watching
+- Sync your TV episode and movie collections to Trakt (manually or triggered by a library update)
+- Keep watched statuses synced between Kodi and Trakt
+- Rate movies and episodes after watching them
+- Custom skin/keymap actions for toggling watched status, and rating (tagging and listing disabled for now)
 
 ### What can be scrobbled?
+
 This plugin will scrobble local media and most remote streaming content. Local media should be played in Kodi library mode. Trakt will attempt to identify the media through different third party IDs available from the metadata. TV shows are identified by TVDb ID or IMDb ID. Movies are identified by TMDb ID or IMDb ID. This allows Trakt to match the correct show or movie more accurately, regardless of the title. The best supported and recommended configuration is to use [TVDb](http://thetvdb.com/) (for tv shows) and [TMDb](http://themoviedb.org) (for movies) as your scrapers.
 
 Remote streaming content will scrobble assuming the metadata is correctly set in Kodi. Add-ons that stream content need to correctly identify TV episodes and movies with as much metadata as possible for Trakt to know what you're watching.
 
 ### Installation
+
 If your not a developer, you should only install this from the official Kodi repo via Kodi itself. If you are a dev, here is how you install the dev version:
 
-1. Download the zip ([download it here](../../zipball/master))
-2. Install script.trakt by zip. Go to *Settings* > *Add-ons* > *Install from zip file* > Choose the just downloaded zip
-3. Navigate to *Settings* > *Add-ons* > *Enabled add-ons* > *Services* > **Trakt**
-4. Select *Trakt* and go to **Configure**
+1. Download the zip ([download it here](../../zipball/main))
+2. Install script.trakt by zip. Go to _Settings_ > _Add-ons_ > _Install from zip file_ > Choose the just downloaded zip
+3. Navigate to _Settings_ > _Add-ons_ > _Enabled add-ons_ > _Services_ > **Trakt**
+4. Select _Trakt_ and go to **Configure**
 5. Get your **PIN** [here](http://www.trakt.tv/pin/999) and enter it, change any other settings as needed
 6. Select **OK** to save your settings
-7. Watch *something* and see it show up on Trakt.tv!
+7. Watch _something_ and see it show up on Trakt.tv!
 
 or
 
-1. Clone this repository (or [download it here](../../zipball/master)) into a folder called **script.trakt** inside your Kodi **addons** folder
+1. Clone this repository (or [download it here](../../zipball/main)) into a folder called **script.trakt** inside your Kodi **addons** folder
 2. Start Kodi (or restart if its already running)
-3. Make sure you have the modules Trakt and dateutil installed. Check under *Settings* > *Add-ons* > *Get Add-ons* > *All Add-ons* > *Add-on libraries* (restart if you had to install these)
-4. Navigate to *Settings* > *Add-ons* > *Enabled add-ons* > *Services* > **Trakt**
-5. Select *Trakt* and go to **Configure**
+3. Make sure you have the modules Trakt and dateutil installed. Check under _Settings_ > _Add-ons_ > _Get Add-ons_ > _All Add-ons_ > _Add-on libraries_ (restart if you had to install these)
+4. Navigate to _Settings_ > _Add-ons_ > _Enabled add-ons_ > _Services_ > **Trakt**
+5. Select _Trakt_ and go to **Configure**
 6. Get your **PIN** [here](http://www.trakt.tv/pin/999) and enter it, change any other settings as needed
 7. Select **OK** to save your settings
-8. Watch *something* and see it show up on Trakt.tv!
+8. Watch _something_ and see it show up on Trakt.tv!
 
-Please note that *something* does not cover all Kodi possible streaming sources. Local files and strm files scrapped to your library should be OK, however generic third party streaming addons can fail. It is up to the developers of these addons to be supported by this plugin. Please take a look https://github.com/trakt/script.trakt/wiki/Providing-id's-to-facilitate-scrobbling
+Please note that _something_ does not cover all Kodi possible streaming sources. Local files and strm files scrapped to your library should be OK, however generic third party streaming addons can fail. It is up to the developers of these addons to be supported by this plugin. Please take a look https://github.com/trakt/script.trakt/wiki/Providing-id's-to-facilitate-scrobbling
 
 ### Problems?
 
 #### "I found something that doesn't work"
 
-* Search the issues on github to see if it has already been reported, if so add your information there.
-* If not, create a new issue and provide as much data about your system as possible, a logfile will also be needed.
+- Search the issues on github to see if it has already been reported, if so add your information there.
+- If not, create a new issue and provide as much data about your system as possible, a logfile will also be needed.
 
 #### Creating logfiles
 
-* To create a logfile, enable the debug setting in Kodi AND script.trakt, otherwise the logfile won't show any data from script.trakt. Check the [Kodi documentation](http://kodi.wiki/view/Log_file) if you don't know where your logfile can be found.
+- To create a logfile, enable the debug setting in Kodi AND script.trakt, otherwise the logfile won't show any data from script.trakt. Check the [Kodi documentation](http://kodi.wiki/view/Log_file) if you don't know where your logfile can be found.
 
 #### Invoke sync via jsonrpc
 
@@ -112,11 +116,14 @@ exec curl -sSLf --include --header 'content-type: application/json;' --request P
 ### Contribute
 
 #### Pull requests
-* Please don't add pull requests for translation updates these have to go work their way through the translation workflow (see [Translations](#translations))
+
+- Please don't add pull requests for translation updates these have to go work their way through the translation workflow (see [Translations](#translations))
 
 #### Translations
-* Translations are done via the Transifex project of Kodi. If you want to support translation efforts, read [this](http://kodi.wiki/view/Translation_System) and look for script-trakt under the XBMC Addons project in Transifex.
+
+- Translations are done via the Transifex project of Kodi. If you want to support translation efforts, read [this](http://kodi.wiki/view/Translation_System) and look for script-trakt under the XBMC Addons project in Transifex.
 
 ### Thanks
-* Special thanks to all who contribute to this plugin! Check the commit history and changelog to see these talented developers.
-* Special thanks to fuzeman for [trakt.py](https://github.com/fuzeman/trakt.py).
+
+- Special thanks to all who contribute to this plugin! Check the commit history and changelog to see these talented developers.
+- Special thanks to fuzeman for [trakt.py](https://github.com/fuzeman/trakt.py).

--- a/script.trakt/addon.xml
+++ b/script.trakt/addon.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.trakt" name="Trakt" version="3.4.1" provider-name="Trakt.tv, Razzeee">
+<addon id="script.trakt" name="Trakt" version="3.4.2" provider-name="Trakt.tv, Razzeee">
     <requires>
         <import addon="xbmc.python" version="3.0.0"/>
-        <import addon="script.module.trakt" version="4.1.0"/>
-        <import addon="script.module.dateutil" version="2.4.2"/>
+        <import addon="script.module.trakt" version="4.4.0"/>
+        <import addon="script.module.dateutil" version="2.8.1"/>
     </requires>
     <extension point="xbmc.python.script" library="defaultscript.py">
         <provides>executable</provides>
@@ -57,7 +57,8 @@
         <forum>https://forum.kodi.tv/showthread.php?tid=220547</forum>
         <website>https://trakt.tv</website>
         <source>https://github.com/trakt/script.trakt</source>
-        <news>- Fix wrong kodi query breaking episode sync</news>
+        <news>- Handle cases of missing ids for tvshows
+- Update translations</news>
         <assets>
             <icon>icon.png</icon>
             <fanart>fanart.jpg</fanart>

--- a/script.trakt/resources/language/resource.language.af_ZA/strings.po
+++ b/script.trakt/resources/language/resource.language.af_ZA/strings.po
@@ -10,32 +10,712 @@ msgstr ""
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Kodi Translation Team\n"
 "Language-Team: Afrikaans (http://www.transifex.com/projects/p/xbmc-addons/language/af/)\n"
+"Language: af\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: af\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 msgctxt "#32000"
 msgid "General"
 msgstr "Algemeen"
 
+# empty strings from id 32001 to 32002
+msgctxt "#32003"
+msgid "Startup Delay"
+msgstr ""
+
 msgctxt "#32004"
 msgid "Rating"
 msgstr "Gradering"
+
+msgctxt "#32005"
+msgid "Rate Movie after watching"
+msgstr ""
+
+msgctxt "#32006"
+msgid "Rate TV show Episode after watching"
+msgstr ""
+
+msgctxt "#32008"
+msgid "Minimum percent watched to display rating dialog"
+msgstr ""
+
+msgctxt "#32009"
+msgid "Allow re-rating of media"
+msgstr ""
+
+msgctxt "#32010"
+msgid "Default rating"
+msgstr ""
+
+# Scrobbling Settings
+msgctxt "#32011"
+msgid "Scrobbling"
+msgstr ""
+
+msgctxt "#32012"
+msgid "Scrobble movies"
+msgstr ""
+
+msgctxt "#32013"
+msgid "Scrobble TV show episodes"
+msgstr ""
+
+msgctxt "#32014"
+msgid "Show notification on scrobble"
+msgstr ""
+
+msgctxt "#32015"
+msgid "Trakt - Scrobbled successfully"
+msgstr ""
+
+msgctxt "#32016"
+msgid "Exclusions"
+msgstr ""
+
+msgctxt "#32017"
+msgid "Exclude Live TV"
+msgstr ""
+
+msgctxt "#32018"
+msgid "Exclude HTTP sources"
+msgstr ""
+
+msgctxt "#32019"
+msgid "Exclude path"
+msgstr ""
+
+msgctxt "#32020"
+msgid "Folder's path (including subfolders)"
+msgstr ""
+
+# empty strings from id 32021 to 32022
+msgctxt "#32023"
+msgid "Can not connect to Trakt"
+msgstr ""
 
 msgctxt "#32024"
 msgid "Error"
 msgstr "Fout"
 
+# empty string with id 32025
+msgctxt "#32026"
+msgid "What Did You Think?"
+msgstr ""
+
+msgctxt "#32027"
+msgid "Totally Ninja!"
+msgstr ""
+
+msgctxt "#32028"
+msgid "Weak Sauce :("
+msgstr ""
+
+msgctxt "#32029"
+msgid "Terrible"
+msgstr ""
+
+msgctxt "#32030"
+msgid "Bad"
+msgstr ""
+
+msgctxt "#32031"
+msgid "Poor"
+msgstr ""
+
+msgctxt "#32032"
+msgid "Meh"
+msgstr ""
+
 msgctxt "#32033"
 msgid "Fair"
 msgstr "Mooi"
+
+msgctxt "#32034"
+msgid "Good"
+msgstr ""
+
+msgctxt "#32035"
+msgid "Great"
+msgstr ""
+
+msgctxt "#32036"
+msgid "Superb"
+msgstr ""
+
+msgctxt "#32037"
+msgid "Unrate this movie"
+msgstr ""
+
+msgctxt "#32038"
+msgid "Unrate this show"
+msgstr ""
+
+msgctxt "#32039"
+msgid "Unrate this episode"
+msgstr ""
+
+msgctxt "#32040"
+msgid "Trakt - Rating submitted successfully"
+msgstr ""
+
+msgctxt "#32041"
+msgid "Trakt - Already rated"
+msgstr ""
+
+msgctxt "#32042"
+msgid "Trakt - Unrated successfully"
+msgstr ""
+
+msgctxt "#32043"
+msgid "Trakt - Already has the same rating"
+msgstr ""
+
+msgctxt "#32044"
+msgid "Trakt - Problem submitting rating"
+msgstr ""
+
+msgctxt "#32045"
+msgid "Synchronize"
+msgstr ""
 
 msgctxt "#32046"
 msgid "Movies"
 msgstr "Flieks"
 
+msgctxt "#32047"
+msgid "Add new movies to Trakt collection"
+msgstr ""
+
+msgctxt "#32048"
+msgid "Add watched movies to Trakt history"
+msgstr ""
+
+msgctxt "#32049"
+msgid "Mark movies from Trakt history as watched in Kodi"
+msgstr ""
+
+msgctxt "#32050"
+msgid "TV Episodes"
+msgstr ""
+
+msgctxt "#32051"
+msgid "Add new TV episodes to Trakt collection"
+msgstr ""
+
+msgctxt "#32052"
+msgid "Add watched TV episodes to Trakt history"
+msgstr ""
+
+msgctxt "#32053"
+msgid "Mark TV episodes from Trakt history as watched in Kodi"
+msgstr ""
+
 msgctxt "#32054"
 msgid "Service"
 msgstr "Diens"
+
+msgctxt "#32055"
+msgid "Sync collection on library update or cleaning"
+msgstr ""
+
+msgctxt "#32056"
+msgid "Show sync notifications"
+msgstr ""
+
+msgctxt "#32057"
+msgid "Remove deleted movies from Trakt collection"
+msgstr ""
+
+msgctxt "#32058"
+msgid "Remove deleted TV episodes from Trakt collection"
+msgstr ""
+
+# empty string with id 32059
+msgctxt "#32060"
+msgid "Hide notifications during playback"
+msgstr ""
+
+msgctxt "#32061"
+msgid "Sync started"
+msgstr ""
+
+msgctxt "#32062"
+msgid "Sync complete"
+msgstr ""
+
+msgctxt "#32063"
+msgid "%i movie(s) will be added to Trakt collection"
+msgstr ""
+
+msgctxt "#32064"
+msgid "%i movie playcount(s) will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32065"
+msgid "%i movie(s) playcount will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32066"
+msgid "Movie Sync Complete"
+msgstr ""
+
+msgctxt "#32067"
+msgid "Going to add %i show(s) to Trakt collection"
+msgstr ""
+
+msgctxt "#32068"
+msgid "Checking for episodes missing from Trakt collection"
+msgstr ""
+
+msgctxt "#32069"
+msgid "%i of %i show(s) have episodes added to Trakt collection"
+msgstr ""
+
+msgctxt "#32070"
+msgid "Going to update %i show(s) missing watched status"
+msgstr ""
+
+msgctxt "#32071"
+msgid "Checking watched episodes on Trakt"
+msgstr ""
+
+msgctxt "#32072"
+msgid "%i show(s) had missing watched status"
+msgstr ""
+
+msgctxt "#32073"
+msgid "%i episodes are being updated"
+msgstr ""
+
+msgctxt "#32074"
+msgid "Checking watched episodes on Kodi"
+msgstr ""
+
+msgctxt "#32075"
+msgid "Episode Sync Complete"
+msgstr ""
+
+msgctxt "#32076"
+msgid "%i movie(s) will be removed from Trakt collection"
+msgstr ""
+
+msgctxt "#32077"
+msgid "Cleaning Trakt TV show collection"
+msgstr ""
+
+msgctxt "#32078"
+msgid "episodes are being removed"
+msgstr ""
+
+msgctxt "#32079"
+msgid "Loading movies from Kodi"
+msgstr ""
+
+msgctxt "#32080"
+msgid "Movies loaded from Kodi"
+msgstr ""
+
+msgctxt "#32081"
+msgid "Retrieving movie collection from Trakt"
+msgstr ""
+
+msgctxt "#32082"
+msgid "Retrieving watched movies from Trakt"
+msgstr ""
+
+msgctxt "#32083"
+msgid "Retrieved movie data from Trakt"
+msgstr ""
+
+msgctxt "#32084"
+msgid "Trakt movie collection is up to date, no movies to add"
+msgstr ""
+
+msgctxt "#32085"
+msgid "%i movie(s) were added to your Trakt collection"
+msgstr ""
+
+msgctxt "#32086"
+msgid "Trakt movie playcounts are up to date"
+msgstr ""
+
+msgctxt "#32087"
+msgid "Playcounts updated for %i movie(s) on Trakt"
+msgstr ""
+
+msgctxt "#32088"
+msgid "Kodi movie playcounts are up to date"
+msgstr ""
+
+msgctxt "#32089"
+msgid "Updating %i of %i movie playcount(s) in Kodi"
+msgstr ""
+
+msgctxt "#32090"
+msgid "Playcounts updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32091"
+msgid "Trakt movie collection is up to date, no movies removed"
+msgstr ""
+
+msgctxt "#32092"
+msgid "%i movie(s) were removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32093"
+msgid "Updating %i of %i movie playcount(s) on Trakt"
+msgstr ""
+
+msgctxt "#32094"
+msgid "Loading episode data from Kodi"
+msgstr ""
+
+msgctxt "#32095"
+msgid "Loading shows from Kodi"
+msgstr ""
+
+msgctxt "#32096"
+msgid "Shows loaded from Kodi"
+msgstr ""
+
+msgctxt "#32097"
+msgid "Parsing %i of %i episode data from Kodi"
+msgstr ""
+
+msgctxt "#32098"
+msgid "Loaded episode data from Kodi"
+msgstr ""
+
+msgctxt "#32099"
+msgid "Loading episode data from Trakt"
+msgstr ""
+
+msgctxt "#32100"
+msgid "Retrieving episode collection from Trakt"
+msgstr ""
+
+msgctxt "#32101"
+msgid "Retrieving watched episodes from Trakt"
+msgstr ""
+
+msgctxt "#32102"
+msgid "Parsing episode data %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32103"
+msgid "Retrieved episode data from Trakt"
+msgstr ""
+
+msgctxt "#32104"
+msgid "Trakt episode collection is up to date, no episodes to add"
+msgstr ""
+
+msgctxt "#32105"
+msgid "%i episode(s) were added to your Trakt collection"
+msgstr ""
+
+msgctxt "#32106"
+msgid "Trakt episode playcounts are up to date"
+msgstr ""
+
+msgctxt "#32107"
+msgid "Kodi episode playcounts are up to date"
+msgstr ""
+
+msgctxt "#32108"
+msgid "Updating %i of %i episode playcount(s) in Kodi"
+msgstr ""
+
+msgctxt "#32109"
+msgid "Playcounts updated for %i show(s) in Kodi"
+msgstr ""
+
+msgctxt "#32110"
+msgid "Trakt episode collection is clean, no episodes to remove"
+msgstr ""
+
+msgctxt "#32111"
+msgid "%i episode(s) are being removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32112"
+msgid "%i episode(s) were removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32113"
+msgid "Trakt - Marked as watched"
+msgstr ""
+
+msgctxt "#32114"
+msgid "Trakt - Failed marking as watched"
+msgstr ""
+
+msgctxt "#32115"
+msgid "%d episode(s) of '%s'"
+msgstr ""
+
+msgctxt "#32116"
+msgid "Enable debug mode"
+msgstr ""
+
+msgctxt "#32117"
+msgid "Sync movie playback progress to Kodi"
+msgstr ""
+
+msgctxt "#32118"
+msgid "Sync episode playback progress to Kodi"
+msgstr ""
+
+msgctxt "#32119"
+msgid "Retrieving episode playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32120"
+msgid "Parsing episode playback progress %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32121"
+msgid "Retrieved episode playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32122"
+msgid "Retrieving movie playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32123"
+msgid "Parsing movie playback progress %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32124"
+msgid "Retrieved movie playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32125"
+msgid "Kodi movie playback progress is up to date"
+msgstr ""
+
+msgctxt "#32126"
+msgid "%i movie(s) playback progress will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32127"
+msgid "Updating %i of %i movie(s) playback progress in Kodi"
+msgstr ""
+
+msgctxt "#32128"
+msgid "Playback progress updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32129"
+msgid "Kodi episode playback progress is up to date"
+msgstr ""
+
+msgctxt "#32130"
+msgid "Updating %i of %i episode(s) playback progress in Kodi"
+msgstr ""
+
+msgctxt "#32131"
+msgid "Playback progress updated for %i episode(s) in Kodi"
+msgstr ""
+
+msgctxt "#32132"
+msgid "Unrate this season"
+msgstr ""
+
+msgctxt "#32133"
+msgid "Manage Movie's Lists"
+msgstr ""
+
+msgctxt "#32134"
+msgid "Manage Show's Lists"
+msgstr ""
+
+msgctxt "#32135"
+msgid "Remove from Watchlist"
+msgstr ""
+
+msgctxt "#32136"
+msgid "Add to watchlist"
+msgstr ""
+
+msgctxt "#32137"
+msgid "Rate this movie"
+msgstr ""
+
+msgctxt "#32138"
+msgid "Rate this show"
+msgstr ""
+
+msgctxt "#32139"
+msgid "Rate this episode"
+msgstr ""
+
+msgctxt "#32140"
+msgid "Toggle watched"
+msgstr ""
+
+msgctxt "#32141"
+msgid "Manage all lists"
+msgstr ""
+
+msgctxt "#32142"
+msgid "Update all tags"
+msgstr ""
+
+msgctxt "#32143"
+msgid "Synchronize library"
+msgstr ""
+
+msgctxt "#32144"
+msgid "How do I authorize the trakt addon to access my trakt.tv account?"
+msgstr ""
+
+# empty strings from id 32145 to 32146
+msgctxt "#32147"
+msgid "Trakt.tv PIN Authorization Failed"
+msgstr ""
+
+# empty string with id 32148
+msgctxt "#32149"
+msgid "Rate this Season"
+msgstr ""
+
+msgctxt "#32150"
+msgid "You will be reminded in 24 hours"
+msgstr ""
+
+msgctxt "#32151"
+msgid "Use Addon Settings later if you change your mind"
+msgstr ""
+
+msgctxt "#32152"
+msgid "Trakt Authorization Complete"
+msgstr ""
+
+msgctxt "#32153"
+msgid "Trakt Account Authorization"
+msgstr ""
+
+msgctxt "#32154"
+msgid "Authorize"
+msgstr ""
+
+msgctxt "#32155"
+msgid "Remind Me Later"
+msgstr ""
+
+msgctxt "#32156"
+msgid "No Thanks"
+msgstr ""
+
+msgctxt "#32157"
+msgid "Account Authorization"
+msgstr ""
+
+# empty string with id 32158
+msgctxt "#32159"
+msgid "Visit {0} or scan the QR code."
+msgstr ""
+
+msgctxt "#32162"
+msgid "The trakt addon CAN NOT be used without authorizing it to access your trakt.tv account."
+msgstr ""
+
+msgctxt "#32163"
+msgid "User"
+msgstr ""
+
+msgctxt "#32164"
+msgid "Fallback to Title/Year matching if necessary"
+msgstr ""
+
+msgctxt "#32165"
+msgid "Trakt - Added to watchlist"
+msgstr ""
+
+msgctxt "#32166"
+msgid "Trakt - Failed adding to watchlist"
+msgstr ""
+
+msgctxt "#32167"
+msgid "Offset scrobble start by X minutes"
+msgstr ""
+
+msgctxt "#32168"
+msgid "Sync ratings"
+msgstr ""
+
+msgctxt "#32169"
+msgid "Kodi movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32170"
+msgid "%i movie(s) ratings will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32171"
+msgid "Updating %i of %i movie ratings in Kodi"
+msgstr ""
+
+msgctxt "#32172"
+msgid "Ratings updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32173"
+msgid "Kodi episode ratings are up to date"
+msgstr ""
+
+msgctxt "#32174"
+msgid "Updating %i of %i episode ratings in Kodi"
+msgstr ""
+
+msgctxt "#32175"
+msgid "Ratings updated for %i episode(s) in Kodi"
+msgstr ""
+
+msgctxt "#32176"
+msgid "Kodi show ratings are up to date"
+msgstr ""
+
+msgctxt "#32177"
+msgid "Updating %i of %i show ratings in Kodi"
+msgstr ""
+
+msgctxt "#32178"
+msgid "Ratings updated for %i show(s) in Kodi"
+msgstr ""
+
+msgctxt "#32179"
+msgid "Trakt movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32180"
+msgid "%i movie ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32181"
+msgid "Trakt show ratings are up to date"
+msgstr ""
+
+msgctxt "#32182"
+msgid "%i show ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32183"
+msgid "Attempt to scrobble MythTV PVR recordings"
+msgstr ""
+
+msgctxt "#32184"
+msgid "Attempt secondary show title search"
+msgstr ""
+
+msgctxt "#32185"
+msgid "Exclude Plugins"
+msgstr ""
+
+msgctxt "#32186"
+msgid "Allow script exclusions"
+msgstr ""

--- a/script.trakt/resources/language/resource.language.am_ET/strings.po
+++ b/script.trakt/resources/language/resource.language.am_ET/strings.po
@@ -7,31 +7,716 @@ msgstr ""
 "Project-Id-Version: XBMC Addons\n"
 "Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: Kodi Translation Team\n"
-"Language-Team: Amharic (http://www.transifex.com/projects/p/xbmc-addons/language/am/)\n"
+"PO-Revision-Date: 2021-03-20 15:56+0000\n"
+"Last-Translator: Christian Gade <gade@kodi.tv>\n"
+"Language-Team: Amharic (Ethiopia) <https://kodi.weblate.cloud/projects/kodi-add-ons-scripts/script-trakt/am_et/>\n"
+"Language: am_ET\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: am\n"
-"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"Plural-Forms: nplurals=2; plural=n > 1;\n"
+"X-Generator: Weblate 4.5.1\n"
 
 msgctxt "#32000"
 msgid "General"
 msgstr "ባጠቃላይ"
 
+# empty strings from id 32001 to 32002
+msgctxt "#32003"
+msgid "Startup Delay"
+msgstr ""
+
 msgctxt "#32004"
 msgid "Rating"
 msgstr "ደረጃው"
+
+msgctxt "#32005"
+msgid "Rate Movie after watching"
+msgstr ""
+
+msgctxt "#32006"
+msgid "Rate TV show Episode after watching"
+msgstr ""
+
+msgctxt "#32008"
+msgid "Minimum percent watched to display rating dialog"
+msgstr ""
+
+msgctxt "#32009"
+msgid "Allow re-rating of media"
+msgstr ""
+
+msgctxt "#32010"
+msgid "Default rating"
+msgstr ""
+
+# Scrobbling Settings
+msgctxt "#32011"
+msgid "Scrobbling"
+msgstr ""
+
+msgctxt "#32012"
+msgid "Scrobble movies"
+msgstr ""
+
+msgctxt "#32013"
+msgid "Scrobble TV show episodes"
+msgstr ""
+
+msgctxt "#32014"
+msgid "Show notification on scrobble"
+msgstr ""
+
+msgctxt "#32015"
+msgid "Trakt - Scrobbled successfully"
+msgstr ""
+
+msgctxt "#32016"
+msgid "Exclusions"
+msgstr ""
+
+msgctxt "#32017"
+msgid "Exclude Live TV"
+msgstr ""
+
+msgctxt "#32018"
+msgid "Exclude HTTP sources"
+msgstr ""
+
+msgctxt "#32019"
+msgid "Exclude path"
+msgstr ""
+
+msgctxt "#32020"
+msgid "Folder's path (including subfolders)"
+msgstr ""
+
+# empty strings from id 32021 to 32022
+msgctxt "#32023"
+msgid "Can not connect to Trakt"
+msgstr ""
 
 msgctxt "#32024"
 msgid "Error"
 msgstr "ስህተት"
 
+# empty string with id 32025
+msgctxt "#32026"
+msgid "What Did You Think?"
+msgstr ""
+
+msgctxt "#32027"
+msgid "Totally Ninja!"
+msgstr ""
+
+msgctxt "#32028"
+msgid "Weak Sauce :("
+msgstr ""
+
+msgctxt "#32029"
+msgid "Terrible"
+msgstr ""
+
+msgctxt "#32030"
+msgid "Bad"
+msgstr ""
+
+msgctxt "#32031"
+msgid "Poor"
+msgstr ""
+
+msgctxt "#32032"
+msgid "Meh"
+msgstr ""
+
 msgctxt "#32033"
 msgid "Fair"
-msgstr "መጠነኛ "
+msgstr "መጠነኛ"
+
+msgctxt "#32034"
+msgid "Good"
+msgstr ""
+
+msgctxt "#32035"
+msgid "Great"
+msgstr ""
+
+msgctxt "#32036"
+msgid "Superb"
+msgstr ""
+
+msgctxt "#32037"
+msgid "Unrate this movie"
+msgstr ""
+
+msgctxt "#32038"
+msgid "Unrate this show"
+msgstr ""
+
+msgctxt "#32039"
+msgid "Unrate this episode"
+msgstr ""
+
+msgctxt "#32040"
+msgid "Trakt - Rating submitted successfully"
+msgstr ""
+
+msgctxt "#32041"
+msgid "Trakt - Already rated"
+msgstr ""
+
+msgctxt "#32042"
+msgid "Trakt - Unrated successfully"
+msgstr ""
+
+msgctxt "#32043"
+msgid "Trakt - Already has the same rating"
+msgstr ""
+
+msgctxt "#32044"
+msgid "Trakt - Problem submitting rating"
+msgstr ""
+
+msgctxt "#32045"
+msgid "Synchronize"
+msgstr ""
 
 msgctxt "#32046"
 msgid "Movies"
 msgstr "ሙቪዎች"
+
+msgctxt "#32047"
+msgid "Add new movies to Trakt collection"
+msgstr ""
+
+msgctxt "#32048"
+msgid "Add watched movies to Trakt history"
+msgstr ""
+
+msgctxt "#32049"
+msgid "Mark movies from Trakt history as watched in Kodi"
+msgstr ""
+
+msgctxt "#32050"
+msgid "TV Episodes"
+msgstr ""
+
+msgctxt "#32051"
+msgid "Add new TV episodes to Trakt collection"
+msgstr ""
+
+msgctxt "#32052"
+msgid "Add watched TV episodes to Trakt history"
+msgstr ""
+
+msgctxt "#32053"
+msgid "Mark TV episodes from Trakt history as watched in Kodi"
+msgstr ""
+
+msgctxt "#32054"
+msgid "Service"
+msgstr ""
+
+msgctxt "#32055"
+msgid "Sync collection on library update or cleaning"
+msgstr ""
+
+msgctxt "#32056"
+msgid "Show sync notifications"
+msgstr ""
+
+msgctxt "#32057"
+msgid "Remove deleted movies from Trakt collection"
+msgstr ""
+
+msgctxt "#32058"
+msgid "Remove deleted TV episodes from Trakt collection"
+msgstr ""
+
+# empty string with id 32059
+msgctxt "#32060"
+msgid "Hide notifications during playback"
+msgstr ""
+
+msgctxt "#32061"
+msgid "Sync started"
+msgstr ""
+
+msgctxt "#32062"
+msgid "Sync complete"
+msgstr ""
+
+msgctxt "#32063"
+msgid "%i movie(s) will be added to Trakt collection"
+msgstr ""
+
+msgctxt "#32064"
+msgid "%i movie playcount(s) will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32065"
+msgid "%i movie(s) playcount will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32066"
+msgid "Movie Sync Complete"
+msgstr ""
+
+msgctxt "#32067"
+msgid "Going to add %i show(s) to Trakt collection"
+msgstr ""
+
+msgctxt "#32068"
+msgid "Checking for episodes missing from Trakt collection"
+msgstr ""
+
+msgctxt "#32069"
+msgid "%i of %i show(s) have episodes added to Trakt collection"
+msgstr ""
+
+msgctxt "#32070"
+msgid "Going to update %i show(s) missing watched status"
+msgstr ""
+
+msgctxt "#32071"
+msgid "Checking watched episodes on Trakt"
+msgstr ""
+
+msgctxt "#32072"
+msgid "%i show(s) had missing watched status"
+msgstr ""
+
+msgctxt "#32073"
+msgid "%i episodes are being updated"
+msgstr ""
+
+msgctxt "#32074"
+msgid "Checking watched episodes on Kodi"
+msgstr ""
+
+msgctxt "#32075"
+msgid "Episode Sync Complete"
+msgstr ""
+
+msgctxt "#32076"
+msgid "%i movie(s) will be removed from Trakt collection"
+msgstr ""
+
+msgctxt "#32077"
+msgid "Cleaning Trakt TV show collection"
+msgstr ""
+
+msgctxt "#32078"
+msgid "episodes are being removed"
+msgstr ""
+
+msgctxt "#32079"
+msgid "Loading movies from Kodi"
+msgstr ""
+
+msgctxt "#32080"
+msgid "Movies loaded from Kodi"
+msgstr ""
+
+msgctxt "#32081"
+msgid "Retrieving movie collection from Trakt"
+msgstr ""
+
+msgctxt "#32082"
+msgid "Retrieving watched movies from Trakt"
+msgstr ""
+
+msgctxt "#32083"
+msgid "Retrieved movie data from Trakt"
+msgstr ""
+
+msgctxt "#32084"
+msgid "Trakt movie collection is up to date, no movies to add"
+msgstr ""
+
+msgctxt "#32085"
+msgid "%i movie(s) were added to your Trakt collection"
+msgstr ""
+
+msgctxt "#32086"
+msgid "Trakt movie playcounts are up to date"
+msgstr ""
+
+msgctxt "#32087"
+msgid "Playcounts updated for %i movie(s) on Trakt"
+msgstr ""
+
+msgctxt "#32088"
+msgid "Kodi movie playcounts are up to date"
+msgstr ""
+
+msgctxt "#32089"
+msgid "Updating %i of %i movie playcount(s) in Kodi"
+msgstr ""
+
+msgctxt "#32090"
+msgid "Playcounts updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32091"
+msgid "Trakt movie collection is up to date, no movies removed"
+msgstr ""
+
+msgctxt "#32092"
+msgid "%i movie(s) were removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32093"
+msgid "Updating %i of %i movie playcount(s) on Trakt"
+msgstr ""
+
+msgctxt "#32094"
+msgid "Loading episode data from Kodi"
+msgstr ""
+
+msgctxt "#32095"
+msgid "Loading shows from Kodi"
+msgstr ""
+
+msgctxt "#32096"
+msgid "Shows loaded from Kodi"
+msgstr ""
+
+msgctxt "#32097"
+msgid "Parsing %i of %i episode data from Kodi"
+msgstr ""
+
+msgctxt "#32098"
+msgid "Loaded episode data from Kodi"
+msgstr ""
+
+msgctxt "#32099"
+msgid "Loading episode data from Trakt"
+msgstr ""
+
+msgctxt "#32100"
+msgid "Retrieving episode collection from Trakt"
+msgstr ""
+
+msgctxt "#32101"
+msgid "Retrieving watched episodes from Trakt"
+msgstr ""
+
+msgctxt "#32102"
+msgid "Parsing episode data %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32103"
+msgid "Retrieved episode data from Trakt"
+msgstr ""
+
+msgctxt "#32104"
+msgid "Trakt episode collection is up to date, no episodes to add"
+msgstr ""
+
+msgctxt "#32105"
+msgid "%i episode(s) were added to your Trakt collection"
+msgstr ""
+
+msgctxt "#32106"
+msgid "Trakt episode playcounts are up to date"
+msgstr ""
+
+msgctxt "#32107"
+msgid "Kodi episode playcounts are up to date"
+msgstr ""
+
+msgctxt "#32108"
+msgid "Updating %i of %i episode playcount(s) in Kodi"
+msgstr ""
+
+msgctxt "#32109"
+msgid "Playcounts updated for %i show(s) in Kodi"
+msgstr ""
+
+msgctxt "#32110"
+msgid "Trakt episode collection is clean, no episodes to remove"
+msgstr ""
+
+msgctxt "#32111"
+msgid "%i episode(s) are being removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32112"
+msgid "%i episode(s) were removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32113"
+msgid "Trakt - Marked as watched"
+msgstr ""
+
+msgctxt "#32114"
+msgid "Trakt - Failed marking as watched"
+msgstr ""
+
+msgctxt "#32115"
+msgid "%d episode(s) of '%s'"
+msgstr ""
+
+msgctxt "#32116"
+msgid "Enable debug mode"
+msgstr ""
+
+msgctxt "#32117"
+msgid "Sync movie playback progress to Kodi"
+msgstr ""
+
+msgctxt "#32118"
+msgid "Sync episode playback progress to Kodi"
+msgstr ""
+
+msgctxt "#32119"
+msgid "Retrieving episode playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32120"
+msgid "Parsing episode playback progress %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32121"
+msgid "Retrieved episode playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32122"
+msgid "Retrieving movie playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32123"
+msgid "Parsing movie playback progress %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32124"
+msgid "Retrieved movie playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32125"
+msgid "Kodi movie playback progress is up to date"
+msgstr ""
+
+msgctxt "#32126"
+msgid "%i movie(s) playback progress will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32127"
+msgid "Updating %i of %i movie(s) playback progress in Kodi"
+msgstr ""
+
+msgctxt "#32128"
+msgid "Playback progress updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32129"
+msgid "Kodi episode playback progress is up to date"
+msgstr ""
+
+msgctxt "#32130"
+msgid "Updating %i of %i episode(s) playback progress in Kodi"
+msgstr ""
+
+msgctxt "#32131"
+msgid "Playback progress updated for %i episode(s) in Kodi"
+msgstr ""
+
+msgctxt "#32132"
+msgid "Unrate this season"
+msgstr ""
+
+msgctxt "#32133"
+msgid "Manage Movie's Lists"
+msgstr ""
+
+msgctxt "#32134"
+msgid "Manage Show's Lists"
+msgstr ""
+
+msgctxt "#32135"
+msgid "Remove from Watchlist"
+msgstr ""
+
+msgctxt "#32136"
+msgid "Add to watchlist"
+msgstr ""
+
+msgctxt "#32137"
+msgid "Rate this movie"
+msgstr ""
+
+msgctxt "#32138"
+msgid "Rate this show"
+msgstr ""
+
+msgctxt "#32139"
+msgid "Rate this episode"
+msgstr ""
+
+msgctxt "#32140"
+msgid "Toggle watched"
+msgstr ""
+
+msgctxt "#32141"
+msgid "Manage all lists"
+msgstr ""
+
+msgctxt "#32142"
+msgid "Update all tags"
+msgstr ""
+
+msgctxt "#32143"
+msgid "Synchronize library"
+msgstr ""
+
+msgctxt "#32144"
+msgid "How do I authorize the trakt addon to access my trakt.tv account?"
+msgstr ""
+
+# empty strings from id 32145 to 32146
+msgctxt "#32147"
+msgid "Trakt.tv PIN Authorization Failed"
+msgstr ""
+
+# empty string with id 32148
+msgctxt "#32149"
+msgid "Rate this Season"
+msgstr ""
+
+msgctxt "#32150"
+msgid "You will be reminded in 24 hours"
+msgstr ""
+
+msgctxt "#32151"
+msgid "Use Addon Settings later if you change your mind"
+msgstr ""
+
+msgctxt "#32152"
+msgid "Trakt Authorization Complete"
+msgstr ""
+
+msgctxt "#32153"
+msgid "Trakt Account Authorization"
+msgstr ""
+
+msgctxt "#32154"
+msgid "Authorize"
+msgstr ""
+
+msgctxt "#32155"
+msgid "Remind Me Later"
+msgstr ""
+
+msgctxt "#32156"
+msgid "No Thanks"
+msgstr ""
+
+msgctxt "#32157"
+msgid "Account Authorization"
+msgstr ""
+
+# empty string with id 32158
+msgctxt "#32159"
+msgid "Visit {0} or scan the QR code."
+msgstr ""
+
+msgctxt "#32162"
+msgid "The trakt addon CAN NOT be used without authorizing it to access your trakt.tv account."
+msgstr ""
+
+msgctxt "#32163"
+msgid "User"
+msgstr ""
+
+msgctxt "#32164"
+msgid "Fallback to Title/Year matching if necessary"
+msgstr ""
+
+msgctxt "#32165"
+msgid "Trakt - Added to watchlist"
+msgstr ""
+
+msgctxt "#32166"
+msgid "Trakt - Failed adding to watchlist"
+msgstr ""
+
+msgctxt "#32167"
+msgid "Offset scrobble start by X minutes"
+msgstr ""
+
+msgctxt "#32168"
+msgid "Sync ratings"
+msgstr ""
+
+msgctxt "#32169"
+msgid "Kodi movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32170"
+msgid "%i movie(s) ratings will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32171"
+msgid "Updating %i of %i movie ratings in Kodi"
+msgstr ""
+
+msgctxt "#32172"
+msgid "Ratings updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32173"
+msgid "Kodi episode ratings are up to date"
+msgstr ""
+
+msgctxt "#32174"
+msgid "Updating %i of %i episode ratings in Kodi"
+msgstr ""
+
+msgctxt "#32175"
+msgid "Ratings updated for %i episode(s) in Kodi"
+msgstr ""
+
+msgctxt "#32176"
+msgid "Kodi show ratings are up to date"
+msgstr ""
+
+msgctxt "#32177"
+msgid "Updating %i of %i show ratings in Kodi"
+msgstr ""
+
+msgctxt "#32178"
+msgid "Ratings updated for %i show(s) in Kodi"
+msgstr ""
+
+msgctxt "#32179"
+msgid "Trakt movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32180"
+msgid "%i movie ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32181"
+msgid "Trakt show ratings are up to date"
+msgstr ""
+
+msgctxt "#32182"
+msgid "%i show ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32183"
+msgid "Attempt to scrobble MythTV PVR recordings"
+msgstr ""
+
+msgctxt "#32184"
+msgid "Attempt secondary show title search"
+msgstr ""
+
+msgctxt "#32185"
+msgid "Exclude Plugins"
+msgstr ""
+
+msgctxt "#32186"
+msgid "Allow script exclusions"
+msgstr ""

--- a/script.trakt/resources/language/resource.language.ar_SA/strings.po
+++ b/script.trakt/resources/language/resource.language.ar_SA/strings.po
@@ -10,28 +10,712 @@ msgstr ""
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Kodi Translation Team\n"
 "Language-Team: Arabic (http://www.transifex.com/projects/p/xbmc-addons/language/ar/)\n"
+"Language: ar\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: ar\n"
 "Plural-Forms: nplurals=6; plural=n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n%100>=3 && n%100<=10 ? 3 : n%100>=11 && n%100<=99 ? 4 : 5;\n"
 
 msgctxt "#32000"
 msgid "General"
 msgstr "عام"
 
+# empty strings from id 32001 to 32002
+msgctxt "#32003"
+msgid "Startup Delay"
+msgstr ""
+
 msgctxt "#32004"
 msgid "Rating"
 msgstr "التقييم"
+
+msgctxt "#32005"
+msgid "Rate Movie after watching"
+msgstr ""
+
+msgctxt "#32006"
+msgid "Rate TV show Episode after watching"
+msgstr ""
+
+msgctxt "#32008"
+msgid "Minimum percent watched to display rating dialog"
+msgstr ""
+
+msgctxt "#32009"
+msgid "Allow re-rating of media"
+msgstr ""
+
+msgctxt "#32010"
+msgid "Default rating"
+msgstr ""
+
+# Scrobbling Settings
+msgctxt "#32011"
+msgid "Scrobbling"
+msgstr ""
+
+msgctxt "#32012"
+msgid "Scrobble movies"
+msgstr ""
+
+msgctxt "#32013"
+msgid "Scrobble TV show episodes"
+msgstr ""
+
+msgctxt "#32014"
+msgid "Show notification on scrobble"
+msgstr ""
+
+msgctxt "#32015"
+msgid "Trakt - Scrobbled successfully"
+msgstr ""
+
+msgctxt "#32016"
+msgid "Exclusions"
+msgstr ""
+
+msgctxt "#32017"
+msgid "Exclude Live TV"
+msgstr ""
+
+msgctxt "#32018"
+msgid "Exclude HTTP sources"
+msgstr ""
+
+msgctxt "#32019"
+msgid "Exclude path"
+msgstr ""
+
+msgctxt "#32020"
+msgid "Folder's path (including subfolders)"
+msgstr ""
+
+# empty strings from id 32021 to 32022
+msgctxt "#32023"
+msgid "Can not connect to Trakt"
+msgstr ""
 
 msgctxt "#32024"
 msgid "Error"
 msgstr "خطأ"
 
+# empty string with id 32025
+msgctxt "#32026"
+msgid "What Did You Think?"
+msgstr ""
+
+msgctxt "#32027"
+msgid "Totally Ninja!"
+msgstr ""
+
+msgctxt "#32028"
+msgid "Weak Sauce :("
+msgstr ""
+
+msgctxt "#32029"
+msgid "Terrible"
+msgstr ""
+
+msgctxt "#32030"
+msgid "Bad"
+msgstr ""
+
+msgctxt "#32031"
+msgid "Poor"
+msgstr ""
+
+msgctxt "#32032"
+msgid "Meh"
+msgstr ""
+
 msgctxt "#32033"
 msgid "Fair"
 msgstr ":عادل"
 
+msgctxt "#32034"
+msgid "Good"
+msgstr ""
+
+msgctxt "#32035"
+msgid "Great"
+msgstr ""
+
+msgctxt "#32036"
+msgid "Superb"
+msgstr ""
+
+msgctxt "#32037"
+msgid "Unrate this movie"
+msgstr ""
+
+msgctxt "#32038"
+msgid "Unrate this show"
+msgstr ""
+
+msgctxt "#32039"
+msgid "Unrate this episode"
+msgstr ""
+
+msgctxt "#32040"
+msgid "Trakt - Rating submitted successfully"
+msgstr ""
+
+msgctxt "#32041"
+msgid "Trakt - Already rated"
+msgstr ""
+
+msgctxt "#32042"
+msgid "Trakt - Unrated successfully"
+msgstr ""
+
+msgctxt "#32043"
+msgid "Trakt - Already has the same rating"
+msgstr ""
+
+msgctxt "#32044"
+msgid "Trakt - Problem submitting rating"
+msgstr ""
+
+msgctxt "#32045"
+msgid "Synchronize"
+msgstr ""
+
 msgctxt "#32046"
 msgid "Movies"
 msgstr "أفلام"
+
+msgctxt "#32047"
+msgid "Add new movies to Trakt collection"
+msgstr ""
+
+msgctxt "#32048"
+msgid "Add watched movies to Trakt history"
+msgstr ""
+
+msgctxt "#32049"
+msgid "Mark movies from Trakt history as watched in Kodi"
+msgstr ""
+
+msgctxt "#32050"
+msgid "TV Episodes"
+msgstr ""
+
+msgctxt "#32051"
+msgid "Add new TV episodes to Trakt collection"
+msgstr ""
+
+msgctxt "#32052"
+msgid "Add watched TV episodes to Trakt history"
+msgstr ""
+
+msgctxt "#32053"
+msgid "Mark TV episodes from Trakt history as watched in Kodi"
+msgstr ""
+
+msgctxt "#32054"
+msgid "Service"
+msgstr ""
+
+msgctxt "#32055"
+msgid "Sync collection on library update or cleaning"
+msgstr ""
+
+msgctxt "#32056"
+msgid "Show sync notifications"
+msgstr ""
+
+msgctxt "#32057"
+msgid "Remove deleted movies from Trakt collection"
+msgstr ""
+
+msgctxt "#32058"
+msgid "Remove deleted TV episodes from Trakt collection"
+msgstr ""
+
+# empty string with id 32059
+msgctxt "#32060"
+msgid "Hide notifications during playback"
+msgstr ""
+
+msgctxt "#32061"
+msgid "Sync started"
+msgstr ""
+
+msgctxt "#32062"
+msgid "Sync complete"
+msgstr ""
+
+msgctxt "#32063"
+msgid "%i movie(s) will be added to Trakt collection"
+msgstr ""
+
+msgctxt "#32064"
+msgid "%i movie playcount(s) will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32065"
+msgid "%i movie(s) playcount will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32066"
+msgid "Movie Sync Complete"
+msgstr ""
+
+msgctxt "#32067"
+msgid "Going to add %i show(s) to Trakt collection"
+msgstr ""
+
+msgctxt "#32068"
+msgid "Checking for episodes missing from Trakt collection"
+msgstr ""
+
+msgctxt "#32069"
+msgid "%i of %i show(s) have episodes added to Trakt collection"
+msgstr ""
+
+msgctxt "#32070"
+msgid "Going to update %i show(s) missing watched status"
+msgstr ""
+
+msgctxt "#32071"
+msgid "Checking watched episodes on Trakt"
+msgstr ""
+
+msgctxt "#32072"
+msgid "%i show(s) had missing watched status"
+msgstr ""
+
+msgctxt "#32073"
+msgid "%i episodes are being updated"
+msgstr ""
+
+msgctxt "#32074"
+msgid "Checking watched episodes on Kodi"
+msgstr ""
+
+msgctxt "#32075"
+msgid "Episode Sync Complete"
+msgstr ""
+
+msgctxt "#32076"
+msgid "%i movie(s) will be removed from Trakt collection"
+msgstr ""
+
+msgctxt "#32077"
+msgid "Cleaning Trakt TV show collection"
+msgstr ""
+
+msgctxt "#32078"
+msgid "episodes are being removed"
+msgstr ""
+
+msgctxt "#32079"
+msgid "Loading movies from Kodi"
+msgstr ""
+
+msgctxt "#32080"
+msgid "Movies loaded from Kodi"
+msgstr ""
+
+msgctxt "#32081"
+msgid "Retrieving movie collection from Trakt"
+msgstr ""
+
+msgctxt "#32082"
+msgid "Retrieving watched movies from Trakt"
+msgstr ""
+
+msgctxt "#32083"
+msgid "Retrieved movie data from Trakt"
+msgstr ""
+
+msgctxt "#32084"
+msgid "Trakt movie collection is up to date, no movies to add"
+msgstr ""
+
+msgctxt "#32085"
+msgid "%i movie(s) were added to your Trakt collection"
+msgstr ""
+
+msgctxt "#32086"
+msgid "Trakt movie playcounts are up to date"
+msgstr ""
+
+msgctxt "#32087"
+msgid "Playcounts updated for %i movie(s) on Trakt"
+msgstr ""
+
+msgctxt "#32088"
+msgid "Kodi movie playcounts are up to date"
+msgstr ""
+
+msgctxt "#32089"
+msgid "Updating %i of %i movie playcount(s) in Kodi"
+msgstr ""
+
+msgctxt "#32090"
+msgid "Playcounts updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32091"
+msgid "Trakt movie collection is up to date, no movies removed"
+msgstr ""
+
+msgctxt "#32092"
+msgid "%i movie(s) were removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32093"
+msgid "Updating %i of %i movie playcount(s) on Trakt"
+msgstr ""
+
+msgctxt "#32094"
+msgid "Loading episode data from Kodi"
+msgstr ""
+
+msgctxt "#32095"
+msgid "Loading shows from Kodi"
+msgstr ""
+
+msgctxt "#32096"
+msgid "Shows loaded from Kodi"
+msgstr ""
+
+msgctxt "#32097"
+msgid "Parsing %i of %i episode data from Kodi"
+msgstr ""
+
+msgctxt "#32098"
+msgid "Loaded episode data from Kodi"
+msgstr ""
+
+msgctxt "#32099"
+msgid "Loading episode data from Trakt"
+msgstr ""
+
+msgctxt "#32100"
+msgid "Retrieving episode collection from Trakt"
+msgstr ""
+
+msgctxt "#32101"
+msgid "Retrieving watched episodes from Trakt"
+msgstr ""
+
+msgctxt "#32102"
+msgid "Parsing episode data %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32103"
+msgid "Retrieved episode data from Trakt"
+msgstr ""
+
+msgctxt "#32104"
+msgid "Trakt episode collection is up to date, no episodes to add"
+msgstr ""
+
+msgctxt "#32105"
+msgid "%i episode(s) were added to your Trakt collection"
+msgstr ""
+
+msgctxt "#32106"
+msgid "Trakt episode playcounts are up to date"
+msgstr ""
+
+msgctxt "#32107"
+msgid "Kodi episode playcounts are up to date"
+msgstr ""
+
+msgctxt "#32108"
+msgid "Updating %i of %i episode playcount(s) in Kodi"
+msgstr ""
+
+msgctxt "#32109"
+msgid "Playcounts updated for %i show(s) in Kodi"
+msgstr ""
+
+msgctxt "#32110"
+msgid "Trakt episode collection is clean, no episodes to remove"
+msgstr ""
+
+msgctxt "#32111"
+msgid "%i episode(s) are being removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32112"
+msgid "%i episode(s) were removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32113"
+msgid "Trakt - Marked as watched"
+msgstr ""
+
+msgctxt "#32114"
+msgid "Trakt - Failed marking as watched"
+msgstr ""
+
+msgctxt "#32115"
+msgid "%d episode(s) of '%s'"
+msgstr ""
+
+msgctxt "#32116"
+msgid "Enable debug mode"
+msgstr ""
+
+msgctxt "#32117"
+msgid "Sync movie playback progress to Kodi"
+msgstr ""
+
+msgctxt "#32118"
+msgid "Sync episode playback progress to Kodi"
+msgstr ""
+
+msgctxt "#32119"
+msgid "Retrieving episode playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32120"
+msgid "Parsing episode playback progress %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32121"
+msgid "Retrieved episode playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32122"
+msgid "Retrieving movie playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32123"
+msgid "Parsing movie playback progress %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32124"
+msgid "Retrieved movie playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32125"
+msgid "Kodi movie playback progress is up to date"
+msgstr ""
+
+msgctxt "#32126"
+msgid "%i movie(s) playback progress will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32127"
+msgid "Updating %i of %i movie(s) playback progress in Kodi"
+msgstr ""
+
+msgctxt "#32128"
+msgid "Playback progress updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32129"
+msgid "Kodi episode playback progress is up to date"
+msgstr ""
+
+msgctxt "#32130"
+msgid "Updating %i of %i episode(s) playback progress in Kodi"
+msgstr ""
+
+msgctxt "#32131"
+msgid "Playback progress updated for %i episode(s) in Kodi"
+msgstr ""
+
+msgctxt "#32132"
+msgid "Unrate this season"
+msgstr ""
+
+msgctxt "#32133"
+msgid "Manage Movie's Lists"
+msgstr ""
+
+msgctxt "#32134"
+msgid "Manage Show's Lists"
+msgstr ""
+
+msgctxt "#32135"
+msgid "Remove from Watchlist"
+msgstr ""
+
+msgctxt "#32136"
+msgid "Add to watchlist"
+msgstr ""
+
+msgctxt "#32137"
+msgid "Rate this movie"
+msgstr ""
+
+msgctxt "#32138"
+msgid "Rate this show"
+msgstr ""
+
+msgctxt "#32139"
+msgid "Rate this episode"
+msgstr ""
+
+msgctxt "#32140"
+msgid "Toggle watched"
+msgstr ""
+
+msgctxt "#32141"
+msgid "Manage all lists"
+msgstr ""
+
+msgctxt "#32142"
+msgid "Update all tags"
+msgstr ""
+
+msgctxt "#32143"
+msgid "Synchronize library"
+msgstr ""
+
+msgctxt "#32144"
+msgid "How do I authorize the trakt addon to access my trakt.tv account?"
+msgstr ""
+
+# empty strings from id 32145 to 32146
+msgctxt "#32147"
+msgid "Trakt.tv PIN Authorization Failed"
+msgstr ""
+
+# empty string with id 32148
+msgctxt "#32149"
+msgid "Rate this Season"
+msgstr ""
+
+msgctxt "#32150"
+msgid "You will be reminded in 24 hours"
+msgstr ""
+
+msgctxt "#32151"
+msgid "Use Addon Settings later if you change your mind"
+msgstr ""
+
+msgctxt "#32152"
+msgid "Trakt Authorization Complete"
+msgstr ""
+
+msgctxt "#32153"
+msgid "Trakt Account Authorization"
+msgstr ""
+
+msgctxt "#32154"
+msgid "Authorize"
+msgstr ""
+
+msgctxt "#32155"
+msgid "Remind Me Later"
+msgstr ""
+
+msgctxt "#32156"
+msgid "No Thanks"
+msgstr ""
+
+msgctxt "#32157"
+msgid "Account Authorization"
+msgstr ""
+
+# empty string with id 32158
+msgctxt "#32159"
+msgid "Visit {0} or scan the QR code."
+msgstr ""
+
+msgctxt "#32162"
+msgid "The trakt addon CAN NOT be used without authorizing it to access your trakt.tv account."
+msgstr ""
+
+msgctxt "#32163"
+msgid "User"
+msgstr ""
+
+msgctxt "#32164"
+msgid "Fallback to Title/Year matching if necessary"
+msgstr ""
+
+msgctxt "#32165"
+msgid "Trakt - Added to watchlist"
+msgstr ""
+
+msgctxt "#32166"
+msgid "Trakt - Failed adding to watchlist"
+msgstr ""
+
+msgctxt "#32167"
+msgid "Offset scrobble start by X minutes"
+msgstr ""
+
+msgctxt "#32168"
+msgid "Sync ratings"
+msgstr ""
+
+msgctxt "#32169"
+msgid "Kodi movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32170"
+msgid "%i movie(s) ratings will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32171"
+msgid "Updating %i of %i movie ratings in Kodi"
+msgstr ""
+
+msgctxt "#32172"
+msgid "Ratings updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32173"
+msgid "Kodi episode ratings are up to date"
+msgstr ""
+
+msgctxt "#32174"
+msgid "Updating %i of %i episode ratings in Kodi"
+msgstr ""
+
+msgctxt "#32175"
+msgid "Ratings updated for %i episode(s) in Kodi"
+msgstr ""
+
+msgctxt "#32176"
+msgid "Kodi show ratings are up to date"
+msgstr ""
+
+msgctxt "#32177"
+msgid "Updating %i of %i show ratings in Kodi"
+msgstr ""
+
+msgctxt "#32178"
+msgid "Ratings updated for %i show(s) in Kodi"
+msgstr ""
+
+msgctxt "#32179"
+msgid "Trakt movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32180"
+msgid "%i movie ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32181"
+msgid "Trakt show ratings are up to date"
+msgstr ""
+
+msgctxt "#32182"
+msgid "%i show ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32183"
+msgid "Attempt to scrobble MythTV PVR recordings"
+msgstr ""
+
+msgctxt "#32184"
+msgid "Attempt secondary show title search"
+msgstr ""
+
+msgctxt "#32185"
+msgid "Exclude Plugins"
+msgstr ""
+
+msgctxt "#32186"
+msgid "Allow script exclusions"
+msgstr ""

--- a/script.trakt/resources/language/resource.language.ast_es/strings.po
+++ b/script.trakt/resources/language/resource.language.ast_es/strings.po
@@ -1,0 +1,722 @@
+# Kodi Media Center language file
+# Addon Name: Trakt
+# Addon id: script.trakt
+# Addon Provider: Trakt.tv, Razze
+msgid ""
+msgstr ""
+"Project-Id-Version: XBMC Addons\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
+"POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: ast_es\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+
+# General Settings
+msgctxt "#32000"
+msgid "General"
+msgstr ""
+
+# empty strings from id 32001 to 32002
+msgctxt "#32003"
+msgid "Startup Delay"
+msgstr ""
+
+msgctxt "#32004"
+msgid "Rating"
+msgstr ""
+
+msgctxt "#32005"
+msgid "Rate Movie after watching"
+msgstr ""
+
+msgctxt "#32006"
+msgid "Rate TV show Episode after watching"
+msgstr ""
+
+msgctxt "#32008"
+msgid "Minimum percent watched to display rating dialog"
+msgstr ""
+
+msgctxt "#32009"
+msgid "Allow re-rating of media"
+msgstr ""
+
+msgctxt "#32010"
+msgid "Default rating"
+msgstr ""
+
+# Scrobbling Settings
+msgctxt "#32011"
+msgid "Scrobbling"
+msgstr ""
+
+msgctxt "#32012"
+msgid "Scrobble movies"
+msgstr ""
+
+msgctxt "#32013"
+msgid "Scrobble TV show episodes"
+msgstr ""
+
+msgctxt "#32014"
+msgid "Show notification on scrobble"
+msgstr ""
+
+msgctxt "#32015"
+msgid "Trakt - Scrobbled successfully"
+msgstr ""
+
+msgctxt "#32016"
+msgid "Exclusions"
+msgstr ""
+
+msgctxt "#32017"
+msgid "Exclude Live TV"
+msgstr ""
+
+msgctxt "#32018"
+msgid "Exclude HTTP sources"
+msgstr ""
+
+msgctxt "#32019"
+msgid "Exclude path"
+msgstr ""
+
+msgctxt "#32020"
+msgid "Folder's path (including subfolders)"
+msgstr ""
+
+# empty strings from id 32021 to 32022
+msgctxt "#32023"
+msgid "Can not connect to Trakt"
+msgstr ""
+
+msgctxt "#32024"
+msgid "Error"
+msgstr ""
+
+# empty string with id 32025
+msgctxt "#32026"
+msgid "What Did You Think?"
+msgstr ""
+
+msgctxt "#32027"
+msgid "Totally Ninja!"
+msgstr ""
+
+msgctxt "#32028"
+msgid "Weak Sauce :("
+msgstr ""
+
+msgctxt "#32029"
+msgid "Terrible"
+msgstr ""
+
+msgctxt "#32030"
+msgid "Bad"
+msgstr ""
+
+msgctxt "#32031"
+msgid "Poor"
+msgstr ""
+
+msgctxt "#32032"
+msgid "Meh"
+msgstr ""
+
+msgctxt "#32033"
+msgid "Fair"
+msgstr ""
+
+msgctxt "#32034"
+msgid "Good"
+msgstr ""
+
+msgctxt "#32035"
+msgid "Great"
+msgstr ""
+
+msgctxt "#32036"
+msgid "Superb"
+msgstr ""
+
+msgctxt "#32037"
+msgid "Unrate this movie"
+msgstr ""
+
+msgctxt "#32038"
+msgid "Unrate this show"
+msgstr ""
+
+msgctxt "#32039"
+msgid "Unrate this episode"
+msgstr ""
+
+msgctxt "#32040"
+msgid "Trakt - Rating submitted successfully"
+msgstr ""
+
+msgctxt "#32041"
+msgid "Trakt - Already rated"
+msgstr ""
+
+msgctxt "#32042"
+msgid "Trakt - Unrated successfully"
+msgstr ""
+
+msgctxt "#32043"
+msgid "Trakt - Already has the same rating"
+msgstr ""
+
+msgctxt "#32044"
+msgid "Trakt - Problem submitting rating"
+msgstr ""
+
+msgctxt "#32045"
+msgid "Synchronize"
+msgstr ""
+
+msgctxt "#32046"
+msgid "Movies"
+msgstr ""
+
+msgctxt "#32047"
+msgid "Add new movies to Trakt collection"
+msgstr ""
+
+msgctxt "#32048"
+msgid "Add watched movies to Trakt history"
+msgstr ""
+
+msgctxt "#32049"
+msgid "Mark movies from Trakt history as watched in Kodi"
+msgstr ""
+
+msgctxt "#32050"
+msgid "TV Episodes"
+msgstr ""
+
+msgctxt "#32051"
+msgid "Add new TV episodes to Trakt collection"
+msgstr ""
+
+msgctxt "#32052"
+msgid "Add watched TV episodes to Trakt history"
+msgstr ""
+
+msgctxt "#32053"
+msgid "Mark TV episodes from Trakt history as watched in Kodi"
+msgstr ""
+
+msgctxt "#32054"
+msgid "Service"
+msgstr ""
+
+msgctxt "#32055"
+msgid "Sync collection on library update or cleaning"
+msgstr ""
+
+msgctxt "#32056"
+msgid "Show sync notifications"
+msgstr ""
+
+msgctxt "#32057"
+msgid "Remove deleted movies from Trakt collection"
+msgstr ""
+
+msgctxt "#32058"
+msgid "Remove deleted TV episodes from Trakt collection"
+msgstr ""
+
+# empty string with id 32059
+msgctxt "#32060"
+msgid "Hide notifications during playback"
+msgstr ""
+
+msgctxt "#32061"
+msgid "Sync started"
+msgstr ""
+
+msgctxt "#32062"
+msgid "Sync complete"
+msgstr ""
+
+msgctxt "#32063"
+msgid "%i movie(s) will be added to Trakt collection"
+msgstr ""
+
+msgctxt "#32064"
+msgid "%i movie playcount(s) will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32065"
+msgid "%i movie(s) playcount will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32066"
+msgid "Movie Sync Complete"
+msgstr ""
+
+msgctxt "#32067"
+msgid "Going to add %i show(s) to Trakt collection"
+msgstr ""
+
+msgctxt "#32068"
+msgid "Checking for episodes missing from Trakt collection"
+msgstr ""
+
+msgctxt "#32069"
+msgid "%i of %i show(s) have episodes added to Trakt collection"
+msgstr ""
+
+msgctxt "#32070"
+msgid "Going to update %i show(s) missing watched status"
+msgstr ""
+
+msgctxt "#32071"
+msgid "Checking watched episodes on Trakt"
+msgstr ""
+
+msgctxt "#32072"
+msgid "%i show(s) had missing watched status"
+msgstr ""
+
+msgctxt "#32073"
+msgid "%i episodes are being updated"
+msgstr ""
+
+msgctxt "#32074"
+msgid "Checking watched episodes on Kodi"
+msgstr ""
+
+msgctxt "#32075"
+msgid "Episode Sync Complete"
+msgstr ""
+
+msgctxt "#32076"
+msgid "%i movie(s) will be removed from Trakt collection"
+msgstr ""
+
+msgctxt "#32077"
+msgid "Cleaning Trakt TV show collection"
+msgstr ""
+
+msgctxt "#32078"
+msgid "episodes are being removed"
+msgstr ""
+
+msgctxt "#32079"
+msgid "Loading movies from Kodi"
+msgstr ""
+
+msgctxt "#32080"
+msgid "Movies loaded from Kodi"
+msgstr ""
+
+msgctxt "#32081"
+msgid "Retrieving movie collection from Trakt"
+msgstr ""
+
+msgctxt "#32082"
+msgid "Retrieving watched movies from Trakt"
+msgstr ""
+
+msgctxt "#32083"
+msgid "Retrieved movie data from Trakt"
+msgstr ""
+
+msgctxt "#32084"
+msgid "Trakt movie collection is up to date, no movies to add"
+msgstr ""
+
+msgctxt "#32085"
+msgid "%i movie(s) were added to your Trakt collection"
+msgstr ""
+
+msgctxt "#32086"
+msgid "Trakt movie playcounts are up to date"
+msgstr ""
+
+msgctxt "#32087"
+msgid "Playcounts updated for %i movie(s) on Trakt"
+msgstr ""
+
+msgctxt "#32088"
+msgid "Kodi movie playcounts are up to date"
+msgstr ""
+
+msgctxt "#32089"
+msgid "Updating %i of %i movie playcount(s) in Kodi"
+msgstr ""
+
+msgctxt "#32090"
+msgid "Playcounts updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32091"
+msgid "Trakt movie collection is up to date, no movies removed"
+msgstr ""
+
+msgctxt "#32092"
+msgid "%i movie(s) were removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32093"
+msgid "Updating %i of %i movie playcount(s) on Trakt"
+msgstr ""
+
+msgctxt "#32094"
+msgid "Loading episode data from Kodi"
+msgstr ""
+
+msgctxt "#32095"
+msgid "Loading shows from Kodi"
+msgstr ""
+
+msgctxt "#32096"
+msgid "Shows loaded from Kodi"
+msgstr ""
+
+msgctxt "#32097"
+msgid "Parsing %i of %i episode data from Kodi"
+msgstr ""
+
+msgctxt "#32098"
+msgid "Loaded episode data from Kodi"
+msgstr ""
+
+msgctxt "#32099"
+msgid "Loading episode data from Trakt"
+msgstr ""
+
+msgctxt "#32100"
+msgid "Retrieving episode collection from Trakt"
+msgstr ""
+
+msgctxt "#32101"
+msgid "Retrieving watched episodes from Trakt"
+msgstr ""
+
+msgctxt "#32102"
+msgid "Parsing episode data %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32103"
+msgid "Retrieved episode data from Trakt"
+msgstr ""
+
+msgctxt "#32104"
+msgid "Trakt episode collection is up to date, no episodes to add"
+msgstr ""
+
+msgctxt "#32105"
+msgid "%i episode(s) were added to your Trakt collection"
+msgstr ""
+
+msgctxt "#32106"
+msgid "Trakt episode playcounts are up to date"
+msgstr ""
+
+msgctxt "#32107"
+msgid "Kodi episode playcounts are up to date"
+msgstr ""
+
+msgctxt "#32108"
+msgid "Updating %i of %i episode playcount(s) in Kodi"
+msgstr ""
+
+msgctxt "#32109"
+msgid "Playcounts updated for %i show(s) in Kodi"
+msgstr ""
+
+msgctxt "#32110"
+msgid "Trakt episode collection is clean, no episodes to remove"
+msgstr ""
+
+msgctxt "#32111"
+msgid "%i episode(s) are being removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32112"
+msgid "%i episode(s) were removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32113"
+msgid "Trakt - Marked as watched"
+msgstr ""
+
+msgctxt "#32114"
+msgid "Trakt - Failed marking as watched"
+msgstr ""
+
+msgctxt "#32115"
+msgid "%d episode(s) of '%s'"
+msgstr ""
+
+msgctxt "#32116"
+msgid "Enable debug mode"
+msgstr ""
+
+msgctxt "#32117"
+msgid "Sync movie playback progress to Kodi"
+msgstr ""
+
+msgctxt "#32118"
+msgid "Sync episode playback progress to Kodi"
+msgstr ""
+
+msgctxt "#32119"
+msgid "Retrieving episode playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32120"
+msgid "Parsing episode playback progress %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32121"
+msgid "Retrieved episode playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32122"
+msgid "Retrieving movie playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32123"
+msgid "Parsing movie playback progress %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32124"
+msgid "Retrieved movie playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32125"
+msgid "Kodi movie playback progress is up to date"
+msgstr ""
+
+msgctxt "#32126"
+msgid "%i movie(s) playback progress will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32127"
+msgid "Updating %i of %i movie(s) playback progress in Kodi"
+msgstr ""
+
+msgctxt "#32128"
+msgid "Playback progress updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32129"
+msgid "Kodi episode playback progress is up to date"
+msgstr ""
+
+msgctxt "#32130"
+msgid "Updating %i of %i episode(s) playback progress in Kodi"
+msgstr ""
+
+msgctxt "#32131"
+msgid "Playback progress updated for %i episode(s) in Kodi"
+msgstr ""
+
+msgctxt "#32132"
+msgid "Unrate this season"
+msgstr ""
+
+msgctxt "#32133"
+msgid "Manage Movie's Lists"
+msgstr ""
+
+msgctxt "#32134"
+msgid "Manage Show's Lists"
+msgstr ""
+
+msgctxt "#32135"
+msgid "Remove from Watchlist"
+msgstr ""
+
+msgctxt "#32136"
+msgid "Add to watchlist"
+msgstr ""
+
+msgctxt "#32137"
+msgid "Rate this movie"
+msgstr ""
+
+msgctxt "#32138"
+msgid "Rate this show"
+msgstr ""
+
+msgctxt "#32139"
+msgid "Rate this episode"
+msgstr ""
+
+msgctxt "#32140"
+msgid "Toggle watched"
+msgstr ""
+
+msgctxt "#32141"
+msgid "Manage all lists"
+msgstr ""
+
+msgctxt "#32142"
+msgid "Update all tags"
+msgstr ""
+
+msgctxt "#32143"
+msgid "Synchronize library"
+msgstr ""
+
+msgctxt "#32144"
+msgid "How do I authorize the trakt addon to access my trakt.tv account?"
+msgstr ""
+
+# empty strings from id 32145 to 32146
+msgctxt "#32147"
+msgid "Trakt.tv PIN Authorization Failed"
+msgstr ""
+
+# empty string with id 32148
+msgctxt "#32149"
+msgid "Rate this Season"
+msgstr ""
+
+msgctxt "#32150"
+msgid "You will be reminded in 24 hours"
+msgstr ""
+
+msgctxt "#32151"
+msgid "Use Addon Settings later if you change your mind"
+msgstr ""
+
+msgctxt "#32152"
+msgid "Trakt Authorization Complete"
+msgstr ""
+
+msgctxt "#32153"
+msgid "Trakt Account Authorization"
+msgstr ""
+
+msgctxt "#32154"
+msgid "Authorize"
+msgstr ""
+
+msgctxt "#32155"
+msgid "Remind Me Later"
+msgstr ""
+
+msgctxt "#32156"
+msgid "No Thanks"
+msgstr ""
+
+msgctxt "#32157"
+msgid "Account Authorization"
+msgstr ""
+
+# empty string with id 32158
+msgctxt "#32159"
+msgid "Visit {0} or scan the QR code."
+msgstr ""
+
+msgctxt "#32162"
+msgid "The trakt addon CAN NOT be used without authorizing it to access your trakt.tv account."
+msgstr ""
+
+msgctxt "#32163"
+msgid "User"
+msgstr ""
+
+msgctxt "#32164"
+msgid "Fallback to Title/Year matching if necessary"
+msgstr ""
+
+msgctxt "#32165"
+msgid "Trakt - Added to watchlist"
+msgstr ""
+
+msgctxt "#32166"
+msgid "Trakt - Failed adding to watchlist"
+msgstr ""
+
+msgctxt "#32167"
+msgid "Offset scrobble start by X minutes"
+msgstr ""
+
+msgctxt "#32168"
+msgid "Sync ratings"
+msgstr ""
+
+msgctxt "#32169"
+msgid "Kodi movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32170"
+msgid "%i movie(s) ratings will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32171"
+msgid "Updating %i of %i movie ratings in Kodi"
+msgstr ""
+
+msgctxt "#32172"
+msgid "Ratings updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32173"
+msgid "Kodi episode ratings are up to date"
+msgstr ""
+
+msgctxt "#32174"
+msgid "Updating %i of %i episode ratings in Kodi"
+msgstr ""
+
+msgctxt "#32175"
+msgid "Ratings updated for %i episode(s) in Kodi"
+msgstr ""
+
+msgctxt "#32176"
+msgid "Kodi show ratings are up to date"
+msgstr ""
+
+msgctxt "#32177"
+msgid "Updating %i of %i show ratings in Kodi"
+msgstr ""
+
+msgctxt "#32178"
+msgid "Ratings updated for %i show(s) in Kodi"
+msgstr ""
+
+msgctxt "#32179"
+msgid "Trakt movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32180"
+msgid "%i movie ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32181"
+msgid "Trakt show ratings are up to date"
+msgstr ""
+
+msgctxt "#32182"
+msgid "%i show ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32183"
+msgid "Attempt to scrobble MythTV PVR recordings"
+msgstr ""
+
+msgctxt "#32184"
+msgid "Attempt secondary show title search"
+msgstr ""
+
+msgctxt "#32185"
+msgid "Exclude Plugins"
+msgstr ""
+
+msgctxt "#32186"
+msgid "Allow script exclusions"
+msgstr ""

--- a/script.trakt/resources/language/resource.language.az_AZ/strings.po
+++ b/script.trakt/resources/language/resource.language.az_AZ/strings.po
@@ -10,20 +10,713 @@ msgstr ""
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Kodi Translation Team\n"
 "Language-Team: Azerbaijani (http://www.transifex.com/projects/p/xbmc-addons/language/az/)\n"
+"Language: az\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: az\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
+
+# General Settings
+msgctxt "#32000"
+msgid "General"
+msgstr ""
+
+# empty strings from id 32001 to 32002
+msgctxt "#32003"
+msgid "Startup Delay"
+msgstr ""
 
 msgctxt "#32004"
 msgid "Rating"
 msgstr "Reytinq"
 
+msgctxt "#32005"
+msgid "Rate Movie after watching"
+msgstr ""
+
+msgctxt "#32006"
+msgid "Rate TV show Episode after watching"
+msgstr ""
+
+msgctxt "#32008"
+msgid "Minimum percent watched to display rating dialog"
+msgstr ""
+
+msgctxt "#32009"
+msgid "Allow re-rating of media"
+msgstr ""
+
+msgctxt "#32010"
+msgid "Default rating"
+msgstr ""
+
+# Scrobbling Settings
+msgctxt "#32011"
+msgid "Scrobbling"
+msgstr ""
+
+msgctxt "#32012"
+msgid "Scrobble movies"
+msgstr ""
+
+msgctxt "#32013"
+msgid "Scrobble TV show episodes"
+msgstr ""
+
+msgctxt "#32014"
+msgid "Show notification on scrobble"
+msgstr ""
+
+msgctxt "#32015"
+msgid "Trakt - Scrobbled successfully"
+msgstr ""
+
+msgctxt "#32016"
+msgid "Exclusions"
+msgstr ""
+
+msgctxt "#32017"
+msgid "Exclude Live TV"
+msgstr ""
+
+msgctxt "#32018"
+msgid "Exclude HTTP sources"
+msgstr ""
+
+msgctxt "#32019"
+msgid "Exclude path"
+msgstr ""
+
+msgctxt "#32020"
+msgid "Folder's path (including subfolders)"
+msgstr ""
+
+# empty strings from id 32021 to 32022
+msgctxt "#32023"
+msgid "Can not connect to Trakt"
+msgstr ""
+
 msgctxt "#32024"
 msgid "Error"
 msgstr "Xəta"
 
+# empty string with id 32025
+msgctxt "#32026"
+msgid "What Did You Think?"
+msgstr ""
+
+msgctxt "#32027"
+msgid "Totally Ninja!"
+msgstr ""
+
+msgctxt "#32028"
+msgid "Weak Sauce :("
+msgstr ""
+
+msgctxt "#32029"
+msgid "Terrible"
+msgstr ""
+
+msgctxt "#32030"
+msgid "Bad"
+msgstr ""
+
+msgctxt "#32031"
+msgid "Poor"
+msgstr ""
+
+msgctxt "#32032"
+msgid "Meh"
+msgstr ""
+
+msgctxt "#32033"
+msgid "Fair"
+msgstr ""
+
+msgctxt "#32034"
+msgid "Good"
+msgstr ""
+
+msgctxt "#32035"
+msgid "Great"
+msgstr ""
+
+msgctxt "#32036"
+msgid "Superb"
+msgstr ""
+
+msgctxt "#32037"
+msgid "Unrate this movie"
+msgstr ""
+
+msgctxt "#32038"
+msgid "Unrate this show"
+msgstr ""
+
+msgctxt "#32039"
+msgid "Unrate this episode"
+msgstr ""
+
+msgctxt "#32040"
+msgid "Trakt - Rating submitted successfully"
+msgstr ""
+
+msgctxt "#32041"
+msgid "Trakt - Already rated"
+msgstr ""
+
+msgctxt "#32042"
+msgid "Trakt - Unrated successfully"
+msgstr ""
+
+msgctxt "#32043"
+msgid "Trakt - Already has the same rating"
+msgstr ""
+
+msgctxt "#32044"
+msgid "Trakt - Problem submitting rating"
+msgstr ""
+
+msgctxt "#32045"
+msgid "Synchronize"
+msgstr ""
+
 msgctxt "#32046"
 msgid "Movies"
 msgstr "Filmlər"
+
+msgctxt "#32047"
+msgid "Add new movies to Trakt collection"
+msgstr ""
+
+msgctxt "#32048"
+msgid "Add watched movies to Trakt history"
+msgstr ""
+
+msgctxt "#32049"
+msgid "Mark movies from Trakt history as watched in Kodi"
+msgstr ""
+
+msgctxt "#32050"
+msgid "TV Episodes"
+msgstr ""
+
+msgctxt "#32051"
+msgid "Add new TV episodes to Trakt collection"
+msgstr ""
+
+msgctxt "#32052"
+msgid "Add watched TV episodes to Trakt history"
+msgstr ""
+
+msgctxt "#32053"
+msgid "Mark TV episodes from Trakt history as watched in Kodi"
+msgstr ""
+
+msgctxt "#32054"
+msgid "Service"
+msgstr ""
+
+msgctxt "#32055"
+msgid "Sync collection on library update or cleaning"
+msgstr ""
+
+msgctxt "#32056"
+msgid "Show sync notifications"
+msgstr ""
+
+msgctxt "#32057"
+msgid "Remove deleted movies from Trakt collection"
+msgstr ""
+
+msgctxt "#32058"
+msgid "Remove deleted TV episodes from Trakt collection"
+msgstr ""
+
+# empty string with id 32059
+msgctxt "#32060"
+msgid "Hide notifications during playback"
+msgstr ""
+
+msgctxt "#32061"
+msgid "Sync started"
+msgstr ""
+
+msgctxt "#32062"
+msgid "Sync complete"
+msgstr ""
+
+msgctxt "#32063"
+msgid "%i movie(s) will be added to Trakt collection"
+msgstr ""
+
+msgctxt "#32064"
+msgid "%i movie playcount(s) will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32065"
+msgid "%i movie(s) playcount will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32066"
+msgid "Movie Sync Complete"
+msgstr ""
+
+msgctxt "#32067"
+msgid "Going to add %i show(s) to Trakt collection"
+msgstr ""
+
+msgctxt "#32068"
+msgid "Checking for episodes missing from Trakt collection"
+msgstr ""
+
+msgctxt "#32069"
+msgid "%i of %i show(s) have episodes added to Trakt collection"
+msgstr ""
+
+msgctxt "#32070"
+msgid "Going to update %i show(s) missing watched status"
+msgstr ""
+
+msgctxt "#32071"
+msgid "Checking watched episodes on Trakt"
+msgstr ""
+
+msgctxt "#32072"
+msgid "%i show(s) had missing watched status"
+msgstr ""
+
+msgctxt "#32073"
+msgid "%i episodes are being updated"
+msgstr ""
+
+msgctxt "#32074"
+msgid "Checking watched episodes on Kodi"
+msgstr ""
+
+msgctxt "#32075"
+msgid "Episode Sync Complete"
+msgstr ""
+
+msgctxt "#32076"
+msgid "%i movie(s) will be removed from Trakt collection"
+msgstr ""
+
+msgctxt "#32077"
+msgid "Cleaning Trakt TV show collection"
+msgstr ""
+
+msgctxt "#32078"
+msgid "episodes are being removed"
+msgstr ""
+
+msgctxt "#32079"
+msgid "Loading movies from Kodi"
+msgstr ""
+
+msgctxt "#32080"
+msgid "Movies loaded from Kodi"
+msgstr ""
+
+msgctxt "#32081"
+msgid "Retrieving movie collection from Trakt"
+msgstr ""
+
+msgctxt "#32082"
+msgid "Retrieving watched movies from Trakt"
+msgstr ""
+
+msgctxt "#32083"
+msgid "Retrieved movie data from Trakt"
+msgstr ""
+
+msgctxt "#32084"
+msgid "Trakt movie collection is up to date, no movies to add"
+msgstr ""
+
+msgctxt "#32085"
+msgid "%i movie(s) were added to your Trakt collection"
+msgstr ""
+
+msgctxt "#32086"
+msgid "Trakt movie playcounts are up to date"
+msgstr ""
+
+msgctxt "#32087"
+msgid "Playcounts updated for %i movie(s) on Trakt"
+msgstr ""
+
+msgctxt "#32088"
+msgid "Kodi movie playcounts are up to date"
+msgstr ""
+
+msgctxt "#32089"
+msgid "Updating %i of %i movie playcount(s) in Kodi"
+msgstr ""
+
+msgctxt "#32090"
+msgid "Playcounts updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32091"
+msgid "Trakt movie collection is up to date, no movies removed"
+msgstr ""
+
+msgctxt "#32092"
+msgid "%i movie(s) were removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32093"
+msgid "Updating %i of %i movie playcount(s) on Trakt"
+msgstr ""
+
+msgctxt "#32094"
+msgid "Loading episode data from Kodi"
+msgstr ""
+
+msgctxt "#32095"
+msgid "Loading shows from Kodi"
+msgstr ""
+
+msgctxt "#32096"
+msgid "Shows loaded from Kodi"
+msgstr ""
+
+msgctxt "#32097"
+msgid "Parsing %i of %i episode data from Kodi"
+msgstr ""
+
+msgctxt "#32098"
+msgid "Loaded episode data from Kodi"
+msgstr ""
+
+msgctxt "#32099"
+msgid "Loading episode data from Trakt"
+msgstr ""
+
+msgctxt "#32100"
+msgid "Retrieving episode collection from Trakt"
+msgstr ""
+
+msgctxt "#32101"
+msgid "Retrieving watched episodes from Trakt"
+msgstr ""
+
+msgctxt "#32102"
+msgid "Parsing episode data %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32103"
+msgid "Retrieved episode data from Trakt"
+msgstr ""
+
+msgctxt "#32104"
+msgid "Trakt episode collection is up to date, no episodes to add"
+msgstr ""
+
+msgctxt "#32105"
+msgid "%i episode(s) were added to your Trakt collection"
+msgstr ""
+
+msgctxt "#32106"
+msgid "Trakt episode playcounts are up to date"
+msgstr ""
+
+msgctxt "#32107"
+msgid "Kodi episode playcounts are up to date"
+msgstr ""
+
+msgctxt "#32108"
+msgid "Updating %i of %i episode playcount(s) in Kodi"
+msgstr ""
+
+msgctxt "#32109"
+msgid "Playcounts updated for %i show(s) in Kodi"
+msgstr ""
+
+msgctxt "#32110"
+msgid "Trakt episode collection is clean, no episodes to remove"
+msgstr ""
+
+msgctxt "#32111"
+msgid "%i episode(s) are being removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32112"
+msgid "%i episode(s) were removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32113"
+msgid "Trakt - Marked as watched"
+msgstr ""
+
+msgctxt "#32114"
+msgid "Trakt - Failed marking as watched"
+msgstr ""
+
+msgctxt "#32115"
+msgid "%d episode(s) of '%s'"
+msgstr ""
+
+msgctxt "#32116"
+msgid "Enable debug mode"
+msgstr ""
+
+msgctxt "#32117"
+msgid "Sync movie playback progress to Kodi"
+msgstr ""
+
+msgctxt "#32118"
+msgid "Sync episode playback progress to Kodi"
+msgstr ""
+
+msgctxt "#32119"
+msgid "Retrieving episode playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32120"
+msgid "Parsing episode playback progress %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32121"
+msgid "Retrieved episode playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32122"
+msgid "Retrieving movie playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32123"
+msgid "Parsing movie playback progress %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32124"
+msgid "Retrieved movie playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32125"
+msgid "Kodi movie playback progress is up to date"
+msgstr ""
+
+msgctxt "#32126"
+msgid "%i movie(s) playback progress will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32127"
+msgid "Updating %i of %i movie(s) playback progress in Kodi"
+msgstr ""
+
+msgctxt "#32128"
+msgid "Playback progress updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32129"
+msgid "Kodi episode playback progress is up to date"
+msgstr ""
+
+msgctxt "#32130"
+msgid "Updating %i of %i episode(s) playback progress in Kodi"
+msgstr ""
+
+msgctxt "#32131"
+msgid "Playback progress updated for %i episode(s) in Kodi"
+msgstr ""
+
+msgctxt "#32132"
+msgid "Unrate this season"
+msgstr ""
+
+msgctxt "#32133"
+msgid "Manage Movie's Lists"
+msgstr ""
+
+msgctxt "#32134"
+msgid "Manage Show's Lists"
+msgstr ""
+
+msgctxt "#32135"
+msgid "Remove from Watchlist"
+msgstr ""
+
+msgctxt "#32136"
+msgid "Add to watchlist"
+msgstr ""
+
+msgctxt "#32137"
+msgid "Rate this movie"
+msgstr ""
+
+msgctxt "#32138"
+msgid "Rate this show"
+msgstr ""
+
+msgctxt "#32139"
+msgid "Rate this episode"
+msgstr ""
+
+msgctxt "#32140"
+msgid "Toggle watched"
+msgstr ""
+
+msgctxt "#32141"
+msgid "Manage all lists"
+msgstr ""
+
+msgctxt "#32142"
+msgid "Update all tags"
+msgstr ""
+
+msgctxt "#32143"
+msgid "Synchronize library"
+msgstr ""
+
+msgctxt "#32144"
+msgid "How do I authorize the trakt addon to access my trakt.tv account?"
+msgstr ""
+
+# empty strings from id 32145 to 32146
+msgctxt "#32147"
+msgid "Trakt.tv PIN Authorization Failed"
+msgstr ""
+
+# empty string with id 32148
+msgctxt "#32149"
+msgid "Rate this Season"
+msgstr ""
+
+msgctxt "#32150"
+msgid "You will be reminded in 24 hours"
+msgstr ""
+
+msgctxt "#32151"
+msgid "Use Addon Settings later if you change your mind"
+msgstr ""
+
+msgctxt "#32152"
+msgid "Trakt Authorization Complete"
+msgstr ""
+
+msgctxt "#32153"
+msgid "Trakt Account Authorization"
+msgstr ""
+
+msgctxt "#32154"
+msgid "Authorize"
+msgstr ""
+
+msgctxt "#32155"
+msgid "Remind Me Later"
+msgstr ""
+
+msgctxt "#32156"
+msgid "No Thanks"
+msgstr ""
+
+msgctxt "#32157"
+msgid "Account Authorization"
+msgstr ""
+
+# empty string with id 32158
+msgctxt "#32159"
+msgid "Visit {0} or scan the QR code."
+msgstr ""
+
+msgctxt "#32162"
+msgid "The trakt addon CAN NOT be used without authorizing it to access your trakt.tv account."
+msgstr ""
+
+msgctxt "#32163"
+msgid "User"
+msgstr ""
+
+msgctxt "#32164"
+msgid "Fallback to Title/Year matching if necessary"
+msgstr ""
+
+msgctxt "#32165"
+msgid "Trakt - Added to watchlist"
+msgstr ""
+
+msgctxt "#32166"
+msgid "Trakt - Failed adding to watchlist"
+msgstr ""
+
+msgctxt "#32167"
+msgid "Offset scrobble start by X minutes"
+msgstr ""
+
+msgctxt "#32168"
+msgid "Sync ratings"
+msgstr ""
+
+msgctxt "#32169"
+msgid "Kodi movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32170"
+msgid "%i movie(s) ratings will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32171"
+msgid "Updating %i of %i movie ratings in Kodi"
+msgstr ""
+
+msgctxt "#32172"
+msgid "Ratings updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32173"
+msgid "Kodi episode ratings are up to date"
+msgstr ""
+
+msgctxt "#32174"
+msgid "Updating %i of %i episode ratings in Kodi"
+msgstr ""
+
+msgctxt "#32175"
+msgid "Ratings updated for %i episode(s) in Kodi"
+msgstr ""
+
+msgctxt "#32176"
+msgid "Kodi show ratings are up to date"
+msgstr ""
+
+msgctxt "#32177"
+msgid "Updating %i of %i show ratings in Kodi"
+msgstr ""
+
+msgctxt "#32178"
+msgid "Ratings updated for %i show(s) in Kodi"
+msgstr ""
+
+msgctxt "#32179"
+msgid "Trakt movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32180"
+msgid "%i movie ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32181"
+msgid "Trakt show ratings are up to date"
+msgstr ""
+
+msgctxt "#32182"
+msgid "%i show ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32183"
+msgid "Attempt to scrobble MythTV PVR recordings"
+msgstr ""
+
+msgctxt "#32184"
+msgid "Attempt secondary show title search"
+msgstr ""
+
+msgctxt "#32185"
+msgid "Exclude Plugins"
+msgstr ""
+
+msgctxt "#32186"
+msgid "Allow script exclusions"
+msgstr ""

--- a/script.trakt/resources/language/resource.language.be_BY/strings.po
+++ b/script.trakt/resources/language/resource.language.be_BY/strings.po
@@ -10,32 +10,712 @@ msgstr ""
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Kodi Translation Team\n"
 "Language-Team: Belarusian (http://www.transifex.com/projects/p/xbmc-addons/language/be/)\n"
+"Language: be\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: be\n"
 "Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 
 msgctxt "#32000"
 msgid "General"
 msgstr "General"
 
+# empty strings from id 32001 to 32002
+msgctxt "#32003"
+msgid "Startup Delay"
+msgstr ""
+
 msgctxt "#32004"
 msgid "Rating"
 msgstr "Rating"
+
+msgctxt "#32005"
+msgid "Rate Movie after watching"
+msgstr ""
+
+msgctxt "#32006"
+msgid "Rate TV show Episode after watching"
+msgstr ""
+
+msgctxt "#32008"
+msgid "Minimum percent watched to display rating dialog"
+msgstr ""
+
+msgctxt "#32009"
+msgid "Allow re-rating of media"
+msgstr ""
+
+msgctxt "#32010"
+msgid "Default rating"
+msgstr ""
+
+# Scrobbling Settings
+msgctxt "#32011"
+msgid "Scrobbling"
+msgstr ""
+
+msgctxt "#32012"
+msgid "Scrobble movies"
+msgstr ""
+
+msgctxt "#32013"
+msgid "Scrobble TV show episodes"
+msgstr ""
+
+msgctxt "#32014"
+msgid "Show notification on scrobble"
+msgstr ""
+
+msgctxt "#32015"
+msgid "Trakt - Scrobbled successfully"
+msgstr ""
+
+msgctxt "#32016"
+msgid "Exclusions"
+msgstr ""
+
+msgctxt "#32017"
+msgid "Exclude Live TV"
+msgstr ""
+
+msgctxt "#32018"
+msgid "Exclude HTTP sources"
+msgstr ""
+
+msgctxt "#32019"
+msgid "Exclude path"
+msgstr ""
+
+msgctxt "#32020"
+msgid "Folder's path (including subfolders)"
+msgstr ""
+
+# empty strings from id 32021 to 32022
+msgctxt "#32023"
+msgid "Can not connect to Trakt"
+msgstr ""
 
 msgctxt "#32024"
 msgid "Error"
 msgstr "Error"
 
+# empty string with id 32025
+msgctxt "#32026"
+msgid "What Did You Think?"
+msgstr ""
+
+msgctxt "#32027"
+msgid "Totally Ninja!"
+msgstr ""
+
+msgctxt "#32028"
+msgid "Weak Sauce :("
+msgstr ""
+
+msgctxt "#32029"
+msgid "Terrible"
+msgstr ""
+
+msgctxt "#32030"
+msgid "Bad"
+msgstr ""
+
+msgctxt "#32031"
+msgid "Poor"
+msgstr ""
+
+msgctxt "#32032"
+msgid "Meh"
+msgstr ""
+
 msgctxt "#32033"
 msgid "Fair"
 msgstr "Сонечна"
+
+msgctxt "#32034"
+msgid "Good"
+msgstr ""
+
+msgctxt "#32035"
+msgid "Great"
+msgstr ""
+
+msgctxt "#32036"
+msgid "Superb"
+msgstr ""
+
+msgctxt "#32037"
+msgid "Unrate this movie"
+msgstr ""
+
+msgctxt "#32038"
+msgid "Unrate this show"
+msgstr ""
+
+msgctxt "#32039"
+msgid "Unrate this episode"
+msgstr ""
+
+msgctxt "#32040"
+msgid "Trakt - Rating submitted successfully"
+msgstr ""
+
+msgctxt "#32041"
+msgid "Trakt - Already rated"
+msgstr ""
+
+msgctxt "#32042"
+msgid "Trakt - Unrated successfully"
+msgstr ""
+
+msgctxt "#32043"
+msgid "Trakt - Already has the same rating"
+msgstr ""
+
+msgctxt "#32044"
+msgid "Trakt - Problem submitting rating"
+msgstr ""
+
+msgctxt "#32045"
+msgid "Synchronize"
+msgstr ""
 
 msgctxt "#32046"
 msgid "Movies"
 msgstr "Фільмы"
 
+msgctxt "#32047"
+msgid "Add new movies to Trakt collection"
+msgstr ""
+
+msgctxt "#32048"
+msgid "Add watched movies to Trakt history"
+msgstr ""
+
+msgctxt "#32049"
+msgid "Mark movies from Trakt history as watched in Kodi"
+msgstr ""
+
+msgctxt "#32050"
+msgid "TV Episodes"
+msgstr ""
+
+msgctxt "#32051"
+msgid "Add new TV episodes to Trakt collection"
+msgstr ""
+
+msgctxt "#32052"
+msgid "Add watched TV episodes to Trakt history"
+msgstr ""
+
+msgctxt "#32053"
+msgid "Mark TV episodes from Trakt history as watched in Kodi"
+msgstr ""
+
+msgctxt "#32054"
+msgid "Service"
+msgstr ""
+
+msgctxt "#32055"
+msgid "Sync collection on library update or cleaning"
+msgstr ""
+
+msgctxt "#32056"
+msgid "Show sync notifications"
+msgstr ""
+
+msgctxt "#32057"
+msgid "Remove deleted movies from Trakt collection"
+msgstr ""
+
+msgctxt "#32058"
+msgid "Remove deleted TV episodes from Trakt collection"
+msgstr ""
+
+# empty string with id 32059
+msgctxt "#32060"
+msgid "Hide notifications during playback"
+msgstr ""
+
+msgctxt "#32061"
+msgid "Sync started"
+msgstr ""
+
+msgctxt "#32062"
+msgid "Sync complete"
+msgstr ""
+
+msgctxt "#32063"
+msgid "%i movie(s) will be added to Trakt collection"
+msgstr ""
+
+msgctxt "#32064"
+msgid "%i movie playcount(s) will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32065"
+msgid "%i movie(s) playcount will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32066"
+msgid "Movie Sync Complete"
+msgstr ""
+
+msgctxt "#32067"
+msgid "Going to add %i show(s) to Trakt collection"
+msgstr ""
+
+msgctxt "#32068"
+msgid "Checking for episodes missing from Trakt collection"
+msgstr ""
+
+msgctxt "#32069"
+msgid "%i of %i show(s) have episodes added to Trakt collection"
+msgstr ""
+
+msgctxt "#32070"
+msgid "Going to update %i show(s) missing watched status"
+msgstr ""
+
+msgctxt "#32071"
+msgid "Checking watched episodes on Trakt"
+msgstr ""
+
+msgctxt "#32072"
+msgid "%i show(s) had missing watched status"
+msgstr ""
+
+msgctxt "#32073"
+msgid "%i episodes are being updated"
+msgstr ""
+
+msgctxt "#32074"
+msgid "Checking watched episodes on Kodi"
+msgstr ""
+
+msgctxt "#32075"
+msgid "Episode Sync Complete"
+msgstr ""
+
+msgctxt "#32076"
+msgid "%i movie(s) will be removed from Trakt collection"
+msgstr ""
+
+msgctxt "#32077"
+msgid "Cleaning Trakt TV show collection"
+msgstr ""
+
+msgctxt "#32078"
+msgid "episodes are being removed"
+msgstr ""
+
+msgctxt "#32079"
+msgid "Loading movies from Kodi"
+msgstr ""
+
+msgctxt "#32080"
+msgid "Movies loaded from Kodi"
+msgstr ""
+
+msgctxt "#32081"
+msgid "Retrieving movie collection from Trakt"
+msgstr ""
+
+msgctxt "#32082"
+msgid "Retrieving watched movies from Trakt"
+msgstr ""
+
+msgctxt "#32083"
+msgid "Retrieved movie data from Trakt"
+msgstr ""
+
+msgctxt "#32084"
+msgid "Trakt movie collection is up to date, no movies to add"
+msgstr ""
+
+msgctxt "#32085"
+msgid "%i movie(s) were added to your Trakt collection"
+msgstr ""
+
+msgctxt "#32086"
+msgid "Trakt movie playcounts are up to date"
+msgstr ""
+
+msgctxt "#32087"
+msgid "Playcounts updated for %i movie(s) on Trakt"
+msgstr ""
+
+msgctxt "#32088"
+msgid "Kodi movie playcounts are up to date"
+msgstr ""
+
+msgctxt "#32089"
+msgid "Updating %i of %i movie playcount(s) in Kodi"
+msgstr ""
+
+msgctxt "#32090"
+msgid "Playcounts updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32091"
+msgid "Trakt movie collection is up to date, no movies removed"
+msgstr ""
+
+msgctxt "#32092"
+msgid "%i movie(s) were removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32093"
+msgid "Updating %i of %i movie playcount(s) on Trakt"
+msgstr ""
+
+msgctxt "#32094"
+msgid "Loading episode data from Kodi"
+msgstr ""
+
+msgctxt "#32095"
+msgid "Loading shows from Kodi"
+msgstr ""
+
+msgctxt "#32096"
+msgid "Shows loaded from Kodi"
+msgstr ""
+
+msgctxt "#32097"
+msgid "Parsing %i of %i episode data from Kodi"
+msgstr ""
+
+msgctxt "#32098"
+msgid "Loaded episode data from Kodi"
+msgstr ""
+
+msgctxt "#32099"
+msgid "Loading episode data from Trakt"
+msgstr ""
+
+msgctxt "#32100"
+msgid "Retrieving episode collection from Trakt"
+msgstr ""
+
+msgctxt "#32101"
+msgid "Retrieving watched episodes from Trakt"
+msgstr ""
+
+msgctxt "#32102"
+msgid "Parsing episode data %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32103"
+msgid "Retrieved episode data from Trakt"
+msgstr ""
+
+msgctxt "#32104"
+msgid "Trakt episode collection is up to date, no episodes to add"
+msgstr ""
+
+msgctxt "#32105"
+msgid "%i episode(s) were added to your Trakt collection"
+msgstr ""
+
+msgctxt "#32106"
+msgid "Trakt episode playcounts are up to date"
+msgstr ""
+
+msgctxt "#32107"
+msgid "Kodi episode playcounts are up to date"
+msgstr ""
+
+msgctxt "#32108"
+msgid "Updating %i of %i episode playcount(s) in Kodi"
+msgstr ""
+
+msgctxt "#32109"
+msgid "Playcounts updated for %i show(s) in Kodi"
+msgstr ""
+
+msgctxt "#32110"
+msgid "Trakt episode collection is clean, no episodes to remove"
+msgstr ""
+
+msgctxt "#32111"
+msgid "%i episode(s) are being removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32112"
+msgid "%i episode(s) were removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32113"
+msgid "Trakt - Marked as watched"
+msgstr ""
+
+msgctxt "#32114"
+msgid "Trakt - Failed marking as watched"
+msgstr ""
+
+msgctxt "#32115"
+msgid "%d episode(s) of '%s'"
+msgstr ""
+
+msgctxt "#32116"
+msgid "Enable debug mode"
+msgstr ""
+
+msgctxt "#32117"
+msgid "Sync movie playback progress to Kodi"
+msgstr ""
+
+msgctxt "#32118"
+msgid "Sync episode playback progress to Kodi"
+msgstr ""
+
+msgctxt "#32119"
+msgid "Retrieving episode playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32120"
+msgid "Parsing episode playback progress %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32121"
+msgid "Retrieved episode playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32122"
+msgid "Retrieving movie playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32123"
+msgid "Parsing movie playback progress %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32124"
+msgid "Retrieved movie playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32125"
+msgid "Kodi movie playback progress is up to date"
+msgstr ""
+
+msgctxt "#32126"
+msgid "%i movie(s) playback progress will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32127"
+msgid "Updating %i of %i movie(s) playback progress in Kodi"
+msgstr ""
+
+msgctxt "#32128"
+msgid "Playback progress updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32129"
+msgid "Kodi episode playback progress is up to date"
+msgstr ""
+
+msgctxt "#32130"
+msgid "Updating %i of %i episode(s) playback progress in Kodi"
+msgstr ""
+
+msgctxt "#32131"
+msgid "Playback progress updated for %i episode(s) in Kodi"
+msgstr ""
+
+msgctxt "#32132"
+msgid "Unrate this season"
+msgstr ""
+
+msgctxt "#32133"
+msgid "Manage Movie's Lists"
+msgstr ""
+
+msgctxt "#32134"
+msgid "Manage Show's Lists"
+msgstr ""
+
+msgctxt "#32135"
+msgid "Remove from Watchlist"
+msgstr ""
+
+msgctxt "#32136"
+msgid "Add to watchlist"
+msgstr ""
+
+msgctxt "#32137"
+msgid "Rate this movie"
+msgstr ""
+
+msgctxt "#32138"
+msgid "Rate this show"
+msgstr ""
+
+msgctxt "#32139"
+msgid "Rate this episode"
+msgstr ""
+
+msgctxt "#32140"
+msgid "Toggle watched"
+msgstr ""
+
+msgctxt "#32141"
+msgid "Manage all lists"
+msgstr ""
+
+msgctxt "#32142"
+msgid "Update all tags"
+msgstr ""
+
+msgctxt "#32143"
+msgid "Synchronize library"
+msgstr ""
+
+msgctxt "#32144"
+msgid "How do I authorize the trakt addon to access my trakt.tv account?"
+msgstr ""
+
+# empty strings from id 32145 to 32146
+msgctxt "#32147"
+msgid "Trakt.tv PIN Authorization Failed"
+msgstr ""
+
+# empty string with id 32148
+msgctxt "#32149"
+msgid "Rate this Season"
+msgstr ""
+
+msgctxt "#32150"
+msgid "You will be reminded in 24 hours"
+msgstr ""
+
+msgctxt "#32151"
+msgid "Use Addon Settings later if you change your mind"
+msgstr ""
+
+msgctxt "#32152"
+msgid "Trakt Authorization Complete"
+msgstr ""
+
+msgctxt "#32153"
+msgid "Trakt Account Authorization"
+msgstr ""
+
+msgctxt "#32154"
+msgid "Authorize"
+msgstr ""
+
+msgctxt "#32155"
+msgid "Remind Me Later"
+msgstr ""
+
+msgctxt "#32156"
+msgid "No Thanks"
+msgstr ""
+
+msgctxt "#32157"
+msgid "Account Authorization"
+msgstr ""
+
+# empty string with id 32158
+msgctxt "#32159"
+msgid "Visit {0} or scan the QR code."
+msgstr ""
+
+msgctxt "#32162"
+msgid "The trakt addon CAN NOT be used without authorizing it to access your trakt.tv account."
+msgstr ""
+
 msgctxt "#32163"
 msgid "User"
 msgstr "User"
+
+msgctxt "#32164"
+msgid "Fallback to Title/Year matching if necessary"
+msgstr ""
+
+msgctxt "#32165"
+msgid "Trakt - Added to watchlist"
+msgstr ""
+
+msgctxt "#32166"
+msgid "Trakt - Failed adding to watchlist"
+msgstr ""
+
+msgctxt "#32167"
+msgid "Offset scrobble start by X minutes"
+msgstr ""
+
+msgctxt "#32168"
+msgid "Sync ratings"
+msgstr ""
+
+msgctxt "#32169"
+msgid "Kodi movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32170"
+msgid "%i movie(s) ratings will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32171"
+msgid "Updating %i of %i movie ratings in Kodi"
+msgstr ""
+
+msgctxt "#32172"
+msgid "Ratings updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32173"
+msgid "Kodi episode ratings are up to date"
+msgstr ""
+
+msgctxt "#32174"
+msgid "Updating %i of %i episode ratings in Kodi"
+msgstr ""
+
+msgctxt "#32175"
+msgid "Ratings updated for %i episode(s) in Kodi"
+msgstr ""
+
+msgctxt "#32176"
+msgid "Kodi show ratings are up to date"
+msgstr ""
+
+msgctxt "#32177"
+msgid "Updating %i of %i show ratings in Kodi"
+msgstr ""
+
+msgctxt "#32178"
+msgid "Ratings updated for %i show(s) in Kodi"
+msgstr ""
+
+msgctxt "#32179"
+msgid "Trakt movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32180"
+msgid "%i movie ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32181"
+msgid "Trakt show ratings are up to date"
+msgstr ""
+
+msgctxt "#32182"
+msgid "%i show ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32183"
+msgid "Attempt to scrobble MythTV PVR recordings"
+msgstr ""
+
+msgctxt "#32184"
+msgid "Attempt secondary show title search"
+msgstr ""
+
+msgctxt "#32185"
+msgid "Exclude Plugins"
+msgstr ""
+
+msgctxt "#32186"
+msgid "Allow script exclusions"
+msgstr ""

--- a/script.trakt/resources/language/resource.language.bg_BG/strings.po
+++ b/script.trakt/resources/language/resource.language.bg_BG/strings.po
@@ -10,31 +10,183 @@ msgstr ""
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Kodi Translation Team\n"
 "Language-Team: Bulgarian (http://www.transifex.com/projects/p/xbmc-addons/language/bg/)\n"
+"Language: bg\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: bg\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 msgctxt "#32000"
 msgid "General"
 msgstr "Общи"
 
+# empty strings from id 32001 to 32002
+msgctxt "#32003"
+msgid "Startup Delay"
+msgstr ""
+
 msgctxt "#32004"
 msgid "Rating"
 msgstr "Рейтинг"
+
+msgctxt "#32005"
+msgid "Rate Movie after watching"
+msgstr ""
+
+msgctxt "#32006"
+msgid "Rate TV show Episode after watching"
+msgstr ""
+
+msgctxt "#32008"
+msgid "Minimum percent watched to display rating dialog"
+msgstr ""
+
+msgctxt "#32009"
+msgid "Allow re-rating of media"
+msgstr ""
+
+msgctxt "#32010"
+msgid "Default rating"
+msgstr ""
+
+# Scrobbling Settings
+msgctxt "#32011"
+msgid "Scrobbling"
+msgstr ""
+
+msgctxt "#32012"
+msgid "Scrobble movies"
+msgstr ""
+
+msgctxt "#32013"
+msgid "Scrobble TV show episodes"
+msgstr ""
+
+msgctxt "#32014"
+msgid "Show notification on scrobble"
+msgstr ""
+
+msgctxt "#32015"
+msgid "Trakt - Scrobbled successfully"
+msgstr ""
+
+msgctxt "#32016"
+msgid "Exclusions"
+msgstr ""
+
+msgctxt "#32017"
+msgid "Exclude Live TV"
+msgstr ""
+
+msgctxt "#32018"
+msgid "Exclude HTTP sources"
+msgstr ""
+
+msgctxt "#32019"
+msgid "Exclude path"
+msgstr ""
+
+msgctxt "#32020"
+msgid "Folder's path (including subfolders)"
+msgstr ""
+
+# empty strings from id 32021 to 32022
+msgctxt "#32023"
+msgid "Can not connect to Trakt"
+msgstr ""
 
 msgctxt "#32024"
 msgid "Error"
 msgstr "Грешка"
 
+# empty string with id 32025
+msgctxt "#32026"
+msgid "What Did You Think?"
+msgstr ""
+
+msgctxt "#32027"
+msgid "Totally Ninja!"
+msgstr ""
+
+msgctxt "#32028"
+msgid "Weak Sauce :("
+msgstr ""
+
+msgctxt "#32029"
+msgid "Terrible"
+msgstr ""
+
+msgctxt "#32030"
+msgid "Bad"
+msgstr ""
+
+msgctxt "#32031"
+msgid "Poor"
+msgstr ""
+
+msgctxt "#32032"
+msgid "Meh"
+msgstr ""
+
 msgctxt "#32033"
 msgid "Fair"
 msgstr "Ясно с малко облаци"
 
+msgctxt "#32034"
+msgid "Good"
+msgstr ""
+
+msgctxt "#32035"
+msgid "Great"
+msgstr ""
+
+msgctxt "#32036"
+msgid "Superb"
+msgstr ""
+
+msgctxt "#32037"
+msgid "Unrate this movie"
+msgstr ""
+
+msgctxt "#32038"
+msgid "Unrate this show"
+msgstr ""
+
+msgctxt "#32039"
+msgid "Unrate this episode"
+msgstr ""
+
+msgctxt "#32040"
+msgid "Trakt - Rating submitted successfully"
+msgstr ""
+
+msgctxt "#32041"
+msgid "Trakt - Already rated"
+msgstr ""
+
+msgctxt "#32042"
+msgid "Trakt - Unrated successfully"
+msgstr ""
+
+msgctxt "#32043"
+msgid "Trakt - Already has the same rating"
+msgstr ""
+
+msgctxt "#32044"
+msgid "Trakt - Problem submitting rating"
+msgstr ""
+
+msgctxt "#32045"
+msgid "Synchronize"
+msgstr ""
+
 msgctxt "#32046"
 msgid "Movies"
 msgstr "Филми"
+
+msgctxt "#32047"
+msgid "Add new movies to Trakt collection"
+msgstr ""
 
 msgctxt "#32048"
 msgid "Add watched movies to Trakt history"
@@ -44,34 +196,526 @@ msgctxt "#32049"
 msgid "Mark movies from Trakt history as watched in Kodi"
 msgstr "Маркирай филмите от историята в Trakt като изгледани в Kodi"
 
+msgctxt "#32050"
+msgid "TV Episodes"
+msgstr ""
+
+msgctxt "#32051"
+msgid "Add new TV episodes to Trakt collection"
+msgstr ""
+
+msgctxt "#32052"
+msgid "Add watched TV episodes to Trakt history"
+msgstr ""
+
+msgctxt "#32053"
+msgid "Mark TV episodes from Trakt history as watched in Kodi"
+msgstr ""
+
 msgctxt "#32054"
 msgid "Service"
 msgstr "Услуга"
+
+msgctxt "#32055"
+msgid "Sync collection on library update or cleaning"
+msgstr ""
+
+msgctxt "#32056"
+msgid "Show sync notifications"
+msgstr ""
+
+msgctxt "#32057"
+msgid "Remove deleted movies from Trakt collection"
+msgstr ""
+
+msgctxt "#32058"
+msgid "Remove deleted TV episodes from Trakt collection"
+msgstr ""
+
+# empty string with id 32059
+msgctxt "#32060"
+msgid "Hide notifications during playback"
+msgstr ""
+
+msgctxt "#32061"
+msgid "Sync started"
+msgstr ""
 
 msgctxt "#32062"
 msgid "Sync complete"
 msgstr "Синхрониирането завърши"
 
+msgctxt "#32063"
+msgid "%i movie(s) will be added to Trakt collection"
+msgstr ""
+
+msgctxt "#32064"
+msgid "%i movie playcount(s) will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32065"
+msgid "%i movie(s) playcount will be updated in Kodi"
+msgstr ""
+
 msgctxt "#32066"
 msgid "Movie Sync Complete"
 msgstr "Синхронизирането на филми завърши"
+
+msgctxt "#32067"
+msgid "Going to add %i show(s) to Trakt collection"
+msgstr ""
+
+msgctxt "#32068"
+msgid "Checking for episodes missing from Trakt collection"
+msgstr ""
+
+msgctxt "#32069"
+msgid "%i of %i show(s) have episodes added to Trakt collection"
+msgstr ""
+
+msgctxt "#32070"
+msgid "Going to update %i show(s) missing watched status"
+msgstr ""
+
+msgctxt "#32071"
+msgid "Checking watched episodes on Trakt"
+msgstr ""
+
+msgctxt "#32072"
+msgid "%i show(s) had missing watched status"
+msgstr ""
+
+msgctxt "#32073"
+msgid "%i episodes are being updated"
+msgstr ""
+
+msgctxt "#32074"
+msgid "Checking watched episodes on Kodi"
+msgstr ""
 
 msgctxt "#32075"
 msgid "Episode Sync Complete"
 msgstr "Синхронизирането на епизоди завърши"
 
+msgctxt "#32076"
+msgid "%i movie(s) will be removed from Trakt collection"
+msgstr ""
+
+msgctxt "#32077"
+msgid "Cleaning Trakt TV show collection"
+msgstr ""
+
+msgctxt "#32078"
+msgid "episodes are being removed"
+msgstr ""
+
+msgctxt "#32079"
+msgid "Loading movies from Kodi"
+msgstr ""
+
+msgctxt "#32080"
+msgid "Movies loaded from Kodi"
+msgstr ""
+
+msgctxt "#32081"
+msgid "Retrieving movie collection from Trakt"
+msgstr ""
+
 msgctxt "#32082"
 msgid "Retrieving watched movies from Trakt"
 msgstr "Извличане на списъка с изгледани филми от Trakt"
+
+msgctxt "#32083"
+msgid "Retrieved movie data from Trakt"
+msgstr ""
+
+msgctxt "#32084"
+msgid "Trakt movie collection is up to date, no movies to add"
+msgstr ""
+
+msgctxt "#32085"
+msgid "%i movie(s) were added to your Trakt collection"
+msgstr ""
+
+msgctxt "#32086"
+msgid "Trakt movie playcounts are up to date"
+msgstr ""
+
+msgctxt "#32087"
+msgid "Playcounts updated for %i movie(s) on Trakt"
+msgstr ""
+
+msgctxt "#32088"
+msgid "Kodi movie playcounts are up to date"
+msgstr ""
+
+msgctxt "#32089"
+msgid "Updating %i of %i movie playcount(s) in Kodi"
+msgstr ""
+
+msgctxt "#32090"
+msgid "Playcounts updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32091"
+msgid "Trakt movie collection is up to date, no movies removed"
+msgstr ""
+
+msgctxt "#32092"
+msgid "%i movie(s) were removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32093"
+msgid "Updating %i of %i movie playcount(s) on Trakt"
+msgstr ""
+
+msgctxt "#32094"
+msgid "Loading episode data from Kodi"
+msgstr ""
+
+msgctxt "#32095"
+msgid "Loading shows from Kodi"
+msgstr ""
+
+msgctxt "#32096"
+msgid "Shows loaded from Kodi"
+msgstr ""
+
+msgctxt "#32097"
+msgid "Parsing %i of %i episode data from Kodi"
+msgstr ""
+
+msgctxt "#32098"
+msgid "Loaded episode data from Kodi"
+msgstr ""
+
+msgctxt "#32099"
+msgid "Loading episode data from Trakt"
+msgstr ""
+
+msgctxt "#32100"
+msgid "Retrieving episode collection from Trakt"
+msgstr ""
 
 msgctxt "#32101"
 msgid "Retrieving watched episodes from Trakt"
 msgstr "Извличане на списъка с изгледани епизоди от Trakt"
 
+msgctxt "#32102"
+msgid "Parsing episode data %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32103"
+msgid "Retrieved episode data from Trakt"
+msgstr ""
+
+msgctxt "#32104"
+msgid "Trakt episode collection is up to date, no episodes to add"
+msgstr ""
+
+msgctxt "#32105"
+msgid "%i episode(s) were added to your Trakt collection"
+msgstr ""
+
+msgctxt "#32106"
+msgid "Trakt episode playcounts are up to date"
+msgstr ""
+
+msgctxt "#32107"
+msgid "Kodi episode playcounts are up to date"
+msgstr ""
+
+msgctxt "#32108"
+msgid "Updating %i of %i episode playcount(s) in Kodi"
+msgstr ""
+
+msgctxt "#32109"
+msgid "Playcounts updated for %i show(s) in Kodi"
+msgstr ""
+
+msgctxt "#32110"
+msgid "Trakt episode collection is clean, no episodes to remove"
+msgstr ""
+
+msgctxt "#32111"
+msgid "%i episode(s) are being removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32112"
+msgid "%i episode(s) were removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32113"
+msgid "Trakt - Marked as watched"
+msgstr ""
+
+msgctxt "#32114"
+msgid "Trakt - Failed marking as watched"
+msgstr ""
+
+msgctxt "#32115"
+msgid "%d episode(s) of '%s'"
+msgstr ""
+
 msgctxt "#32116"
 msgid "Enable debug mode"
 msgstr "Включи дебъг режима"
 
+msgctxt "#32117"
+msgid "Sync movie playback progress to Kodi"
+msgstr ""
+
+msgctxt "#32118"
+msgid "Sync episode playback progress to Kodi"
+msgstr ""
+
+msgctxt "#32119"
+msgid "Retrieving episode playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32120"
+msgid "Parsing episode playback progress %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32121"
+msgid "Retrieved episode playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32122"
+msgid "Retrieving movie playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32123"
+msgid "Parsing movie playback progress %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32124"
+msgid "Retrieved movie playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32125"
+msgid "Kodi movie playback progress is up to date"
+msgstr ""
+
+msgctxt "#32126"
+msgid "%i movie(s) playback progress will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32127"
+msgid "Updating %i of %i movie(s) playback progress in Kodi"
+msgstr ""
+
+msgctxt "#32128"
+msgid "Playback progress updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32129"
+msgid "Kodi episode playback progress is up to date"
+msgstr ""
+
+msgctxt "#32130"
+msgid "Updating %i of %i episode(s) playback progress in Kodi"
+msgstr ""
+
+msgctxt "#32131"
+msgid "Playback progress updated for %i episode(s) in Kodi"
+msgstr ""
+
+msgctxt "#32132"
+msgid "Unrate this season"
+msgstr ""
+
+msgctxt "#32133"
+msgid "Manage Movie's Lists"
+msgstr ""
+
+msgctxt "#32134"
+msgid "Manage Show's Lists"
+msgstr ""
+
+msgctxt "#32135"
+msgid "Remove from Watchlist"
+msgstr ""
+
+msgctxt "#32136"
+msgid "Add to watchlist"
+msgstr ""
+
+msgctxt "#32137"
+msgid "Rate this movie"
+msgstr ""
+
+msgctxt "#32138"
+msgid "Rate this show"
+msgstr ""
+
+msgctxt "#32139"
+msgid "Rate this episode"
+msgstr ""
+
+msgctxt "#32140"
+msgid "Toggle watched"
+msgstr ""
+
+msgctxt "#32141"
+msgid "Manage all lists"
+msgstr ""
+
+msgctxt "#32142"
+msgid "Update all tags"
+msgstr ""
+
+msgctxt "#32143"
+msgid "Synchronize library"
+msgstr ""
+
+msgctxt "#32144"
+msgid "How do I authorize the trakt addon to access my trakt.tv account?"
+msgstr ""
+
+# empty strings from id 32145 to 32146
+msgctxt "#32147"
+msgid "Trakt.tv PIN Authorization Failed"
+msgstr ""
+
+# empty string with id 32148
+msgctxt "#32149"
+msgid "Rate this Season"
+msgstr ""
+
+msgctxt "#32150"
+msgid "You will be reminded in 24 hours"
+msgstr ""
+
+msgctxt "#32151"
+msgid "Use Addon Settings later if you change your mind"
+msgstr ""
+
+msgctxt "#32152"
+msgid "Trakt Authorization Complete"
+msgstr ""
+
+msgctxt "#32153"
+msgid "Trakt Account Authorization"
+msgstr ""
+
+msgctxt "#32154"
+msgid "Authorize"
+msgstr ""
+
+msgctxt "#32155"
+msgid "Remind Me Later"
+msgstr ""
+
+msgctxt "#32156"
+msgid "No Thanks"
+msgstr ""
+
+msgctxt "#32157"
+msgid "Account Authorization"
+msgstr ""
+
+# empty string with id 32158
+msgctxt "#32159"
+msgid "Visit {0} or scan the QR code."
+msgstr ""
+
+msgctxt "#32162"
+msgid "The trakt addon CAN NOT be used without authorizing it to access your trakt.tv account."
+msgstr ""
+
 msgctxt "#32163"
 msgid "User"
 msgstr "Потребител"
+
+msgctxt "#32164"
+msgid "Fallback to Title/Year matching if necessary"
+msgstr ""
+
+msgctxt "#32165"
+msgid "Trakt - Added to watchlist"
+msgstr ""
+
+msgctxt "#32166"
+msgid "Trakt - Failed adding to watchlist"
+msgstr ""
+
+msgctxt "#32167"
+msgid "Offset scrobble start by X minutes"
+msgstr ""
+
+msgctxt "#32168"
+msgid "Sync ratings"
+msgstr ""
+
+msgctxt "#32169"
+msgid "Kodi movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32170"
+msgid "%i movie(s) ratings will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32171"
+msgid "Updating %i of %i movie ratings in Kodi"
+msgstr ""
+
+msgctxt "#32172"
+msgid "Ratings updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32173"
+msgid "Kodi episode ratings are up to date"
+msgstr ""
+
+msgctxt "#32174"
+msgid "Updating %i of %i episode ratings in Kodi"
+msgstr ""
+
+msgctxt "#32175"
+msgid "Ratings updated for %i episode(s) in Kodi"
+msgstr ""
+
+msgctxt "#32176"
+msgid "Kodi show ratings are up to date"
+msgstr ""
+
+msgctxt "#32177"
+msgid "Updating %i of %i show ratings in Kodi"
+msgstr ""
+
+msgctxt "#32178"
+msgid "Ratings updated for %i show(s) in Kodi"
+msgstr ""
+
+msgctxt "#32179"
+msgid "Trakt movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32180"
+msgid "%i movie ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32181"
+msgid "Trakt show ratings are up to date"
+msgstr ""
+
+msgctxt "#32182"
+msgid "%i show ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32183"
+msgid "Attempt to scrobble MythTV PVR recordings"
+msgstr ""
+
+msgctxt "#32184"
+msgid "Attempt secondary show title search"
+msgstr ""
+
+msgctxt "#32185"
+msgid "Exclude Plugins"
+msgstr ""
+
+msgctxt "#32186"
+msgid "Allow script exclusions"
+msgstr ""

--- a/script.trakt/resources/language/resource.language.bs_BA/strings.po
+++ b/script.trakt/resources/language/resource.language.bs_BA/strings.po
@@ -10,28 +10,712 @@ msgstr ""
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Kodi Translation Team\n"
 "Language-Team: Bosnian (http://www.transifex.com/projects/p/xbmc-addons/language/bs/)\n"
+"Language: bs\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: bs\n"
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 
 msgctxt "#32000"
 msgid "General"
 msgstr "Opšte"
 
+# empty strings from id 32001 to 32002
+msgctxt "#32003"
+msgid "Startup Delay"
+msgstr ""
+
 msgctxt "#32004"
 msgid "Rating"
 msgstr "Ocjena"
+
+msgctxt "#32005"
+msgid "Rate Movie after watching"
+msgstr ""
+
+msgctxt "#32006"
+msgid "Rate TV show Episode after watching"
+msgstr ""
+
+msgctxt "#32008"
+msgid "Minimum percent watched to display rating dialog"
+msgstr ""
+
+msgctxt "#32009"
+msgid "Allow re-rating of media"
+msgstr ""
+
+msgctxt "#32010"
+msgid "Default rating"
+msgstr ""
+
+# Scrobbling Settings
+msgctxt "#32011"
+msgid "Scrobbling"
+msgstr ""
+
+msgctxt "#32012"
+msgid "Scrobble movies"
+msgstr ""
+
+msgctxt "#32013"
+msgid "Scrobble TV show episodes"
+msgstr ""
+
+msgctxt "#32014"
+msgid "Show notification on scrobble"
+msgstr ""
+
+msgctxt "#32015"
+msgid "Trakt - Scrobbled successfully"
+msgstr ""
+
+msgctxt "#32016"
+msgid "Exclusions"
+msgstr ""
+
+msgctxt "#32017"
+msgid "Exclude Live TV"
+msgstr ""
+
+msgctxt "#32018"
+msgid "Exclude HTTP sources"
+msgstr ""
+
+msgctxt "#32019"
+msgid "Exclude path"
+msgstr ""
+
+msgctxt "#32020"
+msgid "Folder's path (including subfolders)"
+msgstr ""
+
+# empty strings from id 32021 to 32022
+msgctxt "#32023"
+msgid "Can not connect to Trakt"
+msgstr ""
 
 msgctxt "#32024"
 msgid "Error"
 msgstr "Greška"
 
+# empty string with id 32025
+msgctxt "#32026"
+msgid "What Did You Think?"
+msgstr ""
+
+msgctxt "#32027"
+msgid "Totally Ninja!"
+msgstr ""
+
+msgctxt "#32028"
+msgid "Weak Sauce :("
+msgstr ""
+
+msgctxt "#32029"
+msgid "Terrible"
+msgstr ""
+
+msgctxt "#32030"
+msgid "Bad"
+msgstr ""
+
+msgctxt "#32031"
+msgid "Poor"
+msgstr ""
+
+msgctxt "#32032"
+msgid "Meh"
+msgstr ""
+
 msgctxt "#32033"
 msgid "Fair"
 msgstr "umjereno"
 
+msgctxt "#32034"
+msgid "Good"
+msgstr ""
+
+msgctxt "#32035"
+msgid "Great"
+msgstr ""
+
+msgctxt "#32036"
+msgid "Superb"
+msgstr ""
+
+msgctxt "#32037"
+msgid "Unrate this movie"
+msgstr ""
+
+msgctxt "#32038"
+msgid "Unrate this show"
+msgstr ""
+
+msgctxt "#32039"
+msgid "Unrate this episode"
+msgstr ""
+
+msgctxt "#32040"
+msgid "Trakt - Rating submitted successfully"
+msgstr ""
+
+msgctxt "#32041"
+msgid "Trakt - Already rated"
+msgstr ""
+
+msgctxt "#32042"
+msgid "Trakt - Unrated successfully"
+msgstr ""
+
+msgctxt "#32043"
+msgid "Trakt - Already has the same rating"
+msgstr ""
+
+msgctxt "#32044"
+msgid "Trakt - Problem submitting rating"
+msgstr ""
+
+msgctxt "#32045"
+msgid "Synchronize"
+msgstr ""
+
 msgctxt "#32046"
 msgid "Movies"
 msgstr "Filmovi"
+
+msgctxt "#32047"
+msgid "Add new movies to Trakt collection"
+msgstr ""
+
+msgctxt "#32048"
+msgid "Add watched movies to Trakt history"
+msgstr ""
+
+msgctxt "#32049"
+msgid "Mark movies from Trakt history as watched in Kodi"
+msgstr ""
+
+msgctxt "#32050"
+msgid "TV Episodes"
+msgstr ""
+
+msgctxt "#32051"
+msgid "Add new TV episodes to Trakt collection"
+msgstr ""
+
+msgctxt "#32052"
+msgid "Add watched TV episodes to Trakt history"
+msgstr ""
+
+msgctxt "#32053"
+msgid "Mark TV episodes from Trakt history as watched in Kodi"
+msgstr ""
+
+msgctxt "#32054"
+msgid "Service"
+msgstr ""
+
+msgctxt "#32055"
+msgid "Sync collection on library update or cleaning"
+msgstr ""
+
+msgctxt "#32056"
+msgid "Show sync notifications"
+msgstr ""
+
+msgctxt "#32057"
+msgid "Remove deleted movies from Trakt collection"
+msgstr ""
+
+msgctxt "#32058"
+msgid "Remove deleted TV episodes from Trakt collection"
+msgstr ""
+
+# empty string with id 32059
+msgctxt "#32060"
+msgid "Hide notifications during playback"
+msgstr ""
+
+msgctxt "#32061"
+msgid "Sync started"
+msgstr ""
+
+msgctxt "#32062"
+msgid "Sync complete"
+msgstr ""
+
+msgctxt "#32063"
+msgid "%i movie(s) will be added to Trakt collection"
+msgstr ""
+
+msgctxt "#32064"
+msgid "%i movie playcount(s) will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32065"
+msgid "%i movie(s) playcount will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32066"
+msgid "Movie Sync Complete"
+msgstr ""
+
+msgctxt "#32067"
+msgid "Going to add %i show(s) to Trakt collection"
+msgstr ""
+
+msgctxt "#32068"
+msgid "Checking for episodes missing from Trakt collection"
+msgstr ""
+
+msgctxt "#32069"
+msgid "%i of %i show(s) have episodes added to Trakt collection"
+msgstr ""
+
+msgctxt "#32070"
+msgid "Going to update %i show(s) missing watched status"
+msgstr ""
+
+msgctxt "#32071"
+msgid "Checking watched episodes on Trakt"
+msgstr ""
+
+msgctxt "#32072"
+msgid "%i show(s) had missing watched status"
+msgstr ""
+
+msgctxt "#32073"
+msgid "%i episodes are being updated"
+msgstr ""
+
+msgctxt "#32074"
+msgid "Checking watched episodes on Kodi"
+msgstr ""
+
+msgctxt "#32075"
+msgid "Episode Sync Complete"
+msgstr ""
+
+msgctxt "#32076"
+msgid "%i movie(s) will be removed from Trakt collection"
+msgstr ""
+
+msgctxt "#32077"
+msgid "Cleaning Trakt TV show collection"
+msgstr ""
+
+msgctxt "#32078"
+msgid "episodes are being removed"
+msgstr ""
+
+msgctxt "#32079"
+msgid "Loading movies from Kodi"
+msgstr ""
+
+msgctxt "#32080"
+msgid "Movies loaded from Kodi"
+msgstr ""
+
+msgctxt "#32081"
+msgid "Retrieving movie collection from Trakt"
+msgstr ""
+
+msgctxt "#32082"
+msgid "Retrieving watched movies from Trakt"
+msgstr ""
+
+msgctxt "#32083"
+msgid "Retrieved movie data from Trakt"
+msgstr ""
+
+msgctxt "#32084"
+msgid "Trakt movie collection is up to date, no movies to add"
+msgstr ""
+
+msgctxt "#32085"
+msgid "%i movie(s) were added to your Trakt collection"
+msgstr ""
+
+msgctxt "#32086"
+msgid "Trakt movie playcounts are up to date"
+msgstr ""
+
+msgctxt "#32087"
+msgid "Playcounts updated for %i movie(s) on Trakt"
+msgstr ""
+
+msgctxt "#32088"
+msgid "Kodi movie playcounts are up to date"
+msgstr ""
+
+msgctxt "#32089"
+msgid "Updating %i of %i movie playcount(s) in Kodi"
+msgstr ""
+
+msgctxt "#32090"
+msgid "Playcounts updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32091"
+msgid "Trakt movie collection is up to date, no movies removed"
+msgstr ""
+
+msgctxt "#32092"
+msgid "%i movie(s) were removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32093"
+msgid "Updating %i of %i movie playcount(s) on Trakt"
+msgstr ""
+
+msgctxt "#32094"
+msgid "Loading episode data from Kodi"
+msgstr ""
+
+msgctxt "#32095"
+msgid "Loading shows from Kodi"
+msgstr ""
+
+msgctxt "#32096"
+msgid "Shows loaded from Kodi"
+msgstr ""
+
+msgctxt "#32097"
+msgid "Parsing %i of %i episode data from Kodi"
+msgstr ""
+
+msgctxt "#32098"
+msgid "Loaded episode data from Kodi"
+msgstr ""
+
+msgctxt "#32099"
+msgid "Loading episode data from Trakt"
+msgstr ""
+
+msgctxt "#32100"
+msgid "Retrieving episode collection from Trakt"
+msgstr ""
+
+msgctxt "#32101"
+msgid "Retrieving watched episodes from Trakt"
+msgstr ""
+
+msgctxt "#32102"
+msgid "Parsing episode data %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32103"
+msgid "Retrieved episode data from Trakt"
+msgstr ""
+
+msgctxt "#32104"
+msgid "Trakt episode collection is up to date, no episodes to add"
+msgstr ""
+
+msgctxt "#32105"
+msgid "%i episode(s) were added to your Trakt collection"
+msgstr ""
+
+msgctxt "#32106"
+msgid "Trakt episode playcounts are up to date"
+msgstr ""
+
+msgctxt "#32107"
+msgid "Kodi episode playcounts are up to date"
+msgstr ""
+
+msgctxt "#32108"
+msgid "Updating %i of %i episode playcount(s) in Kodi"
+msgstr ""
+
+msgctxt "#32109"
+msgid "Playcounts updated for %i show(s) in Kodi"
+msgstr ""
+
+msgctxt "#32110"
+msgid "Trakt episode collection is clean, no episodes to remove"
+msgstr ""
+
+msgctxt "#32111"
+msgid "%i episode(s) are being removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32112"
+msgid "%i episode(s) were removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32113"
+msgid "Trakt - Marked as watched"
+msgstr ""
+
+msgctxt "#32114"
+msgid "Trakt - Failed marking as watched"
+msgstr ""
+
+msgctxt "#32115"
+msgid "%d episode(s) of '%s'"
+msgstr ""
+
+msgctxt "#32116"
+msgid "Enable debug mode"
+msgstr ""
+
+msgctxt "#32117"
+msgid "Sync movie playback progress to Kodi"
+msgstr ""
+
+msgctxt "#32118"
+msgid "Sync episode playback progress to Kodi"
+msgstr ""
+
+msgctxt "#32119"
+msgid "Retrieving episode playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32120"
+msgid "Parsing episode playback progress %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32121"
+msgid "Retrieved episode playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32122"
+msgid "Retrieving movie playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32123"
+msgid "Parsing movie playback progress %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32124"
+msgid "Retrieved movie playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32125"
+msgid "Kodi movie playback progress is up to date"
+msgstr ""
+
+msgctxt "#32126"
+msgid "%i movie(s) playback progress will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32127"
+msgid "Updating %i of %i movie(s) playback progress in Kodi"
+msgstr ""
+
+msgctxt "#32128"
+msgid "Playback progress updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32129"
+msgid "Kodi episode playback progress is up to date"
+msgstr ""
+
+msgctxt "#32130"
+msgid "Updating %i of %i episode(s) playback progress in Kodi"
+msgstr ""
+
+msgctxt "#32131"
+msgid "Playback progress updated for %i episode(s) in Kodi"
+msgstr ""
+
+msgctxt "#32132"
+msgid "Unrate this season"
+msgstr ""
+
+msgctxt "#32133"
+msgid "Manage Movie's Lists"
+msgstr ""
+
+msgctxt "#32134"
+msgid "Manage Show's Lists"
+msgstr ""
+
+msgctxt "#32135"
+msgid "Remove from Watchlist"
+msgstr ""
+
+msgctxt "#32136"
+msgid "Add to watchlist"
+msgstr ""
+
+msgctxt "#32137"
+msgid "Rate this movie"
+msgstr ""
+
+msgctxt "#32138"
+msgid "Rate this show"
+msgstr ""
+
+msgctxt "#32139"
+msgid "Rate this episode"
+msgstr ""
+
+msgctxt "#32140"
+msgid "Toggle watched"
+msgstr ""
+
+msgctxt "#32141"
+msgid "Manage all lists"
+msgstr ""
+
+msgctxt "#32142"
+msgid "Update all tags"
+msgstr ""
+
+msgctxt "#32143"
+msgid "Synchronize library"
+msgstr ""
+
+msgctxt "#32144"
+msgid "How do I authorize the trakt addon to access my trakt.tv account?"
+msgstr ""
+
+# empty strings from id 32145 to 32146
+msgctxt "#32147"
+msgid "Trakt.tv PIN Authorization Failed"
+msgstr ""
+
+# empty string with id 32148
+msgctxt "#32149"
+msgid "Rate this Season"
+msgstr ""
+
+msgctxt "#32150"
+msgid "You will be reminded in 24 hours"
+msgstr ""
+
+msgctxt "#32151"
+msgid "Use Addon Settings later if you change your mind"
+msgstr ""
+
+msgctxt "#32152"
+msgid "Trakt Authorization Complete"
+msgstr ""
+
+msgctxt "#32153"
+msgid "Trakt Account Authorization"
+msgstr ""
+
+msgctxt "#32154"
+msgid "Authorize"
+msgstr ""
+
+msgctxt "#32155"
+msgid "Remind Me Later"
+msgstr ""
+
+msgctxt "#32156"
+msgid "No Thanks"
+msgstr ""
+
+msgctxt "#32157"
+msgid "Account Authorization"
+msgstr ""
+
+# empty string with id 32158
+msgctxt "#32159"
+msgid "Visit {0} or scan the QR code."
+msgstr ""
+
+msgctxt "#32162"
+msgid "The trakt addon CAN NOT be used without authorizing it to access your trakt.tv account."
+msgstr ""
+
+msgctxt "#32163"
+msgid "User"
+msgstr ""
+
+msgctxt "#32164"
+msgid "Fallback to Title/Year matching if necessary"
+msgstr ""
+
+msgctxt "#32165"
+msgid "Trakt - Added to watchlist"
+msgstr ""
+
+msgctxt "#32166"
+msgid "Trakt - Failed adding to watchlist"
+msgstr ""
+
+msgctxt "#32167"
+msgid "Offset scrobble start by X minutes"
+msgstr ""
+
+msgctxt "#32168"
+msgid "Sync ratings"
+msgstr ""
+
+msgctxt "#32169"
+msgid "Kodi movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32170"
+msgid "%i movie(s) ratings will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32171"
+msgid "Updating %i of %i movie ratings in Kodi"
+msgstr ""
+
+msgctxt "#32172"
+msgid "Ratings updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32173"
+msgid "Kodi episode ratings are up to date"
+msgstr ""
+
+msgctxt "#32174"
+msgid "Updating %i of %i episode ratings in Kodi"
+msgstr ""
+
+msgctxt "#32175"
+msgid "Ratings updated for %i episode(s) in Kodi"
+msgstr ""
+
+msgctxt "#32176"
+msgid "Kodi show ratings are up to date"
+msgstr ""
+
+msgctxt "#32177"
+msgid "Updating %i of %i show ratings in Kodi"
+msgstr ""
+
+msgctxt "#32178"
+msgid "Ratings updated for %i show(s) in Kodi"
+msgstr ""
+
+msgctxt "#32179"
+msgid "Trakt movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32180"
+msgid "%i movie ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32181"
+msgid "Trakt show ratings are up to date"
+msgstr ""
+
+msgctxt "#32182"
+msgid "%i show ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32183"
+msgid "Attempt to scrobble MythTV PVR recordings"
+msgstr ""
+
+msgctxt "#32184"
+msgid "Attempt secondary show title search"
+msgstr ""
+
+msgctxt "#32185"
+msgid "Exclude Plugins"
+msgstr ""
+
+msgctxt "#32186"
+msgid "Allow script exclusions"
+msgstr ""

--- a/script.trakt/resources/language/resource.language.ca_ES/strings.po
+++ b/script.trakt/resources/language/resource.language.ca_ES/strings.po
@@ -10,31 +10,111 @@ msgstr ""
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Kodi Translation Team\n"
 "Language-Team: Catalan (http://www.transifex.com/projects/p/xbmc-addons/language/ca/)\n"
+"Language: ca\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: ca\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 msgctxt "#32000"
 msgid "General"
 msgstr "General"
 
+# empty strings from id 32001 to 32002
+msgctxt "#32003"
+msgid "Startup Delay"
+msgstr ""
+
 msgctxt "#32004"
 msgid "Rating"
 msgstr "Valoració"
+
+msgctxt "#32005"
+msgid "Rate Movie after watching"
+msgstr ""
+
+msgctxt "#32006"
+msgid "Rate TV show Episode after watching"
+msgstr ""
+
+msgctxt "#32008"
+msgid "Minimum percent watched to display rating dialog"
+msgstr ""
+
+msgctxt "#32009"
+msgid "Allow re-rating of media"
+msgstr ""
 
 msgctxt "#32010"
 msgid "Default rating"
 msgstr "Valoració per defecte"
 
+# Scrobbling Settings
+msgctxt "#32011"
+msgid "Scrobbling"
+msgstr ""
+
+msgctxt "#32012"
+msgid "Scrobble movies"
+msgstr ""
+
+msgctxt "#32013"
+msgid "Scrobble TV show episodes"
+msgstr ""
+
+msgctxt "#32014"
+msgid "Show notification on scrobble"
+msgstr ""
+
+msgctxt "#32015"
+msgid "Trakt - Scrobbled successfully"
+msgstr ""
+
 msgctxt "#32016"
 msgid "Exclusions"
 msgstr "Exclusions"
 
+msgctxt "#32017"
+msgid "Exclude Live TV"
+msgstr ""
+
+msgctxt "#32018"
+msgid "Exclude HTTP sources"
+msgstr ""
+
+msgctxt "#32019"
+msgid "Exclude path"
+msgstr ""
+
+msgctxt "#32020"
+msgid "Folder's path (including subfolders)"
+msgstr ""
+
+# empty strings from id 32021 to 32022
+msgctxt "#32023"
+msgid "Can not connect to Trakt"
+msgstr ""
+
 msgctxt "#32024"
 msgid "Error"
 msgstr "S'ha produït un error"
+
+# empty string with id 32025
+msgctxt "#32026"
+msgid "What Did You Think?"
+msgstr ""
+
+msgctxt "#32027"
+msgid "Totally Ninja!"
+msgstr ""
+
+msgctxt "#32028"
+msgid "Weak Sauce :("
+msgstr ""
+
+msgctxt "#32029"
+msgid "Terrible"
+msgstr ""
 
 msgctxt "#32030"
 msgid "Bad"
@@ -44,9 +124,57 @@ msgctxt "#32031"
 msgid "Poor"
 msgstr "Pobre"
 
+msgctxt "#32032"
+msgid "Meh"
+msgstr ""
+
 msgctxt "#32033"
 msgid "Fair"
 msgstr "Just"
+
+msgctxt "#32034"
+msgid "Good"
+msgstr ""
+
+msgctxt "#32035"
+msgid "Great"
+msgstr ""
+
+msgctxt "#32036"
+msgid "Superb"
+msgstr ""
+
+msgctxt "#32037"
+msgid "Unrate this movie"
+msgstr ""
+
+msgctxt "#32038"
+msgid "Unrate this show"
+msgstr ""
+
+msgctxt "#32039"
+msgid "Unrate this episode"
+msgstr ""
+
+msgctxt "#32040"
+msgid "Trakt - Rating submitted successfully"
+msgstr ""
+
+msgctxt "#32041"
+msgid "Trakt - Already rated"
+msgstr ""
+
+msgctxt "#32042"
+msgid "Trakt - Unrated successfully"
+msgstr ""
+
+msgctxt "#32043"
+msgid "Trakt - Already has the same rating"
+msgstr ""
+
+msgctxt "#32044"
+msgid "Trakt - Problem submitting rating"
+msgstr ""
 
 msgctxt "#32045"
 msgid "Synchronize"
@@ -56,22 +184,536 @@ msgctxt "#32046"
 msgid "Movies"
 msgstr "Pel·lícules"
 
+msgctxt "#32047"
+msgid "Add new movies to Trakt collection"
+msgstr ""
+
+msgctxt "#32048"
+msgid "Add watched movies to Trakt history"
+msgstr ""
+
+msgctxt "#32049"
+msgid "Mark movies from Trakt history as watched in Kodi"
+msgstr ""
+
+msgctxt "#32050"
+msgid "TV Episodes"
+msgstr ""
+
+msgctxt "#32051"
+msgid "Add new TV episodes to Trakt collection"
+msgstr ""
+
+msgctxt "#32052"
+msgid "Add watched TV episodes to Trakt history"
+msgstr ""
+
+msgctxt "#32053"
+msgid "Mark TV episodes from Trakt history as watched in Kodi"
+msgstr ""
+
 msgctxt "#32054"
 msgid "Service"
 msgstr "Servei"
+
+msgctxt "#32055"
+msgid "Sync collection on library update or cleaning"
+msgstr ""
+
+msgctxt "#32056"
+msgid "Show sync notifications"
+msgstr ""
+
+msgctxt "#32057"
+msgid "Remove deleted movies from Trakt collection"
+msgstr ""
+
+msgctxt "#32058"
+msgid "Remove deleted TV episodes from Trakt collection"
+msgstr ""
 
 msgctxt "#32060"
 msgid "Hide notifications during playback"
 msgstr "Amaga les notificacions durant la reproducció"
 
+msgctxt "#32061"
+msgid "Sync started"
+msgstr ""
+
+msgctxt "#32062"
+msgid "Sync complete"
+msgstr ""
+
+msgctxt "#32063"
+msgid "%i movie(s) will be added to Trakt collection"
+msgstr ""
+
+msgctxt "#32064"
+msgid "%i movie playcount(s) will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32065"
+msgid "%i movie(s) playcount will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32066"
+msgid "Movie Sync Complete"
+msgstr ""
+
+msgctxt "#32067"
+msgid "Going to add %i show(s) to Trakt collection"
+msgstr ""
+
+msgctxt "#32068"
+msgid "Checking for episodes missing from Trakt collection"
+msgstr ""
+
+msgctxt "#32069"
+msgid "%i of %i show(s) have episodes added to Trakt collection"
+msgstr ""
+
+msgctxt "#32070"
+msgid "Going to update %i show(s) missing watched status"
+msgstr ""
+
+msgctxt "#32071"
+msgid "Checking watched episodes on Trakt"
+msgstr ""
+
+msgctxt "#32072"
+msgid "%i show(s) had missing watched status"
+msgstr ""
+
+msgctxt "#32073"
+msgid "%i episodes are being updated"
+msgstr ""
+
+msgctxt "#32074"
+msgid "Checking watched episodes on Kodi"
+msgstr ""
+
+msgctxt "#32075"
+msgid "Episode Sync Complete"
+msgstr ""
+
+msgctxt "#32076"
+msgid "%i movie(s) will be removed from Trakt collection"
+msgstr ""
+
+msgctxt "#32077"
+msgid "Cleaning Trakt TV show collection"
+msgstr ""
+
+msgctxt "#32078"
+msgid "episodes are being removed"
+msgstr ""
+
+msgctxt "#32079"
+msgid "Loading movies from Kodi"
+msgstr ""
+
+msgctxt "#32080"
+msgid "Movies loaded from Kodi"
+msgstr ""
+
+msgctxt "#32081"
+msgid "Retrieving movie collection from Trakt"
+msgstr ""
+
+msgctxt "#32082"
+msgid "Retrieving watched movies from Trakt"
+msgstr ""
+
+msgctxt "#32083"
+msgid "Retrieved movie data from Trakt"
+msgstr ""
+
+msgctxt "#32084"
+msgid "Trakt movie collection is up to date, no movies to add"
+msgstr ""
+
+msgctxt "#32085"
+msgid "%i movie(s) were added to your Trakt collection"
+msgstr ""
+
+msgctxt "#32086"
+msgid "Trakt movie playcounts are up to date"
+msgstr ""
+
+msgctxt "#32087"
+msgid "Playcounts updated for %i movie(s) on Trakt"
+msgstr ""
+
+msgctxt "#32088"
+msgid "Kodi movie playcounts are up to date"
+msgstr ""
+
+msgctxt "#32089"
+msgid "Updating %i of %i movie playcount(s) in Kodi"
+msgstr ""
+
+msgctxt "#32090"
+msgid "Playcounts updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32091"
+msgid "Trakt movie collection is up to date, no movies removed"
+msgstr ""
+
+msgctxt "#32092"
+msgid "%i movie(s) were removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32093"
+msgid "Updating %i of %i movie playcount(s) on Trakt"
+msgstr ""
+
+msgctxt "#32094"
+msgid "Loading episode data from Kodi"
+msgstr ""
+
+msgctxt "#32095"
+msgid "Loading shows from Kodi"
+msgstr ""
+
+msgctxt "#32096"
+msgid "Shows loaded from Kodi"
+msgstr ""
+
+msgctxt "#32097"
+msgid "Parsing %i of %i episode data from Kodi"
+msgstr ""
+
+msgctxt "#32098"
+msgid "Loaded episode data from Kodi"
+msgstr ""
+
+msgctxt "#32099"
+msgid "Loading episode data from Trakt"
+msgstr ""
+
+msgctxt "#32100"
+msgid "Retrieving episode collection from Trakt"
+msgstr ""
+
+msgctxt "#32101"
+msgid "Retrieving watched episodes from Trakt"
+msgstr ""
+
+msgctxt "#32102"
+msgid "Parsing episode data %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32103"
+msgid "Retrieved episode data from Trakt"
+msgstr ""
+
+msgctxt "#32104"
+msgid "Trakt episode collection is up to date, no episodes to add"
+msgstr ""
+
+msgctxt "#32105"
+msgid "%i episode(s) were added to your Trakt collection"
+msgstr ""
+
+msgctxt "#32106"
+msgid "Trakt episode playcounts are up to date"
+msgstr ""
+
+msgctxt "#32107"
+msgid "Kodi episode playcounts are up to date"
+msgstr ""
+
+msgctxt "#32108"
+msgid "Updating %i of %i episode playcount(s) in Kodi"
+msgstr ""
+
+msgctxt "#32109"
+msgid "Playcounts updated for %i show(s) in Kodi"
+msgstr ""
+
+msgctxt "#32110"
+msgid "Trakt episode collection is clean, no episodes to remove"
+msgstr ""
+
+msgctxt "#32111"
+msgid "%i episode(s) are being removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32112"
+msgid "%i episode(s) were removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32113"
+msgid "Trakt - Marked as watched"
+msgstr ""
+
+msgctxt "#32114"
+msgid "Trakt - Failed marking as watched"
+msgstr ""
+
+msgctxt "#32115"
+msgid "%d episode(s) of '%s'"
+msgstr ""
+
+msgctxt "#32116"
+msgid "Enable debug mode"
+msgstr ""
+
+msgctxt "#32117"
+msgid "Sync movie playback progress to Kodi"
+msgstr ""
+
+msgctxt "#32118"
+msgid "Sync episode playback progress to Kodi"
+msgstr ""
+
+msgctxt "#32119"
+msgid "Retrieving episode playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32120"
+msgid "Parsing episode playback progress %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32121"
+msgid "Retrieved episode playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32122"
+msgid "Retrieving movie playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32123"
+msgid "Parsing movie playback progress %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32124"
+msgid "Retrieved movie playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32125"
+msgid "Kodi movie playback progress is up to date"
+msgstr ""
+
+msgctxt "#32126"
+msgid "%i movie(s) playback progress will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32127"
+msgid "Updating %i of %i movie(s) playback progress in Kodi"
+msgstr ""
+
+msgctxt "#32128"
+msgid "Playback progress updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32129"
+msgid "Kodi episode playback progress is up to date"
+msgstr ""
+
+msgctxt "#32130"
+msgid "Updating %i of %i episode(s) playback progress in Kodi"
+msgstr ""
+
+msgctxt "#32131"
+msgid "Playback progress updated for %i episode(s) in Kodi"
+msgstr ""
+
+msgctxt "#32132"
+msgid "Unrate this season"
+msgstr ""
+
+msgctxt "#32133"
+msgid "Manage Movie's Lists"
+msgstr ""
+
+msgctxt "#32134"
+msgid "Manage Show's Lists"
+msgstr ""
+
+msgctxt "#32135"
+msgid "Remove from Watchlist"
+msgstr ""
+
+msgctxt "#32136"
+msgid "Add to watchlist"
+msgstr ""
+
+msgctxt "#32137"
+msgid "Rate this movie"
+msgstr ""
+
+msgctxt "#32138"
+msgid "Rate this show"
+msgstr ""
+
+msgctxt "#32139"
+msgid "Rate this episode"
+msgstr ""
+
+msgctxt "#32140"
+msgid "Toggle watched"
+msgstr ""
+
+msgctxt "#32141"
+msgid "Manage all lists"
+msgstr ""
+
+msgctxt "#32142"
+msgid "Update all tags"
+msgstr ""
+
+msgctxt "#32143"
+msgid "Synchronize library"
+msgstr ""
+
+msgctxt "#32144"
+msgid "How do I authorize the trakt addon to access my trakt.tv account?"
+msgstr ""
+
+# empty strings from id 32145 to 32146
+msgctxt "#32147"
+msgid "Trakt.tv PIN Authorization Failed"
+msgstr ""
+
 msgctxt "#32149"
 msgid "Rate this Season"
 msgstr "Valora aquesta temporada"
+
+msgctxt "#32150"
+msgid "You will be reminded in 24 hours"
+msgstr ""
+
+msgctxt "#32151"
+msgid "Use Addon Settings later if you change your mind"
+msgstr ""
+
+msgctxt "#32152"
+msgid "Trakt Authorization Complete"
+msgstr ""
+
+msgctxt "#32153"
+msgid "Trakt Account Authorization"
+msgstr ""
 
 msgctxt "#32154"
 msgid "Authorize"
 msgstr "Autoritza"
 
+msgctxt "#32155"
+msgid "Remind Me Later"
+msgstr ""
+
+msgctxt "#32156"
+msgid "No Thanks"
+msgstr ""
+
+msgctxt "#32157"
+msgid "Account Authorization"
+msgstr ""
+
+# empty string with id 32158
+msgctxt "#32159"
+msgid "Visit {0} or scan the QR code."
+msgstr ""
+
+msgctxt "#32162"
+msgid "The trakt addon CAN NOT be used without authorizing it to access your trakt.tv account."
+msgstr ""
+
 msgctxt "#32163"
 msgid "User"
 msgstr "Usuari"
+
+msgctxt "#32164"
+msgid "Fallback to Title/Year matching if necessary"
+msgstr ""
+
+msgctxt "#32165"
+msgid "Trakt - Added to watchlist"
+msgstr ""
+
+msgctxt "#32166"
+msgid "Trakt - Failed adding to watchlist"
+msgstr ""
+
+msgctxt "#32167"
+msgid "Offset scrobble start by X minutes"
+msgstr ""
+
+msgctxt "#32168"
+msgid "Sync ratings"
+msgstr ""
+
+msgctxt "#32169"
+msgid "Kodi movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32170"
+msgid "%i movie(s) ratings will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32171"
+msgid "Updating %i of %i movie ratings in Kodi"
+msgstr ""
+
+msgctxt "#32172"
+msgid "Ratings updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32173"
+msgid "Kodi episode ratings are up to date"
+msgstr ""
+
+msgctxt "#32174"
+msgid "Updating %i of %i episode ratings in Kodi"
+msgstr ""
+
+msgctxt "#32175"
+msgid "Ratings updated for %i episode(s) in Kodi"
+msgstr ""
+
+msgctxt "#32176"
+msgid "Kodi show ratings are up to date"
+msgstr ""
+
+msgctxt "#32177"
+msgid "Updating %i of %i show ratings in Kodi"
+msgstr ""
+
+msgctxt "#32178"
+msgid "Ratings updated for %i show(s) in Kodi"
+msgstr ""
+
+msgctxt "#32179"
+msgid "Trakt movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32180"
+msgid "%i movie ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32181"
+msgid "Trakt show ratings are up to date"
+msgstr ""
+
+msgctxt "#32182"
+msgid "%i show ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32183"
+msgid "Attempt to scrobble MythTV PVR recordings"
+msgstr ""
+
+msgctxt "#32184"
+msgid "Attempt secondary show title search"
+msgstr ""
+
+msgctxt "#32185"
+msgid "Exclude Plugins"
+msgstr ""
+
+msgctxt "#32186"
+msgid "Allow script exclusions"
+msgstr ""

--- a/script.trakt/resources/language/resource.language.cs_CZ/strings.po
+++ b/script.trakt/resources/language/resource.language.cs_CZ/strings.po
@@ -10,36 +10,712 @@ msgstr ""
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Kodi Translation Team\n"
 "Language-Team: Czech (http://www.transifex.com/projects/p/xbmc-addons/language/cs/)\n"
+"Language: cs\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: cs\n"
 "Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
 
 msgctxt "#32000"
 msgid "General"
 msgstr "Obecné"
 
+# empty strings from id 32001 to 32002
+msgctxt "#32003"
+msgid "Startup Delay"
+msgstr ""
+
 msgctxt "#32004"
 msgid "Rating"
 msgstr "Hodnocení"
+
+msgctxt "#32005"
+msgid "Rate Movie after watching"
+msgstr ""
+
+msgctxt "#32006"
+msgid "Rate TV show Episode after watching"
+msgstr ""
+
+msgctxt "#32008"
+msgid "Minimum percent watched to display rating dialog"
+msgstr ""
+
+msgctxt "#32009"
+msgid "Allow re-rating of media"
+msgstr ""
+
+msgctxt "#32010"
+msgid "Default rating"
+msgstr ""
+
+# Scrobbling Settings
+msgctxt "#32011"
+msgid "Scrobbling"
+msgstr ""
+
+msgctxt "#32012"
+msgid "Scrobble movies"
+msgstr ""
+
+msgctxt "#32013"
+msgid "Scrobble TV show episodes"
+msgstr ""
+
+msgctxt "#32014"
+msgid "Show notification on scrobble"
+msgstr ""
+
+msgctxt "#32015"
+msgid "Trakt - Scrobbled successfully"
+msgstr ""
+
+msgctxt "#32016"
+msgid "Exclusions"
+msgstr ""
+
+msgctxt "#32017"
+msgid "Exclude Live TV"
+msgstr ""
+
+msgctxt "#32018"
+msgid "Exclude HTTP sources"
+msgstr ""
+
+msgctxt "#32019"
+msgid "Exclude path"
+msgstr ""
+
+msgctxt "#32020"
+msgid "Folder's path (including subfolders)"
+msgstr ""
+
+# empty strings from id 32021 to 32022
+msgctxt "#32023"
+msgid "Can not connect to Trakt"
+msgstr ""
 
 msgctxt "#32024"
 msgid "Error"
 msgstr "Chyba"
 
+# empty string with id 32025
+msgctxt "#32026"
+msgid "What Did You Think?"
+msgstr ""
+
+msgctxt "#32027"
+msgid "Totally Ninja!"
+msgstr ""
+
+msgctxt "#32028"
+msgid "Weak Sauce :("
+msgstr ""
+
+msgctxt "#32029"
+msgid "Terrible"
+msgstr ""
+
+msgctxt "#32030"
+msgid "Bad"
+msgstr ""
+
+msgctxt "#32031"
+msgid "Poor"
+msgstr ""
+
+msgctxt "#32032"
+msgid "Meh"
+msgstr ""
+
 msgctxt "#32033"
 msgid "Fair"
 msgstr "Skoro jasno"
+
+msgctxt "#32034"
+msgid "Good"
+msgstr ""
+
+msgctxt "#32035"
+msgid "Great"
+msgstr ""
+
+msgctxt "#32036"
+msgid "Superb"
+msgstr ""
+
+msgctxt "#32037"
+msgid "Unrate this movie"
+msgstr ""
+
+msgctxt "#32038"
+msgid "Unrate this show"
+msgstr ""
+
+msgctxt "#32039"
+msgid "Unrate this episode"
+msgstr ""
+
+msgctxt "#32040"
+msgid "Trakt - Rating submitted successfully"
+msgstr ""
+
+msgctxt "#32041"
+msgid "Trakt - Already rated"
+msgstr ""
+
+msgctxt "#32042"
+msgid "Trakt - Unrated successfully"
+msgstr ""
+
+msgctxt "#32043"
+msgid "Trakt - Already has the same rating"
+msgstr ""
+
+msgctxt "#32044"
+msgid "Trakt - Problem submitting rating"
+msgstr ""
+
+msgctxt "#32045"
+msgid "Synchronize"
+msgstr ""
 
 msgctxt "#32046"
 msgid "Movies"
 msgstr "Filmy"
 
+msgctxt "#32047"
+msgid "Add new movies to Trakt collection"
+msgstr ""
+
+msgctxt "#32048"
+msgid "Add watched movies to Trakt history"
+msgstr ""
+
+msgctxt "#32049"
+msgid "Mark movies from Trakt history as watched in Kodi"
+msgstr ""
+
+msgctxt "#32050"
+msgid "TV Episodes"
+msgstr ""
+
+msgctxt "#32051"
+msgid "Add new TV episodes to Trakt collection"
+msgstr ""
+
+msgctxt "#32052"
+msgid "Add watched TV episodes to Trakt history"
+msgstr ""
+
+msgctxt "#32053"
+msgid "Mark TV episodes from Trakt history as watched in Kodi"
+msgstr ""
+
 msgctxt "#32054"
 msgid "Service"
 msgstr "Služba"
 
+msgctxt "#32055"
+msgid "Sync collection on library update or cleaning"
+msgstr ""
+
+msgctxt "#32056"
+msgid "Show sync notifications"
+msgstr ""
+
+msgctxt "#32057"
+msgid "Remove deleted movies from Trakt collection"
+msgstr ""
+
+msgctxt "#32058"
+msgid "Remove deleted TV episodes from Trakt collection"
+msgstr ""
+
+# empty string with id 32059
+msgctxt "#32060"
+msgid "Hide notifications during playback"
+msgstr ""
+
+msgctxt "#32061"
+msgid "Sync started"
+msgstr ""
+
+msgctxt "#32062"
+msgid "Sync complete"
+msgstr ""
+
+msgctxt "#32063"
+msgid "%i movie(s) will be added to Trakt collection"
+msgstr ""
+
+msgctxt "#32064"
+msgid "%i movie playcount(s) will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32065"
+msgid "%i movie(s) playcount will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32066"
+msgid "Movie Sync Complete"
+msgstr ""
+
+msgctxt "#32067"
+msgid "Going to add %i show(s) to Trakt collection"
+msgstr ""
+
+msgctxt "#32068"
+msgid "Checking for episodes missing from Trakt collection"
+msgstr ""
+
+msgctxt "#32069"
+msgid "%i of %i show(s) have episodes added to Trakt collection"
+msgstr ""
+
+msgctxt "#32070"
+msgid "Going to update %i show(s) missing watched status"
+msgstr ""
+
+msgctxt "#32071"
+msgid "Checking watched episodes on Trakt"
+msgstr ""
+
+msgctxt "#32072"
+msgid "%i show(s) had missing watched status"
+msgstr ""
+
+msgctxt "#32073"
+msgid "%i episodes are being updated"
+msgstr ""
+
+msgctxt "#32074"
+msgid "Checking watched episodes on Kodi"
+msgstr ""
+
+msgctxt "#32075"
+msgid "Episode Sync Complete"
+msgstr ""
+
+msgctxt "#32076"
+msgid "%i movie(s) will be removed from Trakt collection"
+msgstr ""
+
+msgctxt "#32077"
+msgid "Cleaning Trakt TV show collection"
+msgstr ""
+
+msgctxt "#32078"
+msgid "episodes are being removed"
+msgstr ""
+
+msgctxt "#32079"
+msgid "Loading movies from Kodi"
+msgstr ""
+
+msgctxt "#32080"
+msgid "Movies loaded from Kodi"
+msgstr ""
+
+msgctxt "#32081"
+msgid "Retrieving movie collection from Trakt"
+msgstr ""
+
+msgctxt "#32082"
+msgid "Retrieving watched movies from Trakt"
+msgstr ""
+
+msgctxt "#32083"
+msgid "Retrieved movie data from Trakt"
+msgstr ""
+
+msgctxt "#32084"
+msgid "Trakt movie collection is up to date, no movies to add"
+msgstr ""
+
+msgctxt "#32085"
+msgid "%i movie(s) were added to your Trakt collection"
+msgstr ""
+
+msgctxt "#32086"
+msgid "Trakt movie playcounts are up to date"
+msgstr ""
+
+msgctxt "#32087"
+msgid "Playcounts updated for %i movie(s) on Trakt"
+msgstr ""
+
+msgctxt "#32088"
+msgid "Kodi movie playcounts are up to date"
+msgstr ""
+
+msgctxt "#32089"
+msgid "Updating %i of %i movie playcount(s) in Kodi"
+msgstr ""
+
+msgctxt "#32090"
+msgid "Playcounts updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32091"
+msgid "Trakt movie collection is up to date, no movies removed"
+msgstr ""
+
+msgctxt "#32092"
+msgid "%i movie(s) were removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32093"
+msgid "Updating %i of %i movie playcount(s) on Trakt"
+msgstr ""
+
+msgctxt "#32094"
+msgid "Loading episode data from Kodi"
+msgstr ""
+
+msgctxt "#32095"
+msgid "Loading shows from Kodi"
+msgstr ""
+
+msgctxt "#32096"
+msgid "Shows loaded from Kodi"
+msgstr ""
+
+msgctxt "#32097"
+msgid "Parsing %i of %i episode data from Kodi"
+msgstr ""
+
+msgctxt "#32098"
+msgid "Loaded episode data from Kodi"
+msgstr ""
+
+msgctxt "#32099"
+msgid "Loading episode data from Trakt"
+msgstr ""
+
+msgctxt "#32100"
+msgid "Retrieving episode collection from Trakt"
+msgstr ""
+
+msgctxt "#32101"
+msgid "Retrieving watched episodes from Trakt"
+msgstr ""
+
+msgctxt "#32102"
+msgid "Parsing episode data %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32103"
+msgid "Retrieved episode data from Trakt"
+msgstr ""
+
+msgctxt "#32104"
+msgid "Trakt episode collection is up to date, no episodes to add"
+msgstr ""
+
+msgctxt "#32105"
+msgid "%i episode(s) were added to your Trakt collection"
+msgstr ""
+
+msgctxt "#32106"
+msgid "Trakt episode playcounts are up to date"
+msgstr ""
+
+msgctxt "#32107"
+msgid "Kodi episode playcounts are up to date"
+msgstr ""
+
+msgctxt "#32108"
+msgid "Updating %i of %i episode playcount(s) in Kodi"
+msgstr ""
+
+msgctxt "#32109"
+msgid "Playcounts updated for %i show(s) in Kodi"
+msgstr ""
+
+msgctxt "#32110"
+msgid "Trakt episode collection is clean, no episodes to remove"
+msgstr ""
+
+msgctxt "#32111"
+msgid "%i episode(s) are being removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32112"
+msgid "%i episode(s) were removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32113"
+msgid "Trakt - Marked as watched"
+msgstr ""
+
+msgctxt "#32114"
+msgid "Trakt - Failed marking as watched"
+msgstr ""
+
+msgctxt "#32115"
+msgid "%d episode(s) of '%s'"
+msgstr ""
+
+msgctxt "#32116"
+msgid "Enable debug mode"
+msgstr ""
+
+msgctxt "#32117"
+msgid "Sync movie playback progress to Kodi"
+msgstr ""
+
+msgctxt "#32118"
+msgid "Sync episode playback progress to Kodi"
+msgstr ""
+
+msgctxt "#32119"
+msgid "Retrieving episode playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32120"
+msgid "Parsing episode playback progress %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32121"
+msgid "Retrieved episode playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32122"
+msgid "Retrieving movie playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32123"
+msgid "Parsing movie playback progress %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32124"
+msgid "Retrieved movie playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32125"
+msgid "Kodi movie playback progress is up to date"
+msgstr ""
+
+msgctxt "#32126"
+msgid "%i movie(s) playback progress will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32127"
+msgid "Updating %i of %i movie(s) playback progress in Kodi"
+msgstr ""
+
+msgctxt "#32128"
+msgid "Playback progress updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32129"
+msgid "Kodi episode playback progress is up to date"
+msgstr ""
+
+msgctxt "#32130"
+msgid "Updating %i of %i episode(s) playback progress in Kodi"
+msgstr ""
+
+msgctxt "#32131"
+msgid "Playback progress updated for %i episode(s) in Kodi"
+msgstr ""
+
+msgctxt "#32132"
+msgid "Unrate this season"
+msgstr ""
+
+msgctxt "#32133"
+msgid "Manage Movie's Lists"
+msgstr ""
+
+msgctxt "#32134"
+msgid "Manage Show's Lists"
+msgstr ""
+
+msgctxt "#32135"
+msgid "Remove from Watchlist"
+msgstr ""
+
+msgctxt "#32136"
+msgid "Add to watchlist"
+msgstr ""
+
+msgctxt "#32137"
+msgid "Rate this movie"
+msgstr ""
+
+msgctxt "#32138"
+msgid "Rate this show"
+msgstr ""
+
+msgctxt "#32139"
+msgid "Rate this episode"
+msgstr ""
+
+msgctxt "#32140"
+msgid "Toggle watched"
+msgstr ""
+
+msgctxt "#32141"
+msgid "Manage all lists"
+msgstr ""
+
+msgctxt "#32142"
+msgid "Update all tags"
+msgstr ""
+
+msgctxt "#32143"
+msgid "Synchronize library"
+msgstr ""
+
+msgctxt "#32144"
+msgid "How do I authorize the trakt addon to access my trakt.tv account?"
+msgstr ""
+
+# empty strings from id 32145 to 32146
+msgctxt "#32147"
+msgid "Trakt.tv PIN Authorization Failed"
+msgstr ""
+
+# empty string with id 32148
+msgctxt "#32149"
+msgid "Rate this Season"
+msgstr ""
+
+msgctxt "#32150"
+msgid "You will be reminded in 24 hours"
+msgstr ""
+
+msgctxt "#32151"
+msgid "Use Addon Settings later if you change your mind"
+msgstr ""
+
+msgctxt "#32152"
+msgid "Trakt Authorization Complete"
+msgstr ""
+
+msgctxt "#32153"
+msgid "Trakt Account Authorization"
+msgstr ""
+
+msgctxt "#32154"
+msgid "Authorize"
+msgstr ""
+
+msgctxt "#32155"
+msgid "Remind Me Later"
+msgstr ""
+
+msgctxt "#32156"
+msgid "No Thanks"
+msgstr ""
+
+msgctxt "#32157"
+msgid "Account Authorization"
+msgstr ""
+
+# empty string with id 32158
+msgctxt "#32159"
+msgid "Visit {0} or scan the QR code."
+msgstr ""
+
+msgctxt "#32162"
+msgid "The trakt addon CAN NOT be used without authorizing it to access your trakt.tv account."
+msgstr ""
+
 msgctxt "#32163"
 msgid "User"
 msgstr "Uživatel"
+
+msgctxt "#32164"
+msgid "Fallback to Title/Year matching if necessary"
+msgstr ""
+
+msgctxt "#32165"
+msgid "Trakt - Added to watchlist"
+msgstr ""
+
+msgctxt "#32166"
+msgid "Trakt - Failed adding to watchlist"
+msgstr ""
+
+msgctxt "#32167"
+msgid "Offset scrobble start by X minutes"
+msgstr ""
+
+msgctxt "#32168"
+msgid "Sync ratings"
+msgstr ""
+
+msgctxt "#32169"
+msgid "Kodi movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32170"
+msgid "%i movie(s) ratings will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32171"
+msgid "Updating %i of %i movie ratings in Kodi"
+msgstr ""
+
+msgctxt "#32172"
+msgid "Ratings updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32173"
+msgid "Kodi episode ratings are up to date"
+msgstr ""
+
+msgctxt "#32174"
+msgid "Updating %i of %i episode ratings in Kodi"
+msgstr ""
+
+msgctxt "#32175"
+msgid "Ratings updated for %i episode(s) in Kodi"
+msgstr ""
+
+msgctxt "#32176"
+msgid "Kodi show ratings are up to date"
+msgstr ""
+
+msgctxt "#32177"
+msgid "Updating %i of %i show ratings in Kodi"
+msgstr ""
+
+msgctxt "#32178"
+msgid "Ratings updated for %i show(s) in Kodi"
+msgstr ""
+
+msgctxt "#32179"
+msgid "Trakt movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32180"
+msgid "%i movie ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32181"
+msgid "Trakt show ratings are up to date"
+msgstr ""
+
+msgctxt "#32182"
+msgid "%i show ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32183"
+msgid "Attempt to scrobble MythTV PVR recordings"
+msgstr ""
+
+msgctxt "#32184"
+msgid "Attempt secondary show title search"
+msgstr ""
+
+msgctxt "#32185"
+msgid "Exclude Plugins"
+msgstr ""
+
+msgctxt "#32186"
+msgid "Allow script exclusions"
+msgstr ""

--- a/script.trakt/resources/language/resource.language.cy_GB/strings.po
+++ b/script.trakt/resources/language/resource.language.cy_GB/strings.po
@@ -10,32 +10,712 @@ msgstr ""
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Kodi Translation Team\n"
 "Language-Team: Welsh (http://www.transifex.com/projects/p/xbmc-addons/language/cy/)\n"
+"Language: cy\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: cy\n"
 "Plural-Forms: nplurals=4; plural=(n==1) ? 0 : (n==2) ? 1 : (n != 8 && n != 11) ? 2 : 3;\n"
 
 msgctxt "#32000"
 msgid "General"
 msgstr "Cyffredinol"
 
+# empty strings from id 32001 to 32002
+msgctxt "#32003"
+msgid "Startup Delay"
+msgstr ""
+
 msgctxt "#32004"
 msgid "Rating"
 msgstr "Graddio"
+
+msgctxt "#32005"
+msgid "Rate Movie after watching"
+msgstr ""
+
+msgctxt "#32006"
+msgid "Rate TV show Episode after watching"
+msgstr ""
+
+msgctxt "#32008"
+msgid "Minimum percent watched to display rating dialog"
+msgstr ""
+
+msgctxt "#32009"
+msgid "Allow re-rating of media"
+msgstr ""
+
+msgctxt "#32010"
+msgid "Default rating"
+msgstr ""
+
+# Scrobbling Settings
+msgctxt "#32011"
+msgid "Scrobbling"
+msgstr ""
+
+msgctxt "#32012"
+msgid "Scrobble movies"
+msgstr ""
+
+msgctxt "#32013"
+msgid "Scrobble TV show episodes"
+msgstr ""
+
+msgctxt "#32014"
+msgid "Show notification on scrobble"
+msgstr ""
+
+msgctxt "#32015"
+msgid "Trakt - Scrobbled successfully"
+msgstr ""
+
+msgctxt "#32016"
+msgid "Exclusions"
+msgstr ""
+
+msgctxt "#32017"
+msgid "Exclude Live TV"
+msgstr ""
+
+msgctxt "#32018"
+msgid "Exclude HTTP sources"
+msgstr ""
+
+msgctxt "#32019"
+msgid "Exclude path"
+msgstr ""
+
+msgctxt "#32020"
+msgid "Folder's path (including subfolders)"
+msgstr ""
+
+# empty strings from id 32021 to 32022
+msgctxt "#32023"
+msgid "Can not connect to Trakt"
+msgstr ""
 
 msgctxt "#32024"
 msgid "Error"
 msgstr "Gwall"
 
+# empty string with id 32025
+msgctxt "#32026"
+msgid "What Did You Think?"
+msgstr ""
+
+msgctxt "#32027"
+msgid "Totally Ninja!"
+msgstr ""
+
+msgctxt "#32028"
+msgid "Weak Sauce :("
+msgstr ""
+
+msgctxt "#32029"
+msgid "Terrible"
+msgstr ""
+
+msgctxt "#32030"
+msgid "Bad"
+msgstr ""
+
+msgctxt "#32031"
+msgid "Poor"
+msgstr ""
+
+msgctxt "#32032"
+msgid "Meh"
+msgstr ""
+
 msgctxt "#32033"
 msgid "Fair"
 msgstr "Braf"
+
+msgctxt "#32034"
+msgid "Good"
+msgstr ""
+
+msgctxt "#32035"
+msgid "Great"
+msgstr ""
+
+msgctxt "#32036"
+msgid "Superb"
+msgstr ""
+
+msgctxt "#32037"
+msgid "Unrate this movie"
+msgstr ""
+
+msgctxt "#32038"
+msgid "Unrate this show"
+msgstr ""
+
+msgctxt "#32039"
+msgid "Unrate this episode"
+msgstr ""
+
+msgctxt "#32040"
+msgid "Trakt - Rating submitted successfully"
+msgstr ""
+
+msgctxt "#32041"
+msgid "Trakt - Already rated"
+msgstr ""
+
+msgctxt "#32042"
+msgid "Trakt - Unrated successfully"
+msgstr ""
+
+msgctxt "#32043"
+msgid "Trakt - Already has the same rating"
+msgstr ""
+
+msgctxt "#32044"
+msgid "Trakt - Problem submitting rating"
+msgstr ""
+
+msgctxt "#32045"
+msgid "Synchronize"
+msgstr ""
 
 msgctxt "#32046"
 msgid "Movies"
 msgstr "Ffilmiau"
 
+msgctxt "#32047"
+msgid "Add new movies to Trakt collection"
+msgstr ""
+
+msgctxt "#32048"
+msgid "Add watched movies to Trakt history"
+msgstr ""
+
+msgctxt "#32049"
+msgid "Mark movies from Trakt history as watched in Kodi"
+msgstr ""
+
+msgctxt "#32050"
+msgid "TV Episodes"
+msgstr ""
+
+msgctxt "#32051"
+msgid "Add new TV episodes to Trakt collection"
+msgstr ""
+
+msgctxt "#32052"
+msgid "Add watched TV episodes to Trakt history"
+msgstr ""
+
+msgctxt "#32053"
+msgid "Mark TV episodes from Trakt history as watched in Kodi"
+msgstr ""
+
 msgctxt "#32054"
 msgid "Service"
 msgstr "Gwasanaeth"
+
+msgctxt "#32055"
+msgid "Sync collection on library update or cleaning"
+msgstr ""
+
+msgctxt "#32056"
+msgid "Show sync notifications"
+msgstr ""
+
+msgctxt "#32057"
+msgid "Remove deleted movies from Trakt collection"
+msgstr ""
+
+msgctxt "#32058"
+msgid "Remove deleted TV episodes from Trakt collection"
+msgstr ""
+
+# empty string with id 32059
+msgctxt "#32060"
+msgid "Hide notifications during playback"
+msgstr ""
+
+msgctxt "#32061"
+msgid "Sync started"
+msgstr ""
+
+msgctxt "#32062"
+msgid "Sync complete"
+msgstr ""
+
+msgctxt "#32063"
+msgid "%i movie(s) will be added to Trakt collection"
+msgstr ""
+
+msgctxt "#32064"
+msgid "%i movie playcount(s) will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32065"
+msgid "%i movie(s) playcount will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32066"
+msgid "Movie Sync Complete"
+msgstr ""
+
+msgctxt "#32067"
+msgid "Going to add %i show(s) to Trakt collection"
+msgstr ""
+
+msgctxt "#32068"
+msgid "Checking for episodes missing from Trakt collection"
+msgstr ""
+
+msgctxt "#32069"
+msgid "%i of %i show(s) have episodes added to Trakt collection"
+msgstr ""
+
+msgctxt "#32070"
+msgid "Going to update %i show(s) missing watched status"
+msgstr ""
+
+msgctxt "#32071"
+msgid "Checking watched episodes on Trakt"
+msgstr ""
+
+msgctxt "#32072"
+msgid "%i show(s) had missing watched status"
+msgstr ""
+
+msgctxt "#32073"
+msgid "%i episodes are being updated"
+msgstr ""
+
+msgctxt "#32074"
+msgid "Checking watched episodes on Kodi"
+msgstr ""
+
+msgctxt "#32075"
+msgid "Episode Sync Complete"
+msgstr ""
+
+msgctxt "#32076"
+msgid "%i movie(s) will be removed from Trakt collection"
+msgstr ""
+
+msgctxt "#32077"
+msgid "Cleaning Trakt TV show collection"
+msgstr ""
+
+msgctxt "#32078"
+msgid "episodes are being removed"
+msgstr ""
+
+msgctxt "#32079"
+msgid "Loading movies from Kodi"
+msgstr ""
+
+msgctxt "#32080"
+msgid "Movies loaded from Kodi"
+msgstr ""
+
+msgctxt "#32081"
+msgid "Retrieving movie collection from Trakt"
+msgstr ""
+
+msgctxt "#32082"
+msgid "Retrieving watched movies from Trakt"
+msgstr ""
+
+msgctxt "#32083"
+msgid "Retrieved movie data from Trakt"
+msgstr ""
+
+msgctxt "#32084"
+msgid "Trakt movie collection is up to date, no movies to add"
+msgstr ""
+
+msgctxt "#32085"
+msgid "%i movie(s) were added to your Trakt collection"
+msgstr ""
+
+msgctxt "#32086"
+msgid "Trakt movie playcounts are up to date"
+msgstr ""
+
+msgctxt "#32087"
+msgid "Playcounts updated for %i movie(s) on Trakt"
+msgstr ""
+
+msgctxt "#32088"
+msgid "Kodi movie playcounts are up to date"
+msgstr ""
+
+msgctxt "#32089"
+msgid "Updating %i of %i movie playcount(s) in Kodi"
+msgstr ""
+
+msgctxt "#32090"
+msgid "Playcounts updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32091"
+msgid "Trakt movie collection is up to date, no movies removed"
+msgstr ""
+
+msgctxt "#32092"
+msgid "%i movie(s) were removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32093"
+msgid "Updating %i of %i movie playcount(s) on Trakt"
+msgstr ""
+
+msgctxt "#32094"
+msgid "Loading episode data from Kodi"
+msgstr ""
+
+msgctxt "#32095"
+msgid "Loading shows from Kodi"
+msgstr ""
+
+msgctxt "#32096"
+msgid "Shows loaded from Kodi"
+msgstr ""
+
+msgctxt "#32097"
+msgid "Parsing %i of %i episode data from Kodi"
+msgstr ""
+
+msgctxt "#32098"
+msgid "Loaded episode data from Kodi"
+msgstr ""
+
+msgctxt "#32099"
+msgid "Loading episode data from Trakt"
+msgstr ""
+
+msgctxt "#32100"
+msgid "Retrieving episode collection from Trakt"
+msgstr ""
+
+msgctxt "#32101"
+msgid "Retrieving watched episodes from Trakt"
+msgstr ""
+
+msgctxt "#32102"
+msgid "Parsing episode data %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32103"
+msgid "Retrieved episode data from Trakt"
+msgstr ""
+
+msgctxt "#32104"
+msgid "Trakt episode collection is up to date, no episodes to add"
+msgstr ""
+
+msgctxt "#32105"
+msgid "%i episode(s) were added to your Trakt collection"
+msgstr ""
+
+msgctxt "#32106"
+msgid "Trakt episode playcounts are up to date"
+msgstr ""
+
+msgctxt "#32107"
+msgid "Kodi episode playcounts are up to date"
+msgstr ""
+
+msgctxt "#32108"
+msgid "Updating %i of %i episode playcount(s) in Kodi"
+msgstr ""
+
+msgctxt "#32109"
+msgid "Playcounts updated for %i show(s) in Kodi"
+msgstr ""
+
+msgctxt "#32110"
+msgid "Trakt episode collection is clean, no episodes to remove"
+msgstr ""
+
+msgctxt "#32111"
+msgid "%i episode(s) are being removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32112"
+msgid "%i episode(s) were removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32113"
+msgid "Trakt - Marked as watched"
+msgstr ""
+
+msgctxt "#32114"
+msgid "Trakt - Failed marking as watched"
+msgstr ""
+
+msgctxt "#32115"
+msgid "%d episode(s) of '%s'"
+msgstr ""
+
+msgctxt "#32116"
+msgid "Enable debug mode"
+msgstr ""
+
+msgctxt "#32117"
+msgid "Sync movie playback progress to Kodi"
+msgstr ""
+
+msgctxt "#32118"
+msgid "Sync episode playback progress to Kodi"
+msgstr ""
+
+msgctxt "#32119"
+msgid "Retrieving episode playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32120"
+msgid "Parsing episode playback progress %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32121"
+msgid "Retrieved episode playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32122"
+msgid "Retrieving movie playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32123"
+msgid "Parsing movie playback progress %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32124"
+msgid "Retrieved movie playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32125"
+msgid "Kodi movie playback progress is up to date"
+msgstr ""
+
+msgctxt "#32126"
+msgid "%i movie(s) playback progress will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32127"
+msgid "Updating %i of %i movie(s) playback progress in Kodi"
+msgstr ""
+
+msgctxt "#32128"
+msgid "Playback progress updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32129"
+msgid "Kodi episode playback progress is up to date"
+msgstr ""
+
+msgctxt "#32130"
+msgid "Updating %i of %i episode(s) playback progress in Kodi"
+msgstr ""
+
+msgctxt "#32131"
+msgid "Playback progress updated for %i episode(s) in Kodi"
+msgstr ""
+
+msgctxt "#32132"
+msgid "Unrate this season"
+msgstr ""
+
+msgctxt "#32133"
+msgid "Manage Movie's Lists"
+msgstr ""
+
+msgctxt "#32134"
+msgid "Manage Show's Lists"
+msgstr ""
+
+msgctxt "#32135"
+msgid "Remove from Watchlist"
+msgstr ""
+
+msgctxt "#32136"
+msgid "Add to watchlist"
+msgstr ""
+
+msgctxt "#32137"
+msgid "Rate this movie"
+msgstr ""
+
+msgctxt "#32138"
+msgid "Rate this show"
+msgstr ""
+
+msgctxt "#32139"
+msgid "Rate this episode"
+msgstr ""
+
+msgctxt "#32140"
+msgid "Toggle watched"
+msgstr ""
+
+msgctxt "#32141"
+msgid "Manage all lists"
+msgstr ""
+
+msgctxt "#32142"
+msgid "Update all tags"
+msgstr ""
+
+msgctxt "#32143"
+msgid "Synchronize library"
+msgstr ""
+
+msgctxt "#32144"
+msgid "How do I authorize the trakt addon to access my trakt.tv account?"
+msgstr ""
+
+# empty strings from id 32145 to 32146
+msgctxt "#32147"
+msgid "Trakt.tv PIN Authorization Failed"
+msgstr ""
+
+# empty string with id 32148
+msgctxt "#32149"
+msgid "Rate this Season"
+msgstr ""
+
+msgctxt "#32150"
+msgid "You will be reminded in 24 hours"
+msgstr ""
+
+msgctxt "#32151"
+msgid "Use Addon Settings later if you change your mind"
+msgstr ""
+
+msgctxt "#32152"
+msgid "Trakt Authorization Complete"
+msgstr ""
+
+msgctxt "#32153"
+msgid "Trakt Account Authorization"
+msgstr ""
+
+msgctxt "#32154"
+msgid "Authorize"
+msgstr ""
+
+msgctxt "#32155"
+msgid "Remind Me Later"
+msgstr ""
+
+msgctxt "#32156"
+msgid "No Thanks"
+msgstr ""
+
+msgctxt "#32157"
+msgid "Account Authorization"
+msgstr ""
+
+# empty string with id 32158
+msgctxt "#32159"
+msgid "Visit {0} or scan the QR code."
+msgstr ""
+
+msgctxt "#32162"
+msgid "The trakt addon CAN NOT be used without authorizing it to access your trakt.tv account."
+msgstr ""
+
+msgctxt "#32163"
+msgid "User"
+msgstr ""
+
+msgctxt "#32164"
+msgid "Fallback to Title/Year matching if necessary"
+msgstr ""
+
+msgctxt "#32165"
+msgid "Trakt - Added to watchlist"
+msgstr ""
+
+msgctxt "#32166"
+msgid "Trakt - Failed adding to watchlist"
+msgstr ""
+
+msgctxt "#32167"
+msgid "Offset scrobble start by X minutes"
+msgstr ""
+
+msgctxt "#32168"
+msgid "Sync ratings"
+msgstr ""
+
+msgctxt "#32169"
+msgid "Kodi movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32170"
+msgid "%i movie(s) ratings will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32171"
+msgid "Updating %i of %i movie ratings in Kodi"
+msgstr ""
+
+msgctxt "#32172"
+msgid "Ratings updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32173"
+msgid "Kodi episode ratings are up to date"
+msgstr ""
+
+msgctxt "#32174"
+msgid "Updating %i of %i episode ratings in Kodi"
+msgstr ""
+
+msgctxt "#32175"
+msgid "Ratings updated for %i episode(s) in Kodi"
+msgstr ""
+
+msgctxt "#32176"
+msgid "Kodi show ratings are up to date"
+msgstr ""
+
+msgctxt "#32177"
+msgid "Updating %i of %i show ratings in Kodi"
+msgstr ""
+
+msgctxt "#32178"
+msgid "Ratings updated for %i show(s) in Kodi"
+msgstr ""
+
+msgctxt "#32179"
+msgid "Trakt movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32180"
+msgid "%i movie ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32181"
+msgid "Trakt show ratings are up to date"
+msgstr ""
+
+msgctxt "#32182"
+msgid "%i show ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32183"
+msgid "Attempt to scrobble MythTV PVR recordings"
+msgstr ""
+
+msgctxt "#32184"
+msgid "Attempt secondary show title search"
+msgstr ""
+
+msgctxt "#32185"
+msgid "Exclude Plugins"
+msgstr ""
+
+msgctxt "#32186"
+msgid "Allow script exclusions"
+msgstr ""

--- a/script.trakt/resources/language/resource.language.da_DK/strings.po
+++ b/script.trakt/resources/language/resource.language.da_DK/strings.po
@@ -7,14 +7,15 @@ msgstr ""
 "Project-Id-Version: XBMC Addons\n"
 "Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: Kodi Translation Team\n"
-"Language-Team: Danish (http://www.transifex.com/projects/p/xbmc-addons/language/da/)\n"
+"PO-Revision-Date: 2021-03-20 15:56+0000\n"
+"Last-Translator: Christian Gade <gade@kodi.tv>\n"
+"Language-Team: Danish <https://kodi.weblate.cloud/projects/kodi-add-ons-scripts/script-trakt/da_dk/>\n"
+"Language: da_DK\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: da\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Generator: Weblate 4.5.1\n"
 
 msgctxt "#32000"
 msgid "General"
@@ -102,7 +103,7 @@ msgstr "Hvad syntes du?"
 
 msgctxt "#32027"
 msgid "Totally Ninja!"
-msgstr "Fantastisk"
+msgstr "Fantastisk!"
 
 msgctxt "#32028"
 msgid "Weak Sauce :("
@@ -215,6 +216,10 @@ msgstr "Tjeneste"
 msgctxt "#32055"
 msgid "Sync collection on library update or cleaning"
 msgstr "Synkroniser samling ved bibliotek-opdatering eller -rensning"
+
+msgctxt "#32056"
+msgid "Show sync notifications"
+msgstr ""
 
 msgctxt "#32057"
 msgid "Remove deleted movies from Trakt collection"
@@ -452,6 +457,261 @@ msgctxt "#32116"
 msgid "Enable debug mode"
 msgstr "Slå fejlfinding til"
 
+msgctxt "#32117"
+msgid "Sync movie playback progress to Kodi"
+msgstr ""
+
+msgctxt "#32118"
+msgid "Sync episode playback progress to Kodi"
+msgstr ""
+
+msgctxt "#32119"
+msgid "Retrieving episode playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32120"
+msgid "Parsing episode playback progress %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32121"
+msgid "Retrieved episode playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32122"
+msgid "Retrieving movie playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32123"
+msgid "Parsing movie playback progress %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32124"
+msgid "Retrieved movie playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32125"
+msgid "Kodi movie playback progress is up to date"
+msgstr ""
+
+msgctxt "#32126"
+msgid "%i movie(s) playback progress will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32127"
+msgid "Updating %i of %i movie(s) playback progress in Kodi"
+msgstr ""
+
+msgctxt "#32128"
+msgid "Playback progress updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32129"
+msgid "Kodi episode playback progress is up to date"
+msgstr ""
+
+msgctxt "#32130"
+msgid "Updating %i of %i episode(s) playback progress in Kodi"
+msgstr ""
+
+msgctxt "#32131"
+msgid "Playback progress updated for %i episode(s) in Kodi"
+msgstr ""
+
+msgctxt "#32132"
+msgid "Unrate this season"
+msgstr ""
+
+msgctxt "#32133"
+msgid "Manage Movie's Lists"
+msgstr ""
+
+msgctxt "#32134"
+msgid "Manage Show's Lists"
+msgstr ""
+
+msgctxt "#32135"
+msgid "Remove from Watchlist"
+msgstr ""
+
+msgctxt "#32136"
+msgid "Add to watchlist"
+msgstr ""
+
+msgctxt "#32137"
+msgid "Rate this movie"
+msgstr ""
+
+msgctxt "#32138"
+msgid "Rate this show"
+msgstr ""
+
+msgctxt "#32139"
+msgid "Rate this episode"
+msgstr ""
+
+msgctxt "#32140"
+msgid "Toggle watched"
+msgstr ""
+
+msgctxt "#32141"
+msgid "Manage all lists"
+msgstr ""
+
+msgctxt "#32142"
+msgid "Update all tags"
+msgstr ""
+
+msgctxt "#32143"
+msgid "Synchronize library"
+msgstr ""
+
+msgctxt "#32144"
+msgid "How do I authorize the trakt addon to access my trakt.tv account?"
+msgstr ""
+
+# empty strings from id 32145 to 32146
+msgctxt "#32147"
+msgid "Trakt.tv PIN Authorization Failed"
+msgstr ""
+
+# empty string with id 32148
+msgctxt "#32149"
+msgid "Rate this Season"
+msgstr ""
+
+msgctxt "#32150"
+msgid "You will be reminded in 24 hours"
+msgstr ""
+
+msgctxt "#32151"
+msgid "Use Addon Settings later if you change your mind"
+msgstr ""
+
+msgctxt "#32152"
+msgid "Trakt Authorization Complete"
+msgstr ""
+
+msgctxt "#32153"
+msgid "Trakt Account Authorization"
+msgstr ""
+
+msgctxt "#32154"
+msgid "Authorize"
+msgstr ""
+
+msgctxt "#32155"
+msgid "Remind Me Later"
+msgstr ""
+
+msgctxt "#32156"
+msgid "No Thanks"
+msgstr ""
+
+msgctxt "#32157"
+msgid "Account Authorization"
+msgstr ""
+
+# empty string with id 32158
+msgctxt "#32159"
+msgid "Visit {0} or scan the QR code."
+msgstr ""
+
+msgctxt "#32162"
+msgid "The trakt addon CAN NOT be used without authorizing it to access your trakt.tv account."
+msgstr ""
+
 msgctxt "#32163"
 msgid "User"
 msgstr "Bruger"
+
+msgctxt "#32164"
+msgid "Fallback to Title/Year matching if necessary"
+msgstr ""
+
+msgctxt "#32165"
+msgid "Trakt - Added to watchlist"
+msgstr ""
+
+msgctxt "#32166"
+msgid "Trakt - Failed adding to watchlist"
+msgstr ""
+
+msgctxt "#32167"
+msgid "Offset scrobble start by X minutes"
+msgstr ""
+
+msgctxt "#32168"
+msgid "Sync ratings"
+msgstr ""
+
+msgctxt "#32169"
+msgid "Kodi movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32170"
+msgid "%i movie(s) ratings will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32171"
+msgid "Updating %i of %i movie ratings in Kodi"
+msgstr ""
+
+msgctxt "#32172"
+msgid "Ratings updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32173"
+msgid "Kodi episode ratings are up to date"
+msgstr ""
+
+msgctxt "#32174"
+msgid "Updating %i of %i episode ratings in Kodi"
+msgstr ""
+
+msgctxt "#32175"
+msgid "Ratings updated for %i episode(s) in Kodi"
+msgstr ""
+
+msgctxt "#32176"
+msgid "Kodi show ratings are up to date"
+msgstr ""
+
+msgctxt "#32177"
+msgid "Updating %i of %i show ratings in Kodi"
+msgstr ""
+
+msgctxt "#32178"
+msgid "Ratings updated for %i show(s) in Kodi"
+msgstr ""
+
+msgctxt "#32179"
+msgid "Trakt movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32180"
+msgid "%i movie ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32181"
+msgid "Trakt show ratings are up to date"
+msgstr ""
+
+msgctxt "#32182"
+msgid "%i show ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32183"
+msgid "Attempt to scrobble MythTV PVR recordings"
+msgstr ""
+
+msgctxt "#32184"
+msgid "Attempt secondary show title search"
+msgstr ""
+
+msgctxt "#32185"
+msgid "Exclude Plugins"
+msgstr ""
+
+msgctxt "#32186"
+msgid "Allow script exclusions"
+msgstr ""

--- a/script.trakt/resources/language/resource.language.de_DE/strings.po
+++ b/script.trakt/resources/language/resource.language.de_DE/strings.po
@@ -7,14 +7,15 @@ msgstr ""
 "Project-Id-Version: XBMC Addons\n"
 "Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: Kodi Translation Team\n"
-"Language-Team: German (http://www.transifex.com/projects/p/xbmc-addons/language/de/)\n"
+"PO-Revision-Date: 2021-03-20 15:56+0000\n"
+"Last-Translator: Christian Gade <gade@kodi.tv>\n"
+"Language-Team: German <https://kodi.weblate.cloud/projects/kodi-add-ons-scripts/script-trakt/de_de/>\n"
+"Language: de_DE\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: de\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Generator: Weblate 4.5.1\n"
 
 msgctxt "#32000"
 msgid "General"
@@ -262,7 +263,7 @@ msgstr "Füge %i Serie(n) zur Trakt Sammlung hinzu"
 
 msgctxt "#32068"
 msgid "Checking for episodes missing from Trakt collection"
-msgstr "Prüfe Trakt Sammlung auf fehlende Episoden "
+msgstr "Prüfe Trakt Sammlung auf fehlende Episoden"
 
 msgctxt "#32069"
 msgid "%i of %i show(s) have episodes added to Trakt collection"
@@ -608,17 +609,10 @@ msgctxt "#32157"
 msgid "Account Authorization"
 msgstr "Kontoautorisierung"
 
+# empty string with id 32158
 msgctxt "#32159"
-msgid "Visit {0} or scan the QR Code below."
-msgstr "Rufen Sie {0} auf oder scannen Sie den QR-Code unten."
-
-msgctxt "#32160"
-msgid "Authorize the trakt addon to access your account."
-msgstr "Gestatten Sie dem Trakt-Addon Zugriff auf Ihr Konto."
-
-msgctxt "#32161"
-msgid "Enter the PIN provided in the box below."
-msgstr "Geben Sie die PIN in den Kasten unten ein."
+msgid "Visit {0} or scan the QR code."
+msgstr ""
 
 msgctxt "#32162"
 msgid "The trakt addon CAN NOT be used without authorizing it to access your trakt.tv account."
@@ -639,3 +633,95 @@ msgstr "Trakt - Zur Beobachtungsliste hinzugefügt"
 msgctxt "#32166"
 msgid "Trakt - Failed adding to watchlist"
 msgstr "Trakt - Beim Hinzufügen zur Beobachtungsliste gescheitert"
+
+msgctxt "#32167"
+msgid "Offset scrobble start by X minutes"
+msgstr ""
+
+msgctxt "#32168"
+msgid "Sync ratings"
+msgstr ""
+
+msgctxt "#32169"
+msgid "Kodi movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32170"
+msgid "%i movie(s) ratings will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32171"
+msgid "Updating %i of %i movie ratings in Kodi"
+msgstr ""
+
+msgctxt "#32172"
+msgid "Ratings updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32173"
+msgid "Kodi episode ratings are up to date"
+msgstr ""
+
+msgctxt "#32174"
+msgid "Updating %i of %i episode ratings in Kodi"
+msgstr ""
+
+msgctxt "#32175"
+msgid "Ratings updated for %i episode(s) in Kodi"
+msgstr ""
+
+msgctxt "#32176"
+msgid "Kodi show ratings are up to date"
+msgstr ""
+
+msgctxt "#32177"
+msgid "Updating %i of %i show ratings in Kodi"
+msgstr ""
+
+msgctxt "#32178"
+msgid "Ratings updated for %i show(s) in Kodi"
+msgstr ""
+
+msgctxt "#32179"
+msgid "Trakt movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32180"
+msgid "%i movie ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32181"
+msgid "Trakt show ratings are up to date"
+msgstr ""
+
+msgctxt "#32182"
+msgid "%i show ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32183"
+msgid "Attempt to scrobble MythTV PVR recordings"
+msgstr ""
+
+msgctxt "#32184"
+msgid "Attempt secondary show title search"
+msgstr ""
+
+msgctxt "#32185"
+msgid "Exclude Plugins"
+msgstr ""
+
+msgctxt "#32186"
+msgid "Allow script exclusions"
+msgstr ""
+
+#~ msgctxt "#32159"
+#~ msgid "Visit {0} or scan the QR Code below."
+#~ msgstr "Rufen Sie {0} auf oder scannen Sie den QR-Code unten."
+
+#~ msgctxt "#32160"
+#~ msgid "Authorize the trakt addon to access your account."
+#~ msgstr "Gestatten Sie dem Trakt-Addon Zugriff auf Ihr Konto."
+
+#~ msgctxt "#32161"
+#~ msgid "Enter the PIN provided in the box below."
+#~ msgstr "Geben Sie die PIN in den Kasten unten ein."

--- a/script.trakt/resources/language/resource.language.el_GR/strings.po
+++ b/script.trakt/resources/language/resource.language.el_GR/strings.po
@@ -10,10 +10,10 @@ msgstr ""
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Kodi Translation Team\n"
 "Language-Team: Greek (http://www.transifex.com/projects/p/xbmc-addons/language/el/)\n"
+"Language: el\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: el\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 msgctxt "#32000"
@@ -60,6 +60,10 @@ msgctxt "#32013"
 msgid "Scrobble TV show episodes"
 msgstr "Κοινοποίηση επεισοδίων"
 
+msgctxt "#32014"
+msgid "Show notification on scrobble"
+msgstr ""
+
 msgctxt "#32015"
 msgid "Trakt - Scrobbled successfully"
 msgstr "Trakt - Επιτυχής κοινοποίηση"
@@ -79,6 +83,10 @@ msgstr "Εξαίρεση πηγών HTTP"
 msgctxt "#32019"
 msgid "Exclude path"
 msgstr "Εξαίρεση διαδρομής"
+
+msgctxt "#32020"
+msgid "Folder's path (including subfolders)"
+msgstr ""
 
 msgctxt "#32023"
 msgid "Can not connect to Trakt"
@@ -132,6 +140,38 @@ msgctxt "#32036"
 msgid "Superb"
 msgstr "Καταπληκτικό"
 
+msgctxt "#32037"
+msgid "Unrate this movie"
+msgstr ""
+
+msgctxt "#32038"
+msgid "Unrate this show"
+msgstr ""
+
+msgctxt "#32039"
+msgid "Unrate this episode"
+msgstr ""
+
+msgctxt "#32040"
+msgid "Trakt - Rating submitted successfully"
+msgstr ""
+
+msgctxt "#32041"
+msgid "Trakt - Already rated"
+msgstr ""
+
+msgctxt "#32042"
+msgid "Trakt - Unrated successfully"
+msgstr ""
+
+msgctxt "#32043"
+msgid "Trakt - Already has the same rating"
+msgstr ""
+
+msgctxt "#32044"
+msgid "Trakt - Problem submitting rating"
+msgstr ""
+
 msgctxt "#32045"
 msgid "Synchronize"
 msgstr "Συγχρονισμός"
@@ -140,17 +180,53 @@ msgctxt "#32046"
 msgid "Movies"
 msgstr "Ταινίες"
 
+msgctxt "#32047"
+msgid "Add new movies to Trakt collection"
+msgstr ""
+
+msgctxt "#32048"
+msgid "Add watched movies to Trakt history"
+msgstr ""
+
+msgctxt "#32049"
+msgid "Mark movies from Trakt history as watched in Kodi"
+msgstr ""
+
 msgctxt "#32050"
 msgid "TV Episodes"
 msgstr "Επεισόδια"
+
+msgctxt "#32051"
+msgid "Add new TV episodes to Trakt collection"
+msgstr ""
+
+msgctxt "#32052"
+msgid "Add watched TV episodes to Trakt history"
+msgstr ""
+
+msgctxt "#32053"
+msgid "Mark TV episodes from Trakt history as watched in Kodi"
+msgstr ""
 
 msgctxt "#32054"
 msgid "Service"
 msgstr "Υπηρεσία"
 
+msgctxt "#32055"
+msgid "Sync collection on library update or cleaning"
+msgstr ""
+
 msgctxt "#32056"
 msgid "Show sync notifications"
 msgstr "Εμφάνιση ειδοποιήσεων συγχρονισμού"
+
+msgctxt "#32057"
+msgid "Remove deleted movies from Trakt collection"
+msgstr ""
+
+msgctxt "#32058"
+msgid "Remove deleted TV episodes from Trakt collection"
+msgstr ""
 
 msgctxt "#32060"
 msgid "Hide notifications during playback"
@@ -164,18 +240,477 @@ msgctxt "#32062"
 msgid "Sync complete"
 msgstr "Ο συγχρονισμός ολοκληρώθηκε"
 
+msgctxt "#32063"
+msgid "%i movie(s) will be added to Trakt collection"
+msgstr ""
+
+msgctxt "#32064"
+msgid "%i movie playcount(s) will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32065"
+msgid "%i movie(s) playcount will be updated in Kodi"
+msgstr ""
+
 msgctxt "#32066"
 msgid "Movie Sync Complete"
 msgstr "Ολοκληρώθηκε ο Συγχρονισμός Ταινιών"
+
+msgctxt "#32067"
+msgid "Going to add %i show(s) to Trakt collection"
+msgstr ""
+
+msgctxt "#32068"
+msgid "Checking for episodes missing from Trakt collection"
+msgstr ""
+
+msgctxt "#32069"
+msgid "%i of %i show(s) have episodes added to Trakt collection"
+msgstr ""
+
+msgctxt "#32070"
+msgid "Going to update %i show(s) missing watched status"
+msgstr ""
+
+msgctxt "#32071"
+msgid "Checking watched episodes on Trakt"
+msgstr ""
+
+msgctxt "#32072"
+msgid "%i show(s) had missing watched status"
+msgstr ""
 
 msgctxt "#32073"
 msgid "%i episodes are being updated"
 msgstr "%i επεισόδια ενημερώνονται"
 
+msgctxt "#32074"
+msgid "Checking watched episodes on Kodi"
+msgstr ""
+
 msgctxt "#32075"
 msgid "Episode Sync Complete"
 msgstr "Ολοκληρώθηκε ο Συγχρονισμός Επεισοδίων"
 
+msgctxt "#32076"
+msgid "%i movie(s) will be removed from Trakt collection"
+msgstr ""
+
+msgctxt "#32077"
+msgid "Cleaning Trakt TV show collection"
+msgstr ""
+
+msgctxt "#32078"
+msgid "episodes are being removed"
+msgstr ""
+
+msgctxt "#32079"
+msgid "Loading movies from Kodi"
+msgstr ""
+
+msgctxt "#32080"
+msgid "Movies loaded from Kodi"
+msgstr ""
+
+msgctxt "#32081"
+msgid "Retrieving movie collection from Trakt"
+msgstr ""
+
+msgctxt "#32082"
+msgid "Retrieving watched movies from Trakt"
+msgstr ""
+
+msgctxt "#32083"
+msgid "Retrieved movie data from Trakt"
+msgstr ""
+
+msgctxt "#32084"
+msgid "Trakt movie collection is up to date, no movies to add"
+msgstr ""
+
+msgctxt "#32085"
+msgid "%i movie(s) were added to your Trakt collection"
+msgstr ""
+
+msgctxt "#32086"
+msgid "Trakt movie playcounts are up to date"
+msgstr ""
+
+msgctxt "#32087"
+msgid "Playcounts updated for %i movie(s) on Trakt"
+msgstr ""
+
+msgctxt "#32088"
+msgid "Kodi movie playcounts are up to date"
+msgstr ""
+
+msgctxt "#32089"
+msgid "Updating %i of %i movie playcount(s) in Kodi"
+msgstr ""
+
+msgctxt "#32090"
+msgid "Playcounts updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32091"
+msgid "Trakt movie collection is up to date, no movies removed"
+msgstr ""
+
+msgctxt "#32092"
+msgid "%i movie(s) were removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32093"
+msgid "Updating %i of %i movie playcount(s) on Trakt"
+msgstr ""
+
+msgctxt "#32094"
+msgid "Loading episode data from Kodi"
+msgstr ""
+
+msgctxt "#32095"
+msgid "Loading shows from Kodi"
+msgstr ""
+
+msgctxt "#32096"
+msgid "Shows loaded from Kodi"
+msgstr ""
+
+msgctxt "#32097"
+msgid "Parsing %i of %i episode data from Kodi"
+msgstr ""
+
+msgctxt "#32098"
+msgid "Loaded episode data from Kodi"
+msgstr ""
+
+msgctxt "#32099"
+msgid "Loading episode data from Trakt"
+msgstr ""
+
+msgctxt "#32100"
+msgid "Retrieving episode collection from Trakt"
+msgstr ""
+
+msgctxt "#32101"
+msgid "Retrieving watched episodes from Trakt"
+msgstr ""
+
+msgctxt "#32102"
+msgid "Parsing episode data %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32103"
+msgid "Retrieved episode data from Trakt"
+msgstr ""
+
+msgctxt "#32104"
+msgid "Trakt episode collection is up to date, no episodes to add"
+msgstr ""
+
+msgctxt "#32105"
+msgid "%i episode(s) were added to your Trakt collection"
+msgstr ""
+
+msgctxt "#32106"
+msgid "Trakt episode playcounts are up to date"
+msgstr ""
+
+msgctxt "#32107"
+msgid "Kodi episode playcounts are up to date"
+msgstr ""
+
+msgctxt "#32108"
+msgid "Updating %i of %i episode playcount(s) in Kodi"
+msgstr ""
+
+msgctxt "#32109"
+msgid "Playcounts updated for %i show(s) in Kodi"
+msgstr ""
+
+msgctxt "#32110"
+msgid "Trakt episode collection is clean, no episodes to remove"
+msgstr ""
+
+msgctxt "#32111"
+msgid "%i episode(s) are being removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32112"
+msgid "%i episode(s) were removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32113"
+msgid "Trakt - Marked as watched"
+msgstr ""
+
+msgctxt "#32114"
+msgid "Trakt - Failed marking as watched"
+msgstr ""
+
+msgctxt "#32115"
+msgid "%d episode(s) of '%s'"
+msgstr ""
+
+msgctxt "#32116"
+msgid "Enable debug mode"
+msgstr ""
+
+msgctxt "#32117"
+msgid "Sync movie playback progress to Kodi"
+msgstr ""
+
+msgctxt "#32118"
+msgid "Sync episode playback progress to Kodi"
+msgstr ""
+
+msgctxt "#32119"
+msgid "Retrieving episode playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32120"
+msgid "Parsing episode playback progress %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32121"
+msgid "Retrieved episode playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32122"
+msgid "Retrieving movie playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32123"
+msgid "Parsing movie playback progress %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32124"
+msgid "Retrieved movie playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32125"
+msgid "Kodi movie playback progress is up to date"
+msgstr ""
+
+msgctxt "#32126"
+msgid "%i movie(s) playback progress will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32127"
+msgid "Updating %i of %i movie(s) playback progress in Kodi"
+msgstr ""
+
+msgctxt "#32128"
+msgid "Playback progress updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32129"
+msgid "Kodi episode playback progress is up to date"
+msgstr ""
+
+msgctxt "#32130"
+msgid "Updating %i of %i episode(s) playback progress in Kodi"
+msgstr ""
+
+msgctxt "#32131"
+msgid "Playback progress updated for %i episode(s) in Kodi"
+msgstr ""
+
+msgctxt "#32132"
+msgid "Unrate this season"
+msgstr ""
+
+msgctxt "#32133"
+msgid "Manage Movie's Lists"
+msgstr ""
+
+msgctxt "#32134"
+msgid "Manage Show's Lists"
+msgstr ""
+
+msgctxt "#32135"
+msgid "Remove from Watchlist"
+msgstr ""
+
+msgctxt "#32136"
+msgid "Add to watchlist"
+msgstr ""
+
+msgctxt "#32137"
+msgid "Rate this movie"
+msgstr ""
+
+msgctxt "#32138"
+msgid "Rate this show"
+msgstr ""
+
+msgctxt "#32139"
+msgid "Rate this episode"
+msgstr ""
+
+msgctxt "#32140"
+msgid "Toggle watched"
+msgstr ""
+
+msgctxt "#32141"
+msgid "Manage all lists"
+msgstr ""
+
+msgctxt "#32142"
+msgid "Update all tags"
+msgstr ""
+
+msgctxt "#32143"
+msgid "Synchronize library"
+msgstr ""
+
+msgctxt "#32144"
+msgid "How do I authorize the trakt addon to access my trakt.tv account?"
+msgstr ""
+
+# empty strings from id 32145 to 32146
+msgctxt "#32147"
+msgid "Trakt.tv PIN Authorization Failed"
+msgstr ""
+
+# empty string with id 32148
+msgctxt "#32149"
+msgid "Rate this Season"
+msgstr ""
+
+msgctxt "#32150"
+msgid "You will be reminded in 24 hours"
+msgstr ""
+
+msgctxt "#32151"
+msgid "Use Addon Settings later if you change your mind"
+msgstr ""
+
+msgctxt "#32152"
+msgid "Trakt Authorization Complete"
+msgstr ""
+
+msgctxt "#32153"
+msgid "Trakt Account Authorization"
+msgstr ""
+
+msgctxt "#32154"
+msgid "Authorize"
+msgstr ""
+
+msgctxt "#32155"
+msgid "Remind Me Later"
+msgstr ""
+
+msgctxt "#32156"
+msgid "No Thanks"
+msgstr ""
+
+msgctxt "#32157"
+msgid "Account Authorization"
+msgstr ""
+
+# empty string with id 32158
+msgctxt "#32159"
+msgid "Visit {0} or scan the QR code."
+msgstr ""
+
+msgctxt "#32162"
+msgid "The trakt addon CAN NOT be used without authorizing it to access your trakt.tv account."
+msgstr ""
+
 msgctxt "#32163"
 msgid "User"
 msgstr "Χρήστης"
+
+msgctxt "#32164"
+msgid "Fallback to Title/Year matching if necessary"
+msgstr ""
+
+msgctxt "#32165"
+msgid "Trakt - Added to watchlist"
+msgstr ""
+
+msgctxt "#32166"
+msgid "Trakt - Failed adding to watchlist"
+msgstr ""
+
+msgctxt "#32167"
+msgid "Offset scrobble start by X minutes"
+msgstr ""
+
+msgctxt "#32168"
+msgid "Sync ratings"
+msgstr ""
+
+msgctxt "#32169"
+msgid "Kodi movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32170"
+msgid "%i movie(s) ratings will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32171"
+msgid "Updating %i of %i movie ratings in Kodi"
+msgstr ""
+
+msgctxt "#32172"
+msgid "Ratings updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32173"
+msgid "Kodi episode ratings are up to date"
+msgstr ""
+
+msgctxt "#32174"
+msgid "Updating %i of %i episode ratings in Kodi"
+msgstr ""
+
+msgctxt "#32175"
+msgid "Ratings updated for %i episode(s) in Kodi"
+msgstr ""
+
+msgctxt "#32176"
+msgid "Kodi show ratings are up to date"
+msgstr ""
+
+msgctxt "#32177"
+msgid "Updating %i of %i show ratings in Kodi"
+msgstr ""
+
+msgctxt "#32178"
+msgid "Ratings updated for %i show(s) in Kodi"
+msgstr ""
+
+msgctxt "#32179"
+msgid "Trakt movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32180"
+msgid "%i movie ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32181"
+msgid "Trakt show ratings are up to date"
+msgstr ""
+
+msgctxt "#32182"
+msgid "%i show ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32183"
+msgid "Attempt to scrobble MythTV PVR recordings"
+msgstr ""
+
+msgctxt "#32184"
+msgid "Attempt secondary show title search"
+msgstr ""
+
+msgctxt "#32185"
+msgid "Exclude Plugins"
+msgstr ""
+
+msgctxt "#32186"
+msgid "Allow script exclusions"
+msgstr ""

--- a/script.trakt/resources/language/resource.language.en_AU/strings.po
+++ b/script.trakt/resources/language/resource.language.en_AU/strings.po
@@ -10,36 +10,712 @@ msgstr ""
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Kodi Translation Team\n"
 "Language-Team: English (Australia) (http://www.transifex.com/projects/p/xbmc-addons/language/en_AU/)\n"
+"Language: en_AU\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: en_AU\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 msgctxt "#32000"
 msgid "General"
 msgstr "General"
 
+# empty strings from id 32001 to 32002
+msgctxt "#32003"
+msgid "Startup Delay"
+msgstr ""
+
 msgctxt "#32004"
 msgid "Rating"
 msgstr "Rating"
+
+msgctxt "#32005"
+msgid "Rate Movie after watching"
+msgstr ""
+
+msgctxt "#32006"
+msgid "Rate TV show Episode after watching"
+msgstr ""
+
+msgctxt "#32008"
+msgid "Minimum percent watched to display rating dialog"
+msgstr ""
+
+msgctxt "#32009"
+msgid "Allow re-rating of media"
+msgstr ""
+
+msgctxt "#32010"
+msgid "Default rating"
+msgstr ""
+
+# Scrobbling Settings
+msgctxt "#32011"
+msgid "Scrobbling"
+msgstr ""
+
+msgctxt "#32012"
+msgid "Scrobble movies"
+msgstr ""
+
+msgctxt "#32013"
+msgid "Scrobble TV show episodes"
+msgstr ""
+
+msgctxt "#32014"
+msgid "Show notification on scrobble"
+msgstr ""
+
+msgctxt "#32015"
+msgid "Trakt - Scrobbled successfully"
+msgstr ""
+
+msgctxt "#32016"
+msgid "Exclusions"
+msgstr ""
+
+msgctxt "#32017"
+msgid "Exclude Live TV"
+msgstr ""
+
+msgctxt "#32018"
+msgid "Exclude HTTP sources"
+msgstr ""
+
+msgctxt "#32019"
+msgid "Exclude path"
+msgstr ""
+
+msgctxt "#32020"
+msgid "Folder's path (including subfolders)"
+msgstr ""
+
+# empty strings from id 32021 to 32022
+msgctxt "#32023"
+msgid "Can not connect to Trakt"
+msgstr ""
 
 msgctxt "#32024"
 msgid "Error"
 msgstr "Error"
 
+# empty string with id 32025
+msgctxt "#32026"
+msgid "What Did You Think?"
+msgstr ""
+
+msgctxt "#32027"
+msgid "Totally Ninja!"
+msgstr ""
+
+msgctxt "#32028"
+msgid "Weak Sauce :("
+msgstr ""
+
+msgctxt "#32029"
+msgid "Terrible"
+msgstr ""
+
+msgctxt "#32030"
+msgid "Bad"
+msgstr ""
+
+msgctxt "#32031"
+msgid "Poor"
+msgstr ""
+
+msgctxt "#32032"
+msgid "Meh"
+msgstr ""
+
 msgctxt "#32033"
 msgid "Fair"
 msgstr "Fair"
+
+msgctxt "#32034"
+msgid "Good"
+msgstr ""
+
+msgctxt "#32035"
+msgid "Great"
+msgstr ""
+
+msgctxt "#32036"
+msgid "Superb"
+msgstr ""
+
+msgctxt "#32037"
+msgid "Unrate this movie"
+msgstr ""
+
+msgctxt "#32038"
+msgid "Unrate this show"
+msgstr ""
+
+msgctxt "#32039"
+msgid "Unrate this episode"
+msgstr ""
+
+msgctxt "#32040"
+msgid "Trakt - Rating submitted successfully"
+msgstr ""
+
+msgctxt "#32041"
+msgid "Trakt - Already rated"
+msgstr ""
+
+msgctxt "#32042"
+msgid "Trakt - Unrated successfully"
+msgstr ""
+
+msgctxt "#32043"
+msgid "Trakt - Already has the same rating"
+msgstr ""
+
+msgctxt "#32044"
+msgid "Trakt - Problem submitting rating"
+msgstr ""
+
+msgctxt "#32045"
+msgid "Synchronize"
+msgstr ""
 
 msgctxt "#32046"
 msgid "Movies"
 msgstr "Movies"
 
+msgctxt "#32047"
+msgid "Add new movies to Trakt collection"
+msgstr ""
+
+msgctxt "#32048"
+msgid "Add watched movies to Trakt history"
+msgstr ""
+
+msgctxt "#32049"
+msgid "Mark movies from Trakt history as watched in Kodi"
+msgstr ""
+
+msgctxt "#32050"
+msgid "TV Episodes"
+msgstr ""
+
+msgctxt "#32051"
+msgid "Add new TV episodes to Trakt collection"
+msgstr ""
+
+msgctxt "#32052"
+msgid "Add watched TV episodes to Trakt history"
+msgstr ""
+
+msgctxt "#32053"
+msgid "Mark TV episodes from Trakt history as watched in Kodi"
+msgstr ""
+
 msgctxt "#32054"
 msgid "Service"
 msgstr "Service"
 
+msgctxt "#32055"
+msgid "Sync collection on library update or cleaning"
+msgstr ""
+
+msgctxt "#32056"
+msgid "Show sync notifications"
+msgstr ""
+
+msgctxt "#32057"
+msgid "Remove deleted movies from Trakt collection"
+msgstr ""
+
+msgctxt "#32058"
+msgid "Remove deleted TV episodes from Trakt collection"
+msgstr ""
+
+# empty string with id 32059
+msgctxt "#32060"
+msgid "Hide notifications during playback"
+msgstr ""
+
+msgctxt "#32061"
+msgid "Sync started"
+msgstr ""
+
+msgctxt "#32062"
+msgid "Sync complete"
+msgstr ""
+
+msgctxt "#32063"
+msgid "%i movie(s) will be added to Trakt collection"
+msgstr ""
+
+msgctxt "#32064"
+msgid "%i movie playcount(s) will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32065"
+msgid "%i movie(s) playcount will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32066"
+msgid "Movie Sync Complete"
+msgstr ""
+
+msgctxt "#32067"
+msgid "Going to add %i show(s) to Trakt collection"
+msgstr ""
+
+msgctxt "#32068"
+msgid "Checking for episodes missing from Trakt collection"
+msgstr ""
+
+msgctxt "#32069"
+msgid "%i of %i show(s) have episodes added to Trakt collection"
+msgstr ""
+
+msgctxt "#32070"
+msgid "Going to update %i show(s) missing watched status"
+msgstr ""
+
+msgctxt "#32071"
+msgid "Checking watched episodes on Trakt"
+msgstr ""
+
+msgctxt "#32072"
+msgid "%i show(s) had missing watched status"
+msgstr ""
+
+msgctxt "#32073"
+msgid "%i episodes are being updated"
+msgstr ""
+
+msgctxt "#32074"
+msgid "Checking watched episodes on Kodi"
+msgstr ""
+
+msgctxt "#32075"
+msgid "Episode Sync Complete"
+msgstr ""
+
+msgctxt "#32076"
+msgid "%i movie(s) will be removed from Trakt collection"
+msgstr ""
+
+msgctxt "#32077"
+msgid "Cleaning Trakt TV show collection"
+msgstr ""
+
+msgctxt "#32078"
+msgid "episodes are being removed"
+msgstr ""
+
+msgctxt "#32079"
+msgid "Loading movies from Kodi"
+msgstr ""
+
+msgctxt "#32080"
+msgid "Movies loaded from Kodi"
+msgstr ""
+
+msgctxt "#32081"
+msgid "Retrieving movie collection from Trakt"
+msgstr ""
+
+msgctxt "#32082"
+msgid "Retrieving watched movies from Trakt"
+msgstr ""
+
+msgctxt "#32083"
+msgid "Retrieved movie data from Trakt"
+msgstr ""
+
+msgctxt "#32084"
+msgid "Trakt movie collection is up to date, no movies to add"
+msgstr ""
+
+msgctxt "#32085"
+msgid "%i movie(s) were added to your Trakt collection"
+msgstr ""
+
+msgctxt "#32086"
+msgid "Trakt movie playcounts are up to date"
+msgstr ""
+
+msgctxt "#32087"
+msgid "Playcounts updated for %i movie(s) on Trakt"
+msgstr ""
+
+msgctxt "#32088"
+msgid "Kodi movie playcounts are up to date"
+msgstr ""
+
+msgctxt "#32089"
+msgid "Updating %i of %i movie playcount(s) in Kodi"
+msgstr ""
+
+msgctxt "#32090"
+msgid "Playcounts updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32091"
+msgid "Trakt movie collection is up to date, no movies removed"
+msgstr ""
+
+msgctxt "#32092"
+msgid "%i movie(s) were removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32093"
+msgid "Updating %i of %i movie playcount(s) on Trakt"
+msgstr ""
+
+msgctxt "#32094"
+msgid "Loading episode data from Kodi"
+msgstr ""
+
+msgctxt "#32095"
+msgid "Loading shows from Kodi"
+msgstr ""
+
+msgctxt "#32096"
+msgid "Shows loaded from Kodi"
+msgstr ""
+
+msgctxt "#32097"
+msgid "Parsing %i of %i episode data from Kodi"
+msgstr ""
+
+msgctxt "#32098"
+msgid "Loaded episode data from Kodi"
+msgstr ""
+
+msgctxt "#32099"
+msgid "Loading episode data from Trakt"
+msgstr ""
+
+msgctxt "#32100"
+msgid "Retrieving episode collection from Trakt"
+msgstr ""
+
+msgctxt "#32101"
+msgid "Retrieving watched episodes from Trakt"
+msgstr ""
+
+msgctxt "#32102"
+msgid "Parsing episode data %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32103"
+msgid "Retrieved episode data from Trakt"
+msgstr ""
+
+msgctxt "#32104"
+msgid "Trakt episode collection is up to date, no episodes to add"
+msgstr ""
+
+msgctxt "#32105"
+msgid "%i episode(s) were added to your Trakt collection"
+msgstr ""
+
+msgctxt "#32106"
+msgid "Trakt episode playcounts are up to date"
+msgstr ""
+
+msgctxt "#32107"
+msgid "Kodi episode playcounts are up to date"
+msgstr ""
+
+msgctxt "#32108"
+msgid "Updating %i of %i episode playcount(s) in Kodi"
+msgstr ""
+
+msgctxt "#32109"
+msgid "Playcounts updated for %i show(s) in Kodi"
+msgstr ""
+
+msgctxt "#32110"
+msgid "Trakt episode collection is clean, no episodes to remove"
+msgstr ""
+
+msgctxt "#32111"
+msgid "%i episode(s) are being removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32112"
+msgid "%i episode(s) were removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32113"
+msgid "Trakt - Marked as watched"
+msgstr ""
+
+msgctxt "#32114"
+msgid "Trakt - Failed marking as watched"
+msgstr ""
+
+msgctxt "#32115"
+msgid "%d episode(s) of '%s'"
+msgstr ""
+
+msgctxt "#32116"
+msgid "Enable debug mode"
+msgstr ""
+
+msgctxt "#32117"
+msgid "Sync movie playback progress to Kodi"
+msgstr ""
+
+msgctxt "#32118"
+msgid "Sync episode playback progress to Kodi"
+msgstr ""
+
+msgctxt "#32119"
+msgid "Retrieving episode playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32120"
+msgid "Parsing episode playback progress %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32121"
+msgid "Retrieved episode playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32122"
+msgid "Retrieving movie playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32123"
+msgid "Parsing movie playback progress %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32124"
+msgid "Retrieved movie playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32125"
+msgid "Kodi movie playback progress is up to date"
+msgstr ""
+
+msgctxt "#32126"
+msgid "%i movie(s) playback progress will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32127"
+msgid "Updating %i of %i movie(s) playback progress in Kodi"
+msgstr ""
+
+msgctxt "#32128"
+msgid "Playback progress updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32129"
+msgid "Kodi episode playback progress is up to date"
+msgstr ""
+
+msgctxt "#32130"
+msgid "Updating %i of %i episode(s) playback progress in Kodi"
+msgstr ""
+
+msgctxt "#32131"
+msgid "Playback progress updated for %i episode(s) in Kodi"
+msgstr ""
+
+msgctxt "#32132"
+msgid "Unrate this season"
+msgstr ""
+
+msgctxt "#32133"
+msgid "Manage Movie's Lists"
+msgstr ""
+
+msgctxt "#32134"
+msgid "Manage Show's Lists"
+msgstr ""
+
+msgctxt "#32135"
+msgid "Remove from Watchlist"
+msgstr ""
+
+msgctxt "#32136"
+msgid "Add to watchlist"
+msgstr ""
+
+msgctxt "#32137"
+msgid "Rate this movie"
+msgstr ""
+
+msgctxt "#32138"
+msgid "Rate this show"
+msgstr ""
+
+msgctxt "#32139"
+msgid "Rate this episode"
+msgstr ""
+
+msgctxt "#32140"
+msgid "Toggle watched"
+msgstr ""
+
+msgctxt "#32141"
+msgid "Manage all lists"
+msgstr ""
+
+msgctxt "#32142"
+msgid "Update all tags"
+msgstr ""
+
+msgctxt "#32143"
+msgid "Synchronize library"
+msgstr ""
+
+msgctxt "#32144"
+msgid "How do I authorize the trakt addon to access my trakt.tv account?"
+msgstr ""
+
+# empty strings from id 32145 to 32146
+msgctxt "#32147"
+msgid "Trakt.tv PIN Authorization Failed"
+msgstr ""
+
+# empty string with id 32148
+msgctxt "#32149"
+msgid "Rate this Season"
+msgstr ""
+
+msgctxt "#32150"
+msgid "You will be reminded in 24 hours"
+msgstr ""
+
+msgctxt "#32151"
+msgid "Use Addon Settings later if you change your mind"
+msgstr ""
+
+msgctxt "#32152"
+msgid "Trakt Authorization Complete"
+msgstr ""
+
+msgctxt "#32153"
+msgid "Trakt Account Authorization"
+msgstr ""
+
+msgctxt "#32154"
+msgid "Authorize"
+msgstr ""
+
+msgctxt "#32155"
+msgid "Remind Me Later"
+msgstr ""
+
+msgctxt "#32156"
+msgid "No Thanks"
+msgstr ""
+
+msgctxt "#32157"
+msgid "Account Authorization"
+msgstr ""
+
+# empty string with id 32158
+msgctxt "#32159"
+msgid "Visit {0} or scan the QR code."
+msgstr ""
+
+msgctxt "#32162"
+msgid "The trakt addon CAN NOT be used without authorizing it to access your trakt.tv account."
+msgstr ""
+
 msgctxt "#32163"
 msgid "User"
 msgstr "User"
+
+msgctxt "#32164"
+msgid "Fallback to Title/Year matching if necessary"
+msgstr ""
+
+msgctxt "#32165"
+msgid "Trakt - Added to watchlist"
+msgstr ""
+
+msgctxt "#32166"
+msgid "Trakt - Failed adding to watchlist"
+msgstr ""
+
+msgctxt "#32167"
+msgid "Offset scrobble start by X minutes"
+msgstr ""
+
+msgctxt "#32168"
+msgid "Sync ratings"
+msgstr ""
+
+msgctxt "#32169"
+msgid "Kodi movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32170"
+msgid "%i movie(s) ratings will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32171"
+msgid "Updating %i of %i movie ratings in Kodi"
+msgstr ""
+
+msgctxt "#32172"
+msgid "Ratings updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32173"
+msgid "Kodi episode ratings are up to date"
+msgstr ""
+
+msgctxt "#32174"
+msgid "Updating %i of %i episode ratings in Kodi"
+msgstr ""
+
+msgctxt "#32175"
+msgid "Ratings updated for %i episode(s) in Kodi"
+msgstr ""
+
+msgctxt "#32176"
+msgid "Kodi show ratings are up to date"
+msgstr ""
+
+msgctxt "#32177"
+msgid "Updating %i of %i show ratings in Kodi"
+msgstr ""
+
+msgctxt "#32178"
+msgid "Ratings updated for %i show(s) in Kodi"
+msgstr ""
+
+msgctxt "#32179"
+msgid "Trakt movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32180"
+msgid "%i movie ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32181"
+msgid "Trakt show ratings are up to date"
+msgstr ""
+
+msgctxt "#32182"
+msgid "%i show ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32183"
+msgid "Attempt to scrobble MythTV PVR recordings"
+msgstr ""
+
+msgctxt "#32184"
+msgid "Attempt secondary show title search"
+msgstr ""
+
+msgctxt "#32185"
+msgid "Exclude Plugins"
+msgstr ""
+
+msgctxt "#32186"
+msgid "Allow script exclusions"
+msgstr ""

--- a/script.trakt/resources/language/resource.language.en_NZ/strings.po
+++ b/script.trakt/resources/language/resource.language.en_NZ/strings.po
@@ -10,10 +10,10 @@ msgstr ""
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Kodi Translation Team\n"
 "Language-Team: English (New Zealand) (http://www.transifex.com/projects/p/xbmc-addons/language/en_NZ/)\n"
+"Language: en_NZ\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: en_NZ\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 msgctxt "#32000"
@@ -608,17 +608,10 @@ msgctxt "#32157"
 msgid "Account Authorization"
 msgstr "Account Authorisation"
 
+# empty string with id 32158
 msgctxt "#32159"
-msgid "Visit {0} or scan the QR Code below."
-msgstr "Visit {0} or scan the QR Code below."
-
-msgctxt "#32160"
-msgid "Authorize the trakt addon to access your account."
-msgstr "Authorise the trakt addon to access your account."
-
-msgctxt "#32161"
-msgid "Enter the PIN provided in the box below."
-msgstr "Enter the PIN provided in the box below."
+msgid "Visit {0} or scan the QR code."
+msgstr ""
 
 msgctxt "#32162"
 msgid "The trakt addon CAN NOT be used without authorizing it to access your trakt.tv account."
@@ -639,3 +632,95 @@ msgstr "Trakt - Added to watchlist"
 msgctxt "#32166"
 msgid "Trakt - Failed adding to watchlist"
 msgstr "Trakt - Failed adding to watchlist"
+
+msgctxt "#32167"
+msgid "Offset scrobble start by X minutes"
+msgstr ""
+
+msgctxt "#32168"
+msgid "Sync ratings"
+msgstr ""
+
+msgctxt "#32169"
+msgid "Kodi movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32170"
+msgid "%i movie(s) ratings will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32171"
+msgid "Updating %i of %i movie ratings in Kodi"
+msgstr ""
+
+msgctxt "#32172"
+msgid "Ratings updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32173"
+msgid "Kodi episode ratings are up to date"
+msgstr ""
+
+msgctxt "#32174"
+msgid "Updating %i of %i episode ratings in Kodi"
+msgstr ""
+
+msgctxt "#32175"
+msgid "Ratings updated for %i episode(s) in Kodi"
+msgstr ""
+
+msgctxt "#32176"
+msgid "Kodi show ratings are up to date"
+msgstr ""
+
+msgctxt "#32177"
+msgid "Updating %i of %i show ratings in Kodi"
+msgstr ""
+
+msgctxt "#32178"
+msgid "Ratings updated for %i show(s) in Kodi"
+msgstr ""
+
+msgctxt "#32179"
+msgid "Trakt movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32180"
+msgid "%i movie ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32181"
+msgid "Trakt show ratings are up to date"
+msgstr ""
+
+msgctxt "#32182"
+msgid "%i show ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32183"
+msgid "Attempt to scrobble MythTV PVR recordings"
+msgstr ""
+
+msgctxt "#32184"
+msgid "Attempt secondary show title search"
+msgstr ""
+
+msgctxt "#32185"
+msgid "Exclude Plugins"
+msgstr ""
+
+msgctxt "#32186"
+msgid "Allow script exclusions"
+msgstr ""
+
+#~ msgctxt "#32159"
+#~ msgid "Visit {0} or scan the QR Code below."
+#~ msgstr "Visit {0} or scan the QR Code below."
+
+#~ msgctxt "#32160"
+#~ msgid "Authorize the trakt addon to access your account."
+#~ msgstr "Authorise the trakt addon to access your account."
+
+#~ msgctxt "#32161"
+#~ msgid "Enter the PIN provided in the box below."
+#~ msgstr "Enter the PIN provided in the box below."

--- a/script.trakt/resources/language/resource.language.en_US/strings.po
+++ b/script.trakt/resources/language/resource.language.en_US/strings.po
@@ -10,10 +10,10 @@ msgstr ""
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Kodi Translation Team\n"
 "Language-Team: English (US) (http://www.transifex.com/projects/p/xbmc-addons/language/en_US/)\n"
+"Language: en_US\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: en_US\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 msgctxt "#32000"
@@ -608,17 +608,10 @@ msgctxt "#32157"
 msgid "Account Authorization"
 msgstr "Account Authorization"
 
+# empty string with id 32158
 msgctxt "#32159"
-msgid "Visit {0} or scan the QR Code below."
-msgstr "Visit {0} or scan the QR Code below."
-
-msgctxt "#32160"
-msgid "Authorize the trakt addon to access your account."
-msgstr "Authorize the trakt addon to access your account."
-
-msgctxt "#32161"
-msgid "Enter the PIN provided in the box below."
-msgstr "Enter the PIN provided in the box below."
+msgid "Visit {0} or scan the QR code."
+msgstr ""
 
 msgctxt "#32162"
 msgid "The trakt addon CAN NOT be used without authorizing it to access your trakt.tv account."
@@ -639,3 +632,95 @@ msgstr "Trakt - Added to watchlist"
 msgctxt "#32166"
 msgid "Trakt - Failed adding to watchlist"
 msgstr "Trakt - Failed adding to watchlist"
+
+msgctxt "#32167"
+msgid "Offset scrobble start by X minutes"
+msgstr ""
+
+msgctxt "#32168"
+msgid "Sync ratings"
+msgstr ""
+
+msgctxt "#32169"
+msgid "Kodi movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32170"
+msgid "%i movie(s) ratings will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32171"
+msgid "Updating %i of %i movie ratings in Kodi"
+msgstr ""
+
+msgctxt "#32172"
+msgid "Ratings updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32173"
+msgid "Kodi episode ratings are up to date"
+msgstr ""
+
+msgctxt "#32174"
+msgid "Updating %i of %i episode ratings in Kodi"
+msgstr ""
+
+msgctxt "#32175"
+msgid "Ratings updated for %i episode(s) in Kodi"
+msgstr ""
+
+msgctxt "#32176"
+msgid "Kodi show ratings are up to date"
+msgstr ""
+
+msgctxt "#32177"
+msgid "Updating %i of %i show ratings in Kodi"
+msgstr ""
+
+msgctxt "#32178"
+msgid "Ratings updated for %i show(s) in Kodi"
+msgstr ""
+
+msgctxt "#32179"
+msgid "Trakt movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32180"
+msgid "%i movie ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32181"
+msgid "Trakt show ratings are up to date"
+msgstr ""
+
+msgctxt "#32182"
+msgid "%i show ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32183"
+msgid "Attempt to scrobble MythTV PVR recordings"
+msgstr ""
+
+msgctxt "#32184"
+msgid "Attempt secondary show title search"
+msgstr ""
+
+msgctxt "#32185"
+msgid "Exclude Plugins"
+msgstr ""
+
+msgctxt "#32186"
+msgid "Allow script exclusions"
+msgstr ""
+
+#~ msgctxt "#32159"
+#~ msgid "Visit {0} or scan the QR Code below."
+#~ msgstr "Visit {0} or scan the QR Code below."
+
+#~ msgctxt "#32160"
+#~ msgid "Authorize the trakt addon to access your account."
+#~ msgstr "Authorize the trakt addon to access your account."
+
+#~ msgctxt "#32161"
+#~ msgid "Enter the PIN provided in the box below."
+#~ msgstr "Enter the PIN provided in the box below."

--- a/script.trakt/resources/language/resource.language.eo/strings.po
+++ b/script.trakt/resources/language/resource.language.eo/strings.po
@@ -10,24 +10,712 @@ msgstr ""
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Kodi Translation Team\n"
 "Language-Team: Esperanto (http://www.transifex.com/projects/p/xbmc-addons/language/eo/)\n"
+"Language: eo\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: eo\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 msgctxt "#32000"
 msgid "General"
 msgstr "Generalo"
 
+# empty strings from id 32001 to 32002
+msgctxt "#32003"
+msgid "Startup Delay"
+msgstr ""
+
+msgctxt "#32004"
+msgid "Rating"
+msgstr ""
+
+msgctxt "#32005"
+msgid "Rate Movie after watching"
+msgstr ""
+
+msgctxt "#32006"
+msgid "Rate TV show Episode after watching"
+msgstr ""
+
+msgctxt "#32008"
+msgid "Minimum percent watched to display rating dialog"
+msgstr ""
+
+msgctxt "#32009"
+msgid "Allow re-rating of media"
+msgstr ""
+
+msgctxt "#32010"
+msgid "Default rating"
+msgstr ""
+
+# Scrobbling Settings
+msgctxt "#32011"
+msgid "Scrobbling"
+msgstr ""
+
+msgctxt "#32012"
+msgid "Scrobble movies"
+msgstr ""
+
+msgctxt "#32013"
+msgid "Scrobble TV show episodes"
+msgstr ""
+
+msgctxt "#32014"
+msgid "Show notification on scrobble"
+msgstr ""
+
+msgctxt "#32015"
+msgid "Trakt - Scrobbled successfully"
+msgstr ""
+
+msgctxt "#32016"
+msgid "Exclusions"
+msgstr ""
+
+msgctxt "#32017"
+msgid "Exclude Live TV"
+msgstr ""
+
+msgctxt "#32018"
+msgid "Exclude HTTP sources"
+msgstr ""
+
+msgctxt "#32019"
+msgid "Exclude path"
+msgstr ""
+
+msgctxt "#32020"
+msgid "Folder's path (including subfolders)"
+msgstr ""
+
+# empty strings from id 32021 to 32022
+msgctxt "#32023"
+msgid "Can not connect to Trakt"
+msgstr ""
+
 msgctxt "#32024"
 msgid "Error"
 msgstr "Eraro"
+
+# empty string with id 32025
+msgctxt "#32026"
+msgid "What Did You Think?"
+msgstr ""
+
+msgctxt "#32027"
+msgid "Totally Ninja!"
+msgstr ""
+
+msgctxt "#32028"
+msgid "Weak Sauce :("
+msgstr ""
+
+msgctxt "#32029"
+msgid "Terrible"
+msgstr ""
+
+msgctxt "#32030"
+msgid "Bad"
+msgstr ""
+
+msgctxt "#32031"
+msgid "Poor"
+msgstr ""
+
+msgctxt "#32032"
+msgid "Meh"
+msgstr ""
 
 msgctxt "#32033"
 msgid "Fair"
 msgstr "Fair"
 
+msgctxt "#32034"
+msgid "Good"
+msgstr ""
+
+msgctxt "#32035"
+msgid "Great"
+msgstr ""
+
+msgctxt "#32036"
+msgid "Superb"
+msgstr ""
+
+msgctxt "#32037"
+msgid "Unrate this movie"
+msgstr ""
+
+msgctxt "#32038"
+msgid "Unrate this show"
+msgstr ""
+
+msgctxt "#32039"
+msgid "Unrate this episode"
+msgstr ""
+
+msgctxt "#32040"
+msgid "Trakt - Rating submitted successfully"
+msgstr ""
+
+msgctxt "#32041"
+msgid "Trakt - Already rated"
+msgstr ""
+
+msgctxt "#32042"
+msgid "Trakt - Unrated successfully"
+msgstr ""
+
+msgctxt "#32043"
+msgid "Trakt - Already has the same rating"
+msgstr ""
+
+msgctxt "#32044"
+msgid "Trakt - Problem submitting rating"
+msgstr ""
+
+msgctxt "#32045"
+msgid "Synchronize"
+msgstr ""
+
 msgctxt "#32046"
 msgid "Movies"
 msgstr "Filmoj"
+
+msgctxt "#32047"
+msgid "Add new movies to Trakt collection"
+msgstr ""
+
+msgctxt "#32048"
+msgid "Add watched movies to Trakt history"
+msgstr ""
+
+msgctxt "#32049"
+msgid "Mark movies from Trakt history as watched in Kodi"
+msgstr ""
+
+msgctxt "#32050"
+msgid "TV Episodes"
+msgstr ""
+
+msgctxt "#32051"
+msgid "Add new TV episodes to Trakt collection"
+msgstr ""
+
+msgctxt "#32052"
+msgid "Add watched TV episodes to Trakt history"
+msgstr ""
+
+msgctxt "#32053"
+msgid "Mark TV episodes from Trakt history as watched in Kodi"
+msgstr ""
+
+msgctxt "#32054"
+msgid "Service"
+msgstr ""
+
+msgctxt "#32055"
+msgid "Sync collection on library update or cleaning"
+msgstr ""
+
+msgctxt "#32056"
+msgid "Show sync notifications"
+msgstr ""
+
+msgctxt "#32057"
+msgid "Remove deleted movies from Trakt collection"
+msgstr ""
+
+msgctxt "#32058"
+msgid "Remove deleted TV episodes from Trakt collection"
+msgstr ""
+
+# empty string with id 32059
+msgctxt "#32060"
+msgid "Hide notifications during playback"
+msgstr ""
+
+msgctxt "#32061"
+msgid "Sync started"
+msgstr ""
+
+msgctxt "#32062"
+msgid "Sync complete"
+msgstr ""
+
+msgctxt "#32063"
+msgid "%i movie(s) will be added to Trakt collection"
+msgstr ""
+
+msgctxt "#32064"
+msgid "%i movie playcount(s) will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32065"
+msgid "%i movie(s) playcount will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32066"
+msgid "Movie Sync Complete"
+msgstr ""
+
+msgctxt "#32067"
+msgid "Going to add %i show(s) to Trakt collection"
+msgstr ""
+
+msgctxt "#32068"
+msgid "Checking for episodes missing from Trakt collection"
+msgstr ""
+
+msgctxt "#32069"
+msgid "%i of %i show(s) have episodes added to Trakt collection"
+msgstr ""
+
+msgctxt "#32070"
+msgid "Going to update %i show(s) missing watched status"
+msgstr ""
+
+msgctxt "#32071"
+msgid "Checking watched episodes on Trakt"
+msgstr ""
+
+msgctxt "#32072"
+msgid "%i show(s) had missing watched status"
+msgstr ""
+
+msgctxt "#32073"
+msgid "%i episodes are being updated"
+msgstr ""
+
+msgctxt "#32074"
+msgid "Checking watched episodes on Kodi"
+msgstr ""
+
+msgctxt "#32075"
+msgid "Episode Sync Complete"
+msgstr ""
+
+msgctxt "#32076"
+msgid "%i movie(s) will be removed from Trakt collection"
+msgstr ""
+
+msgctxt "#32077"
+msgid "Cleaning Trakt TV show collection"
+msgstr ""
+
+msgctxt "#32078"
+msgid "episodes are being removed"
+msgstr ""
+
+msgctxt "#32079"
+msgid "Loading movies from Kodi"
+msgstr ""
+
+msgctxt "#32080"
+msgid "Movies loaded from Kodi"
+msgstr ""
+
+msgctxt "#32081"
+msgid "Retrieving movie collection from Trakt"
+msgstr ""
+
+msgctxt "#32082"
+msgid "Retrieving watched movies from Trakt"
+msgstr ""
+
+msgctxt "#32083"
+msgid "Retrieved movie data from Trakt"
+msgstr ""
+
+msgctxt "#32084"
+msgid "Trakt movie collection is up to date, no movies to add"
+msgstr ""
+
+msgctxt "#32085"
+msgid "%i movie(s) were added to your Trakt collection"
+msgstr ""
+
+msgctxt "#32086"
+msgid "Trakt movie playcounts are up to date"
+msgstr ""
+
+msgctxt "#32087"
+msgid "Playcounts updated for %i movie(s) on Trakt"
+msgstr ""
+
+msgctxt "#32088"
+msgid "Kodi movie playcounts are up to date"
+msgstr ""
+
+msgctxt "#32089"
+msgid "Updating %i of %i movie playcount(s) in Kodi"
+msgstr ""
+
+msgctxt "#32090"
+msgid "Playcounts updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32091"
+msgid "Trakt movie collection is up to date, no movies removed"
+msgstr ""
+
+msgctxt "#32092"
+msgid "%i movie(s) were removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32093"
+msgid "Updating %i of %i movie playcount(s) on Trakt"
+msgstr ""
+
+msgctxt "#32094"
+msgid "Loading episode data from Kodi"
+msgstr ""
+
+msgctxt "#32095"
+msgid "Loading shows from Kodi"
+msgstr ""
+
+msgctxt "#32096"
+msgid "Shows loaded from Kodi"
+msgstr ""
+
+msgctxt "#32097"
+msgid "Parsing %i of %i episode data from Kodi"
+msgstr ""
+
+msgctxt "#32098"
+msgid "Loaded episode data from Kodi"
+msgstr ""
+
+msgctxt "#32099"
+msgid "Loading episode data from Trakt"
+msgstr ""
+
+msgctxt "#32100"
+msgid "Retrieving episode collection from Trakt"
+msgstr ""
+
+msgctxt "#32101"
+msgid "Retrieving watched episodes from Trakt"
+msgstr ""
+
+msgctxt "#32102"
+msgid "Parsing episode data %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32103"
+msgid "Retrieved episode data from Trakt"
+msgstr ""
+
+msgctxt "#32104"
+msgid "Trakt episode collection is up to date, no episodes to add"
+msgstr ""
+
+msgctxt "#32105"
+msgid "%i episode(s) were added to your Trakt collection"
+msgstr ""
+
+msgctxt "#32106"
+msgid "Trakt episode playcounts are up to date"
+msgstr ""
+
+msgctxt "#32107"
+msgid "Kodi episode playcounts are up to date"
+msgstr ""
+
+msgctxt "#32108"
+msgid "Updating %i of %i episode playcount(s) in Kodi"
+msgstr ""
+
+msgctxt "#32109"
+msgid "Playcounts updated for %i show(s) in Kodi"
+msgstr ""
+
+msgctxt "#32110"
+msgid "Trakt episode collection is clean, no episodes to remove"
+msgstr ""
+
+msgctxt "#32111"
+msgid "%i episode(s) are being removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32112"
+msgid "%i episode(s) were removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32113"
+msgid "Trakt - Marked as watched"
+msgstr ""
+
+msgctxt "#32114"
+msgid "Trakt - Failed marking as watched"
+msgstr ""
+
+msgctxt "#32115"
+msgid "%d episode(s) of '%s'"
+msgstr ""
+
+msgctxt "#32116"
+msgid "Enable debug mode"
+msgstr ""
+
+msgctxt "#32117"
+msgid "Sync movie playback progress to Kodi"
+msgstr ""
+
+msgctxt "#32118"
+msgid "Sync episode playback progress to Kodi"
+msgstr ""
+
+msgctxt "#32119"
+msgid "Retrieving episode playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32120"
+msgid "Parsing episode playback progress %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32121"
+msgid "Retrieved episode playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32122"
+msgid "Retrieving movie playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32123"
+msgid "Parsing movie playback progress %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32124"
+msgid "Retrieved movie playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32125"
+msgid "Kodi movie playback progress is up to date"
+msgstr ""
+
+msgctxt "#32126"
+msgid "%i movie(s) playback progress will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32127"
+msgid "Updating %i of %i movie(s) playback progress in Kodi"
+msgstr ""
+
+msgctxt "#32128"
+msgid "Playback progress updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32129"
+msgid "Kodi episode playback progress is up to date"
+msgstr ""
+
+msgctxt "#32130"
+msgid "Updating %i of %i episode(s) playback progress in Kodi"
+msgstr ""
+
+msgctxt "#32131"
+msgid "Playback progress updated for %i episode(s) in Kodi"
+msgstr ""
+
+msgctxt "#32132"
+msgid "Unrate this season"
+msgstr ""
+
+msgctxt "#32133"
+msgid "Manage Movie's Lists"
+msgstr ""
+
+msgctxt "#32134"
+msgid "Manage Show's Lists"
+msgstr ""
+
+msgctxt "#32135"
+msgid "Remove from Watchlist"
+msgstr ""
+
+msgctxt "#32136"
+msgid "Add to watchlist"
+msgstr ""
+
+msgctxt "#32137"
+msgid "Rate this movie"
+msgstr ""
+
+msgctxt "#32138"
+msgid "Rate this show"
+msgstr ""
+
+msgctxt "#32139"
+msgid "Rate this episode"
+msgstr ""
+
+msgctxt "#32140"
+msgid "Toggle watched"
+msgstr ""
+
+msgctxt "#32141"
+msgid "Manage all lists"
+msgstr ""
+
+msgctxt "#32142"
+msgid "Update all tags"
+msgstr ""
+
+msgctxt "#32143"
+msgid "Synchronize library"
+msgstr ""
+
+msgctxt "#32144"
+msgid "How do I authorize the trakt addon to access my trakt.tv account?"
+msgstr ""
+
+# empty strings from id 32145 to 32146
+msgctxt "#32147"
+msgid "Trakt.tv PIN Authorization Failed"
+msgstr ""
+
+# empty string with id 32148
+msgctxt "#32149"
+msgid "Rate this Season"
+msgstr ""
+
+msgctxt "#32150"
+msgid "You will be reminded in 24 hours"
+msgstr ""
+
+msgctxt "#32151"
+msgid "Use Addon Settings later if you change your mind"
+msgstr ""
+
+msgctxt "#32152"
+msgid "Trakt Authorization Complete"
+msgstr ""
+
+msgctxt "#32153"
+msgid "Trakt Account Authorization"
+msgstr ""
+
+msgctxt "#32154"
+msgid "Authorize"
+msgstr ""
+
+msgctxt "#32155"
+msgid "Remind Me Later"
+msgstr ""
+
+msgctxt "#32156"
+msgid "No Thanks"
+msgstr ""
+
+msgctxt "#32157"
+msgid "Account Authorization"
+msgstr ""
+
+# empty string with id 32158
+msgctxt "#32159"
+msgid "Visit {0} or scan the QR code."
+msgstr ""
+
+msgctxt "#32162"
+msgid "The trakt addon CAN NOT be used without authorizing it to access your trakt.tv account."
+msgstr ""
+
+msgctxt "#32163"
+msgid "User"
+msgstr ""
+
+msgctxt "#32164"
+msgid "Fallback to Title/Year matching if necessary"
+msgstr ""
+
+msgctxt "#32165"
+msgid "Trakt - Added to watchlist"
+msgstr ""
+
+msgctxt "#32166"
+msgid "Trakt - Failed adding to watchlist"
+msgstr ""
+
+msgctxt "#32167"
+msgid "Offset scrobble start by X minutes"
+msgstr ""
+
+msgctxt "#32168"
+msgid "Sync ratings"
+msgstr ""
+
+msgctxt "#32169"
+msgid "Kodi movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32170"
+msgid "%i movie(s) ratings will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32171"
+msgid "Updating %i of %i movie ratings in Kodi"
+msgstr ""
+
+msgctxt "#32172"
+msgid "Ratings updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32173"
+msgid "Kodi episode ratings are up to date"
+msgstr ""
+
+msgctxt "#32174"
+msgid "Updating %i of %i episode ratings in Kodi"
+msgstr ""
+
+msgctxt "#32175"
+msgid "Ratings updated for %i episode(s) in Kodi"
+msgstr ""
+
+msgctxt "#32176"
+msgid "Kodi show ratings are up to date"
+msgstr ""
+
+msgctxt "#32177"
+msgid "Updating %i of %i show ratings in Kodi"
+msgstr ""
+
+msgctxt "#32178"
+msgid "Ratings updated for %i show(s) in Kodi"
+msgstr ""
+
+msgctxt "#32179"
+msgid "Trakt movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32180"
+msgid "%i movie ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32181"
+msgid "Trakt show ratings are up to date"
+msgstr ""
+
+msgctxt "#32182"
+msgid "%i show ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32183"
+msgid "Attempt to scrobble MythTV PVR recordings"
+msgstr ""
+
+msgctxt "#32184"
+msgid "Attempt secondary show title search"
+msgstr ""
+
+msgctxt "#32185"
+msgid "Exclude Plugins"
+msgstr ""
+
+msgctxt "#32186"
+msgid "Allow script exclusions"
+msgstr ""

--- a/script.trakt/resources/language/resource.language.es_AR/strings.po
+++ b/script.trakt/resources/language/resource.language.es_AR/strings.po
@@ -10,36 +10,712 @@ msgstr ""
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Kodi Translation Team\n"
 "Language-Team: Spanish (Argentina) (http://www.transifex.com/projects/p/xbmc-addons/language/es_AR/)\n"
+"Language: es_AR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: es_AR\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 msgctxt "#32000"
 msgid "General"
 msgstr "General"
 
+# empty strings from id 32001 to 32002
+msgctxt "#32003"
+msgid "Startup Delay"
+msgstr ""
+
 msgctxt "#32004"
 msgid "Rating"
 msgstr "Valoración"
+
+msgctxt "#32005"
+msgid "Rate Movie after watching"
+msgstr ""
+
+msgctxt "#32006"
+msgid "Rate TV show Episode after watching"
+msgstr ""
+
+msgctxt "#32008"
+msgid "Minimum percent watched to display rating dialog"
+msgstr ""
+
+msgctxt "#32009"
+msgid "Allow re-rating of media"
+msgstr ""
+
+msgctxt "#32010"
+msgid "Default rating"
+msgstr ""
+
+# Scrobbling Settings
+msgctxt "#32011"
+msgid "Scrobbling"
+msgstr ""
+
+msgctxt "#32012"
+msgid "Scrobble movies"
+msgstr ""
+
+msgctxt "#32013"
+msgid "Scrobble TV show episodes"
+msgstr ""
+
+msgctxt "#32014"
+msgid "Show notification on scrobble"
+msgstr ""
+
+msgctxt "#32015"
+msgid "Trakt - Scrobbled successfully"
+msgstr ""
+
+msgctxt "#32016"
+msgid "Exclusions"
+msgstr ""
+
+msgctxt "#32017"
+msgid "Exclude Live TV"
+msgstr ""
+
+msgctxt "#32018"
+msgid "Exclude HTTP sources"
+msgstr ""
+
+msgctxt "#32019"
+msgid "Exclude path"
+msgstr ""
+
+msgctxt "#32020"
+msgid "Folder's path (including subfolders)"
+msgstr ""
+
+# empty strings from id 32021 to 32022
+msgctxt "#32023"
+msgid "Can not connect to Trakt"
+msgstr ""
 
 msgctxt "#32024"
 msgid "Error"
 msgstr "Error"
 
+# empty string with id 32025
+msgctxt "#32026"
+msgid "What Did You Think?"
+msgstr ""
+
+msgctxt "#32027"
+msgid "Totally Ninja!"
+msgstr ""
+
+msgctxt "#32028"
+msgid "Weak Sauce :("
+msgstr ""
+
+msgctxt "#32029"
+msgid "Terrible"
+msgstr ""
+
+msgctxt "#32030"
+msgid "Bad"
+msgstr ""
+
+msgctxt "#32031"
+msgid "Poor"
+msgstr ""
+
+msgctxt "#32032"
+msgid "Meh"
+msgstr ""
+
 msgctxt "#32033"
 msgid "Fair"
 msgstr "Bueno"
+
+msgctxt "#32034"
+msgid "Good"
+msgstr ""
+
+msgctxt "#32035"
+msgid "Great"
+msgstr ""
+
+msgctxt "#32036"
+msgid "Superb"
+msgstr ""
+
+msgctxt "#32037"
+msgid "Unrate this movie"
+msgstr ""
+
+msgctxt "#32038"
+msgid "Unrate this show"
+msgstr ""
+
+msgctxt "#32039"
+msgid "Unrate this episode"
+msgstr ""
+
+msgctxt "#32040"
+msgid "Trakt - Rating submitted successfully"
+msgstr ""
+
+msgctxt "#32041"
+msgid "Trakt - Already rated"
+msgstr ""
+
+msgctxt "#32042"
+msgid "Trakt - Unrated successfully"
+msgstr ""
+
+msgctxt "#32043"
+msgid "Trakt - Already has the same rating"
+msgstr ""
+
+msgctxt "#32044"
+msgid "Trakt - Problem submitting rating"
+msgstr ""
+
+msgctxt "#32045"
+msgid "Synchronize"
+msgstr ""
 
 msgctxt "#32046"
 msgid "Movies"
 msgstr "Películas"
 
+msgctxt "#32047"
+msgid "Add new movies to Trakt collection"
+msgstr ""
+
+msgctxt "#32048"
+msgid "Add watched movies to Trakt history"
+msgstr ""
+
+msgctxt "#32049"
+msgid "Mark movies from Trakt history as watched in Kodi"
+msgstr ""
+
+msgctxt "#32050"
+msgid "TV Episodes"
+msgstr ""
+
+msgctxt "#32051"
+msgid "Add new TV episodes to Trakt collection"
+msgstr ""
+
+msgctxt "#32052"
+msgid "Add watched TV episodes to Trakt history"
+msgstr ""
+
+msgctxt "#32053"
+msgid "Mark TV episodes from Trakt history as watched in Kodi"
+msgstr ""
+
 msgctxt "#32054"
 msgid "Service"
 msgstr "Servicio"
 
+msgctxt "#32055"
+msgid "Sync collection on library update or cleaning"
+msgstr ""
+
+msgctxt "#32056"
+msgid "Show sync notifications"
+msgstr ""
+
+msgctxt "#32057"
+msgid "Remove deleted movies from Trakt collection"
+msgstr ""
+
+msgctxt "#32058"
+msgid "Remove deleted TV episodes from Trakt collection"
+msgstr ""
+
+# empty string with id 32059
+msgctxt "#32060"
+msgid "Hide notifications during playback"
+msgstr ""
+
+msgctxt "#32061"
+msgid "Sync started"
+msgstr ""
+
+msgctxt "#32062"
+msgid "Sync complete"
+msgstr ""
+
+msgctxt "#32063"
+msgid "%i movie(s) will be added to Trakt collection"
+msgstr ""
+
+msgctxt "#32064"
+msgid "%i movie playcount(s) will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32065"
+msgid "%i movie(s) playcount will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32066"
+msgid "Movie Sync Complete"
+msgstr ""
+
+msgctxt "#32067"
+msgid "Going to add %i show(s) to Trakt collection"
+msgstr ""
+
+msgctxt "#32068"
+msgid "Checking for episodes missing from Trakt collection"
+msgstr ""
+
+msgctxt "#32069"
+msgid "%i of %i show(s) have episodes added to Trakt collection"
+msgstr ""
+
+msgctxt "#32070"
+msgid "Going to update %i show(s) missing watched status"
+msgstr ""
+
+msgctxt "#32071"
+msgid "Checking watched episodes on Trakt"
+msgstr ""
+
+msgctxt "#32072"
+msgid "%i show(s) had missing watched status"
+msgstr ""
+
+msgctxt "#32073"
+msgid "%i episodes are being updated"
+msgstr ""
+
+msgctxt "#32074"
+msgid "Checking watched episodes on Kodi"
+msgstr ""
+
+msgctxt "#32075"
+msgid "Episode Sync Complete"
+msgstr ""
+
+msgctxt "#32076"
+msgid "%i movie(s) will be removed from Trakt collection"
+msgstr ""
+
+msgctxt "#32077"
+msgid "Cleaning Trakt TV show collection"
+msgstr ""
+
+msgctxt "#32078"
+msgid "episodes are being removed"
+msgstr ""
+
+msgctxt "#32079"
+msgid "Loading movies from Kodi"
+msgstr ""
+
+msgctxt "#32080"
+msgid "Movies loaded from Kodi"
+msgstr ""
+
+msgctxt "#32081"
+msgid "Retrieving movie collection from Trakt"
+msgstr ""
+
+msgctxt "#32082"
+msgid "Retrieving watched movies from Trakt"
+msgstr ""
+
+msgctxt "#32083"
+msgid "Retrieved movie data from Trakt"
+msgstr ""
+
+msgctxt "#32084"
+msgid "Trakt movie collection is up to date, no movies to add"
+msgstr ""
+
+msgctxt "#32085"
+msgid "%i movie(s) were added to your Trakt collection"
+msgstr ""
+
+msgctxt "#32086"
+msgid "Trakt movie playcounts are up to date"
+msgstr ""
+
+msgctxt "#32087"
+msgid "Playcounts updated for %i movie(s) on Trakt"
+msgstr ""
+
+msgctxt "#32088"
+msgid "Kodi movie playcounts are up to date"
+msgstr ""
+
+msgctxt "#32089"
+msgid "Updating %i of %i movie playcount(s) in Kodi"
+msgstr ""
+
+msgctxt "#32090"
+msgid "Playcounts updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32091"
+msgid "Trakt movie collection is up to date, no movies removed"
+msgstr ""
+
+msgctxt "#32092"
+msgid "%i movie(s) were removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32093"
+msgid "Updating %i of %i movie playcount(s) on Trakt"
+msgstr ""
+
+msgctxt "#32094"
+msgid "Loading episode data from Kodi"
+msgstr ""
+
+msgctxt "#32095"
+msgid "Loading shows from Kodi"
+msgstr ""
+
+msgctxt "#32096"
+msgid "Shows loaded from Kodi"
+msgstr ""
+
+msgctxt "#32097"
+msgid "Parsing %i of %i episode data from Kodi"
+msgstr ""
+
+msgctxt "#32098"
+msgid "Loaded episode data from Kodi"
+msgstr ""
+
+msgctxt "#32099"
+msgid "Loading episode data from Trakt"
+msgstr ""
+
+msgctxt "#32100"
+msgid "Retrieving episode collection from Trakt"
+msgstr ""
+
+msgctxt "#32101"
+msgid "Retrieving watched episodes from Trakt"
+msgstr ""
+
+msgctxt "#32102"
+msgid "Parsing episode data %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32103"
+msgid "Retrieved episode data from Trakt"
+msgstr ""
+
+msgctxt "#32104"
+msgid "Trakt episode collection is up to date, no episodes to add"
+msgstr ""
+
+msgctxt "#32105"
+msgid "%i episode(s) were added to your Trakt collection"
+msgstr ""
+
+msgctxt "#32106"
+msgid "Trakt episode playcounts are up to date"
+msgstr ""
+
+msgctxt "#32107"
+msgid "Kodi episode playcounts are up to date"
+msgstr ""
+
+msgctxt "#32108"
+msgid "Updating %i of %i episode playcount(s) in Kodi"
+msgstr ""
+
+msgctxt "#32109"
+msgid "Playcounts updated for %i show(s) in Kodi"
+msgstr ""
+
+msgctxt "#32110"
+msgid "Trakt episode collection is clean, no episodes to remove"
+msgstr ""
+
+msgctxt "#32111"
+msgid "%i episode(s) are being removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32112"
+msgid "%i episode(s) were removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32113"
+msgid "Trakt - Marked as watched"
+msgstr ""
+
+msgctxt "#32114"
+msgid "Trakt - Failed marking as watched"
+msgstr ""
+
+msgctxt "#32115"
+msgid "%d episode(s) of '%s'"
+msgstr ""
+
+msgctxt "#32116"
+msgid "Enable debug mode"
+msgstr ""
+
+msgctxt "#32117"
+msgid "Sync movie playback progress to Kodi"
+msgstr ""
+
+msgctxt "#32118"
+msgid "Sync episode playback progress to Kodi"
+msgstr ""
+
+msgctxt "#32119"
+msgid "Retrieving episode playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32120"
+msgid "Parsing episode playback progress %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32121"
+msgid "Retrieved episode playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32122"
+msgid "Retrieving movie playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32123"
+msgid "Parsing movie playback progress %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32124"
+msgid "Retrieved movie playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32125"
+msgid "Kodi movie playback progress is up to date"
+msgstr ""
+
+msgctxt "#32126"
+msgid "%i movie(s) playback progress will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32127"
+msgid "Updating %i of %i movie(s) playback progress in Kodi"
+msgstr ""
+
+msgctxt "#32128"
+msgid "Playback progress updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32129"
+msgid "Kodi episode playback progress is up to date"
+msgstr ""
+
+msgctxt "#32130"
+msgid "Updating %i of %i episode(s) playback progress in Kodi"
+msgstr ""
+
+msgctxt "#32131"
+msgid "Playback progress updated for %i episode(s) in Kodi"
+msgstr ""
+
+msgctxt "#32132"
+msgid "Unrate this season"
+msgstr ""
+
+msgctxt "#32133"
+msgid "Manage Movie's Lists"
+msgstr ""
+
+msgctxt "#32134"
+msgid "Manage Show's Lists"
+msgstr ""
+
+msgctxt "#32135"
+msgid "Remove from Watchlist"
+msgstr ""
+
+msgctxt "#32136"
+msgid "Add to watchlist"
+msgstr ""
+
+msgctxt "#32137"
+msgid "Rate this movie"
+msgstr ""
+
+msgctxt "#32138"
+msgid "Rate this show"
+msgstr ""
+
+msgctxt "#32139"
+msgid "Rate this episode"
+msgstr ""
+
+msgctxt "#32140"
+msgid "Toggle watched"
+msgstr ""
+
+msgctxt "#32141"
+msgid "Manage all lists"
+msgstr ""
+
+msgctxt "#32142"
+msgid "Update all tags"
+msgstr ""
+
+msgctxt "#32143"
+msgid "Synchronize library"
+msgstr ""
+
+msgctxt "#32144"
+msgid "How do I authorize the trakt addon to access my trakt.tv account?"
+msgstr ""
+
+# empty strings from id 32145 to 32146
+msgctxt "#32147"
+msgid "Trakt.tv PIN Authorization Failed"
+msgstr ""
+
+# empty string with id 32148
+msgctxt "#32149"
+msgid "Rate this Season"
+msgstr ""
+
+msgctxt "#32150"
+msgid "You will be reminded in 24 hours"
+msgstr ""
+
+msgctxt "#32151"
+msgid "Use Addon Settings later if you change your mind"
+msgstr ""
+
+msgctxt "#32152"
+msgid "Trakt Authorization Complete"
+msgstr ""
+
+msgctxt "#32153"
+msgid "Trakt Account Authorization"
+msgstr ""
+
+msgctxt "#32154"
+msgid "Authorize"
+msgstr ""
+
+msgctxt "#32155"
+msgid "Remind Me Later"
+msgstr ""
+
+msgctxt "#32156"
+msgid "No Thanks"
+msgstr ""
+
+msgctxt "#32157"
+msgid "Account Authorization"
+msgstr ""
+
+# empty string with id 32158
+msgctxt "#32159"
+msgid "Visit {0} or scan the QR code."
+msgstr ""
+
+msgctxt "#32162"
+msgid "The trakt addon CAN NOT be used without authorizing it to access your trakt.tv account."
+msgstr ""
+
 msgctxt "#32163"
 msgid "User"
 msgstr "Usuarios"
+
+msgctxt "#32164"
+msgid "Fallback to Title/Year matching if necessary"
+msgstr ""
+
+msgctxt "#32165"
+msgid "Trakt - Added to watchlist"
+msgstr ""
+
+msgctxt "#32166"
+msgid "Trakt - Failed adding to watchlist"
+msgstr ""
+
+msgctxt "#32167"
+msgid "Offset scrobble start by X minutes"
+msgstr ""
+
+msgctxt "#32168"
+msgid "Sync ratings"
+msgstr ""
+
+msgctxt "#32169"
+msgid "Kodi movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32170"
+msgid "%i movie(s) ratings will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32171"
+msgid "Updating %i of %i movie ratings in Kodi"
+msgstr ""
+
+msgctxt "#32172"
+msgid "Ratings updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32173"
+msgid "Kodi episode ratings are up to date"
+msgstr ""
+
+msgctxt "#32174"
+msgid "Updating %i of %i episode ratings in Kodi"
+msgstr ""
+
+msgctxt "#32175"
+msgid "Ratings updated for %i episode(s) in Kodi"
+msgstr ""
+
+msgctxt "#32176"
+msgid "Kodi show ratings are up to date"
+msgstr ""
+
+msgctxt "#32177"
+msgid "Updating %i of %i show ratings in Kodi"
+msgstr ""
+
+msgctxt "#32178"
+msgid "Ratings updated for %i show(s) in Kodi"
+msgstr ""
+
+msgctxt "#32179"
+msgid "Trakt movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32180"
+msgid "%i movie ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32181"
+msgid "Trakt show ratings are up to date"
+msgstr ""
+
+msgctxt "#32182"
+msgid "%i show ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32183"
+msgid "Attempt to scrobble MythTV PVR recordings"
+msgstr ""
+
+msgctxt "#32184"
+msgid "Attempt secondary show title search"
+msgstr ""
+
+msgctxt "#32185"
+msgid "Exclude Plugins"
+msgstr ""
+
+msgctxt "#32186"
+msgid "Allow script exclusions"
+msgstr ""

--- a/script.trakt/resources/language/resource.language.es_ES/strings.po
+++ b/script.trakt/resources/language/resource.language.es_ES/strings.po
@@ -7,14 +7,15 @@ msgstr ""
 "Project-Id-Version: XBMC Addons\n"
 "Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: Kodi Translation Team\n"
-"Language-Team: Spanish (http://www.transifex.com/projects/p/xbmc-addons/language/es/)\n"
+"PO-Revision-Date: 2021-03-20 15:56+0000\n"
+"Last-Translator: Christian Gade <gade@kodi.tv>\n"
+"Language-Team: Spanish (Spain) <https://kodi.weblate.cloud/projects/kodi-add-ons-scripts/script-trakt/es_es/>\n"
+"Language: es_ES\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: es\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Generator: Weblate 4.5.1\n"
 
 msgctxt "#32000"
 msgid "General"
@@ -70,7 +71,7 @@ msgstr "Trakt - Scrobble completado con éxito"
 
 msgctxt "#32016"
 msgid "Exclusions"
-msgstr "Exclusiones "
+msgstr "Exclusiones"
 
 msgctxt "#32017"
 msgid "Exclude Live TV"
@@ -190,7 +191,7 @@ msgstr "Añadir Peliculas vistas al historial de Trakt"
 
 msgctxt "#32049"
 msgid "Mark movies from Trakt history as watched in Kodi"
-msgstr "Marcar Películas del historial de Trakt como vistas en Kodi."
+msgstr "Marcar Películas del historial de Trakt como vistas en Kodi"
 
 msgctxt "#32050"
 msgid "TV Episodes"
@@ -206,7 +207,7 @@ msgstr "Añadir Episodios vistos al historial de Trakt"
 
 msgctxt "#32053"
 msgid "Mark TV episodes from Trakt history as watched in Kodi"
-msgstr "Marcar Episodios del historial de Trakt como vistos en Kodi."
+msgstr "Marcar Episodios del historial de Trakt como vistos en Kodi"
 
 msgctxt "#32054"
 msgid "Service"
@@ -216,13 +217,17 @@ msgctxt "#32055"
 msgid "Sync collection on library update or cleaning"
 msgstr "Sincronizar la colección al actualizar o limpiar la libreria"
 
+msgctxt "#32056"
+msgid "Show sync notifications"
+msgstr ""
+
 msgctxt "#32057"
 msgid "Remove deleted movies from Trakt collection"
-msgstr "Eliminar de la colección de Trakt las Películas borradas."
+msgstr "Eliminar de la colección de Trakt las Películas borradas"
 
 msgctxt "#32058"
 msgid "Remove deleted TV episodes from Trakt collection"
-msgstr "Eliminar de la colección de Trakt los Episodios borrados."
+msgstr "Eliminar de la colección de Trakt los Episodios borrados"
 
 msgctxt "#32060"
 msgid "Hide notifications during playback"
@@ -246,7 +251,7 @@ msgstr "Contador(es) de %i Películas se actualizará en Trakt"
 
 msgctxt "#32065"
 msgid "%i movie(s) playcount will be updated in Kodi"
-msgstr "Contador de reproducciones de %i Película(s) se actualizará en Kodi."
+msgstr "Contador de reproducciones de %i Película(s) se actualizará en Kodi"
 
 msgctxt "#32066"
 msgid "Movie Sync Complete"
@@ -398,7 +403,7 @@ msgstr "Emparejando datos de %i de %i Episodios desde Trakt"
 
 msgctxt "#32103"
 msgid "Retrieved episode data from Trakt"
-msgstr "Recuperados los datos de Episodios desde Trakt."
+msgstr "Recuperados los datos de Episodios desde Trakt"
 
 msgctxt "#32104"
 msgid "Trakt episode collection is up to date, no episodes to add"
@@ -426,7 +431,7 @@ msgstr "Actualizado el contador de reproducciones de %i Serie(s) en Kodi"
 
 msgctxt "#32110"
 msgid "Trakt episode collection is clean, no episodes to remove"
-msgstr "La colección de Episodios de Trakt está limpio, no hay Episodios que eliminar."
+msgstr "La colección de Episodios de Trakt está limpio, no hay Episodios que eliminar"
 
 msgctxt "#32111"
 msgid "%i episode(s) are being removed from your Trakt collection"
@@ -454,11 +459,11 @@ msgstr "Activar modo depuración"
 
 msgctxt "#32117"
 msgid "Sync movie playback progress to Kodi"
-msgstr "Sincronizando  el progreso de reproducción de Películas a Kodi"
+msgstr "Sincronizando el progreso de reproducción de Películas a Kodi"
 
 msgctxt "#32118"
 msgid "Sync episode playback progress to Kodi"
-msgstr "Sincronizando  el progreso de reproducción de Episodios a Kodi"
+msgstr "Sincronizando el progreso de reproducción de Episodios a Kodi"
 
 msgctxt "#32119"
 msgid "Retrieving episode playback progress from Trakt"
@@ -528,6 +533,38 @@ msgctxt "#32135"
 msgid "Remove from Watchlist"
 msgstr "Eliminar de la lista de reproducción"
 
+msgctxt "#32136"
+msgid "Add to watchlist"
+msgstr ""
+
+msgctxt "#32137"
+msgid "Rate this movie"
+msgstr ""
+
+msgctxt "#32138"
+msgid "Rate this show"
+msgstr ""
+
+msgctxt "#32139"
+msgid "Rate this episode"
+msgstr ""
+
+msgctxt "#32140"
+msgid "Toggle watched"
+msgstr ""
+
+msgctxt "#32141"
+msgid "Manage all lists"
+msgstr ""
+
+msgctxt "#32142"
+msgid "Update all tags"
+msgstr ""
+
+msgctxt "#32143"
+msgid "Synchronize library"
+msgstr ""
+
 msgctxt "#32144"
 msgid "How do I authorize the trakt addon to access my trakt.tv account?"
 msgstr "¿Cómo autorizo al addon de trakt a acceder a mi cuenta trakt?"
@@ -572,13 +609,10 @@ msgctxt "#32157"
 msgid "Account Authorization"
 msgstr "Autorización de cuenta."
 
-msgctxt "#32160"
-msgid "Authorize the trakt addon to access your account."
-msgstr "Autoriza el addon de trakt a acceder a tu cuenta."
-
-msgctxt "#32161"
-msgid "Enter the PIN provided in the box below."
-msgstr "Introduce el PIN proporcionado en el cuadro de abajo."
+# empty string with id 32158
+msgctxt "#32159"
+msgid "Visit {0} or scan the QR code."
+msgstr ""
 
 msgctxt "#32162"
 msgid "The trakt addon CAN NOT be used without authorizing it to access your trakt.tv account."
@@ -591,3 +625,99 @@ msgstr "Usuario"
 msgctxt "#32164"
 msgid "Fallback to Title/Year matching if necessary"
 msgstr "Retorna a Título/Año emparejando si es necesario"
+
+msgctxt "#32165"
+msgid "Trakt - Added to watchlist"
+msgstr ""
+
+msgctxt "#32166"
+msgid "Trakt - Failed adding to watchlist"
+msgstr ""
+
+msgctxt "#32167"
+msgid "Offset scrobble start by X minutes"
+msgstr ""
+
+msgctxt "#32168"
+msgid "Sync ratings"
+msgstr ""
+
+msgctxt "#32169"
+msgid "Kodi movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32170"
+msgid "%i movie(s) ratings will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32171"
+msgid "Updating %i of %i movie ratings in Kodi"
+msgstr ""
+
+msgctxt "#32172"
+msgid "Ratings updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32173"
+msgid "Kodi episode ratings are up to date"
+msgstr ""
+
+msgctxt "#32174"
+msgid "Updating %i of %i episode ratings in Kodi"
+msgstr ""
+
+msgctxt "#32175"
+msgid "Ratings updated for %i episode(s) in Kodi"
+msgstr ""
+
+msgctxt "#32176"
+msgid "Kodi show ratings are up to date"
+msgstr ""
+
+msgctxt "#32177"
+msgid "Updating %i of %i show ratings in Kodi"
+msgstr ""
+
+msgctxt "#32178"
+msgid "Ratings updated for %i show(s) in Kodi"
+msgstr ""
+
+msgctxt "#32179"
+msgid "Trakt movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32180"
+msgid "%i movie ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32181"
+msgid "Trakt show ratings are up to date"
+msgstr ""
+
+msgctxt "#32182"
+msgid "%i show ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32183"
+msgid "Attempt to scrobble MythTV PVR recordings"
+msgstr ""
+
+msgctxt "#32184"
+msgid "Attempt secondary show title search"
+msgstr ""
+
+msgctxt "#32185"
+msgid "Exclude Plugins"
+msgstr ""
+
+msgctxt "#32186"
+msgid "Allow script exclusions"
+msgstr ""
+
+#~ msgctxt "#32160"
+#~ msgid "Authorize the trakt addon to access your account."
+#~ msgstr "Autoriza el addon de trakt a acceder a tu cuenta."
+
+#~ msgctxt "#32161"
+#~ msgid "Enter the PIN provided in the box below."
+#~ msgstr "Introduce el PIN proporcionado en el cuadro de abajo."

--- a/script.trakt/resources/language/resource.language.es_MX/strings.po
+++ b/script.trakt/resources/language/resource.language.es_MX/strings.po
@@ -7,35 +7,716 @@ msgstr ""
 "Project-Id-Version: XBMC Addons\n"
 "Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: Kodi Translation Team\n"
-"Language-Team: Spanish (Mexico) (http://www.transifex.com/projects/p/xbmc-addons/language/es_MX/)\n"
+"PO-Revision-Date: 2021-03-25 13:52+0000\n"
+"Last-Translator: Edson Armando <edsonarmando78@outlook.com>\n"
+"Language-Team: Spanish (Mexico) <https://kodi.weblate.cloud/projects/kodi-add-ons-scripts/script-trakt/es_mx/>\n"
+"Language: es_MX\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: es_MX\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Generator: Weblate 4.5.1\n"
 
 msgctxt "#32000"
 msgid "General"
 msgstr "General"
 
+# empty strings from id 32001 to 32002
+msgctxt "#32003"
+msgid "Startup Delay"
+msgstr "Retraso de inicio"
+
 msgctxt "#32004"
 msgid "Rating"
 msgstr "Calificación"
+
+msgctxt "#32005"
+msgid "Rate Movie after watching"
+msgstr "Calificar película después de ver"
+
+msgctxt "#32006"
+msgid "Rate TV show Episode after watching"
+msgstr "Calificar serie después de ver"
+
+msgctxt "#32008"
+msgid "Minimum percent watched to display rating dialog"
+msgstr "Porcentaje mínimo visto para mostrar diálogo de calificación"
+
+msgctxt "#32009"
+msgid "Allow re-rating of media"
+msgstr "Permitir calificar nuevamente"
+
+msgctxt "#32010"
+msgid "Default rating"
+msgstr "Calificación por defecto"
+
+# Scrobbling Settings
+msgctxt "#32011"
+msgid "Scrobbling"
+msgstr ""
+
+msgctxt "#32012"
+msgid "Scrobble movies"
+msgstr ""
+
+msgctxt "#32013"
+msgid "Scrobble TV show episodes"
+msgstr ""
+
+msgctxt "#32014"
+msgid "Show notification on scrobble"
+msgstr ""
+
+msgctxt "#32015"
+msgid "Trakt - Scrobbled successfully"
+msgstr ""
+
+msgctxt "#32016"
+msgid "Exclusions"
+msgstr "Exclusiones"
+
+msgctxt "#32017"
+msgid "Exclude Live TV"
+msgstr "Excluir TV en vivo"
+
+msgctxt "#32018"
+msgid "Exclude HTTP sources"
+msgstr "Excluir fuentes HTTP"
+
+msgctxt "#32019"
+msgid "Exclude path"
+msgstr "Excluir ruta"
+
+msgctxt "#32020"
+msgid "Folder's path (including subfolders)"
+msgstr "Ruta a la carpeta (incluyendo subcarpetas)"
+
+# empty strings from id 32021 to 32022
+msgctxt "#32023"
+msgid "Can not connect to Trakt"
+msgstr "No se puede conectar con Trakt"
 
 msgctxt "#32024"
 msgid "Error"
 msgstr "Error"
 
+# empty string with id 32025
+msgctxt "#32026"
+msgid "What Did You Think?"
+msgstr "¿Qué te pareció?"
+
+msgctxt "#32027"
+msgid "Totally Ninja!"
+msgstr "¡Súper chido!"
+
+msgctxt "#32028"
+msgid "Weak Sauce :("
+msgstr "Peor que chile que no pica"
+
+msgctxt "#32029"
+msgid "Terrible"
+msgstr "Muy malo"
+
+msgctxt "#32030"
+msgid "Bad"
+msgstr "Malo"
+
+msgctxt "#32031"
+msgid "Poor"
+msgstr "Medio malo"
+
+msgctxt "#32032"
+msgid "Meh"
+msgstr "Término medio"
+
 msgctxt "#32033"
 msgid "Fair"
 msgstr "Bueno"
+
+msgctxt "#32034"
+msgid "Good"
+msgstr "Bueno"
+
+msgctxt "#32035"
+msgid "Great"
+msgstr "Muy bueno"
+
+msgctxt "#32036"
+msgid "Superb"
+msgstr "Buenísimo"
+
+msgctxt "#32037"
+msgid "Unrate this movie"
+msgstr "Des-calificar esta película"
+
+msgctxt "#32038"
+msgid "Unrate this show"
+msgstr "Des-calificar esta serie"
+
+msgctxt "#32039"
+msgid "Unrate this episode"
+msgstr "Des-calificar este episodio"
+
+msgctxt "#32040"
+msgid "Trakt - Rating submitted successfully"
+msgstr "Trakt - Calificación enviada con éxito"
+
+msgctxt "#32041"
+msgid "Trakt - Already rated"
+msgstr "Trakt - Ya se ha calificado"
+
+msgctxt "#32042"
+msgid "Trakt - Unrated successfully"
+msgstr "Trakt - Des-calificado con éxito"
+
+msgctxt "#32043"
+msgid "Trakt - Already has the same rating"
+msgstr "Trakt - Misma calificación"
+
+msgctxt "#32044"
+msgid "Trakt - Problem submitting rating"
+msgstr "Trakt - Problemas al enviar la calificación"
+
+msgctxt "#32045"
+msgid "Synchronize"
+msgstr "Sincronizar"
 
 msgctxt "#32046"
 msgid "Movies"
 msgstr "Películas"
 
+msgctxt "#32047"
+msgid "Add new movies to Trakt collection"
+msgstr "Agregar nuevas películas a la colección de Trakt"
+
+msgctxt "#32048"
+msgid "Add watched movies to Trakt history"
+msgstr "Agregar películas vistas al historial de Trakt"
+
+msgctxt "#32049"
+msgid "Mark movies from Trakt history as watched in Kodi"
+msgstr "Marcar películas del historial de Trakt como vistas en Kodi"
+
+msgctxt "#32050"
+msgid "TV Episodes"
+msgstr "Episodios"
+
+msgctxt "#32051"
+msgid "Add new TV episodes to Trakt collection"
+msgstr "Agrergar nuevos episodios a la colección de Trakt"
+
+msgctxt "#32052"
+msgid "Add watched TV episodes to Trakt history"
+msgstr "Agregar episodios vistos al historial de Trakt"
+
+msgctxt "#32053"
+msgid "Mark TV episodes from Trakt history as watched in Kodi"
+msgstr "Marcar episodios del historial de Trakt como vistos en Kodi"
+
 msgctxt "#32054"
 msgid "Service"
 msgstr "Servicio"
+
+msgctxt "#32055"
+msgid "Sync collection on library update or cleaning"
+msgstr "Sincronizar colección al limpiar o actualizar la biblioteca"
+
+msgctxt "#32056"
+msgid "Show sync notifications"
+msgstr "Mostrar notificaciones de sincronización"
+
+msgctxt "#32057"
+msgid "Remove deleted movies from Trakt collection"
+msgstr "Quitar películas eliminadas de la colección de Trakt"
+
+msgctxt "#32058"
+msgid "Remove deleted TV episodes from Trakt collection"
+msgstr "Quitar episodios eliminados de la colección de Trakt"
+
+# empty string with id 32059
+msgctxt "#32060"
+msgid "Hide notifications during playback"
+msgstr "Ocultar notificaciones durante la reproducción"
+
+msgctxt "#32061"
+msgid "Sync started"
+msgstr "Sincronización iniciada"
+
+msgctxt "#32062"
+msgid "Sync complete"
+msgstr "Sincronización completada"
+
+msgctxt "#32063"
+msgid "%i movie(s) will be added to Trakt collection"
+msgstr "%i película(s) se agregará(n) a la colección de Trakt"
+
+msgctxt "#32064"
+msgid "%i movie playcount(s) will be updated on Trakt"
+msgstr "%i reproducción(es) de película se actualizará(n) en Trakt"
+
+msgctxt "#32065"
+msgid "%i movie(s) playcount will be updated in Kodi"
+msgstr "%i reproducciones de película(s) se actualizará(n) en Kodi"
+
+msgctxt "#32066"
+msgid "Movie Sync Complete"
+msgstr "Sincronización de películas completada"
+
+msgctxt "#32067"
+msgid "Going to add %i show(s) to Trakt collection"
+msgstr "Se agregará(n) %i serie(s) a la colección de Trakt"
+
+msgctxt "#32068"
+msgid "Checking for episodes missing from Trakt collection"
+msgstr ""
+
+msgctxt "#32069"
+msgid "%i of %i show(s) have episodes added to Trakt collection"
+msgstr ""
+
+msgctxt "#32070"
+msgid "Going to update %i show(s) missing watched status"
+msgstr ""
+
+msgctxt "#32071"
+msgid "Checking watched episodes on Trakt"
+msgstr ""
+
+msgctxt "#32072"
+msgid "%i show(s) had missing watched status"
+msgstr ""
+
+msgctxt "#32073"
+msgid "%i episodes are being updated"
+msgstr ""
+
+msgctxt "#32074"
+msgid "Checking watched episodes on Kodi"
+msgstr ""
+
+msgctxt "#32075"
+msgid "Episode Sync Complete"
+msgstr ""
+
+msgctxt "#32076"
+msgid "%i movie(s) will be removed from Trakt collection"
+msgstr ""
+
+msgctxt "#32077"
+msgid "Cleaning Trakt TV show collection"
+msgstr ""
+
+msgctxt "#32078"
+msgid "episodes are being removed"
+msgstr ""
+
+msgctxt "#32079"
+msgid "Loading movies from Kodi"
+msgstr ""
+
+msgctxt "#32080"
+msgid "Movies loaded from Kodi"
+msgstr ""
+
+msgctxt "#32081"
+msgid "Retrieving movie collection from Trakt"
+msgstr ""
+
+msgctxt "#32082"
+msgid "Retrieving watched movies from Trakt"
+msgstr ""
+
+msgctxt "#32083"
+msgid "Retrieved movie data from Trakt"
+msgstr ""
+
+msgctxt "#32084"
+msgid "Trakt movie collection is up to date, no movies to add"
+msgstr ""
+
+msgctxt "#32085"
+msgid "%i movie(s) were added to your Trakt collection"
+msgstr ""
+
+msgctxt "#32086"
+msgid "Trakt movie playcounts are up to date"
+msgstr ""
+
+msgctxt "#32087"
+msgid "Playcounts updated for %i movie(s) on Trakt"
+msgstr ""
+
+msgctxt "#32088"
+msgid "Kodi movie playcounts are up to date"
+msgstr ""
+
+msgctxt "#32089"
+msgid "Updating %i of %i movie playcount(s) in Kodi"
+msgstr ""
+
+msgctxt "#32090"
+msgid "Playcounts updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32091"
+msgid "Trakt movie collection is up to date, no movies removed"
+msgstr ""
+
+msgctxt "#32092"
+msgid "%i movie(s) were removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32093"
+msgid "Updating %i of %i movie playcount(s) on Trakt"
+msgstr ""
+
+msgctxt "#32094"
+msgid "Loading episode data from Kodi"
+msgstr ""
+
+msgctxt "#32095"
+msgid "Loading shows from Kodi"
+msgstr ""
+
+msgctxt "#32096"
+msgid "Shows loaded from Kodi"
+msgstr ""
+
+msgctxt "#32097"
+msgid "Parsing %i of %i episode data from Kodi"
+msgstr ""
+
+msgctxt "#32098"
+msgid "Loaded episode data from Kodi"
+msgstr ""
+
+msgctxt "#32099"
+msgid "Loading episode data from Trakt"
+msgstr ""
+
+msgctxt "#32100"
+msgid "Retrieving episode collection from Trakt"
+msgstr ""
+
+msgctxt "#32101"
+msgid "Retrieving watched episodes from Trakt"
+msgstr ""
+
+msgctxt "#32102"
+msgid "Parsing episode data %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32103"
+msgid "Retrieved episode data from Trakt"
+msgstr ""
+
+msgctxt "#32104"
+msgid "Trakt episode collection is up to date, no episodes to add"
+msgstr ""
+
+msgctxt "#32105"
+msgid "%i episode(s) were added to your Trakt collection"
+msgstr ""
+
+msgctxt "#32106"
+msgid "Trakt episode playcounts are up to date"
+msgstr ""
+
+msgctxt "#32107"
+msgid "Kodi episode playcounts are up to date"
+msgstr ""
+
+msgctxt "#32108"
+msgid "Updating %i of %i episode playcount(s) in Kodi"
+msgstr ""
+
+msgctxt "#32109"
+msgid "Playcounts updated for %i show(s) in Kodi"
+msgstr ""
+
+msgctxt "#32110"
+msgid "Trakt episode collection is clean, no episodes to remove"
+msgstr ""
+
+msgctxt "#32111"
+msgid "%i episode(s) are being removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32112"
+msgid "%i episode(s) were removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32113"
+msgid "Trakt - Marked as watched"
+msgstr ""
+
+msgctxt "#32114"
+msgid "Trakt - Failed marking as watched"
+msgstr ""
+
+msgctxt "#32115"
+msgid "%d episode(s) of '%s'"
+msgstr ""
+
+msgctxt "#32116"
+msgid "Enable debug mode"
+msgstr ""
+
+msgctxt "#32117"
+msgid "Sync movie playback progress to Kodi"
+msgstr ""
+
+msgctxt "#32118"
+msgid "Sync episode playback progress to Kodi"
+msgstr ""
+
+msgctxt "#32119"
+msgid "Retrieving episode playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32120"
+msgid "Parsing episode playback progress %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32121"
+msgid "Retrieved episode playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32122"
+msgid "Retrieving movie playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32123"
+msgid "Parsing movie playback progress %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32124"
+msgid "Retrieved movie playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32125"
+msgid "Kodi movie playback progress is up to date"
+msgstr ""
+
+msgctxt "#32126"
+msgid "%i movie(s) playback progress will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32127"
+msgid "Updating %i of %i movie(s) playback progress in Kodi"
+msgstr ""
+
+msgctxt "#32128"
+msgid "Playback progress updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32129"
+msgid "Kodi episode playback progress is up to date"
+msgstr ""
+
+msgctxt "#32130"
+msgid "Updating %i of %i episode(s) playback progress in Kodi"
+msgstr ""
+
+msgctxt "#32131"
+msgid "Playback progress updated for %i episode(s) in Kodi"
+msgstr ""
+
+msgctxt "#32132"
+msgid "Unrate this season"
+msgstr ""
+
+msgctxt "#32133"
+msgid "Manage Movie's Lists"
+msgstr ""
+
+msgctxt "#32134"
+msgid "Manage Show's Lists"
+msgstr ""
+
+msgctxt "#32135"
+msgid "Remove from Watchlist"
+msgstr ""
+
+msgctxt "#32136"
+msgid "Add to watchlist"
+msgstr ""
+
+msgctxt "#32137"
+msgid "Rate this movie"
+msgstr ""
+
+msgctxt "#32138"
+msgid "Rate this show"
+msgstr ""
+
+msgctxt "#32139"
+msgid "Rate this episode"
+msgstr ""
+
+msgctxt "#32140"
+msgid "Toggle watched"
+msgstr ""
+
+msgctxt "#32141"
+msgid "Manage all lists"
+msgstr ""
+
+msgctxt "#32142"
+msgid "Update all tags"
+msgstr ""
+
+msgctxt "#32143"
+msgid "Synchronize library"
+msgstr ""
+
+msgctxt "#32144"
+msgid "How do I authorize the trakt addon to access my trakt.tv account?"
+msgstr ""
+
+# empty strings from id 32145 to 32146
+msgctxt "#32147"
+msgid "Trakt.tv PIN Authorization Failed"
+msgstr ""
+
+# empty string with id 32148
+msgctxt "#32149"
+msgid "Rate this Season"
+msgstr ""
+
+msgctxt "#32150"
+msgid "You will be reminded in 24 hours"
+msgstr ""
+
+msgctxt "#32151"
+msgid "Use Addon Settings later if you change your mind"
+msgstr ""
+
+msgctxt "#32152"
+msgid "Trakt Authorization Complete"
+msgstr ""
+
+msgctxt "#32153"
+msgid "Trakt Account Authorization"
+msgstr ""
+
+msgctxt "#32154"
+msgid "Authorize"
+msgstr ""
+
+msgctxt "#32155"
+msgid "Remind Me Later"
+msgstr ""
+
+msgctxt "#32156"
+msgid "No Thanks"
+msgstr ""
+
+msgctxt "#32157"
+msgid "Account Authorization"
+msgstr ""
+
+# empty string with id 32158
+msgctxt "#32159"
+msgid "Visit {0} or scan the QR code."
+msgstr ""
+
+msgctxt "#32162"
+msgid "The trakt addon CAN NOT be used without authorizing it to access your trakt.tv account."
+msgstr ""
+
+msgctxt "#32163"
+msgid "User"
+msgstr ""
+
+msgctxt "#32164"
+msgid "Fallback to Title/Year matching if necessary"
+msgstr ""
+
+msgctxt "#32165"
+msgid "Trakt - Added to watchlist"
+msgstr ""
+
+msgctxt "#32166"
+msgid "Trakt - Failed adding to watchlist"
+msgstr ""
+
+msgctxt "#32167"
+msgid "Offset scrobble start by X minutes"
+msgstr ""
+
+msgctxt "#32168"
+msgid "Sync ratings"
+msgstr ""
+
+msgctxt "#32169"
+msgid "Kodi movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32170"
+msgid "%i movie(s) ratings will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32171"
+msgid "Updating %i of %i movie ratings in Kodi"
+msgstr ""
+
+msgctxt "#32172"
+msgid "Ratings updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32173"
+msgid "Kodi episode ratings are up to date"
+msgstr ""
+
+msgctxt "#32174"
+msgid "Updating %i of %i episode ratings in Kodi"
+msgstr ""
+
+msgctxt "#32175"
+msgid "Ratings updated for %i episode(s) in Kodi"
+msgstr ""
+
+msgctxt "#32176"
+msgid "Kodi show ratings are up to date"
+msgstr ""
+
+msgctxt "#32177"
+msgid "Updating %i of %i show ratings in Kodi"
+msgstr ""
+
+msgctxt "#32178"
+msgid "Ratings updated for %i show(s) in Kodi"
+msgstr ""
+
+msgctxt "#32179"
+msgid "Trakt movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32180"
+msgid "%i movie ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32181"
+msgid "Trakt show ratings are up to date"
+msgstr ""
+
+msgctxt "#32182"
+msgid "%i show ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32183"
+msgid "Attempt to scrobble MythTV PVR recordings"
+msgstr ""
+
+msgctxt "#32184"
+msgid "Attempt secondary show title search"
+msgstr ""
+
+msgctxt "#32185"
+msgid "Exclude Plugins"
+msgstr ""
+
+msgctxt "#32186"
+msgid "Allow script exclusions"
+msgstr ""

--- a/script.trakt/resources/language/resource.language.et_EE/strings.po
+++ b/script.trakt/resources/language/resource.language.et_EE/strings.po
@@ -10,32 +10,712 @@ msgstr ""
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Kodi Translation Team\n"
 "Language-Team: Estonian (http://www.transifex.com/projects/p/xbmc-addons/language/et/)\n"
+"Language: et\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: et\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 msgctxt "#32000"
 msgid "General"
 msgstr "Üldine"
 
+# empty strings from id 32001 to 32002
+msgctxt "#32003"
+msgid "Startup Delay"
+msgstr ""
+
 msgctxt "#32004"
 msgid "Rating"
 msgstr "Hinne"
+
+msgctxt "#32005"
+msgid "Rate Movie after watching"
+msgstr ""
+
+msgctxt "#32006"
+msgid "Rate TV show Episode after watching"
+msgstr ""
+
+msgctxt "#32008"
+msgid "Minimum percent watched to display rating dialog"
+msgstr ""
+
+msgctxt "#32009"
+msgid "Allow re-rating of media"
+msgstr ""
+
+msgctxt "#32010"
+msgid "Default rating"
+msgstr ""
+
+# Scrobbling Settings
+msgctxt "#32011"
+msgid "Scrobbling"
+msgstr ""
+
+msgctxt "#32012"
+msgid "Scrobble movies"
+msgstr ""
+
+msgctxt "#32013"
+msgid "Scrobble TV show episodes"
+msgstr ""
+
+msgctxt "#32014"
+msgid "Show notification on scrobble"
+msgstr ""
+
+msgctxt "#32015"
+msgid "Trakt - Scrobbled successfully"
+msgstr ""
+
+msgctxt "#32016"
+msgid "Exclusions"
+msgstr ""
+
+msgctxt "#32017"
+msgid "Exclude Live TV"
+msgstr ""
+
+msgctxt "#32018"
+msgid "Exclude HTTP sources"
+msgstr ""
+
+msgctxt "#32019"
+msgid "Exclude path"
+msgstr ""
+
+msgctxt "#32020"
+msgid "Folder's path (including subfolders)"
+msgstr ""
+
+# empty strings from id 32021 to 32022
+msgctxt "#32023"
+msgid "Can not connect to Trakt"
+msgstr ""
 
 msgctxt "#32024"
 msgid "Error"
 msgstr "Viga"
 
+# empty string with id 32025
+msgctxt "#32026"
+msgid "What Did You Think?"
+msgstr ""
+
+msgctxt "#32027"
+msgid "Totally Ninja!"
+msgstr ""
+
+msgctxt "#32028"
+msgid "Weak Sauce :("
+msgstr ""
+
+msgctxt "#32029"
+msgid "Terrible"
+msgstr ""
+
+msgctxt "#32030"
+msgid "Bad"
+msgstr ""
+
+msgctxt "#32031"
+msgid "Poor"
+msgstr ""
+
+msgctxt "#32032"
+msgid "Meh"
+msgstr ""
+
 msgctxt "#32033"
 msgid "Fair"
 msgstr "keskmine"
+
+msgctxt "#32034"
+msgid "Good"
+msgstr ""
+
+msgctxt "#32035"
+msgid "Great"
+msgstr ""
+
+msgctxt "#32036"
+msgid "Superb"
+msgstr ""
+
+msgctxt "#32037"
+msgid "Unrate this movie"
+msgstr ""
+
+msgctxt "#32038"
+msgid "Unrate this show"
+msgstr ""
+
+msgctxt "#32039"
+msgid "Unrate this episode"
+msgstr ""
+
+msgctxt "#32040"
+msgid "Trakt - Rating submitted successfully"
+msgstr ""
+
+msgctxt "#32041"
+msgid "Trakt - Already rated"
+msgstr ""
+
+msgctxt "#32042"
+msgid "Trakt - Unrated successfully"
+msgstr ""
+
+msgctxt "#32043"
+msgid "Trakt - Already has the same rating"
+msgstr ""
+
+msgctxt "#32044"
+msgid "Trakt - Problem submitting rating"
+msgstr ""
+
+msgctxt "#32045"
+msgid "Synchronize"
+msgstr ""
 
 msgctxt "#32046"
 msgid "Movies"
 msgstr "Filmid"
 
+msgctxt "#32047"
+msgid "Add new movies to Trakt collection"
+msgstr ""
+
+msgctxt "#32048"
+msgid "Add watched movies to Trakt history"
+msgstr ""
+
+msgctxt "#32049"
+msgid "Mark movies from Trakt history as watched in Kodi"
+msgstr ""
+
+msgctxt "#32050"
+msgid "TV Episodes"
+msgstr ""
+
+msgctxt "#32051"
+msgid "Add new TV episodes to Trakt collection"
+msgstr ""
+
+msgctxt "#32052"
+msgid "Add watched TV episodes to Trakt history"
+msgstr ""
+
+msgctxt "#32053"
+msgid "Mark TV episodes from Trakt history as watched in Kodi"
+msgstr ""
+
 msgctxt "#32054"
 msgid "Service"
 msgstr "Teenus"
+
+msgctxt "#32055"
+msgid "Sync collection on library update or cleaning"
+msgstr ""
+
+msgctxt "#32056"
+msgid "Show sync notifications"
+msgstr ""
+
+msgctxt "#32057"
+msgid "Remove deleted movies from Trakt collection"
+msgstr ""
+
+msgctxt "#32058"
+msgid "Remove deleted TV episodes from Trakt collection"
+msgstr ""
+
+# empty string with id 32059
+msgctxt "#32060"
+msgid "Hide notifications during playback"
+msgstr ""
+
+msgctxt "#32061"
+msgid "Sync started"
+msgstr ""
+
+msgctxt "#32062"
+msgid "Sync complete"
+msgstr ""
+
+msgctxt "#32063"
+msgid "%i movie(s) will be added to Trakt collection"
+msgstr ""
+
+msgctxt "#32064"
+msgid "%i movie playcount(s) will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32065"
+msgid "%i movie(s) playcount will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32066"
+msgid "Movie Sync Complete"
+msgstr ""
+
+msgctxt "#32067"
+msgid "Going to add %i show(s) to Trakt collection"
+msgstr ""
+
+msgctxt "#32068"
+msgid "Checking for episodes missing from Trakt collection"
+msgstr ""
+
+msgctxt "#32069"
+msgid "%i of %i show(s) have episodes added to Trakt collection"
+msgstr ""
+
+msgctxt "#32070"
+msgid "Going to update %i show(s) missing watched status"
+msgstr ""
+
+msgctxt "#32071"
+msgid "Checking watched episodes on Trakt"
+msgstr ""
+
+msgctxt "#32072"
+msgid "%i show(s) had missing watched status"
+msgstr ""
+
+msgctxt "#32073"
+msgid "%i episodes are being updated"
+msgstr ""
+
+msgctxt "#32074"
+msgid "Checking watched episodes on Kodi"
+msgstr ""
+
+msgctxt "#32075"
+msgid "Episode Sync Complete"
+msgstr ""
+
+msgctxt "#32076"
+msgid "%i movie(s) will be removed from Trakt collection"
+msgstr ""
+
+msgctxt "#32077"
+msgid "Cleaning Trakt TV show collection"
+msgstr ""
+
+msgctxt "#32078"
+msgid "episodes are being removed"
+msgstr ""
+
+msgctxt "#32079"
+msgid "Loading movies from Kodi"
+msgstr ""
+
+msgctxt "#32080"
+msgid "Movies loaded from Kodi"
+msgstr ""
+
+msgctxt "#32081"
+msgid "Retrieving movie collection from Trakt"
+msgstr ""
+
+msgctxt "#32082"
+msgid "Retrieving watched movies from Trakt"
+msgstr ""
+
+msgctxt "#32083"
+msgid "Retrieved movie data from Trakt"
+msgstr ""
+
+msgctxt "#32084"
+msgid "Trakt movie collection is up to date, no movies to add"
+msgstr ""
+
+msgctxt "#32085"
+msgid "%i movie(s) were added to your Trakt collection"
+msgstr ""
+
+msgctxt "#32086"
+msgid "Trakt movie playcounts are up to date"
+msgstr ""
+
+msgctxt "#32087"
+msgid "Playcounts updated for %i movie(s) on Trakt"
+msgstr ""
+
+msgctxt "#32088"
+msgid "Kodi movie playcounts are up to date"
+msgstr ""
+
+msgctxt "#32089"
+msgid "Updating %i of %i movie playcount(s) in Kodi"
+msgstr ""
+
+msgctxt "#32090"
+msgid "Playcounts updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32091"
+msgid "Trakt movie collection is up to date, no movies removed"
+msgstr ""
+
+msgctxt "#32092"
+msgid "%i movie(s) were removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32093"
+msgid "Updating %i of %i movie playcount(s) on Trakt"
+msgstr ""
+
+msgctxt "#32094"
+msgid "Loading episode data from Kodi"
+msgstr ""
+
+msgctxt "#32095"
+msgid "Loading shows from Kodi"
+msgstr ""
+
+msgctxt "#32096"
+msgid "Shows loaded from Kodi"
+msgstr ""
+
+msgctxt "#32097"
+msgid "Parsing %i of %i episode data from Kodi"
+msgstr ""
+
+msgctxt "#32098"
+msgid "Loaded episode data from Kodi"
+msgstr ""
+
+msgctxt "#32099"
+msgid "Loading episode data from Trakt"
+msgstr ""
+
+msgctxt "#32100"
+msgid "Retrieving episode collection from Trakt"
+msgstr ""
+
+msgctxt "#32101"
+msgid "Retrieving watched episodes from Trakt"
+msgstr ""
+
+msgctxt "#32102"
+msgid "Parsing episode data %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32103"
+msgid "Retrieved episode data from Trakt"
+msgstr ""
+
+msgctxt "#32104"
+msgid "Trakt episode collection is up to date, no episodes to add"
+msgstr ""
+
+msgctxt "#32105"
+msgid "%i episode(s) were added to your Trakt collection"
+msgstr ""
+
+msgctxt "#32106"
+msgid "Trakt episode playcounts are up to date"
+msgstr ""
+
+msgctxt "#32107"
+msgid "Kodi episode playcounts are up to date"
+msgstr ""
+
+msgctxt "#32108"
+msgid "Updating %i of %i episode playcount(s) in Kodi"
+msgstr ""
+
+msgctxt "#32109"
+msgid "Playcounts updated for %i show(s) in Kodi"
+msgstr ""
+
+msgctxt "#32110"
+msgid "Trakt episode collection is clean, no episodes to remove"
+msgstr ""
+
+msgctxt "#32111"
+msgid "%i episode(s) are being removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32112"
+msgid "%i episode(s) were removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32113"
+msgid "Trakt - Marked as watched"
+msgstr ""
+
+msgctxt "#32114"
+msgid "Trakt - Failed marking as watched"
+msgstr ""
+
+msgctxt "#32115"
+msgid "%d episode(s) of '%s'"
+msgstr ""
+
+msgctxt "#32116"
+msgid "Enable debug mode"
+msgstr ""
+
+msgctxt "#32117"
+msgid "Sync movie playback progress to Kodi"
+msgstr ""
+
+msgctxt "#32118"
+msgid "Sync episode playback progress to Kodi"
+msgstr ""
+
+msgctxt "#32119"
+msgid "Retrieving episode playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32120"
+msgid "Parsing episode playback progress %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32121"
+msgid "Retrieved episode playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32122"
+msgid "Retrieving movie playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32123"
+msgid "Parsing movie playback progress %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32124"
+msgid "Retrieved movie playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32125"
+msgid "Kodi movie playback progress is up to date"
+msgstr ""
+
+msgctxt "#32126"
+msgid "%i movie(s) playback progress will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32127"
+msgid "Updating %i of %i movie(s) playback progress in Kodi"
+msgstr ""
+
+msgctxt "#32128"
+msgid "Playback progress updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32129"
+msgid "Kodi episode playback progress is up to date"
+msgstr ""
+
+msgctxt "#32130"
+msgid "Updating %i of %i episode(s) playback progress in Kodi"
+msgstr ""
+
+msgctxt "#32131"
+msgid "Playback progress updated for %i episode(s) in Kodi"
+msgstr ""
+
+msgctxt "#32132"
+msgid "Unrate this season"
+msgstr ""
+
+msgctxt "#32133"
+msgid "Manage Movie's Lists"
+msgstr ""
+
+msgctxt "#32134"
+msgid "Manage Show's Lists"
+msgstr ""
+
+msgctxt "#32135"
+msgid "Remove from Watchlist"
+msgstr ""
+
+msgctxt "#32136"
+msgid "Add to watchlist"
+msgstr ""
+
+msgctxt "#32137"
+msgid "Rate this movie"
+msgstr ""
+
+msgctxt "#32138"
+msgid "Rate this show"
+msgstr ""
+
+msgctxt "#32139"
+msgid "Rate this episode"
+msgstr ""
+
+msgctxt "#32140"
+msgid "Toggle watched"
+msgstr ""
+
+msgctxt "#32141"
+msgid "Manage all lists"
+msgstr ""
+
+msgctxt "#32142"
+msgid "Update all tags"
+msgstr ""
+
+msgctxt "#32143"
+msgid "Synchronize library"
+msgstr ""
+
+msgctxt "#32144"
+msgid "How do I authorize the trakt addon to access my trakt.tv account?"
+msgstr ""
+
+# empty strings from id 32145 to 32146
+msgctxt "#32147"
+msgid "Trakt.tv PIN Authorization Failed"
+msgstr ""
+
+# empty string with id 32148
+msgctxt "#32149"
+msgid "Rate this Season"
+msgstr ""
+
+msgctxt "#32150"
+msgid "You will be reminded in 24 hours"
+msgstr ""
+
+msgctxt "#32151"
+msgid "Use Addon Settings later if you change your mind"
+msgstr ""
+
+msgctxt "#32152"
+msgid "Trakt Authorization Complete"
+msgstr ""
+
+msgctxt "#32153"
+msgid "Trakt Account Authorization"
+msgstr ""
+
+msgctxt "#32154"
+msgid "Authorize"
+msgstr ""
+
+msgctxt "#32155"
+msgid "Remind Me Later"
+msgstr ""
+
+msgctxt "#32156"
+msgid "No Thanks"
+msgstr ""
+
+msgctxt "#32157"
+msgid "Account Authorization"
+msgstr ""
+
+# empty string with id 32158
+msgctxt "#32159"
+msgid "Visit {0} or scan the QR code."
+msgstr ""
+
+msgctxt "#32162"
+msgid "The trakt addon CAN NOT be used without authorizing it to access your trakt.tv account."
+msgstr ""
+
+msgctxt "#32163"
+msgid "User"
+msgstr ""
+
+msgctxt "#32164"
+msgid "Fallback to Title/Year matching if necessary"
+msgstr ""
+
+msgctxt "#32165"
+msgid "Trakt - Added to watchlist"
+msgstr ""
+
+msgctxt "#32166"
+msgid "Trakt - Failed adding to watchlist"
+msgstr ""
+
+msgctxt "#32167"
+msgid "Offset scrobble start by X minutes"
+msgstr ""
+
+msgctxt "#32168"
+msgid "Sync ratings"
+msgstr ""
+
+msgctxt "#32169"
+msgid "Kodi movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32170"
+msgid "%i movie(s) ratings will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32171"
+msgid "Updating %i of %i movie ratings in Kodi"
+msgstr ""
+
+msgctxt "#32172"
+msgid "Ratings updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32173"
+msgid "Kodi episode ratings are up to date"
+msgstr ""
+
+msgctxt "#32174"
+msgid "Updating %i of %i episode ratings in Kodi"
+msgstr ""
+
+msgctxt "#32175"
+msgid "Ratings updated for %i episode(s) in Kodi"
+msgstr ""
+
+msgctxt "#32176"
+msgid "Kodi show ratings are up to date"
+msgstr ""
+
+msgctxt "#32177"
+msgid "Updating %i of %i show ratings in Kodi"
+msgstr ""
+
+msgctxt "#32178"
+msgid "Ratings updated for %i show(s) in Kodi"
+msgstr ""
+
+msgctxt "#32179"
+msgid "Trakt movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32180"
+msgid "%i movie ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32181"
+msgid "Trakt show ratings are up to date"
+msgstr ""
+
+msgctxt "#32182"
+msgid "%i show ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32183"
+msgid "Attempt to scrobble MythTV PVR recordings"
+msgstr ""
+
+msgctxt "#32184"
+msgid "Attempt secondary show title search"
+msgstr ""
+
+msgctxt "#32185"
+msgid "Exclude Plugins"
+msgstr ""
+
+msgctxt "#32186"
+msgid "Allow script exclusions"
+msgstr ""

--- a/script.trakt/resources/language/resource.language.eu_ES/strings.po
+++ b/script.trakt/resources/language/resource.language.eu_ES/strings.po
@@ -10,28 +10,712 @@ msgstr ""
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Kodi Translation Team\n"
 "Language-Team: Basque (http://www.transifex.com/projects/p/xbmc-addons/language/eu/)\n"
+"Language: eu\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: eu\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 msgctxt "#32000"
 msgid "General"
 msgstr "Orokorra"
 
+# empty strings from id 32001 to 32002
+msgctxt "#32003"
+msgid "Startup Delay"
+msgstr ""
+
 msgctxt "#32004"
 msgid "Rating"
 msgstr "Balorazioa"
+
+msgctxt "#32005"
+msgid "Rate Movie after watching"
+msgstr ""
+
+msgctxt "#32006"
+msgid "Rate TV show Episode after watching"
+msgstr ""
+
+msgctxt "#32008"
+msgid "Minimum percent watched to display rating dialog"
+msgstr ""
+
+msgctxt "#32009"
+msgid "Allow re-rating of media"
+msgstr ""
+
+msgctxt "#32010"
+msgid "Default rating"
+msgstr ""
+
+# Scrobbling Settings
+msgctxt "#32011"
+msgid "Scrobbling"
+msgstr ""
+
+msgctxt "#32012"
+msgid "Scrobble movies"
+msgstr ""
+
+msgctxt "#32013"
+msgid "Scrobble TV show episodes"
+msgstr ""
+
+msgctxt "#32014"
+msgid "Show notification on scrobble"
+msgstr ""
+
+msgctxt "#32015"
+msgid "Trakt - Scrobbled successfully"
+msgstr ""
+
+msgctxt "#32016"
+msgid "Exclusions"
+msgstr ""
+
+msgctxt "#32017"
+msgid "Exclude Live TV"
+msgstr ""
+
+msgctxt "#32018"
+msgid "Exclude HTTP sources"
+msgstr ""
+
+msgctxt "#32019"
+msgid "Exclude path"
+msgstr ""
+
+msgctxt "#32020"
+msgid "Folder's path (including subfolders)"
+msgstr ""
+
+# empty strings from id 32021 to 32022
+msgctxt "#32023"
+msgid "Can not connect to Trakt"
+msgstr ""
 
 msgctxt "#32024"
 msgid "Error"
 msgstr "Errorea"
 
+# empty string with id 32025
+msgctxt "#32026"
+msgid "What Did You Think?"
+msgstr ""
+
+msgctxt "#32027"
+msgid "Totally Ninja!"
+msgstr ""
+
+msgctxt "#32028"
+msgid "Weak Sauce :("
+msgstr ""
+
+msgctxt "#32029"
+msgid "Terrible"
+msgstr ""
+
+msgctxt "#32030"
+msgid "Bad"
+msgstr ""
+
+msgctxt "#32031"
+msgid "Poor"
+msgstr ""
+
+msgctxt "#32032"
+msgid "Meh"
+msgstr ""
+
 msgctxt "#32033"
 msgid "Fair"
 msgstr "Egokia"
 
+msgctxt "#32034"
+msgid "Good"
+msgstr ""
+
+msgctxt "#32035"
+msgid "Great"
+msgstr ""
+
+msgctxt "#32036"
+msgid "Superb"
+msgstr ""
+
+msgctxt "#32037"
+msgid "Unrate this movie"
+msgstr ""
+
+msgctxt "#32038"
+msgid "Unrate this show"
+msgstr ""
+
+msgctxt "#32039"
+msgid "Unrate this episode"
+msgstr ""
+
+msgctxt "#32040"
+msgid "Trakt - Rating submitted successfully"
+msgstr ""
+
+msgctxt "#32041"
+msgid "Trakt - Already rated"
+msgstr ""
+
+msgctxt "#32042"
+msgid "Trakt - Unrated successfully"
+msgstr ""
+
+msgctxt "#32043"
+msgid "Trakt - Already has the same rating"
+msgstr ""
+
+msgctxt "#32044"
+msgid "Trakt - Problem submitting rating"
+msgstr ""
+
+msgctxt "#32045"
+msgid "Synchronize"
+msgstr ""
+
 msgctxt "#32046"
 msgid "Movies"
 msgstr "Filmak"
+
+msgctxt "#32047"
+msgid "Add new movies to Trakt collection"
+msgstr ""
+
+msgctxt "#32048"
+msgid "Add watched movies to Trakt history"
+msgstr ""
+
+msgctxt "#32049"
+msgid "Mark movies from Trakt history as watched in Kodi"
+msgstr ""
+
+msgctxt "#32050"
+msgid "TV Episodes"
+msgstr ""
+
+msgctxt "#32051"
+msgid "Add new TV episodes to Trakt collection"
+msgstr ""
+
+msgctxt "#32052"
+msgid "Add watched TV episodes to Trakt history"
+msgstr ""
+
+msgctxt "#32053"
+msgid "Mark TV episodes from Trakt history as watched in Kodi"
+msgstr ""
+
+msgctxt "#32054"
+msgid "Service"
+msgstr ""
+
+msgctxt "#32055"
+msgid "Sync collection on library update or cleaning"
+msgstr ""
+
+msgctxt "#32056"
+msgid "Show sync notifications"
+msgstr ""
+
+msgctxt "#32057"
+msgid "Remove deleted movies from Trakt collection"
+msgstr ""
+
+msgctxt "#32058"
+msgid "Remove deleted TV episodes from Trakt collection"
+msgstr ""
+
+# empty string with id 32059
+msgctxt "#32060"
+msgid "Hide notifications during playback"
+msgstr ""
+
+msgctxt "#32061"
+msgid "Sync started"
+msgstr ""
+
+msgctxt "#32062"
+msgid "Sync complete"
+msgstr ""
+
+msgctxt "#32063"
+msgid "%i movie(s) will be added to Trakt collection"
+msgstr ""
+
+msgctxt "#32064"
+msgid "%i movie playcount(s) will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32065"
+msgid "%i movie(s) playcount will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32066"
+msgid "Movie Sync Complete"
+msgstr ""
+
+msgctxt "#32067"
+msgid "Going to add %i show(s) to Trakt collection"
+msgstr ""
+
+msgctxt "#32068"
+msgid "Checking for episodes missing from Trakt collection"
+msgstr ""
+
+msgctxt "#32069"
+msgid "%i of %i show(s) have episodes added to Trakt collection"
+msgstr ""
+
+msgctxt "#32070"
+msgid "Going to update %i show(s) missing watched status"
+msgstr ""
+
+msgctxt "#32071"
+msgid "Checking watched episodes on Trakt"
+msgstr ""
+
+msgctxt "#32072"
+msgid "%i show(s) had missing watched status"
+msgstr ""
+
+msgctxt "#32073"
+msgid "%i episodes are being updated"
+msgstr ""
+
+msgctxt "#32074"
+msgid "Checking watched episodes on Kodi"
+msgstr ""
+
+msgctxt "#32075"
+msgid "Episode Sync Complete"
+msgstr ""
+
+msgctxt "#32076"
+msgid "%i movie(s) will be removed from Trakt collection"
+msgstr ""
+
+msgctxt "#32077"
+msgid "Cleaning Trakt TV show collection"
+msgstr ""
+
+msgctxt "#32078"
+msgid "episodes are being removed"
+msgstr ""
+
+msgctxt "#32079"
+msgid "Loading movies from Kodi"
+msgstr ""
+
+msgctxt "#32080"
+msgid "Movies loaded from Kodi"
+msgstr ""
+
+msgctxt "#32081"
+msgid "Retrieving movie collection from Trakt"
+msgstr ""
+
+msgctxt "#32082"
+msgid "Retrieving watched movies from Trakt"
+msgstr ""
+
+msgctxt "#32083"
+msgid "Retrieved movie data from Trakt"
+msgstr ""
+
+msgctxt "#32084"
+msgid "Trakt movie collection is up to date, no movies to add"
+msgstr ""
+
+msgctxt "#32085"
+msgid "%i movie(s) were added to your Trakt collection"
+msgstr ""
+
+msgctxt "#32086"
+msgid "Trakt movie playcounts are up to date"
+msgstr ""
+
+msgctxt "#32087"
+msgid "Playcounts updated for %i movie(s) on Trakt"
+msgstr ""
+
+msgctxt "#32088"
+msgid "Kodi movie playcounts are up to date"
+msgstr ""
+
+msgctxt "#32089"
+msgid "Updating %i of %i movie playcount(s) in Kodi"
+msgstr ""
+
+msgctxt "#32090"
+msgid "Playcounts updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32091"
+msgid "Trakt movie collection is up to date, no movies removed"
+msgstr ""
+
+msgctxt "#32092"
+msgid "%i movie(s) were removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32093"
+msgid "Updating %i of %i movie playcount(s) on Trakt"
+msgstr ""
+
+msgctxt "#32094"
+msgid "Loading episode data from Kodi"
+msgstr ""
+
+msgctxt "#32095"
+msgid "Loading shows from Kodi"
+msgstr ""
+
+msgctxt "#32096"
+msgid "Shows loaded from Kodi"
+msgstr ""
+
+msgctxt "#32097"
+msgid "Parsing %i of %i episode data from Kodi"
+msgstr ""
+
+msgctxt "#32098"
+msgid "Loaded episode data from Kodi"
+msgstr ""
+
+msgctxt "#32099"
+msgid "Loading episode data from Trakt"
+msgstr ""
+
+msgctxt "#32100"
+msgid "Retrieving episode collection from Trakt"
+msgstr ""
+
+msgctxt "#32101"
+msgid "Retrieving watched episodes from Trakt"
+msgstr ""
+
+msgctxt "#32102"
+msgid "Parsing episode data %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32103"
+msgid "Retrieved episode data from Trakt"
+msgstr ""
+
+msgctxt "#32104"
+msgid "Trakt episode collection is up to date, no episodes to add"
+msgstr ""
+
+msgctxt "#32105"
+msgid "%i episode(s) were added to your Trakt collection"
+msgstr ""
+
+msgctxt "#32106"
+msgid "Trakt episode playcounts are up to date"
+msgstr ""
+
+msgctxt "#32107"
+msgid "Kodi episode playcounts are up to date"
+msgstr ""
+
+msgctxt "#32108"
+msgid "Updating %i of %i episode playcount(s) in Kodi"
+msgstr ""
+
+msgctxt "#32109"
+msgid "Playcounts updated for %i show(s) in Kodi"
+msgstr ""
+
+msgctxt "#32110"
+msgid "Trakt episode collection is clean, no episodes to remove"
+msgstr ""
+
+msgctxt "#32111"
+msgid "%i episode(s) are being removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32112"
+msgid "%i episode(s) were removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32113"
+msgid "Trakt - Marked as watched"
+msgstr ""
+
+msgctxt "#32114"
+msgid "Trakt - Failed marking as watched"
+msgstr ""
+
+msgctxt "#32115"
+msgid "%d episode(s) of '%s'"
+msgstr ""
+
+msgctxt "#32116"
+msgid "Enable debug mode"
+msgstr ""
+
+msgctxt "#32117"
+msgid "Sync movie playback progress to Kodi"
+msgstr ""
+
+msgctxt "#32118"
+msgid "Sync episode playback progress to Kodi"
+msgstr ""
+
+msgctxt "#32119"
+msgid "Retrieving episode playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32120"
+msgid "Parsing episode playback progress %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32121"
+msgid "Retrieved episode playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32122"
+msgid "Retrieving movie playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32123"
+msgid "Parsing movie playback progress %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32124"
+msgid "Retrieved movie playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32125"
+msgid "Kodi movie playback progress is up to date"
+msgstr ""
+
+msgctxt "#32126"
+msgid "%i movie(s) playback progress will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32127"
+msgid "Updating %i of %i movie(s) playback progress in Kodi"
+msgstr ""
+
+msgctxt "#32128"
+msgid "Playback progress updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32129"
+msgid "Kodi episode playback progress is up to date"
+msgstr ""
+
+msgctxt "#32130"
+msgid "Updating %i of %i episode(s) playback progress in Kodi"
+msgstr ""
+
+msgctxt "#32131"
+msgid "Playback progress updated for %i episode(s) in Kodi"
+msgstr ""
+
+msgctxt "#32132"
+msgid "Unrate this season"
+msgstr ""
+
+msgctxt "#32133"
+msgid "Manage Movie's Lists"
+msgstr ""
+
+msgctxt "#32134"
+msgid "Manage Show's Lists"
+msgstr ""
+
+msgctxt "#32135"
+msgid "Remove from Watchlist"
+msgstr ""
+
+msgctxt "#32136"
+msgid "Add to watchlist"
+msgstr ""
+
+msgctxt "#32137"
+msgid "Rate this movie"
+msgstr ""
+
+msgctxt "#32138"
+msgid "Rate this show"
+msgstr ""
+
+msgctxt "#32139"
+msgid "Rate this episode"
+msgstr ""
+
+msgctxt "#32140"
+msgid "Toggle watched"
+msgstr ""
+
+msgctxt "#32141"
+msgid "Manage all lists"
+msgstr ""
+
+msgctxt "#32142"
+msgid "Update all tags"
+msgstr ""
+
+msgctxt "#32143"
+msgid "Synchronize library"
+msgstr ""
+
+msgctxt "#32144"
+msgid "How do I authorize the trakt addon to access my trakt.tv account?"
+msgstr ""
+
+# empty strings from id 32145 to 32146
+msgctxt "#32147"
+msgid "Trakt.tv PIN Authorization Failed"
+msgstr ""
+
+# empty string with id 32148
+msgctxt "#32149"
+msgid "Rate this Season"
+msgstr ""
+
+msgctxt "#32150"
+msgid "You will be reminded in 24 hours"
+msgstr ""
+
+msgctxt "#32151"
+msgid "Use Addon Settings later if you change your mind"
+msgstr ""
+
+msgctxt "#32152"
+msgid "Trakt Authorization Complete"
+msgstr ""
+
+msgctxt "#32153"
+msgid "Trakt Account Authorization"
+msgstr ""
+
+msgctxt "#32154"
+msgid "Authorize"
+msgstr ""
+
+msgctxt "#32155"
+msgid "Remind Me Later"
+msgstr ""
+
+msgctxt "#32156"
+msgid "No Thanks"
+msgstr ""
+
+msgctxt "#32157"
+msgid "Account Authorization"
+msgstr ""
+
+# empty string with id 32158
+msgctxt "#32159"
+msgid "Visit {0} or scan the QR code."
+msgstr ""
+
+msgctxt "#32162"
+msgid "The trakt addon CAN NOT be used without authorizing it to access your trakt.tv account."
+msgstr ""
+
+msgctxt "#32163"
+msgid "User"
+msgstr ""
+
+msgctxt "#32164"
+msgid "Fallback to Title/Year matching if necessary"
+msgstr ""
+
+msgctxt "#32165"
+msgid "Trakt - Added to watchlist"
+msgstr ""
+
+msgctxt "#32166"
+msgid "Trakt - Failed adding to watchlist"
+msgstr ""
+
+msgctxt "#32167"
+msgid "Offset scrobble start by X minutes"
+msgstr ""
+
+msgctxt "#32168"
+msgid "Sync ratings"
+msgstr ""
+
+msgctxt "#32169"
+msgid "Kodi movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32170"
+msgid "%i movie(s) ratings will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32171"
+msgid "Updating %i of %i movie ratings in Kodi"
+msgstr ""
+
+msgctxt "#32172"
+msgid "Ratings updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32173"
+msgid "Kodi episode ratings are up to date"
+msgstr ""
+
+msgctxt "#32174"
+msgid "Updating %i of %i episode ratings in Kodi"
+msgstr ""
+
+msgctxt "#32175"
+msgid "Ratings updated for %i episode(s) in Kodi"
+msgstr ""
+
+msgctxt "#32176"
+msgid "Kodi show ratings are up to date"
+msgstr ""
+
+msgctxt "#32177"
+msgid "Updating %i of %i show ratings in Kodi"
+msgstr ""
+
+msgctxt "#32178"
+msgid "Ratings updated for %i show(s) in Kodi"
+msgstr ""
+
+msgctxt "#32179"
+msgid "Trakt movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32180"
+msgid "%i movie ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32181"
+msgid "Trakt show ratings are up to date"
+msgstr ""
+
+msgctxt "#32182"
+msgid "%i show ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32183"
+msgid "Attempt to scrobble MythTV PVR recordings"
+msgstr ""
+
+msgctxt "#32184"
+msgid "Attempt secondary show title search"
+msgstr ""
+
+msgctxt "#32185"
+msgid "Exclude Plugins"
+msgstr ""
+
+msgctxt "#32186"
+msgid "Allow script exclusions"
+msgstr ""

--- a/script.trakt/resources/language/resource.language.fa_AF/strings.po
+++ b/script.trakt/resources/language/resource.language.fa_AF/strings.po
@@ -10,12 +10,712 @@ msgstr ""
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Kodi Translation Team\n"
 "Language-Team: Persian (http://www.transifex.com/projects/p/xbmc-addons/language/fa/)\n"
+"Language: fa\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: fa\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 msgctxt "#32000"
 msgid "General"
 msgstr "عمومی"
+
+# empty strings from id 32001 to 32002
+msgctxt "#32003"
+msgid "Startup Delay"
+msgstr ""
+
+msgctxt "#32004"
+msgid "Rating"
+msgstr ""
+
+msgctxt "#32005"
+msgid "Rate Movie after watching"
+msgstr ""
+
+msgctxt "#32006"
+msgid "Rate TV show Episode after watching"
+msgstr ""
+
+msgctxt "#32008"
+msgid "Minimum percent watched to display rating dialog"
+msgstr ""
+
+msgctxt "#32009"
+msgid "Allow re-rating of media"
+msgstr ""
+
+msgctxt "#32010"
+msgid "Default rating"
+msgstr ""
+
+# Scrobbling Settings
+msgctxt "#32011"
+msgid "Scrobbling"
+msgstr ""
+
+msgctxt "#32012"
+msgid "Scrobble movies"
+msgstr ""
+
+msgctxt "#32013"
+msgid "Scrobble TV show episodes"
+msgstr ""
+
+msgctxt "#32014"
+msgid "Show notification on scrobble"
+msgstr ""
+
+msgctxt "#32015"
+msgid "Trakt - Scrobbled successfully"
+msgstr ""
+
+msgctxt "#32016"
+msgid "Exclusions"
+msgstr ""
+
+msgctxt "#32017"
+msgid "Exclude Live TV"
+msgstr ""
+
+msgctxt "#32018"
+msgid "Exclude HTTP sources"
+msgstr ""
+
+msgctxt "#32019"
+msgid "Exclude path"
+msgstr ""
+
+msgctxt "#32020"
+msgid "Folder's path (including subfolders)"
+msgstr ""
+
+# empty strings from id 32021 to 32022
+msgctxt "#32023"
+msgid "Can not connect to Trakt"
+msgstr ""
+
+msgctxt "#32024"
+msgid "Error"
+msgstr ""
+
+# empty string with id 32025
+msgctxt "#32026"
+msgid "What Did You Think?"
+msgstr ""
+
+msgctxt "#32027"
+msgid "Totally Ninja!"
+msgstr ""
+
+msgctxt "#32028"
+msgid "Weak Sauce :("
+msgstr ""
+
+msgctxt "#32029"
+msgid "Terrible"
+msgstr ""
+
+msgctxt "#32030"
+msgid "Bad"
+msgstr ""
+
+msgctxt "#32031"
+msgid "Poor"
+msgstr ""
+
+msgctxt "#32032"
+msgid "Meh"
+msgstr ""
+
+msgctxt "#32033"
+msgid "Fair"
+msgstr ""
+
+msgctxt "#32034"
+msgid "Good"
+msgstr ""
+
+msgctxt "#32035"
+msgid "Great"
+msgstr ""
+
+msgctxt "#32036"
+msgid "Superb"
+msgstr ""
+
+msgctxt "#32037"
+msgid "Unrate this movie"
+msgstr ""
+
+msgctxt "#32038"
+msgid "Unrate this show"
+msgstr ""
+
+msgctxt "#32039"
+msgid "Unrate this episode"
+msgstr ""
+
+msgctxt "#32040"
+msgid "Trakt - Rating submitted successfully"
+msgstr ""
+
+msgctxt "#32041"
+msgid "Trakt - Already rated"
+msgstr ""
+
+msgctxt "#32042"
+msgid "Trakt - Unrated successfully"
+msgstr ""
+
+msgctxt "#32043"
+msgid "Trakt - Already has the same rating"
+msgstr ""
+
+msgctxt "#32044"
+msgid "Trakt - Problem submitting rating"
+msgstr ""
+
+msgctxt "#32045"
+msgid "Synchronize"
+msgstr ""
+
+msgctxt "#32046"
+msgid "Movies"
+msgstr ""
+
+msgctxt "#32047"
+msgid "Add new movies to Trakt collection"
+msgstr ""
+
+msgctxt "#32048"
+msgid "Add watched movies to Trakt history"
+msgstr ""
+
+msgctxt "#32049"
+msgid "Mark movies from Trakt history as watched in Kodi"
+msgstr ""
+
+msgctxt "#32050"
+msgid "TV Episodes"
+msgstr ""
+
+msgctxt "#32051"
+msgid "Add new TV episodes to Trakt collection"
+msgstr ""
+
+msgctxt "#32052"
+msgid "Add watched TV episodes to Trakt history"
+msgstr ""
+
+msgctxt "#32053"
+msgid "Mark TV episodes from Trakt history as watched in Kodi"
+msgstr ""
+
+msgctxt "#32054"
+msgid "Service"
+msgstr ""
+
+msgctxt "#32055"
+msgid "Sync collection on library update or cleaning"
+msgstr ""
+
+msgctxt "#32056"
+msgid "Show sync notifications"
+msgstr ""
+
+msgctxt "#32057"
+msgid "Remove deleted movies from Trakt collection"
+msgstr ""
+
+msgctxt "#32058"
+msgid "Remove deleted TV episodes from Trakt collection"
+msgstr ""
+
+# empty string with id 32059
+msgctxt "#32060"
+msgid "Hide notifications during playback"
+msgstr ""
+
+msgctxt "#32061"
+msgid "Sync started"
+msgstr ""
+
+msgctxt "#32062"
+msgid "Sync complete"
+msgstr ""
+
+msgctxt "#32063"
+msgid "%i movie(s) will be added to Trakt collection"
+msgstr ""
+
+msgctxt "#32064"
+msgid "%i movie playcount(s) will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32065"
+msgid "%i movie(s) playcount will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32066"
+msgid "Movie Sync Complete"
+msgstr ""
+
+msgctxt "#32067"
+msgid "Going to add %i show(s) to Trakt collection"
+msgstr ""
+
+msgctxt "#32068"
+msgid "Checking for episodes missing from Trakt collection"
+msgstr ""
+
+msgctxt "#32069"
+msgid "%i of %i show(s) have episodes added to Trakt collection"
+msgstr ""
+
+msgctxt "#32070"
+msgid "Going to update %i show(s) missing watched status"
+msgstr ""
+
+msgctxt "#32071"
+msgid "Checking watched episodes on Trakt"
+msgstr ""
+
+msgctxt "#32072"
+msgid "%i show(s) had missing watched status"
+msgstr ""
+
+msgctxt "#32073"
+msgid "%i episodes are being updated"
+msgstr ""
+
+msgctxt "#32074"
+msgid "Checking watched episodes on Kodi"
+msgstr ""
+
+msgctxt "#32075"
+msgid "Episode Sync Complete"
+msgstr ""
+
+msgctxt "#32076"
+msgid "%i movie(s) will be removed from Trakt collection"
+msgstr ""
+
+msgctxt "#32077"
+msgid "Cleaning Trakt TV show collection"
+msgstr ""
+
+msgctxt "#32078"
+msgid "episodes are being removed"
+msgstr ""
+
+msgctxt "#32079"
+msgid "Loading movies from Kodi"
+msgstr ""
+
+msgctxt "#32080"
+msgid "Movies loaded from Kodi"
+msgstr ""
+
+msgctxt "#32081"
+msgid "Retrieving movie collection from Trakt"
+msgstr ""
+
+msgctxt "#32082"
+msgid "Retrieving watched movies from Trakt"
+msgstr ""
+
+msgctxt "#32083"
+msgid "Retrieved movie data from Trakt"
+msgstr ""
+
+msgctxt "#32084"
+msgid "Trakt movie collection is up to date, no movies to add"
+msgstr ""
+
+msgctxt "#32085"
+msgid "%i movie(s) were added to your Trakt collection"
+msgstr ""
+
+msgctxt "#32086"
+msgid "Trakt movie playcounts are up to date"
+msgstr ""
+
+msgctxt "#32087"
+msgid "Playcounts updated for %i movie(s) on Trakt"
+msgstr ""
+
+msgctxt "#32088"
+msgid "Kodi movie playcounts are up to date"
+msgstr ""
+
+msgctxt "#32089"
+msgid "Updating %i of %i movie playcount(s) in Kodi"
+msgstr ""
+
+msgctxt "#32090"
+msgid "Playcounts updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32091"
+msgid "Trakt movie collection is up to date, no movies removed"
+msgstr ""
+
+msgctxt "#32092"
+msgid "%i movie(s) were removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32093"
+msgid "Updating %i of %i movie playcount(s) on Trakt"
+msgstr ""
+
+msgctxt "#32094"
+msgid "Loading episode data from Kodi"
+msgstr ""
+
+msgctxt "#32095"
+msgid "Loading shows from Kodi"
+msgstr ""
+
+msgctxt "#32096"
+msgid "Shows loaded from Kodi"
+msgstr ""
+
+msgctxt "#32097"
+msgid "Parsing %i of %i episode data from Kodi"
+msgstr ""
+
+msgctxt "#32098"
+msgid "Loaded episode data from Kodi"
+msgstr ""
+
+msgctxt "#32099"
+msgid "Loading episode data from Trakt"
+msgstr ""
+
+msgctxt "#32100"
+msgid "Retrieving episode collection from Trakt"
+msgstr ""
+
+msgctxt "#32101"
+msgid "Retrieving watched episodes from Trakt"
+msgstr ""
+
+msgctxt "#32102"
+msgid "Parsing episode data %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32103"
+msgid "Retrieved episode data from Trakt"
+msgstr ""
+
+msgctxt "#32104"
+msgid "Trakt episode collection is up to date, no episodes to add"
+msgstr ""
+
+msgctxt "#32105"
+msgid "%i episode(s) were added to your Trakt collection"
+msgstr ""
+
+msgctxt "#32106"
+msgid "Trakt episode playcounts are up to date"
+msgstr ""
+
+msgctxt "#32107"
+msgid "Kodi episode playcounts are up to date"
+msgstr ""
+
+msgctxt "#32108"
+msgid "Updating %i of %i episode playcount(s) in Kodi"
+msgstr ""
+
+msgctxt "#32109"
+msgid "Playcounts updated for %i show(s) in Kodi"
+msgstr ""
+
+msgctxt "#32110"
+msgid "Trakt episode collection is clean, no episodes to remove"
+msgstr ""
+
+msgctxt "#32111"
+msgid "%i episode(s) are being removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32112"
+msgid "%i episode(s) were removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32113"
+msgid "Trakt - Marked as watched"
+msgstr ""
+
+msgctxt "#32114"
+msgid "Trakt - Failed marking as watched"
+msgstr ""
+
+msgctxt "#32115"
+msgid "%d episode(s) of '%s'"
+msgstr ""
+
+msgctxt "#32116"
+msgid "Enable debug mode"
+msgstr ""
+
+msgctxt "#32117"
+msgid "Sync movie playback progress to Kodi"
+msgstr ""
+
+msgctxt "#32118"
+msgid "Sync episode playback progress to Kodi"
+msgstr ""
+
+msgctxt "#32119"
+msgid "Retrieving episode playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32120"
+msgid "Parsing episode playback progress %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32121"
+msgid "Retrieved episode playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32122"
+msgid "Retrieving movie playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32123"
+msgid "Parsing movie playback progress %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32124"
+msgid "Retrieved movie playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32125"
+msgid "Kodi movie playback progress is up to date"
+msgstr ""
+
+msgctxt "#32126"
+msgid "%i movie(s) playback progress will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32127"
+msgid "Updating %i of %i movie(s) playback progress in Kodi"
+msgstr ""
+
+msgctxt "#32128"
+msgid "Playback progress updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32129"
+msgid "Kodi episode playback progress is up to date"
+msgstr ""
+
+msgctxt "#32130"
+msgid "Updating %i of %i episode(s) playback progress in Kodi"
+msgstr ""
+
+msgctxt "#32131"
+msgid "Playback progress updated for %i episode(s) in Kodi"
+msgstr ""
+
+msgctxt "#32132"
+msgid "Unrate this season"
+msgstr ""
+
+msgctxt "#32133"
+msgid "Manage Movie's Lists"
+msgstr ""
+
+msgctxt "#32134"
+msgid "Manage Show's Lists"
+msgstr ""
+
+msgctxt "#32135"
+msgid "Remove from Watchlist"
+msgstr ""
+
+msgctxt "#32136"
+msgid "Add to watchlist"
+msgstr ""
+
+msgctxt "#32137"
+msgid "Rate this movie"
+msgstr ""
+
+msgctxt "#32138"
+msgid "Rate this show"
+msgstr ""
+
+msgctxt "#32139"
+msgid "Rate this episode"
+msgstr ""
+
+msgctxt "#32140"
+msgid "Toggle watched"
+msgstr ""
+
+msgctxt "#32141"
+msgid "Manage all lists"
+msgstr ""
+
+msgctxt "#32142"
+msgid "Update all tags"
+msgstr ""
+
+msgctxt "#32143"
+msgid "Synchronize library"
+msgstr ""
+
+msgctxt "#32144"
+msgid "How do I authorize the trakt addon to access my trakt.tv account?"
+msgstr ""
+
+# empty strings from id 32145 to 32146
+msgctxt "#32147"
+msgid "Trakt.tv PIN Authorization Failed"
+msgstr ""
+
+# empty string with id 32148
+msgctxt "#32149"
+msgid "Rate this Season"
+msgstr ""
+
+msgctxt "#32150"
+msgid "You will be reminded in 24 hours"
+msgstr ""
+
+msgctxt "#32151"
+msgid "Use Addon Settings later if you change your mind"
+msgstr ""
+
+msgctxt "#32152"
+msgid "Trakt Authorization Complete"
+msgstr ""
+
+msgctxt "#32153"
+msgid "Trakt Account Authorization"
+msgstr ""
+
+msgctxt "#32154"
+msgid "Authorize"
+msgstr ""
+
+msgctxt "#32155"
+msgid "Remind Me Later"
+msgstr ""
+
+msgctxt "#32156"
+msgid "No Thanks"
+msgstr ""
+
+msgctxt "#32157"
+msgid "Account Authorization"
+msgstr ""
+
+# empty string with id 32158
+msgctxt "#32159"
+msgid "Visit {0} or scan the QR code."
+msgstr ""
+
+msgctxt "#32162"
+msgid "The trakt addon CAN NOT be used without authorizing it to access your trakt.tv account."
+msgstr ""
+
+msgctxt "#32163"
+msgid "User"
+msgstr ""
+
+msgctxt "#32164"
+msgid "Fallback to Title/Year matching if necessary"
+msgstr ""
+
+msgctxt "#32165"
+msgid "Trakt - Added to watchlist"
+msgstr ""
+
+msgctxt "#32166"
+msgid "Trakt - Failed adding to watchlist"
+msgstr ""
+
+msgctxt "#32167"
+msgid "Offset scrobble start by X minutes"
+msgstr ""
+
+msgctxt "#32168"
+msgid "Sync ratings"
+msgstr ""
+
+msgctxt "#32169"
+msgid "Kodi movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32170"
+msgid "%i movie(s) ratings will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32171"
+msgid "Updating %i of %i movie ratings in Kodi"
+msgstr ""
+
+msgctxt "#32172"
+msgid "Ratings updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32173"
+msgid "Kodi episode ratings are up to date"
+msgstr ""
+
+msgctxt "#32174"
+msgid "Updating %i of %i episode ratings in Kodi"
+msgstr ""
+
+msgctxt "#32175"
+msgid "Ratings updated for %i episode(s) in Kodi"
+msgstr ""
+
+msgctxt "#32176"
+msgid "Kodi show ratings are up to date"
+msgstr ""
+
+msgctxt "#32177"
+msgid "Updating %i of %i show ratings in Kodi"
+msgstr ""
+
+msgctxt "#32178"
+msgid "Ratings updated for %i show(s) in Kodi"
+msgstr ""
+
+msgctxt "#32179"
+msgid "Trakt movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32180"
+msgid "%i movie ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32181"
+msgid "Trakt show ratings are up to date"
+msgstr ""
+
+msgctxt "#32182"
+msgid "%i show ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32183"
+msgid "Attempt to scrobble MythTV PVR recordings"
+msgstr ""
+
+msgctxt "#32184"
+msgid "Attempt secondary show title search"
+msgstr ""
+
+msgctxt "#32185"
+msgid "Exclude Plugins"
+msgstr ""
+
+msgctxt "#32186"
+msgid "Allow script exclusions"
+msgstr ""

--- a/script.trakt/resources/language/resource.language.fa_IR/strings.po
+++ b/script.trakt/resources/language/resource.language.fa_IR/strings.po
@@ -10,32 +10,712 @@ msgstr ""
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Kodi Translation Team\n"
 "Language-Team: Persian (Iran) (http://www.transifex.com/projects/p/xbmc-addons/language/fa_IR/)\n"
+"Language: fa_IR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: fa_IR\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 msgctxt "#32000"
 msgid "General"
 msgstr "عمومی"
 
+# empty strings from id 32001 to 32002
+msgctxt "#32003"
+msgid "Startup Delay"
+msgstr ""
+
 msgctxt "#32004"
 msgid "Rating"
 msgstr "رتبه بندی"
+
+msgctxt "#32005"
+msgid "Rate Movie after watching"
+msgstr ""
+
+msgctxt "#32006"
+msgid "Rate TV show Episode after watching"
+msgstr ""
+
+msgctxt "#32008"
+msgid "Minimum percent watched to display rating dialog"
+msgstr ""
+
+msgctxt "#32009"
+msgid "Allow re-rating of media"
+msgstr ""
+
+msgctxt "#32010"
+msgid "Default rating"
+msgstr ""
+
+# Scrobbling Settings
+msgctxt "#32011"
+msgid "Scrobbling"
+msgstr ""
+
+msgctxt "#32012"
+msgid "Scrobble movies"
+msgstr ""
+
+msgctxt "#32013"
+msgid "Scrobble TV show episodes"
+msgstr ""
+
+msgctxt "#32014"
+msgid "Show notification on scrobble"
+msgstr ""
+
+msgctxt "#32015"
+msgid "Trakt - Scrobbled successfully"
+msgstr ""
+
+msgctxt "#32016"
+msgid "Exclusions"
+msgstr ""
+
+msgctxt "#32017"
+msgid "Exclude Live TV"
+msgstr ""
+
+msgctxt "#32018"
+msgid "Exclude HTTP sources"
+msgstr ""
+
+msgctxt "#32019"
+msgid "Exclude path"
+msgstr ""
+
+msgctxt "#32020"
+msgid "Folder's path (including subfolders)"
+msgstr ""
+
+# empty strings from id 32021 to 32022
+msgctxt "#32023"
+msgid "Can not connect to Trakt"
+msgstr ""
 
 msgctxt "#32024"
 msgid "Error"
 msgstr "خطا"
 
+# empty string with id 32025
+msgctxt "#32026"
+msgid "What Did You Think?"
+msgstr ""
+
+msgctxt "#32027"
+msgid "Totally Ninja!"
+msgstr ""
+
+msgctxt "#32028"
+msgid "Weak Sauce :("
+msgstr ""
+
+msgctxt "#32029"
+msgid "Terrible"
+msgstr ""
+
+msgctxt "#32030"
+msgid "Bad"
+msgstr ""
+
+msgctxt "#32031"
+msgid "Poor"
+msgstr ""
+
+msgctxt "#32032"
+msgid "Meh"
+msgstr ""
+
 msgctxt "#32033"
 msgid "Fair"
 msgstr "آفتابی"
+
+msgctxt "#32034"
+msgid "Good"
+msgstr ""
+
+msgctxt "#32035"
+msgid "Great"
+msgstr ""
+
+msgctxt "#32036"
+msgid "Superb"
+msgstr ""
+
+msgctxt "#32037"
+msgid "Unrate this movie"
+msgstr ""
+
+msgctxt "#32038"
+msgid "Unrate this show"
+msgstr ""
+
+msgctxt "#32039"
+msgid "Unrate this episode"
+msgstr ""
+
+msgctxt "#32040"
+msgid "Trakt - Rating submitted successfully"
+msgstr ""
+
+msgctxt "#32041"
+msgid "Trakt - Already rated"
+msgstr ""
+
+msgctxt "#32042"
+msgid "Trakt - Unrated successfully"
+msgstr ""
+
+msgctxt "#32043"
+msgid "Trakt - Already has the same rating"
+msgstr ""
+
+msgctxt "#32044"
+msgid "Trakt - Problem submitting rating"
+msgstr ""
+
+msgctxt "#32045"
+msgid "Synchronize"
+msgstr ""
 
 msgctxt "#32046"
 msgid "Movies"
 msgstr "فیلم ها"
 
+msgctxt "#32047"
+msgid "Add new movies to Trakt collection"
+msgstr ""
+
+msgctxt "#32048"
+msgid "Add watched movies to Trakt history"
+msgstr ""
+
+msgctxt "#32049"
+msgid "Mark movies from Trakt history as watched in Kodi"
+msgstr ""
+
+msgctxt "#32050"
+msgid "TV Episodes"
+msgstr ""
+
+msgctxt "#32051"
+msgid "Add new TV episodes to Trakt collection"
+msgstr ""
+
+msgctxt "#32052"
+msgid "Add watched TV episodes to Trakt history"
+msgstr ""
+
+msgctxt "#32053"
+msgid "Mark TV episodes from Trakt history as watched in Kodi"
+msgstr ""
+
 msgctxt "#32054"
 msgid "Service"
 msgstr "سرویس"
+
+msgctxt "#32055"
+msgid "Sync collection on library update or cleaning"
+msgstr ""
+
+msgctxt "#32056"
+msgid "Show sync notifications"
+msgstr ""
+
+msgctxt "#32057"
+msgid "Remove deleted movies from Trakt collection"
+msgstr ""
+
+msgctxt "#32058"
+msgid "Remove deleted TV episodes from Trakt collection"
+msgstr ""
+
+# empty string with id 32059
+msgctxt "#32060"
+msgid "Hide notifications during playback"
+msgstr ""
+
+msgctxt "#32061"
+msgid "Sync started"
+msgstr ""
+
+msgctxt "#32062"
+msgid "Sync complete"
+msgstr ""
+
+msgctxt "#32063"
+msgid "%i movie(s) will be added to Trakt collection"
+msgstr ""
+
+msgctxt "#32064"
+msgid "%i movie playcount(s) will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32065"
+msgid "%i movie(s) playcount will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32066"
+msgid "Movie Sync Complete"
+msgstr ""
+
+msgctxt "#32067"
+msgid "Going to add %i show(s) to Trakt collection"
+msgstr ""
+
+msgctxt "#32068"
+msgid "Checking for episodes missing from Trakt collection"
+msgstr ""
+
+msgctxt "#32069"
+msgid "%i of %i show(s) have episodes added to Trakt collection"
+msgstr ""
+
+msgctxt "#32070"
+msgid "Going to update %i show(s) missing watched status"
+msgstr ""
+
+msgctxt "#32071"
+msgid "Checking watched episodes on Trakt"
+msgstr ""
+
+msgctxt "#32072"
+msgid "%i show(s) had missing watched status"
+msgstr ""
+
+msgctxt "#32073"
+msgid "%i episodes are being updated"
+msgstr ""
+
+msgctxt "#32074"
+msgid "Checking watched episodes on Kodi"
+msgstr ""
+
+msgctxt "#32075"
+msgid "Episode Sync Complete"
+msgstr ""
+
+msgctxt "#32076"
+msgid "%i movie(s) will be removed from Trakt collection"
+msgstr ""
+
+msgctxt "#32077"
+msgid "Cleaning Trakt TV show collection"
+msgstr ""
+
+msgctxt "#32078"
+msgid "episodes are being removed"
+msgstr ""
+
+msgctxt "#32079"
+msgid "Loading movies from Kodi"
+msgstr ""
+
+msgctxt "#32080"
+msgid "Movies loaded from Kodi"
+msgstr ""
+
+msgctxt "#32081"
+msgid "Retrieving movie collection from Trakt"
+msgstr ""
+
+msgctxt "#32082"
+msgid "Retrieving watched movies from Trakt"
+msgstr ""
+
+msgctxt "#32083"
+msgid "Retrieved movie data from Trakt"
+msgstr ""
+
+msgctxt "#32084"
+msgid "Trakt movie collection is up to date, no movies to add"
+msgstr ""
+
+msgctxt "#32085"
+msgid "%i movie(s) were added to your Trakt collection"
+msgstr ""
+
+msgctxt "#32086"
+msgid "Trakt movie playcounts are up to date"
+msgstr ""
+
+msgctxt "#32087"
+msgid "Playcounts updated for %i movie(s) on Trakt"
+msgstr ""
+
+msgctxt "#32088"
+msgid "Kodi movie playcounts are up to date"
+msgstr ""
+
+msgctxt "#32089"
+msgid "Updating %i of %i movie playcount(s) in Kodi"
+msgstr ""
+
+msgctxt "#32090"
+msgid "Playcounts updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32091"
+msgid "Trakt movie collection is up to date, no movies removed"
+msgstr ""
+
+msgctxt "#32092"
+msgid "%i movie(s) were removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32093"
+msgid "Updating %i of %i movie playcount(s) on Trakt"
+msgstr ""
+
+msgctxt "#32094"
+msgid "Loading episode data from Kodi"
+msgstr ""
+
+msgctxt "#32095"
+msgid "Loading shows from Kodi"
+msgstr ""
+
+msgctxt "#32096"
+msgid "Shows loaded from Kodi"
+msgstr ""
+
+msgctxt "#32097"
+msgid "Parsing %i of %i episode data from Kodi"
+msgstr ""
+
+msgctxt "#32098"
+msgid "Loaded episode data from Kodi"
+msgstr ""
+
+msgctxt "#32099"
+msgid "Loading episode data from Trakt"
+msgstr ""
+
+msgctxt "#32100"
+msgid "Retrieving episode collection from Trakt"
+msgstr ""
+
+msgctxt "#32101"
+msgid "Retrieving watched episodes from Trakt"
+msgstr ""
+
+msgctxt "#32102"
+msgid "Parsing episode data %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32103"
+msgid "Retrieved episode data from Trakt"
+msgstr ""
+
+msgctxt "#32104"
+msgid "Trakt episode collection is up to date, no episodes to add"
+msgstr ""
+
+msgctxt "#32105"
+msgid "%i episode(s) were added to your Trakt collection"
+msgstr ""
+
+msgctxt "#32106"
+msgid "Trakt episode playcounts are up to date"
+msgstr ""
+
+msgctxt "#32107"
+msgid "Kodi episode playcounts are up to date"
+msgstr ""
+
+msgctxt "#32108"
+msgid "Updating %i of %i episode playcount(s) in Kodi"
+msgstr ""
+
+msgctxt "#32109"
+msgid "Playcounts updated for %i show(s) in Kodi"
+msgstr ""
+
+msgctxt "#32110"
+msgid "Trakt episode collection is clean, no episodes to remove"
+msgstr ""
+
+msgctxt "#32111"
+msgid "%i episode(s) are being removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32112"
+msgid "%i episode(s) were removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32113"
+msgid "Trakt - Marked as watched"
+msgstr ""
+
+msgctxt "#32114"
+msgid "Trakt - Failed marking as watched"
+msgstr ""
+
+msgctxt "#32115"
+msgid "%d episode(s) of '%s'"
+msgstr ""
+
+msgctxt "#32116"
+msgid "Enable debug mode"
+msgstr ""
+
+msgctxt "#32117"
+msgid "Sync movie playback progress to Kodi"
+msgstr ""
+
+msgctxt "#32118"
+msgid "Sync episode playback progress to Kodi"
+msgstr ""
+
+msgctxt "#32119"
+msgid "Retrieving episode playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32120"
+msgid "Parsing episode playback progress %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32121"
+msgid "Retrieved episode playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32122"
+msgid "Retrieving movie playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32123"
+msgid "Parsing movie playback progress %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32124"
+msgid "Retrieved movie playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32125"
+msgid "Kodi movie playback progress is up to date"
+msgstr ""
+
+msgctxt "#32126"
+msgid "%i movie(s) playback progress will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32127"
+msgid "Updating %i of %i movie(s) playback progress in Kodi"
+msgstr ""
+
+msgctxt "#32128"
+msgid "Playback progress updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32129"
+msgid "Kodi episode playback progress is up to date"
+msgstr ""
+
+msgctxt "#32130"
+msgid "Updating %i of %i episode(s) playback progress in Kodi"
+msgstr ""
+
+msgctxt "#32131"
+msgid "Playback progress updated for %i episode(s) in Kodi"
+msgstr ""
+
+msgctxt "#32132"
+msgid "Unrate this season"
+msgstr ""
+
+msgctxt "#32133"
+msgid "Manage Movie's Lists"
+msgstr ""
+
+msgctxt "#32134"
+msgid "Manage Show's Lists"
+msgstr ""
+
+msgctxt "#32135"
+msgid "Remove from Watchlist"
+msgstr ""
+
+msgctxt "#32136"
+msgid "Add to watchlist"
+msgstr ""
+
+msgctxt "#32137"
+msgid "Rate this movie"
+msgstr ""
+
+msgctxt "#32138"
+msgid "Rate this show"
+msgstr ""
+
+msgctxt "#32139"
+msgid "Rate this episode"
+msgstr ""
+
+msgctxt "#32140"
+msgid "Toggle watched"
+msgstr ""
+
+msgctxt "#32141"
+msgid "Manage all lists"
+msgstr ""
+
+msgctxt "#32142"
+msgid "Update all tags"
+msgstr ""
+
+msgctxt "#32143"
+msgid "Synchronize library"
+msgstr ""
+
+msgctxt "#32144"
+msgid "How do I authorize the trakt addon to access my trakt.tv account?"
+msgstr ""
+
+# empty strings from id 32145 to 32146
+msgctxt "#32147"
+msgid "Trakt.tv PIN Authorization Failed"
+msgstr ""
+
+# empty string with id 32148
+msgctxt "#32149"
+msgid "Rate this Season"
+msgstr ""
+
+msgctxt "#32150"
+msgid "You will be reminded in 24 hours"
+msgstr ""
+
+msgctxt "#32151"
+msgid "Use Addon Settings later if you change your mind"
+msgstr ""
+
+msgctxt "#32152"
+msgid "Trakt Authorization Complete"
+msgstr ""
+
+msgctxt "#32153"
+msgid "Trakt Account Authorization"
+msgstr ""
+
+msgctxt "#32154"
+msgid "Authorize"
+msgstr ""
+
+msgctxt "#32155"
+msgid "Remind Me Later"
+msgstr ""
+
+msgctxt "#32156"
+msgid "No Thanks"
+msgstr ""
+
+msgctxt "#32157"
+msgid "Account Authorization"
+msgstr ""
+
+# empty string with id 32158
+msgctxt "#32159"
+msgid "Visit {0} or scan the QR code."
+msgstr ""
+
+msgctxt "#32162"
+msgid "The trakt addon CAN NOT be used without authorizing it to access your trakt.tv account."
+msgstr ""
+
+msgctxt "#32163"
+msgid "User"
+msgstr ""
+
+msgctxt "#32164"
+msgid "Fallback to Title/Year matching if necessary"
+msgstr ""
+
+msgctxt "#32165"
+msgid "Trakt - Added to watchlist"
+msgstr ""
+
+msgctxt "#32166"
+msgid "Trakt - Failed adding to watchlist"
+msgstr ""
+
+msgctxt "#32167"
+msgid "Offset scrobble start by X minutes"
+msgstr ""
+
+msgctxt "#32168"
+msgid "Sync ratings"
+msgstr ""
+
+msgctxt "#32169"
+msgid "Kodi movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32170"
+msgid "%i movie(s) ratings will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32171"
+msgid "Updating %i of %i movie ratings in Kodi"
+msgstr ""
+
+msgctxt "#32172"
+msgid "Ratings updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32173"
+msgid "Kodi episode ratings are up to date"
+msgstr ""
+
+msgctxt "#32174"
+msgid "Updating %i of %i episode ratings in Kodi"
+msgstr ""
+
+msgctxt "#32175"
+msgid "Ratings updated for %i episode(s) in Kodi"
+msgstr ""
+
+msgctxt "#32176"
+msgid "Kodi show ratings are up to date"
+msgstr ""
+
+msgctxt "#32177"
+msgid "Updating %i of %i show ratings in Kodi"
+msgstr ""
+
+msgctxt "#32178"
+msgid "Ratings updated for %i show(s) in Kodi"
+msgstr ""
+
+msgctxt "#32179"
+msgid "Trakt movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32180"
+msgid "%i movie ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32181"
+msgid "Trakt show ratings are up to date"
+msgstr ""
+
+msgctxt "#32182"
+msgid "%i show ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32183"
+msgid "Attempt to scrobble MythTV PVR recordings"
+msgstr ""
+
+msgctxt "#32184"
+msgid "Attempt secondary show title search"
+msgstr ""
+
+msgctxt "#32185"
+msgid "Exclude Plugins"
+msgstr ""
+
+msgctxt "#32186"
+msgid "Allow script exclusions"
+msgstr ""

--- a/script.trakt/resources/language/resource.language.fi_FI/strings.po
+++ b/script.trakt/resources/language/resource.language.fi_FI/strings.po
@@ -10,10 +10,10 @@ msgstr ""
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Kodi Translation Team\n"
 "Language-Team: Finnish (http://www.transifex.com/projects/p/xbmc-addons/language/fi/)\n"
+"Language: fi\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: fi\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 msgctxt "#32000"
@@ -216,6 +216,10 @@ msgctxt "#32055"
 msgid "Sync collection on library update or cleaning"
 msgstr "Synkronoi kokoelma kirjaston päivityksessä tai siivouksessa"
 
+msgctxt "#32056"
+msgid "Show sync notifications"
+msgstr ""
+
 msgctxt "#32057"
 msgid "Remove deleted movies from Trakt collection"
 msgstr "Poista poistetut elokuvat Trakt kokoelmasta"
@@ -244,9 +248,25 @@ msgctxt "#32064"
 msgid "%i movie playcount(s) will be updated on Trakt"
 msgstr "%i elokuvan katselukerta(/kerrat) päivitetään Trakt:iin"
 
+msgctxt "#32065"
+msgid "%i movie(s) playcount will be updated in Kodi"
+msgstr ""
+
 msgctxt "#32066"
 msgid "Movie Sync Complete"
 msgstr "Elokuvien synkronointi valmis"
+
+msgctxt "#32067"
+msgid "Going to add %i show(s) to Trakt collection"
+msgstr ""
+
+msgctxt "#32068"
+msgid "Checking for episodes missing from Trakt collection"
+msgstr ""
+
+msgctxt "#32069"
+msgid "%i of %i show(s) have episodes added to Trakt collection"
+msgstr ""
 
 msgctxt "#32070"
 msgid "Going to update %i show(s) missing watched status"
@@ -256,6 +276,10 @@ msgctxt "#32071"
 msgid "Checking watched episodes on Trakt"
 msgstr "Tarkistetaan katsotut jaksot Trakt.tv:stä"
 
+msgctxt "#32072"
+msgid "%i show(s) had missing watched status"
+msgstr ""
+
 msgctxt "#32073"
 msgid "%i episodes are being updated"
 msgstr "%i jaksoa päivitetään"
@@ -263,6 +287,14 @@ msgstr "%i jaksoa päivitetään"
 msgctxt "#32074"
 msgid "Checking watched episodes on Kodi"
 msgstr "Tarkistetaan Kodissa katsotut jaksot"
+
+msgctxt "#32075"
+msgid "Episode Sync Complete"
+msgstr ""
+
+msgctxt "#32076"
+msgid "%i movie(s) will be removed from Trakt collection"
+msgstr ""
 
 msgctxt "#32077"
 msgid "Cleaning Trakt TV show collection"
@@ -280,6 +312,26 @@ msgctxt "#32080"
 msgid "Movies loaded from Kodi"
 msgstr "Elokuvat ladattu Kodista"
 
+msgctxt "#32081"
+msgid "Retrieving movie collection from Trakt"
+msgstr ""
+
+msgctxt "#32082"
+msgid "Retrieving watched movies from Trakt"
+msgstr ""
+
+msgctxt "#32083"
+msgid "Retrieved movie data from Trakt"
+msgstr ""
+
+msgctxt "#32084"
+msgid "Trakt movie collection is up to date, no movies to add"
+msgstr ""
+
+msgctxt "#32085"
+msgid "%i movie(s) were added to your Trakt collection"
+msgstr ""
+
 msgctxt "#32086"
 msgid "Trakt movie playcounts are up to date"
 msgstr "Traktin elokuvien katselukerrat ovat ajantasalla"
@@ -292,17 +344,101 @@ msgctxt "#32088"
 msgid "Kodi movie playcounts are up to date"
 msgstr "Kodin elokuvien katselukerrat ovat ajantasalla"
 
+msgctxt "#32089"
+msgid "Updating %i of %i movie playcount(s) in Kodi"
+msgstr ""
+
 msgctxt "#32090"
 msgid "Playcounts updated for %i movie(s) in Kodi"
 msgstr "Katselukerrat päivitetty %i elokuvalle Kodissa"
+
+msgctxt "#32091"
+msgid "Trakt movie collection is up to date, no movies removed"
+msgstr ""
+
+msgctxt "#32092"
+msgid "%i movie(s) were removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32093"
+msgid "Updating %i of %i movie playcount(s) on Trakt"
+msgstr ""
 
 msgctxt "#32094"
 msgid "Loading episode data from Kodi"
 msgstr "Ladataan jakson tietoja Kodista"
 
+msgctxt "#32095"
+msgid "Loading shows from Kodi"
+msgstr ""
+
 msgctxt "#32096"
 msgid "Shows loaded from Kodi"
 msgstr "Sarjat ladattu Kodista"
+
+msgctxt "#32097"
+msgid "Parsing %i of %i episode data from Kodi"
+msgstr ""
+
+msgctxt "#32098"
+msgid "Loaded episode data from Kodi"
+msgstr ""
+
+msgctxt "#32099"
+msgid "Loading episode data from Trakt"
+msgstr ""
+
+msgctxt "#32100"
+msgid "Retrieving episode collection from Trakt"
+msgstr ""
+
+msgctxt "#32101"
+msgid "Retrieving watched episodes from Trakt"
+msgstr ""
+
+msgctxt "#32102"
+msgid "Parsing episode data %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32103"
+msgid "Retrieved episode data from Trakt"
+msgstr ""
+
+msgctxt "#32104"
+msgid "Trakt episode collection is up to date, no episodes to add"
+msgstr ""
+
+msgctxt "#32105"
+msgid "%i episode(s) were added to your Trakt collection"
+msgstr ""
+
+msgctxt "#32106"
+msgid "Trakt episode playcounts are up to date"
+msgstr ""
+
+msgctxt "#32107"
+msgid "Kodi episode playcounts are up to date"
+msgstr ""
+
+msgctxt "#32108"
+msgid "Updating %i of %i episode playcount(s) in Kodi"
+msgstr ""
+
+msgctxt "#32109"
+msgid "Playcounts updated for %i show(s) in Kodi"
+msgstr ""
+
+msgctxt "#32110"
+msgid "Trakt episode collection is clean, no episodes to remove"
+msgstr ""
+
+msgctxt "#32111"
+msgid "%i episode(s) are being removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32112"
+msgid "%i episode(s) were removed from your Trakt collection"
+msgstr ""
 
 msgctxt "#32113"
 msgid "Trakt - Marked as watched"
@@ -312,17 +448,121 @@ msgctxt "#32114"
 msgid "Trakt - Failed marking as watched"
 msgstr "Trakt - Katsotuksi merkitseminen epäonnistui"
 
+msgctxt "#32115"
+msgid "%d episode(s) of '%s'"
+msgstr ""
+
 msgctxt "#32116"
 msgid "Enable debug mode"
 msgstr "Kytke debug tila päälle"
+
+msgctxt "#32117"
+msgid "Sync movie playback progress to Kodi"
+msgstr ""
+
+msgctxt "#32118"
+msgid "Sync episode playback progress to Kodi"
+msgstr ""
+
+msgctxt "#32119"
+msgid "Retrieving episode playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32120"
+msgid "Parsing episode playback progress %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32121"
+msgid "Retrieved episode playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32122"
+msgid "Retrieving movie playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32123"
+msgid "Parsing movie playback progress %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32124"
+msgid "Retrieved movie playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32125"
+msgid "Kodi movie playback progress is up to date"
+msgstr ""
+
+msgctxt "#32126"
+msgid "%i movie(s) playback progress will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32127"
+msgid "Updating %i of %i movie(s) playback progress in Kodi"
+msgstr ""
+
+msgctxt "#32128"
+msgid "Playback progress updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32129"
+msgid "Kodi episode playback progress is up to date"
+msgstr ""
+
+msgctxt "#32130"
+msgid "Updating %i of %i episode(s) playback progress in Kodi"
+msgstr ""
+
+msgctxt "#32131"
+msgid "Playback progress updated for %i episode(s) in Kodi"
+msgstr ""
 
 msgctxt "#32132"
 msgid "Unrate this season"
 msgstr "Poista tämän kauden arvostelu"
 
+msgctxt "#32133"
+msgid "Manage Movie's Lists"
+msgstr ""
+
+msgctxt "#32134"
+msgid "Manage Show's Lists"
+msgstr ""
+
 msgctxt "#32135"
 msgid "Remove from Watchlist"
 msgstr "Poista katselulistasta"
+
+msgctxt "#32136"
+msgid "Add to watchlist"
+msgstr ""
+
+msgctxt "#32137"
+msgid "Rate this movie"
+msgstr ""
+
+msgctxt "#32138"
+msgid "Rate this show"
+msgstr ""
+
+msgctxt "#32139"
+msgid "Rate this episode"
+msgstr ""
+
+msgctxt "#32140"
+msgid "Toggle watched"
+msgstr ""
+
+msgctxt "#32141"
+msgid "Manage all lists"
+msgstr ""
+
+msgctxt "#32142"
+msgid "Update all tags"
+msgstr ""
+
+msgctxt "#32143"
+msgid "Synchronize library"
+msgstr ""
 
 msgctxt "#32144"
 msgid "How do I authorize the trakt addon to access my trakt.tv account?"
@@ -368,10 +608,111 @@ msgctxt "#32157"
 msgid "Account Authorization"
 msgstr "Tilin valtuuttaminen"
 
-msgctxt "#32161"
-msgid "Enter the PIN provided in the box below."
-msgstr "Syötä annettu PIN alla olevaan laatikkoon"
+# empty string with id 32158
+msgctxt "#32159"
+msgid "Visit {0} or scan the QR code."
+msgstr ""
+
+msgctxt "#32162"
+msgid "The trakt addon CAN NOT be used without authorizing it to access your trakt.tv account."
+msgstr ""
 
 msgctxt "#32163"
 msgid "User"
 msgstr "Käyttäjä"
+
+msgctxt "#32164"
+msgid "Fallback to Title/Year matching if necessary"
+msgstr ""
+
+msgctxt "#32165"
+msgid "Trakt - Added to watchlist"
+msgstr ""
+
+msgctxt "#32166"
+msgid "Trakt - Failed adding to watchlist"
+msgstr ""
+
+msgctxt "#32167"
+msgid "Offset scrobble start by X minutes"
+msgstr ""
+
+msgctxt "#32168"
+msgid "Sync ratings"
+msgstr ""
+
+msgctxt "#32169"
+msgid "Kodi movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32170"
+msgid "%i movie(s) ratings will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32171"
+msgid "Updating %i of %i movie ratings in Kodi"
+msgstr ""
+
+msgctxt "#32172"
+msgid "Ratings updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32173"
+msgid "Kodi episode ratings are up to date"
+msgstr ""
+
+msgctxt "#32174"
+msgid "Updating %i of %i episode ratings in Kodi"
+msgstr ""
+
+msgctxt "#32175"
+msgid "Ratings updated for %i episode(s) in Kodi"
+msgstr ""
+
+msgctxt "#32176"
+msgid "Kodi show ratings are up to date"
+msgstr ""
+
+msgctxt "#32177"
+msgid "Updating %i of %i show ratings in Kodi"
+msgstr ""
+
+msgctxt "#32178"
+msgid "Ratings updated for %i show(s) in Kodi"
+msgstr ""
+
+msgctxt "#32179"
+msgid "Trakt movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32180"
+msgid "%i movie ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32181"
+msgid "Trakt show ratings are up to date"
+msgstr ""
+
+msgctxt "#32182"
+msgid "%i show ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32183"
+msgid "Attempt to scrobble MythTV PVR recordings"
+msgstr ""
+
+msgctxt "#32184"
+msgid "Attempt secondary show title search"
+msgstr ""
+
+msgctxt "#32185"
+msgid "Exclude Plugins"
+msgstr ""
+
+msgctxt "#32186"
+msgid "Allow script exclusions"
+msgstr ""
+
+#~ msgctxt "#32161"
+#~ msgid "Enter the PIN provided in the box below."
+#~ msgstr "Syötä annettu PIN alla olevaan laatikkoon"

--- a/script.trakt/resources/language/resource.language.fo_FO/strings.po
+++ b/script.trakt/resources/language/resource.language.fo_FO/strings.po
@@ -10,28 +10,712 @@ msgstr ""
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Kodi Translation Team\n"
 "Language-Team: Faroese (http://www.transifex.com/projects/p/xbmc-addons/language/fo/)\n"
+"Language: fo\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: fo\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 msgctxt "#32000"
 msgid "General"
 msgstr "Vanligt"
 
+# empty strings from id 32001 to 32002
+msgctxt "#32003"
+msgid "Startup Delay"
+msgstr ""
+
 msgctxt "#32004"
 msgid "Rating"
 msgstr "Atkvøður"
+
+msgctxt "#32005"
+msgid "Rate Movie after watching"
+msgstr ""
+
+msgctxt "#32006"
+msgid "Rate TV show Episode after watching"
+msgstr ""
+
+msgctxt "#32008"
+msgid "Minimum percent watched to display rating dialog"
+msgstr ""
+
+msgctxt "#32009"
+msgid "Allow re-rating of media"
+msgstr ""
+
+msgctxt "#32010"
+msgid "Default rating"
+msgstr ""
+
+# Scrobbling Settings
+msgctxt "#32011"
+msgid "Scrobbling"
+msgstr ""
+
+msgctxt "#32012"
+msgid "Scrobble movies"
+msgstr ""
+
+msgctxt "#32013"
+msgid "Scrobble TV show episodes"
+msgstr ""
+
+msgctxt "#32014"
+msgid "Show notification on scrobble"
+msgstr ""
+
+msgctxt "#32015"
+msgid "Trakt - Scrobbled successfully"
+msgstr ""
+
+msgctxt "#32016"
+msgid "Exclusions"
+msgstr ""
+
+msgctxt "#32017"
+msgid "Exclude Live TV"
+msgstr ""
+
+msgctxt "#32018"
+msgid "Exclude HTTP sources"
+msgstr ""
+
+msgctxt "#32019"
+msgid "Exclude path"
+msgstr ""
+
+msgctxt "#32020"
+msgid "Folder's path (including subfolders)"
+msgstr ""
+
+# empty strings from id 32021 to 32022
+msgctxt "#32023"
+msgid "Can not connect to Trakt"
+msgstr ""
 
 msgctxt "#32024"
 msgid "Error"
 msgstr "Feilur"
 
+# empty string with id 32025
+msgctxt "#32026"
+msgid "What Did You Think?"
+msgstr ""
+
+msgctxt "#32027"
+msgid "Totally Ninja!"
+msgstr ""
+
+msgctxt "#32028"
+msgid "Weak Sauce :("
+msgstr ""
+
+msgctxt "#32029"
+msgid "Terrible"
+msgstr ""
+
+msgctxt "#32030"
+msgid "Bad"
+msgstr ""
+
+msgctxt "#32031"
+msgid "Poor"
+msgstr ""
+
+msgctxt "#32032"
+msgid "Meh"
+msgstr ""
+
 msgctxt "#32033"
 msgid "Fair"
 msgstr "Lætt"
 
+msgctxt "#32034"
+msgid "Good"
+msgstr ""
+
+msgctxt "#32035"
+msgid "Great"
+msgstr ""
+
+msgctxt "#32036"
+msgid "Superb"
+msgstr ""
+
+msgctxt "#32037"
+msgid "Unrate this movie"
+msgstr ""
+
+msgctxt "#32038"
+msgid "Unrate this show"
+msgstr ""
+
+msgctxt "#32039"
+msgid "Unrate this episode"
+msgstr ""
+
+msgctxt "#32040"
+msgid "Trakt - Rating submitted successfully"
+msgstr ""
+
+msgctxt "#32041"
+msgid "Trakt - Already rated"
+msgstr ""
+
+msgctxt "#32042"
+msgid "Trakt - Unrated successfully"
+msgstr ""
+
+msgctxt "#32043"
+msgid "Trakt - Already has the same rating"
+msgstr ""
+
+msgctxt "#32044"
+msgid "Trakt - Problem submitting rating"
+msgstr ""
+
+msgctxt "#32045"
+msgid "Synchronize"
+msgstr ""
+
 msgctxt "#32046"
 msgid "Movies"
 msgstr "Filmar"
+
+msgctxt "#32047"
+msgid "Add new movies to Trakt collection"
+msgstr ""
+
+msgctxt "#32048"
+msgid "Add watched movies to Trakt history"
+msgstr ""
+
+msgctxt "#32049"
+msgid "Mark movies from Trakt history as watched in Kodi"
+msgstr ""
+
+msgctxt "#32050"
+msgid "TV Episodes"
+msgstr ""
+
+msgctxt "#32051"
+msgid "Add new TV episodes to Trakt collection"
+msgstr ""
+
+msgctxt "#32052"
+msgid "Add watched TV episodes to Trakt history"
+msgstr ""
+
+msgctxt "#32053"
+msgid "Mark TV episodes from Trakt history as watched in Kodi"
+msgstr ""
+
+msgctxt "#32054"
+msgid "Service"
+msgstr ""
+
+msgctxt "#32055"
+msgid "Sync collection on library update or cleaning"
+msgstr ""
+
+msgctxt "#32056"
+msgid "Show sync notifications"
+msgstr ""
+
+msgctxt "#32057"
+msgid "Remove deleted movies from Trakt collection"
+msgstr ""
+
+msgctxt "#32058"
+msgid "Remove deleted TV episodes from Trakt collection"
+msgstr ""
+
+# empty string with id 32059
+msgctxt "#32060"
+msgid "Hide notifications during playback"
+msgstr ""
+
+msgctxt "#32061"
+msgid "Sync started"
+msgstr ""
+
+msgctxt "#32062"
+msgid "Sync complete"
+msgstr ""
+
+msgctxt "#32063"
+msgid "%i movie(s) will be added to Trakt collection"
+msgstr ""
+
+msgctxt "#32064"
+msgid "%i movie playcount(s) will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32065"
+msgid "%i movie(s) playcount will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32066"
+msgid "Movie Sync Complete"
+msgstr ""
+
+msgctxt "#32067"
+msgid "Going to add %i show(s) to Trakt collection"
+msgstr ""
+
+msgctxt "#32068"
+msgid "Checking for episodes missing from Trakt collection"
+msgstr ""
+
+msgctxt "#32069"
+msgid "%i of %i show(s) have episodes added to Trakt collection"
+msgstr ""
+
+msgctxt "#32070"
+msgid "Going to update %i show(s) missing watched status"
+msgstr ""
+
+msgctxt "#32071"
+msgid "Checking watched episodes on Trakt"
+msgstr ""
+
+msgctxt "#32072"
+msgid "%i show(s) had missing watched status"
+msgstr ""
+
+msgctxt "#32073"
+msgid "%i episodes are being updated"
+msgstr ""
+
+msgctxt "#32074"
+msgid "Checking watched episodes on Kodi"
+msgstr ""
+
+msgctxt "#32075"
+msgid "Episode Sync Complete"
+msgstr ""
+
+msgctxt "#32076"
+msgid "%i movie(s) will be removed from Trakt collection"
+msgstr ""
+
+msgctxt "#32077"
+msgid "Cleaning Trakt TV show collection"
+msgstr ""
+
+msgctxt "#32078"
+msgid "episodes are being removed"
+msgstr ""
+
+msgctxt "#32079"
+msgid "Loading movies from Kodi"
+msgstr ""
+
+msgctxt "#32080"
+msgid "Movies loaded from Kodi"
+msgstr ""
+
+msgctxt "#32081"
+msgid "Retrieving movie collection from Trakt"
+msgstr ""
+
+msgctxt "#32082"
+msgid "Retrieving watched movies from Trakt"
+msgstr ""
+
+msgctxt "#32083"
+msgid "Retrieved movie data from Trakt"
+msgstr ""
+
+msgctxt "#32084"
+msgid "Trakt movie collection is up to date, no movies to add"
+msgstr ""
+
+msgctxt "#32085"
+msgid "%i movie(s) were added to your Trakt collection"
+msgstr ""
+
+msgctxt "#32086"
+msgid "Trakt movie playcounts are up to date"
+msgstr ""
+
+msgctxt "#32087"
+msgid "Playcounts updated for %i movie(s) on Trakt"
+msgstr ""
+
+msgctxt "#32088"
+msgid "Kodi movie playcounts are up to date"
+msgstr ""
+
+msgctxt "#32089"
+msgid "Updating %i of %i movie playcount(s) in Kodi"
+msgstr ""
+
+msgctxt "#32090"
+msgid "Playcounts updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32091"
+msgid "Trakt movie collection is up to date, no movies removed"
+msgstr ""
+
+msgctxt "#32092"
+msgid "%i movie(s) were removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32093"
+msgid "Updating %i of %i movie playcount(s) on Trakt"
+msgstr ""
+
+msgctxt "#32094"
+msgid "Loading episode data from Kodi"
+msgstr ""
+
+msgctxt "#32095"
+msgid "Loading shows from Kodi"
+msgstr ""
+
+msgctxt "#32096"
+msgid "Shows loaded from Kodi"
+msgstr ""
+
+msgctxt "#32097"
+msgid "Parsing %i of %i episode data from Kodi"
+msgstr ""
+
+msgctxt "#32098"
+msgid "Loaded episode data from Kodi"
+msgstr ""
+
+msgctxt "#32099"
+msgid "Loading episode data from Trakt"
+msgstr ""
+
+msgctxt "#32100"
+msgid "Retrieving episode collection from Trakt"
+msgstr ""
+
+msgctxt "#32101"
+msgid "Retrieving watched episodes from Trakt"
+msgstr ""
+
+msgctxt "#32102"
+msgid "Parsing episode data %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32103"
+msgid "Retrieved episode data from Trakt"
+msgstr ""
+
+msgctxt "#32104"
+msgid "Trakt episode collection is up to date, no episodes to add"
+msgstr ""
+
+msgctxt "#32105"
+msgid "%i episode(s) were added to your Trakt collection"
+msgstr ""
+
+msgctxt "#32106"
+msgid "Trakt episode playcounts are up to date"
+msgstr ""
+
+msgctxt "#32107"
+msgid "Kodi episode playcounts are up to date"
+msgstr ""
+
+msgctxt "#32108"
+msgid "Updating %i of %i episode playcount(s) in Kodi"
+msgstr ""
+
+msgctxt "#32109"
+msgid "Playcounts updated for %i show(s) in Kodi"
+msgstr ""
+
+msgctxt "#32110"
+msgid "Trakt episode collection is clean, no episodes to remove"
+msgstr ""
+
+msgctxt "#32111"
+msgid "%i episode(s) are being removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32112"
+msgid "%i episode(s) were removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32113"
+msgid "Trakt - Marked as watched"
+msgstr ""
+
+msgctxt "#32114"
+msgid "Trakt - Failed marking as watched"
+msgstr ""
+
+msgctxt "#32115"
+msgid "%d episode(s) of '%s'"
+msgstr ""
+
+msgctxt "#32116"
+msgid "Enable debug mode"
+msgstr ""
+
+msgctxt "#32117"
+msgid "Sync movie playback progress to Kodi"
+msgstr ""
+
+msgctxt "#32118"
+msgid "Sync episode playback progress to Kodi"
+msgstr ""
+
+msgctxt "#32119"
+msgid "Retrieving episode playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32120"
+msgid "Parsing episode playback progress %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32121"
+msgid "Retrieved episode playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32122"
+msgid "Retrieving movie playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32123"
+msgid "Parsing movie playback progress %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32124"
+msgid "Retrieved movie playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32125"
+msgid "Kodi movie playback progress is up to date"
+msgstr ""
+
+msgctxt "#32126"
+msgid "%i movie(s) playback progress will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32127"
+msgid "Updating %i of %i movie(s) playback progress in Kodi"
+msgstr ""
+
+msgctxt "#32128"
+msgid "Playback progress updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32129"
+msgid "Kodi episode playback progress is up to date"
+msgstr ""
+
+msgctxt "#32130"
+msgid "Updating %i of %i episode(s) playback progress in Kodi"
+msgstr ""
+
+msgctxt "#32131"
+msgid "Playback progress updated for %i episode(s) in Kodi"
+msgstr ""
+
+msgctxt "#32132"
+msgid "Unrate this season"
+msgstr ""
+
+msgctxt "#32133"
+msgid "Manage Movie's Lists"
+msgstr ""
+
+msgctxt "#32134"
+msgid "Manage Show's Lists"
+msgstr ""
+
+msgctxt "#32135"
+msgid "Remove from Watchlist"
+msgstr ""
+
+msgctxt "#32136"
+msgid "Add to watchlist"
+msgstr ""
+
+msgctxt "#32137"
+msgid "Rate this movie"
+msgstr ""
+
+msgctxt "#32138"
+msgid "Rate this show"
+msgstr ""
+
+msgctxt "#32139"
+msgid "Rate this episode"
+msgstr ""
+
+msgctxt "#32140"
+msgid "Toggle watched"
+msgstr ""
+
+msgctxt "#32141"
+msgid "Manage all lists"
+msgstr ""
+
+msgctxt "#32142"
+msgid "Update all tags"
+msgstr ""
+
+msgctxt "#32143"
+msgid "Synchronize library"
+msgstr ""
+
+msgctxt "#32144"
+msgid "How do I authorize the trakt addon to access my trakt.tv account?"
+msgstr ""
+
+# empty strings from id 32145 to 32146
+msgctxt "#32147"
+msgid "Trakt.tv PIN Authorization Failed"
+msgstr ""
+
+# empty string with id 32148
+msgctxt "#32149"
+msgid "Rate this Season"
+msgstr ""
+
+msgctxt "#32150"
+msgid "You will be reminded in 24 hours"
+msgstr ""
+
+msgctxt "#32151"
+msgid "Use Addon Settings later if you change your mind"
+msgstr ""
+
+msgctxt "#32152"
+msgid "Trakt Authorization Complete"
+msgstr ""
+
+msgctxt "#32153"
+msgid "Trakt Account Authorization"
+msgstr ""
+
+msgctxt "#32154"
+msgid "Authorize"
+msgstr ""
+
+msgctxt "#32155"
+msgid "Remind Me Later"
+msgstr ""
+
+msgctxt "#32156"
+msgid "No Thanks"
+msgstr ""
+
+msgctxt "#32157"
+msgid "Account Authorization"
+msgstr ""
+
+# empty string with id 32158
+msgctxt "#32159"
+msgid "Visit {0} or scan the QR code."
+msgstr ""
+
+msgctxt "#32162"
+msgid "The trakt addon CAN NOT be used without authorizing it to access your trakt.tv account."
+msgstr ""
+
+msgctxt "#32163"
+msgid "User"
+msgstr ""
+
+msgctxt "#32164"
+msgid "Fallback to Title/Year matching if necessary"
+msgstr ""
+
+msgctxt "#32165"
+msgid "Trakt - Added to watchlist"
+msgstr ""
+
+msgctxt "#32166"
+msgid "Trakt - Failed adding to watchlist"
+msgstr ""
+
+msgctxt "#32167"
+msgid "Offset scrobble start by X minutes"
+msgstr ""
+
+msgctxt "#32168"
+msgid "Sync ratings"
+msgstr ""
+
+msgctxt "#32169"
+msgid "Kodi movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32170"
+msgid "%i movie(s) ratings will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32171"
+msgid "Updating %i of %i movie ratings in Kodi"
+msgstr ""
+
+msgctxt "#32172"
+msgid "Ratings updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32173"
+msgid "Kodi episode ratings are up to date"
+msgstr ""
+
+msgctxt "#32174"
+msgid "Updating %i of %i episode ratings in Kodi"
+msgstr ""
+
+msgctxt "#32175"
+msgid "Ratings updated for %i episode(s) in Kodi"
+msgstr ""
+
+msgctxt "#32176"
+msgid "Kodi show ratings are up to date"
+msgstr ""
+
+msgctxt "#32177"
+msgid "Updating %i of %i show ratings in Kodi"
+msgstr ""
+
+msgctxt "#32178"
+msgid "Ratings updated for %i show(s) in Kodi"
+msgstr ""
+
+msgctxt "#32179"
+msgid "Trakt movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32180"
+msgid "%i movie ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32181"
+msgid "Trakt show ratings are up to date"
+msgstr ""
+
+msgctxt "#32182"
+msgid "%i show ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32183"
+msgid "Attempt to scrobble MythTV PVR recordings"
+msgstr ""
+
+msgctxt "#32184"
+msgid "Attempt secondary show title search"
+msgstr ""
+
+msgctxt "#32185"
+msgid "Exclude Plugins"
+msgstr ""
+
+msgctxt "#32186"
+msgid "Allow script exclusions"
+msgstr ""

--- a/script.trakt/resources/language/resource.language.fr_CA/strings.po
+++ b/script.trakt/resources/language/resource.language.fr_CA/strings.po
@@ -7,14 +7,15 @@ msgstr ""
 "Project-Id-Version: XBMC Addons\n"
 "Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: Kodi Translation Team\n"
-"Language-Team: French (Canada) (http://www.transifex.com/projects/p/xbmc-addons/language/fr_CA/)\n"
+"PO-Revision-Date: 2021-03-20 15:56+0000\n"
+"Last-Translator: Christian Gade <gade@kodi.tv>\n"
+"Language-Team: French (Canada) <https://kodi.weblate.cloud/projects/kodi-add-ons-scripts/script-trakt/fr_ca/>\n"
+"Language: fr_CA\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: fr_CA\n"
-"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"Plural-Forms: nplurals=2; plural=n > 1;\n"
+"X-Generator: Weblate 4.5.1\n"
 
 msgctxt "#32000"
 msgid "General"
@@ -242,7 +243,7 @@ msgstr "Synchro terminée"
 
 msgctxt "#32063"
 msgid "%i movie(s) will be added to Trakt collection"
-msgstr "%i film(s) sera/seront ajouté(s) à la collection Trakt\n "
+msgstr "%i film(s) sera/seront ajouté(s) à la collection Trakt"
 
 msgctxt "#32064"
 msgid "%i movie playcount(s) will be updated on Trakt"
@@ -358,7 +359,7 @@ msgstr "La collection de films de Trakt est à jour, aucun film n'a été suppri
 
 msgctxt "#32092"
 msgid "%i movie(s) were removed from your Trakt collection"
-msgstr "%i film(s) a/ont été retiré(s) de votre collection Trakt "
+msgstr "%i film(s) a/ont été retiré(s) de votre collection Trakt"
 
 msgctxt "#32093"
 msgid "Updating %i of %i movie playcount(s) on Trakt"
@@ -434,11 +435,11 @@ msgstr "La collection d'épisodes de Trakt est propre, aucun épisode à supprim
 
 msgctxt "#32111"
 msgid "%i episode(s) are being removed from your Trakt collection"
-msgstr "%i épisode(s) est/sont en cours de retrait de votre collection Trakt "
+msgstr "%i épisode(s) est/sont en cours de retrait de votre collection Trakt"
 
 msgctxt "#32112"
 msgid "%i episode(s) were removed from your Trakt collection"
-msgstr "%i épisode(s) a/ont été retiré(s) de votre collection Trakt "
+msgstr "%i épisode(s) a/ont été retiré(s) de votre collection Trakt"
 
 msgctxt "#32113"
 msgid "Trakt - Marked as watched"
@@ -586,7 +587,7 @@ msgstr "Utilisez les paramètres d'addiciels ultérieurement si vous changez d'a
 
 msgctxt "#32152"
 msgid "Trakt Authorization Complete"
-msgstr "Trakt - Autorisation terminée "
+msgstr "Trakt - Autorisation terminée"
 
 msgctxt "#32153"
 msgid "Trakt Account Authorization"
@@ -608,17 +609,10 @@ msgctxt "#32157"
 msgid "Account Authorization"
 msgstr "Autorisation de compte"
 
+# empty string with id 32158
 msgctxt "#32159"
-msgid "Visit {0} or scan the QR Code below."
-msgstr "Visiter {0} ou lire le code QR ci-dessous."
-
-msgctxt "#32160"
-msgid "Authorize the trakt addon to access your account."
-msgstr "Autorisez l'addiciel trakt à accéder à votre compte."
-
-msgctxt "#32161"
-msgid "Enter the PIN provided in the box below."
-msgstr "Saisissez le NIP fourni dans la boîte ci-dessous."
+msgid "Visit {0} or scan the QR code."
+msgstr ""
 
 msgctxt "#32162"
 msgid "The trakt addon CAN NOT be used without authorizing it to access your trakt.tv account."
@@ -639,3 +633,95 @@ msgstr "Trakt - Ajouter à la liste de suivi"
 msgctxt "#32166"
 msgid "Trakt - Failed adding to watchlist"
 msgstr "Trakt - Échec d'ajout à la liste de suivi"
+
+msgctxt "#32167"
+msgid "Offset scrobble start by X minutes"
+msgstr ""
+
+msgctxt "#32168"
+msgid "Sync ratings"
+msgstr ""
+
+msgctxt "#32169"
+msgid "Kodi movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32170"
+msgid "%i movie(s) ratings will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32171"
+msgid "Updating %i of %i movie ratings in Kodi"
+msgstr ""
+
+msgctxt "#32172"
+msgid "Ratings updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32173"
+msgid "Kodi episode ratings are up to date"
+msgstr ""
+
+msgctxt "#32174"
+msgid "Updating %i of %i episode ratings in Kodi"
+msgstr ""
+
+msgctxt "#32175"
+msgid "Ratings updated for %i episode(s) in Kodi"
+msgstr ""
+
+msgctxt "#32176"
+msgid "Kodi show ratings are up to date"
+msgstr ""
+
+msgctxt "#32177"
+msgid "Updating %i of %i show ratings in Kodi"
+msgstr ""
+
+msgctxt "#32178"
+msgid "Ratings updated for %i show(s) in Kodi"
+msgstr ""
+
+msgctxt "#32179"
+msgid "Trakt movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32180"
+msgid "%i movie ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32181"
+msgid "Trakt show ratings are up to date"
+msgstr ""
+
+msgctxt "#32182"
+msgid "%i show ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32183"
+msgid "Attempt to scrobble MythTV PVR recordings"
+msgstr ""
+
+msgctxt "#32184"
+msgid "Attempt secondary show title search"
+msgstr ""
+
+msgctxt "#32185"
+msgid "Exclude Plugins"
+msgstr ""
+
+msgctxt "#32186"
+msgid "Allow script exclusions"
+msgstr ""
+
+#~ msgctxt "#32159"
+#~ msgid "Visit {0} or scan the QR Code below."
+#~ msgstr "Visiter {0} ou lire le code QR ci-dessous."
+
+#~ msgctxt "#32160"
+#~ msgid "Authorize the trakt addon to access your account."
+#~ msgstr "Autorisez l'addiciel trakt à accéder à votre compte."
+
+#~ msgctxt "#32161"
+#~ msgid "Enter the PIN provided in the box below."
+#~ msgstr "Saisissez le NIP fourni dans la boîte ci-dessous."

--- a/script.trakt/resources/language/resource.language.fr_FR/strings.po
+++ b/script.trakt/resources/language/resource.language.fr_FR/strings.po
@@ -7,14 +7,15 @@ msgstr ""
 "Project-Id-Version: XBMC Addons\n"
 "Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: Kodi Translation Team\n"
-"Language-Team: French (http://www.transifex.com/projects/p/xbmc-addons/language/fr/)\n"
+"PO-Revision-Date: 2021-03-20 15:56+0000\n"
+"Last-Translator: Christian Gade <gade@kodi.tv>\n"
+"Language-Team: French (France) <https://kodi.weblate.cloud/projects/kodi-add-ons-scripts/script-trakt/fr_fr/>\n"
+"Language: fr_FR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: fr\n"
-"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"Plural-Forms: nplurals=2; plural=n > 1;\n"
+"X-Generator: Weblate 4.5.1\n"
 
 msgctxt "#32000"
 msgid "General"
@@ -214,7 +215,7 @@ msgstr "Service"
 
 msgctxt "#32055"
 msgid "Sync collection on library update or cleaning"
-msgstr "Synchroniser la collection lors de la mise à jour ou du nettoyage de la médiathèque "
+msgstr "Synchroniser la collection lors de la mise à jour ou du nettoyage de la médiathèque"
 
 msgctxt "#32056"
 msgid "Show sync notifications"
@@ -608,17 +609,10 @@ msgctxt "#32157"
 msgid "Account Authorization"
 msgstr "Autorisation de compte"
 
+# empty string with id 32158
 msgctxt "#32159"
-msgid "Visit {0} or scan the QR Code below."
-msgstr "Suivre {0} ou scanner le code QR ci-dessous."
-
-msgctxt "#32160"
-msgid "Authorize the trakt addon to access your account."
-msgstr "Autorise l'extension trakt à accéder à votre compte."
-
-msgctxt "#32161"
-msgid "Enter the PIN provided in the box below."
-msgstr "Saisir le code PIN fourni dans la boîte de dialogue ci-dessous :"
+msgid "Visit {0} or scan the QR code."
+msgstr ""
 
 msgctxt "#32162"
 msgid "The trakt addon CAN NOT be used without authorizing it to access your trakt.tv account."
@@ -639,3 +633,95 @@ msgstr "Trakt - Ajouter à une liste de Lecture"
 msgctxt "#32166"
 msgid "Trakt - Failed adding to watchlist"
 msgstr "Trakt - Échec de l'ajout à la liste de lecture"
+
+msgctxt "#32167"
+msgid "Offset scrobble start by X minutes"
+msgstr ""
+
+msgctxt "#32168"
+msgid "Sync ratings"
+msgstr ""
+
+msgctxt "#32169"
+msgid "Kodi movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32170"
+msgid "%i movie(s) ratings will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32171"
+msgid "Updating %i of %i movie ratings in Kodi"
+msgstr ""
+
+msgctxt "#32172"
+msgid "Ratings updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32173"
+msgid "Kodi episode ratings are up to date"
+msgstr ""
+
+msgctxt "#32174"
+msgid "Updating %i of %i episode ratings in Kodi"
+msgstr ""
+
+msgctxt "#32175"
+msgid "Ratings updated for %i episode(s) in Kodi"
+msgstr ""
+
+msgctxt "#32176"
+msgid "Kodi show ratings are up to date"
+msgstr ""
+
+msgctxt "#32177"
+msgid "Updating %i of %i show ratings in Kodi"
+msgstr ""
+
+msgctxt "#32178"
+msgid "Ratings updated for %i show(s) in Kodi"
+msgstr ""
+
+msgctxt "#32179"
+msgid "Trakt movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32180"
+msgid "%i movie ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32181"
+msgid "Trakt show ratings are up to date"
+msgstr ""
+
+msgctxt "#32182"
+msgid "%i show ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32183"
+msgid "Attempt to scrobble MythTV PVR recordings"
+msgstr ""
+
+msgctxt "#32184"
+msgid "Attempt secondary show title search"
+msgstr ""
+
+msgctxt "#32185"
+msgid "Exclude Plugins"
+msgstr ""
+
+msgctxt "#32186"
+msgid "Allow script exclusions"
+msgstr ""
+
+#~ msgctxt "#32159"
+#~ msgid "Visit {0} or scan the QR Code below."
+#~ msgstr "Suivre {0} ou scanner le code QR ci-dessous."
+
+#~ msgctxt "#32160"
+#~ msgid "Authorize the trakt addon to access your account."
+#~ msgstr "Autorise l'extension trakt à accéder à votre compte."
+
+#~ msgctxt "#32161"
+#~ msgid "Enter the PIN provided in the box below."
+#~ msgstr "Saisir le code PIN fourni dans la boîte de dialogue ci-dessous :"

--- a/script.trakt/resources/language/resource.language.gl_ES/strings.po
+++ b/script.trakt/resources/language/resource.language.gl_ES/strings.po
@@ -10,36 +10,712 @@ msgstr ""
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Kodi Translation Team\n"
 "Language-Team: Galician (http://www.transifex.com/projects/p/xbmc-addons/language/gl/)\n"
+"Language: gl\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: gl\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 msgctxt "#32000"
 msgid "General"
 msgstr "Xeral"
 
+# empty strings from id 32001 to 32002
+msgctxt "#32003"
+msgid "Startup Delay"
+msgstr ""
+
 msgctxt "#32004"
 msgid "Rating"
 msgstr "Valoración"
+
+msgctxt "#32005"
+msgid "Rate Movie after watching"
+msgstr ""
+
+msgctxt "#32006"
+msgid "Rate TV show Episode after watching"
+msgstr ""
+
+msgctxt "#32008"
+msgid "Minimum percent watched to display rating dialog"
+msgstr ""
+
+msgctxt "#32009"
+msgid "Allow re-rating of media"
+msgstr ""
+
+msgctxt "#32010"
+msgid "Default rating"
+msgstr ""
+
+# Scrobbling Settings
+msgctxt "#32011"
+msgid "Scrobbling"
+msgstr ""
+
+msgctxt "#32012"
+msgid "Scrobble movies"
+msgstr ""
+
+msgctxt "#32013"
+msgid "Scrobble TV show episodes"
+msgstr ""
+
+msgctxt "#32014"
+msgid "Show notification on scrobble"
+msgstr ""
+
+msgctxt "#32015"
+msgid "Trakt - Scrobbled successfully"
+msgstr ""
+
+msgctxt "#32016"
+msgid "Exclusions"
+msgstr ""
+
+msgctxt "#32017"
+msgid "Exclude Live TV"
+msgstr ""
+
+msgctxt "#32018"
+msgid "Exclude HTTP sources"
+msgstr ""
+
+msgctxt "#32019"
+msgid "Exclude path"
+msgstr ""
+
+msgctxt "#32020"
+msgid "Folder's path (including subfolders)"
+msgstr ""
+
+# empty strings from id 32021 to 32022
+msgctxt "#32023"
+msgid "Can not connect to Trakt"
+msgstr ""
 
 msgctxt "#32024"
 msgid "Error"
 msgstr "Erro"
 
+# empty string with id 32025
+msgctxt "#32026"
+msgid "What Did You Think?"
+msgstr ""
+
+msgctxt "#32027"
+msgid "Totally Ninja!"
+msgstr ""
+
+msgctxt "#32028"
+msgid "Weak Sauce :("
+msgstr ""
+
+msgctxt "#32029"
+msgid "Terrible"
+msgstr ""
+
+msgctxt "#32030"
+msgid "Bad"
+msgstr ""
+
+msgctxt "#32031"
+msgid "Poor"
+msgstr ""
+
+msgctxt "#32032"
+msgid "Meh"
+msgstr ""
+
 msgctxt "#32033"
 msgid "Fair"
 msgstr "Bo"
+
+msgctxt "#32034"
+msgid "Good"
+msgstr ""
+
+msgctxt "#32035"
+msgid "Great"
+msgstr ""
+
+msgctxt "#32036"
+msgid "Superb"
+msgstr ""
+
+msgctxt "#32037"
+msgid "Unrate this movie"
+msgstr ""
+
+msgctxt "#32038"
+msgid "Unrate this show"
+msgstr ""
+
+msgctxt "#32039"
+msgid "Unrate this episode"
+msgstr ""
+
+msgctxt "#32040"
+msgid "Trakt - Rating submitted successfully"
+msgstr ""
+
+msgctxt "#32041"
+msgid "Trakt - Already rated"
+msgstr ""
+
+msgctxt "#32042"
+msgid "Trakt - Unrated successfully"
+msgstr ""
+
+msgctxt "#32043"
+msgid "Trakt - Already has the same rating"
+msgstr ""
+
+msgctxt "#32044"
+msgid "Trakt - Problem submitting rating"
+msgstr ""
+
+msgctxt "#32045"
+msgid "Synchronize"
+msgstr ""
 
 msgctxt "#32046"
 msgid "Movies"
 msgstr "Filmes"
 
+msgctxt "#32047"
+msgid "Add new movies to Trakt collection"
+msgstr ""
+
+msgctxt "#32048"
+msgid "Add watched movies to Trakt history"
+msgstr ""
+
+msgctxt "#32049"
+msgid "Mark movies from Trakt history as watched in Kodi"
+msgstr ""
+
+msgctxt "#32050"
+msgid "TV Episodes"
+msgstr ""
+
+msgctxt "#32051"
+msgid "Add new TV episodes to Trakt collection"
+msgstr ""
+
+msgctxt "#32052"
+msgid "Add watched TV episodes to Trakt history"
+msgstr ""
+
+msgctxt "#32053"
+msgid "Mark TV episodes from Trakt history as watched in Kodi"
+msgstr ""
+
 msgctxt "#32054"
 msgid "Service"
 msgstr "Servizo"
 
+msgctxt "#32055"
+msgid "Sync collection on library update or cleaning"
+msgstr ""
+
+msgctxt "#32056"
+msgid "Show sync notifications"
+msgstr ""
+
+msgctxt "#32057"
+msgid "Remove deleted movies from Trakt collection"
+msgstr ""
+
+msgctxt "#32058"
+msgid "Remove deleted TV episodes from Trakt collection"
+msgstr ""
+
+# empty string with id 32059
+msgctxt "#32060"
+msgid "Hide notifications during playback"
+msgstr ""
+
+msgctxt "#32061"
+msgid "Sync started"
+msgstr ""
+
+msgctxt "#32062"
+msgid "Sync complete"
+msgstr ""
+
+msgctxt "#32063"
+msgid "%i movie(s) will be added to Trakt collection"
+msgstr ""
+
+msgctxt "#32064"
+msgid "%i movie playcount(s) will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32065"
+msgid "%i movie(s) playcount will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32066"
+msgid "Movie Sync Complete"
+msgstr ""
+
+msgctxt "#32067"
+msgid "Going to add %i show(s) to Trakt collection"
+msgstr ""
+
+msgctxt "#32068"
+msgid "Checking for episodes missing from Trakt collection"
+msgstr ""
+
+msgctxt "#32069"
+msgid "%i of %i show(s) have episodes added to Trakt collection"
+msgstr ""
+
+msgctxt "#32070"
+msgid "Going to update %i show(s) missing watched status"
+msgstr ""
+
+msgctxt "#32071"
+msgid "Checking watched episodes on Trakt"
+msgstr ""
+
+msgctxt "#32072"
+msgid "%i show(s) had missing watched status"
+msgstr ""
+
+msgctxt "#32073"
+msgid "%i episodes are being updated"
+msgstr ""
+
+msgctxt "#32074"
+msgid "Checking watched episodes on Kodi"
+msgstr ""
+
+msgctxt "#32075"
+msgid "Episode Sync Complete"
+msgstr ""
+
+msgctxt "#32076"
+msgid "%i movie(s) will be removed from Trakt collection"
+msgstr ""
+
+msgctxt "#32077"
+msgid "Cleaning Trakt TV show collection"
+msgstr ""
+
+msgctxt "#32078"
+msgid "episodes are being removed"
+msgstr ""
+
+msgctxt "#32079"
+msgid "Loading movies from Kodi"
+msgstr ""
+
+msgctxt "#32080"
+msgid "Movies loaded from Kodi"
+msgstr ""
+
+msgctxt "#32081"
+msgid "Retrieving movie collection from Trakt"
+msgstr ""
+
+msgctxt "#32082"
+msgid "Retrieving watched movies from Trakt"
+msgstr ""
+
+msgctxt "#32083"
+msgid "Retrieved movie data from Trakt"
+msgstr ""
+
+msgctxt "#32084"
+msgid "Trakt movie collection is up to date, no movies to add"
+msgstr ""
+
+msgctxt "#32085"
+msgid "%i movie(s) were added to your Trakt collection"
+msgstr ""
+
+msgctxt "#32086"
+msgid "Trakt movie playcounts are up to date"
+msgstr ""
+
+msgctxt "#32087"
+msgid "Playcounts updated for %i movie(s) on Trakt"
+msgstr ""
+
+msgctxt "#32088"
+msgid "Kodi movie playcounts are up to date"
+msgstr ""
+
+msgctxt "#32089"
+msgid "Updating %i of %i movie playcount(s) in Kodi"
+msgstr ""
+
+msgctxt "#32090"
+msgid "Playcounts updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32091"
+msgid "Trakt movie collection is up to date, no movies removed"
+msgstr ""
+
+msgctxt "#32092"
+msgid "%i movie(s) were removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32093"
+msgid "Updating %i of %i movie playcount(s) on Trakt"
+msgstr ""
+
+msgctxt "#32094"
+msgid "Loading episode data from Kodi"
+msgstr ""
+
+msgctxt "#32095"
+msgid "Loading shows from Kodi"
+msgstr ""
+
+msgctxt "#32096"
+msgid "Shows loaded from Kodi"
+msgstr ""
+
+msgctxt "#32097"
+msgid "Parsing %i of %i episode data from Kodi"
+msgstr ""
+
+msgctxt "#32098"
+msgid "Loaded episode data from Kodi"
+msgstr ""
+
+msgctxt "#32099"
+msgid "Loading episode data from Trakt"
+msgstr ""
+
+msgctxt "#32100"
+msgid "Retrieving episode collection from Trakt"
+msgstr ""
+
+msgctxt "#32101"
+msgid "Retrieving watched episodes from Trakt"
+msgstr ""
+
+msgctxt "#32102"
+msgid "Parsing episode data %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32103"
+msgid "Retrieved episode data from Trakt"
+msgstr ""
+
+msgctxt "#32104"
+msgid "Trakt episode collection is up to date, no episodes to add"
+msgstr ""
+
+msgctxt "#32105"
+msgid "%i episode(s) were added to your Trakt collection"
+msgstr ""
+
+msgctxt "#32106"
+msgid "Trakt episode playcounts are up to date"
+msgstr ""
+
+msgctxt "#32107"
+msgid "Kodi episode playcounts are up to date"
+msgstr ""
+
+msgctxt "#32108"
+msgid "Updating %i of %i episode playcount(s) in Kodi"
+msgstr ""
+
+msgctxt "#32109"
+msgid "Playcounts updated for %i show(s) in Kodi"
+msgstr ""
+
+msgctxt "#32110"
+msgid "Trakt episode collection is clean, no episodes to remove"
+msgstr ""
+
+msgctxt "#32111"
+msgid "%i episode(s) are being removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32112"
+msgid "%i episode(s) were removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32113"
+msgid "Trakt - Marked as watched"
+msgstr ""
+
+msgctxt "#32114"
+msgid "Trakt - Failed marking as watched"
+msgstr ""
+
+msgctxt "#32115"
+msgid "%d episode(s) of '%s'"
+msgstr ""
+
+msgctxt "#32116"
+msgid "Enable debug mode"
+msgstr ""
+
+msgctxt "#32117"
+msgid "Sync movie playback progress to Kodi"
+msgstr ""
+
+msgctxt "#32118"
+msgid "Sync episode playback progress to Kodi"
+msgstr ""
+
+msgctxt "#32119"
+msgid "Retrieving episode playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32120"
+msgid "Parsing episode playback progress %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32121"
+msgid "Retrieved episode playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32122"
+msgid "Retrieving movie playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32123"
+msgid "Parsing movie playback progress %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32124"
+msgid "Retrieved movie playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32125"
+msgid "Kodi movie playback progress is up to date"
+msgstr ""
+
+msgctxt "#32126"
+msgid "%i movie(s) playback progress will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32127"
+msgid "Updating %i of %i movie(s) playback progress in Kodi"
+msgstr ""
+
+msgctxt "#32128"
+msgid "Playback progress updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32129"
+msgid "Kodi episode playback progress is up to date"
+msgstr ""
+
+msgctxt "#32130"
+msgid "Updating %i of %i episode(s) playback progress in Kodi"
+msgstr ""
+
+msgctxt "#32131"
+msgid "Playback progress updated for %i episode(s) in Kodi"
+msgstr ""
+
+msgctxt "#32132"
+msgid "Unrate this season"
+msgstr ""
+
+msgctxt "#32133"
+msgid "Manage Movie's Lists"
+msgstr ""
+
+msgctxt "#32134"
+msgid "Manage Show's Lists"
+msgstr ""
+
+msgctxt "#32135"
+msgid "Remove from Watchlist"
+msgstr ""
+
+msgctxt "#32136"
+msgid "Add to watchlist"
+msgstr ""
+
+msgctxt "#32137"
+msgid "Rate this movie"
+msgstr ""
+
+msgctxt "#32138"
+msgid "Rate this show"
+msgstr ""
+
+msgctxt "#32139"
+msgid "Rate this episode"
+msgstr ""
+
+msgctxt "#32140"
+msgid "Toggle watched"
+msgstr ""
+
+msgctxt "#32141"
+msgid "Manage all lists"
+msgstr ""
+
+msgctxt "#32142"
+msgid "Update all tags"
+msgstr ""
+
+msgctxt "#32143"
+msgid "Synchronize library"
+msgstr ""
+
+msgctxt "#32144"
+msgid "How do I authorize the trakt addon to access my trakt.tv account?"
+msgstr ""
+
+# empty strings from id 32145 to 32146
+msgctxt "#32147"
+msgid "Trakt.tv PIN Authorization Failed"
+msgstr ""
+
+# empty string with id 32148
+msgctxt "#32149"
+msgid "Rate this Season"
+msgstr ""
+
+msgctxt "#32150"
+msgid "You will be reminded in 24 hours"
+msgstr ""
+
+msgctxt "#32151"
+msgid "Use Addon Settings later if you change your mind"
+msgstr ""
+
+msgctxt "#32152"
+msgid "Trakt Authorization Complete"
+msgstr ""
+
+msgctxt "#32153"
+msgid "Trakt Account Authorization"
+msgstr ""
+
+msgctxt "#32154"
+msgid "Authorize"
+msgstr ""
+
+msgctxt "#32155"
+msgid "Remind Me Later"
+msgstr ""
+
+msgctxt "#32156"
+msgid "No Thanks"
+msgstr ""
+
+msgctxt "#32157"
+msgid "Account Authorization"
+msgstr ""
+
+# empty string with id 32158
+msgctxt "#32159"
+msgid "Visit {0} or scan the QR code."
+msgstr ""
+
+msgctxt "#32162"
+msgid "The trakt addon CAN NOT be used without authorizing it to access your trakt.tv account."
+msgstr ""
+
 msgctxt "#32163"
 msgid "User"
 msgstr "Usuario"
+
+msgctxt "#32164"
+msgid "Fallback to Title/Year matching if necessary"
+msgstr ""
+
+msgctxt "#32165"
+msgid "Trakt - Added to watchlist"
+msgstr ""
+
+msgctxt "#32166"
+msgid "Trakt - Failed adding to watchlist"
+msgstr ""
+
+msgctxt "#32167"
+msgid "Offset scrobble start by X minutes"
+msgstr ""
+
+msgctxt "#32168"
+msgid "Sync ratings"
+msgstr ""
+
+msgctxt "#32169"
+msgid "Kodi movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32170"
+msgid "%i movie(s) ratings will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32171"
+msgid "Updating %i of %i movie ratings in Kodi"
+msgstr ""
+
+msgctxt "#32172"
+msgid "Ratings updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32173"
+msgid "Kodi episode ratings are up to date"
+msgstr ""
+
+msgctxt "#32174"
+msgid "Updating %i of %i episode ratings in Kodi"
+msgstr ""
+
+msgctxt "#32175"
+msgid "Ratings updated for %i episode(s) in Kodi"
+msgstr ""
+
+msgctxt "#32176"
+msgid "Kodi show ratings are up to date"
+msgstr ""
+
+msgctxt "#32177"
+msgid "Updating %i of %i show ratings in Kodi"
+msgstr ""
+
+msgctxt "#32178"
+msgid "Ratings updated for %i show(s) in Kodi"
+msgstr ""
+
+msgctxt "#32179"
+msgid "Trakt movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32180"
+msgid "%i movie ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32181"
+msgid "Trakt show ratings are up to date"
+msgstr ""
+
+msgctxt "#32182"
+msgid "%i show ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32183"
+msgid "Attempt to scrobble MythTV PVR recordings"
+msgstr ""
+
+msgctxt "#32184"
+msgid "Attempt secondary show title search"
+msgstr ""
+
+msgctxt "#32185"
+msgid "Exclude Plugins"
+msgstr ""
+
+msgctxt "#32186"
+msgid "Allow script exclusions"
+msgstr ""

--- a/script.trakt/resources/language/resource.language.he_IL/strings.po
+++ b/script.trakt/resources/language/resource.language.he_IL/strings.po
@@ -7,14 +7,15 @@ msgstr ""
 "Project-Id-Version: XBMC Addons\n"
 "Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: Kodi Translation Team\n"
-"Language-Team: Hebrew (http://www.transifex.com/projects/p/xbmc-addons/language/he/)\n"
+"PO-Revision-Date: 2021-03-20 15:56+0000\n"
+"Last-Translator: Christian Gade <gade@kodi.tv>\n"
+"Language-Team: Hebrew (Israel) <https://kodi.weblate.cloud/projects/kodi-add-ons-scripts/script-trakt/he_il/>\n"
+"Language: he_IL\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: he\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Weblate 4.5.1\n"
 
 msgctxt "#32000"
 msgid "General"
@@ -498,7 +499,7 @@ msgstr "ל-%i סרט(ים) יעודכנו תהלך הצפייה"
 
 msgctxt "#32127"
 msgid "Updating %i of %i movie(s) playback progress in Kodi"
-msgstr "מעדכן תהליך צפייה %i מתוך %i סרט(ים) "
+msgstr "מעדכן תהליך צפייה %i מתוך %i סרט(ים)"
 
 msgctxt "#32128"
 msgid "Playback progress updated for %i movie(s) in Kodi"
@@ -510,7 +511,7 @@ msgstr "תהליך צפיית פרק ב-Kodi מעודכן"
 
 msgctxt "#32130"
 msgid "Updating %i of %i episode(s) playback progress in Kodi"
-msgstr "מעדכן תהליך צפייה %i מתוך %i פרק(ים) "
+msgstr "מעדכן תהליך צפייה %i מתוך %i פרק(ים)"
 
 msgctxt "#32131"
 msgid "Playback progress updated for %i episode(s) in Kodi"
@@ -608,17 +609,10 @@ msgctxt "#32157"
 msgid "Account Authorization"
 msgstr "אישור חשבון"
 
+# empty string with id 32158
 msgctxt "#32159"
-msgid "Visit {0} or scan the QR Code below."
-msgstr "בקר ב- {0} או סרוק את קוד ה-QR למטה."
-
-msgctxt "#32160"
-msgid "Authorize the trakt addon to access your account."
-msgstr "אשר את התוסף Trakt כדי לגשת אל החשבון שלך"
-
-msgctxt "#32161"
-msgid "Enter the PIN provided in the box below."
-msgstr "הזן את קוד ה-PIN שקיבלת בקופסא למטה."
+msgid "Visit {0} or scan the QR code."
+msgstr ""
 
 msgctxt "#32162"
 msgid "The trakt addon CAN NOT be used without authorizing it to access your trakt.tv account."
@@ -639,3 +633,95 @@ msgstr "Trakt - התווסף לרשימת צפייה"
 msgctxt "#32166"
 msgid "Trakt - Failed adding to watchlist"
 msgstr "Trakt - הוספה לרשימת צפייה נכשלה"
+
+msgctxt "#32167"
+msgid "Offset scrobble start by X minutes"
+msgstr ""
+
+msgctxt "#32168"
+msgid "Sync ratings"
+msgstr ""
+
+msgctxt "#32169"
+msgid "Kodi movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32170"
+msgid "%i movie(s) ratings will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32171"
+msgid "Updating %i of %i movie ratings in Kodi"
+msgstr ""
+
+msgctxt "#32172"
+msgid "Ratings updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32173"
+msgid "Kodi episode ratings are up to date"
+msgstr ""
+
+msgctxt "#32174"
+msgid "Updating %i of %i episode ratings in Kodi"
+msgstr ""
+
+msgctxt "#32175"
+msgid "Ratings updated for %i episode(s) in Kodi"
+msgstr ""
+
+msgctxt "#32176"
+msgid "Kodi show ratings are up to date"
+msgstr ""
+
+msgctxt "#32177"
+msgid "Updating %i of %i show ratings in Kodi"
+msgstr ""
+
+msgctxt "#32178"
+msgid "Ratings updated for %i show(s) in Kodi"
+msgstr ""
+
+msgctxt "#32179"
+msgid "Trakt movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32180"
+msgid "%i movie ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32181"
+msgid "Trakt show ratings are up to date"
+msgstr ""
+
+msgctxt "#32182"
+msgid "%i show ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32183"
+msgid "Attempt to scrobble MythTV PVR recordings"
+msgstr ""
+
+msgctxt "#32184"
+msgid "Attempt secondary show title search"
+msgstr ""
+
+msgctxt "#32185"
+msgid "Exclude Plugins"
+msgstr ""
+
+msgctxt "#32186"
+msgid "Allow script exclusions"
+msgstr ""
+
+#~ msgctxt "#32159"
+#~ msgid "Visit {0} or scan the QR Code below."
+#~ msgstr "בקר ב- {0} או סרוק את קוד ה-QR למטה."
+
+#~ msgctxt "#32160"
+#~ msgid "Authorize the trakt addon to access your account."
+#~ msgstr "אשר את התוסף Trakt כדי לגשת אל החשבון שלך"
+
+#~ msgctxt "#32161"
+#~ msgid "Enter the PIN provided in the box below."
+#~ msgstr "הזן את קוד ה-PIN שקיבלת בקופסא למטה."

--- a/script.trakt/resources/language/resource.language.hi_IN/strings.po
+++ b/script.trakt/resources/language/resource.language.hi_IN/strings.po
@@ -10,28 +10,712 @@ msgstr ""
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Kodi Translation Team\n"
 "Language-Team: Hindi (Devanagiri) (http://www.transifex.com/projects/p/xbmc-addons/language/hi/)\n"
+"Language: hi\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: hi\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 msgctxt "#32000"
 msgid "General"
 msgstr "सामान्य"
 
+# empty strings from id 32001 to 32002
+msgctxt "#32003"
+msgid "Startup Delay"
+msgstr ""
+
 msgctxt "#32004"
 msgid "Rating"
 msgstr "रेटिंग"
+
+msgctxt "#32005"
+msgid "Rate Movie after watching"
+msgstr ""
+
+msgctxt "#32006"
+msgid "Rate TV show Episode after watching"
+msgstr ""
+
+msgctxt "#32008"
+msgid "Minimum percent watched to display rating dialog"
+msgstr ""
+
+msgctxt "#32009"
+msgid "Allow re-rating of media"
+msgstr ""
+
+msgctxt "#32010"
+msgid "Default rating"
+msgstr ""
+
+# Scrobbling Settings
+msgctxt "#32011"
+msgid "Scrobbling"
+msgstr ""
+
+msgctxt "#32012"
+msgid "Scrobble movies"
+msgstr ""
+
+msgctxt "#32013"
+msgid "Scrobble TV show episodes"
+msgstr ""
+
+msgctxt "#32014"
+msgid "Show notification on scrobble"
+msgstr ""
+
+msgctxt "#32015"
+msgid "Trakt - Scrobbled successfully"
+msgstr ""
+
+msgctxt "#32016"
+msgid "Exclusions"
+msgstr ""
+
+msgctxt "#32017"
+msgid "Exclude Live TV"
+msgstr ""
+
+msgctxt "#32018"
+msgid "Exclude HTTP sources"
+msgstr ""
+
+msgctxt "#32019"
+msgid "Exclude path"
+msgstr ""
+
+msgctxt "#32020"
+msgid "Folder's path (including subfolders)"
+msgstr ""
+
+# empty strings from id 32021 to 32022
+msgctxt "#32023"
+msgid "Can not connect to Trakt"
+msgstr ""
 
 msgctxt "#32024"
 msgid "Error"
 msgstr "एर्रोर"
 
+# empty string with id 32025
+msgctxt "#32026"
+msgid "What Did You Think?"
+msgstr ""
+
+msgctxt "#32027"
+msgid "Totally Ninja!"
+msgstr ""
+
+msgctxt "#32028"
+msgid "Weak Sauce :("
+msgstr ""
+
+msgctxt "#32029"
+msgid "Terrible"
+msgstr ""
+
+msgctxt "#32030"
+msgid "Bad"
+msgstr ""
+
+msgctxt "#32031"
+msgid "Poor"
+msgstr ""
+
+msgctxt "#32032"
+msgid "Meh"
+msgstr ""
+
 msgctxt "#32033"
 msgid "Fair"
 msgstr "निष्पक्ष"
 
+msgctxt "#32034"
+msgid "Good"
+msgstr ""
+
+msgctxt "#32035"
+msgid "Great"
+msgstr ""
+
+msgctxt "#32036"
+msgid "Superb"
+msgstr ""
+
+msgctxt "#32037"
+msgid "Unrate this movie"
+msgstr ""
+
+msgctxt "#32038"
+msgid "Unrate this show"
+msgstr ""
+
+msgctxt "#32039"
+msgid "Unrate this episode"
+msgstr ""
+
+msgctxt "#32040"
+msgid "Trakt - Rating submitted successfully"
+msgstr ""
+
+msgctxt "#32041"
+msgid "Trakt - Already rated"
+msgstr ""
+
+msgctxt "#32042"
+msgid "Trakt - Unrated successfully"
+msgstr ""
+
+msgctxt "#32043"
+msgid "Trakt - Already has the same rating"
+msgstr ""
+
+msgctxt "#32044"
+msgid "Trakt - Problem submitting rating"
+msgstr ""
+
+msgctxt "#32045"
+msgid "Synchronize"
+msgstr ""
+
 msgctxt "#32046"
 msgid "Movies"
 msgstr "सिनेमा"
+
+msgctxt "#32047"
+msgid "Add new movies to Trakt collection"
+msgstr ""
+
+msgctxt "#32048"
+msgid "Add watched movies to Trakt history"
+msgstr ""
+
+msgctxt "#32049"
+msgid "Mark movies from Trakt history as watched in Kodi"
+msgstr ""
+
+msgctxt "#32050"
+msgid "TV Episodes"
+msgstr ""
+
+msgctxt "#32051"
+msgid "Add new TV episodes to Trakt collection"
+msgstr ""
+
+msgctxt "#32052"
+msgid "Add watched TV episodes to Trakt history"
+msgstr ""
+
+msgctxt "#32053"
+msgid "Mark TV episodes from Trakt history as watched in Kodi"
+msgstr ""
+
+msgctxt "#32054"
+msgid "Service"
+msgstr ""
+
+msgctxt "#32055"
+msgid "Sync collection on library update or cleaning"
+msgstr ""
+
+msgctxt "#32056"
+msgid "Show sync notifications"
+msgstr ""
+
+msgctxt "#32057"
+msgid "Remove deleted movies from Trakt collection"
+msgstr ""
+
+msgctxt "#32058"
+msgid "Remove deleted TV episodes from Trakt collection"
+msgstr ""
+
+# empty string with id 32059
+msgctxt "#32060"
+msgid "Hide notifications during playback"
+msgstr ""
+
+msgctxt "#32061"
+msgid "Sync started"
+msgstr ""
+
+msgctxt "#32062"
+msgid "Sync complete"
+msgstr ""
+
+msgctxt "#32063"
+msgid "%i movie(s) will be added to Trakt collection"
+msgstr ""
+
+msgctxt "#32064"
+msgid "%i movie playcount(s) will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32065"
+msgid "%i movie(s) playcount will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32066"
+msgid "Movie Sync Complete"
+msgstr ""
+
+msgctxt "#32067"
+msgid "Going to add %i show(s) to Trakt collection"
+msgstr ""
+
+msgctxt "#32068"
+msgid "Checking for episodes missing from Trakt collection"
+msgstr ""
+
+msgctxt "#32069"
+msgid "%i of %i show(s) have episodes added to Trakt collection"
+msgstr ""
+
+msgctxt "#32070"
+msgid "Going to update %i show(s) missing watched status"
+msgstr ""
+
+msgctxt "#32071"
+msgid "Checking watched episodes on Trakt"
+msgstr ""
+
+msgctxt "#32072"
+msgid "%i show(s) had missing watched status"
+msgstr ""
+
+msgctxt "#32073"
+msgid "%i episodes are being updated"
+msgstr ""
+
+msgctxt "#32074"
+msgid "Checking watched episodes on Kodi"
+msgstr ""
+
+msgctxt "#32075"
+msgid "Episode Sync Complete"
+msgstr ""
+
+msgctxt "#32076"
+msgid "%i movie(s) will be removed from Trakt collection"
+msgstr ""
+
+msgctxt "#32077"
+msgid "Cleaning Trakt TV show collection"
+msgstr ""
+
+msgctxt "#32078"
+msgid "episodes are being removed"
+msgstr ""
+
+msgctxt "#32079"
+msgid "Loading movies from Kodi"
+msgstr ""
+
+msgctxt "#32080"
+msgid "Movies loaded from Kodi"
+msgstr ""
+
+msgctxt "#32081"
+msgid "Retrieving movie collection from Trakt"
+msgstr ""
+
+msgctxt "#32082"
+msgid "Retrieving watched movies from Trakt"
+msgstr ""
+
+msgctxt "#32083"
+msgid "Retrieved movie data from Trakt"
+msgstr ""
+
+msgctxt "#32084"
+msgid "Trakt movie collection is up to date, no movies to add"
+msgstr ""
+
+msgctxt "#32085"
+msgid "%i movie(s) were added to your Trakt collection"
+msgstr ""
+
+msgctxt "#32086"
+msgid "Trakt movie playcounts are up to date"
+msgstr ""
+
+msgctxt "#32087"
+msgid "Playcounts updated for %i movie(s) on Trakt"
+msgstr ""
+
+msgctxt "#32088"
+msgid "Kodi movie playcounts are up to date"
+msgstr ""
+
+msgctxt "#32089"
+msgid "Updating %i of %i movie playcount(s) in Kodi"
+msgstr ""
+
+msgctxt "#32090"
+msgid "Playcounts updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32091"
+msgid "Trakt movie collection is up to date, no movies removed"
+msgstr ""
+
+msgctxt "#32092"
+msgid "%i movie(s) were removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32093"
+msgid "Updating %i of %i movie playcount(s) on Trakt"
+msgstr ""
+
+msgctxt "#32094"
+msgid "Loading episode data from Kodi"
+msgstr ""
+
+msgctxt "#32095"
+msgid "Loading shows from Kodi"
+msgstr ""
+
+msgctxt "#32096"
+msgid "Shows loaded from Kodi"
+msgstr ""
+
+msgctxt "#32097"
+msgid "Parsing %i of %i episode data from Kodi"
+msgstr ""
+
+msgctxt "#32098"
+msgid "Loaded episode data from Kodi"
+msgstr ""
+
+msgctxt "#32099"
+msgid "Loading episode data from Trakt"
+msgstr ""
+
+msgctxt "#32100"
+msgid "Retrieving episode collection from Trakt"
+msgstr ""
+
+msgctxt "#32101"
+msgid "Retrieving watched episodes from Trakt"
+msgstr ""
+
+msgctxt "#32102"
+msgid "Parsing episode data %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32103"
+msgid "Retrieved episode data from Trakt"
+msgstr ""
+
+msgctxt "#32104"
+msgid "Trakt episode collection is up to date, no episodes to add"
+msgstr ""
+
+msgctxt "#32105"
+msgid "%i episode(s) were added to your Trakt collection"
+msgstr ""
+
+msgctxt "#32106"
+msgid "Trakt episode playcounts are up to date"
+msgstr ""
+
+msgctxt "#32107"
+msgid "Kodi episode playcounts are up to date"
+msgstr ""
+
+msgctxt "#32108"
+msgid "Updating %i of %i episode playcount(s) in Kodi"
+msgstr ""
+
+msgctxt "#32109"
+msgid "Playcounts updated for %i show(s) in Kodi"
+msgstr ""
+
+msgctxt "#32110"
+msgid "Trakt episode collection is clean, no episodes to remove"
+msgstr ""
+
+msgctxt "#32111"
+msgid "%i episode(s) are being removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32112"
+msgid "%i episode(s) were removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32113"
+msgid "Trakt - Marked as watched"
+msgstr ""
+
+msgctxt "#32114"
+msgid "Trakt - Failed marking as watched"
+msgstr ""
+
+msgctxt "#32115"
+msgid "%d episode(s) of '%s'"
+msgstr ""
+
+msgctxt "#32116"
+msgid "Enable debug mode"
+msgstr ""
+
+msgctxt "#32117"
+msgid "Sync movie playback progress to Kodi"
+msgstr ""
+
+msgctxt "#32118"
+msgid "Sync episode playback progress to Kodi"
+msgstr ""
+
+msgctxt "#32119"
+msgid "Retrieving episode playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32120"
+msgid "Parsing episode playback progress %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32121"
+msgid "Retrieved episode playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32122"
+msgid "Retrieving movie playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32123"
+msgid "Parsing movie playback progress %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32124"
+msgid "Retrieved movie playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32125"
+msgid "Kodi movie playback progress is up to date"
+msgstr ""
+
+msgctxt "#32126"
+msgid "%i movie(s) playback progress will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32127"
+msgid "Updating %i of %i movie(s) playback progress in Kodi"
+msgstr ""
+
+msgctxt "#32128"
+msgid "Playback progress updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32129"
+msgid "Kodi episode playback progress is up to date"
+msgstr ""
+
+msgctxt "#32130"
+msgid "Updating %i of %i episode(s) playback progress in Kodi"
+msgstr ""
+
+msgctxt "#32131"
+msgid "Playback progress updated for %i episode(s) in Kodi"
+msgstr ""
+
+msgctxt "#32132"
+msgid "Unrate this season"
+msgstr ""
+
+msgctxt "#32133"
+msgid "Manage Movie's Lists"
+msgstr ""
+
+msgctxt "#32134"
+msgid "Manage Show's Lists"
+msgstr ""
+
+msgctxt "#32135"
+msgid "Remove from Watchlist"
+msgstr ""
+
+msgctxt "#32136"
+msgid "Add to watchlist"
+msgstr ""
+
+msgctxt "#32137"
+msgid "Rate this movie"
+msgstr ""
+
+msgctxt "#32138"
+msgid "Rate this show"
+msgstr ""
+
+msgctxt "#32139"
+msgid "Rate this episode"
+msgstr ""
+
+msgctxt "#32140"
+msgid "Toggle watched"
+msgstr ""
+
+msgctxt "#32141"
+msgid "Manage all lists"
+msgstr ""
+
+msgctxt "#32142"
+msgid "Update all tags"
+msgstr ""
+
+msgctxt "#32143"
+msgid "Synchronize library"
+msgstr ""
+
+msgctxt "#32144"
+msgid "How do I authorize the trakt addon to access my trakt.tv account?"
+msgstr ""
+
+# empty strings from id 32145 to 32146
+msgctxt "#32147"
+msgid "Trakt.tv PIN Authorization Failed"
+msgstr ""
+
+# empty string with id 32148
+msgctxt "#32149"
+msgid "Rate this Season"
+msgstr ""
+
+msgctxt "#32150"
+msgid "You will be reminded in 24 hours"
+msgstr ""
+
+msgctxt "#32151"
+msgid "Use Addon Settings later if you change your mind"
+msgstr ""
+
+msgctxt "#32152"
+msgid "Trakt Authorization Complete"
+msgstr ""
+
+msgctxt "#32153"
+msgid "Trakt Account Authorization"
+msgstr ""
+
+msgctxt "#32154"
+msgid "Authorize"
+msgstr ""
+
+msgctxt "#32155"
+msgid "Remind Me Later"
+msgstr ""
+
+msgctxt "#32156"
+msgid "No Thanks"
+msgstr ""
+
+msgctxt "#32157"
+msgid "Account Authorization"
+msgstr ""
+
+# empty string with id 32158
+msgctxt "#32159"
+msgid "Visit {0} or scan the QR code."
+msgstr ""
+
+msgctxt "#32162"
+msgid "The trakt addon CAN NOT be used without authorizing it to access your trakt.tv account."
+msgstr ""
+
+msgctxt "#32163"
+msgid "User"
+msgstr ""
+
+msgctxt "#32164"
+msgid "Fallback to Title/Year matching if necessary"
+msgstr ""
+
+msgctxt "#32165"
+msgid "Trakt - Added to watchlist"
+msgstr ""
+
+msgctxt "#32166"
+msgid "Trakt - Failed adding to watchlist"
+msgstr ""
+
+msgctxt "#32167"
+msgid "Offset scrobble start by X minutes"
+msgstr ""
+
+msgctxt "#32168"
+msgid "Sync ratings"
+msgstr ""
+
+msgctxt "#32169"
+msgid "Kodi movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32170"
+msgid "%i movie(s) ratings will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32171"
+msgid "Updating %i of %i movie ratings in Kodi"
+msgstr ""
+
+msgctxt "#32172"
+msgid "Ratings updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32173"
+msgid "Kodi episode ratings are up to date"
+msgstr ""
+
+msgctxt "#32174"
+msgid "Updating %i of %i episode ratings in Kodi"
+msgstr ""
+
+msgctxt "#32175"
+msgid "Ratings updated for %i episode(s) in Kodi"
+msgstr ""
+
+msgctxt "#32176"
+msgid "Kodi show ratings are up to date"
+msgstr ""
+
+msgctxt "#32177"
+msgid "Updating %i of %i show ratings in Kodi"
+msgstr ""
+
+msgctxt "#32178"
+msgid "Ratings updated for %i show(s) in Kodi"
+msgstr ""
+
+msgctxt "#32179"
+msgid "Trakt movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32180"
+msgid "%i movie ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32181"
+msgid "Trakt show ratings are up to date"
+msgstr ""
+
+msgctxt "#32182"
+msgid "%i show ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32183"
+msgid "Attempt to scrobble MythTV PVR recordings"
+msgstr ""
+
+msgctxt "#32184"
+msgid "Attempt secondary show title search"
+msgstr ""
+
+msgctxt "#32185"
+msgid "Exclude Plugins"
+msgstr ""
+
+msgctxt "#32186"
+msgid "Allow script exclusions"
+msgstr ""

--- a/script.trakt/resources/language/resource.language.hr_HR/strings.po
+++ b/script.trakt/resources/language/resource.language.hr_HR/strings.po
@@ -10,10 +10,10 @@ msgstr ""
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Kodi Translation Team\n"
 "Language-Team: Croatian (http://www.transifex.com/projects/p/xbmc-addons/language/hr/)\n"
+"Language: hr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: hr\n"
 "Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 
 msgctxt "#32000"
@@ -140,14 +140,578 @@ msgctxt "#32036"
 msgid "Superb"
 msgstr "Veličanstveno"
 
+msgctxt "#32037"
+msgid "Unrate this movie"
+msgstr ""
+
+msgctxt "#32038"
+msgid "Unrate this show"
+msgstr ""
+
+msgctxt "#32039"
+msgid "Unrate this episode"
+msgstr ""
+
+msgctxt "#32040"
+msgid "Trakt - Rating submitted successfully"
+msgstr ""
+
+msgctxt "#32041"
+msgid "Trakt - Already rated"
+msgstr ""
+
+msgctxt "#32042"
+msgid "Trakt - Unrated successfully"
+msgstr ""
+
+msgctxt "#32043"
+msgid "Trakt - Already has the same rating"
+msgstr ""
+
+msgctxt "#32044"
+msgid "Trakt - Problem submitting rating"
+msgstr ""
+
+msgctxt "#32045"
+msgid "Synchronize"
+msgstr ""
+
 msgctxt "#32046"
 msgid "Movies"
 msgstr "Filmovi"
+
+msgctxt "#32047"
+msgid "Add new movies to Trakt collection"
+msgstr ""
+
+msgctxt "#32048"
+msgid "Add watched movies to Trakt history"
+msgstr ""
+
+msgctxt "#32049"
+msgid "Mark movies from Trakt history as watched in Kodi"
+msgstr ""
+
+msgctxt "#32050"
+msgid "TV Episodes"
+msgstr ""
+
+msgctxt "#32051"
+msgid "Add new TV episodes to Trakt collection"
+msgstr ""
+
+msgctxt "#32052"
+msgid "Add watched TV episodes to Trakt history"
+msgstr ""
+
+msgctxt "#32053"
+msgid "Mark TV episodes from Trakt history as watched in Kodi"
+msgstr ""
 
 msgctxt "#32054"
 msgid "Service"
 msgstr "Usluga"
 
+msgctxt "#32055"
+msgid "Sync collection on library update or cleaning"
+msgstr ""
+
+msgctxt "#32056"
+msgid "Show sync notifications"
+msgstr ""
+
+msgctxt "#32057"
+msgid "Remove deleted movies from Trakt collection"
+msgstr ""
+
+msgctxt "#32058"
+msgid "Remove deleted TV episodes from Trakt collection"
+msgstr ""
+
+# empty string with id 32059
+msgctxt "#32060"
+msgid "Hide notifications during playback"
+msgstr ""
+
+msgctxt "#32061"
+msgid "Sync started"
+msgstr ""
+
+msgctxt "#32062"
+msgid "Sync complete"
+msgstr ""
+
+msgctxt "#32063"
+msgid "%i movie(s) will be added to Trakt collection"
+msgstr ""
+
+msgctxt "#32064"
+msgid "%i movie playcount(s) will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32065"
+msgid "%i movie(s) playcount will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32066"
+msgid "Movie Sync Complete"
+msgstr ""
+
+msgctxt "#32067"
+msgid "Going to add %i show(s) to Trakt collection"
+msgstr ""
+
+msgctxt "#32068"
+msgid "Checking for episodes missing from Trakt collection"
+msgstr ""
+
+msgctxt "#32069"
+msgid "%i of %i show(s) have episodes added to Trakt collection"
+msgstr ""
+
+msgctxt "#32070"
+msgid "Going to update %i show(s) missing watched status"
+msgstr ""
+
+msgctxt "#32071"
+msgid "Checking watched episodes on Trakt"
+msgstr ""
+
+msgctxt "#32072"
+msgid "%i show(s) had missing watched status"
+msgstr ""
+
+msgctxt "#32073"
+msgid "%i episodes are being updated"
+msgstr ""
+
+msgctxt "#32074"
+msgid "Checking watched episodes on Kodi"
+msgstr ""
+
+msgctxt "#32075"
+msgid "Episode Sync Complete"
+msgstr ""
+
+msgctxt "#32076"
+msgid "%i movie(s) will be removed from Trakt collection"
+msgstr ""
+
+msgctxt "#32077"
+msgid "Cleaning Trakt TV show collection"
+msgstr ""
+
+msgctxt "#32078"
+msgid "episodes are being removed"
+msgstr ""
+
+msgctxt "#32079"
+msgid "Loading movies from Kodi"
+msgstr ""
+
+msgctxt "#32080"
+msgid "Movies loaded from Kodi"
+msgstr ""
+
+msgctxt "#32081"
+msgid "Retrieving movie collection from Trakt"
+msgstr ""
+
+msgctxt "#32082"
+msgid "Retrieving watched movies from Trakt"
+msgstr ""
+
+msgctxt "#32083"
+msgid "Retrieved movie data from Trakt"
+msgstr ""
+
+msgctxt "#32084"
+msgid "Trakt movie collection is up to date, no movies to add"
+msgstr ""
+
+msgctxt "#32085"
+msgid "%i movie(s) were added to your Trakt collection"
+msgstr ""
+
+msgctxt "#32086"
+msgid "Trakt movie playcounts are up to date"
+msgstr ""
+
+msgctxt "#32087"
+msgid "Playcounts updated for %i movie(s) on Trakt"
+msgstr ""
+
+msgctxt "#32088"
+msgid "Kodi movie playcounts are up to date"
+msgstr ""
+
+msgctxt "#32089"
+msgid "Updating %i of %i movie playcount(s) in Kodi"
+msgstr ""
+
+msgctxt "#32090"
+msgid "Playcounts updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32091"
+msgid "Trakt movie collection is up to date, no movies removed"
+msgstr ""
+
+msgctxt "#32092"
+msgid "%i movie(s) were removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32093"
+msgid "Updating %i of %i movie playcount(s) on Trakt"
+msgstr ""
+
+msgctxt "#32094"
+msgid "Loading episode data from Kodi"
+msgstr ""
+
+msgctxt "#32095"
+msgid "Loading shows from Kodi"
+msgstr ""
+
+msgctxt "#32096"
+msgid "Shows loaded from Kodi"
+msgstr ""
+
+msgctxt "#32097"
+msgid "Parsing %i of %i episode data from Kodi"
+msgstr ""
+
+msgctxt "#32098"
+msgid "Loaded episode data from Kodi"
+msgstr ""
+
+msgctxt "#32099"
+msgid "Loading episode data from Trakt"
+msgstr ""
+
+msgctxt "#32100"
+msgid "Retrieving episode collection from Trakt"
+msgstr ""
+
+msgctxt "#32101"
+msgid "Retrieving watched episodes from Trakt"
+msgstr ""
+
+msgctxt "#32102"
+msgid "Parsing episode data %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32103"
+msgid "Retrieved episode data from Trakt"
+msgstr ""
+
+msgctxt "#32104"
+msgid "Trakt episode collection is up to date, no episodes to add"
+msgstr ""
+
+msgctxt "#32105"
+msgid "%i episode(s) were added to your Trakt collection"
+msgstr ""
+
+msgctxt "#32106"
+msgid "Trakt episode playcounts are up to date"
+msgstr ""
+
+msgctxt "#32107"
+msgid "Kodi episode playcounts are up to date"
+msgstr ""
+
+msgctxt "#32108"
+msgid "Updating %i of %i episode playcount(s) in Kodi"
+msgstr ""
+
+msgctxt "#32109"
+msgid "Playcounts updated for %i show(s) in Kodi"
+msgstr ""
+
+msgctxt "#32110"
+msgid "Trakt episode collection is clean, no episodes to remove"
+msgstr ""
+
+msgctxt "#32111"
+msgid "%i episode(s) are being removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32112"
+msgid "%i episode(s) were removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32113"
+msgid "Trakt - Marked as watched"
+msgstr ""
+
+msgctxt "#32114"
+msgid "Trakt - Failed marking as watched"
+msgstr ""
+
+msgctxt "#32115"
+msgid "%d episode(s) of '%s'"
+msgstr ""
+
+msgctxt "#32116"
+msgid "Enable debug mode"
+msgstr ""
+
+msgctxt "#32117"
+msgid "Sync movie playback progress to Kodi"
+msgstr ""
+
+msgctxt "#32118"
+msgid "Sync episode playback progress to Kodi"
+msgstr ""
+
+msgctxt "#32119"
+msgid "Retrieving episode playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32120"
+msgid "Parsing episode playback progress %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32121"
+msgid "Retrieved episode playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32122"
+msgid "Retrieving movie playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32123"
+msgid "Parsing movie playback progress %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32124"
+msgid "Retrieved movie playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32125"
+msgid "Kodi movie playback progress is up to date"
+msgstr ""
+
+msgctxt "#32126"
+msgid "%i movie(s) playback progress will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32127"
+msgid "Updating %i of %i movie(s) playback progress in Kodi"
+msgstr ""
+
+msgctxt "#32128"
+msgid "Playback progress updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32129"
+msgid "Kodi episode playback progress is up to date"
+msgstr ""
+
+msgctxt "#32130"
+msgid "Updating %i of %i episode(s) playback progress in Kodi"
+msgstr ""
+
+msgctxt "#32131"
+msgid "Playback progress updated for %i episode(s) in Kodi"
+msgstr ""
+
+msgctxt "#32132"
+msgid "Unrate this season"
+msgstr ""
+
+msgctxt "#32133"
+msgid "Manage Movie's Lists"
+msgstr ""
+
+msgctxt "#32134"
+msgid "Manage Show's Lists"
+msgstr ""
+
+msgctxt "#32135"
+msgid "Remove from Watchlist"
+msgstr ""
+
+msgctxt "#32136"
+msgid "Add to watchlist"
+msgstr ""
+
+msgctxt "#32137"
+msgid "Rate this movie"
+msgstr ""
+
+msgctxt "#32138"
+msgid "Rate this show"
+msgstr ""
+
+msgctxt "#32139"
+msgid "Rate this episode"
+msgstr ""
+
+msgctxt "#32140"
+msgid "Toggle watched"
+msgstr ""
+
+msgctxt "#32141"
+msgid "Manage all lists"
+msgstr ""
+
+msgctxt "#32142"
+msgid "Update all tags"
+msgstr ""
+
+msgctxt "#32143"
+msgid "Synchronize library"
+msgstr ""
+
+msgctxt "#32144"
+msgid "How do I authorize the trakt addon to access my trakt.tv account?"
+msgstr ""
+
+# empty strings from id 32145 to 32146
+msgctxt "#32147"
+msgid "Trakt.tv PIN Authorization Failed"
+msgstr ""
+
+# empty string with id 32148
+msgctxt "#32149"
+msgid "Rate this Season"
+msgstr ""
+
+msgctxt "#32150"
+msgid "You will be reminded in 24 hours"
+msgstr ""
+
+msgctxt "#32151"
+msgid "Use Addon Settings later if you change your mind"
+msgstr ""
+
+msgctxt "#32152"
+msgid "Trakt Authorization Complete"
+msgstr ""
+
+msgctxt "#32153"
+msgid "Trakt Account Authorization"
+msgstr ""
+
+msgctxt "#32154"
+msgid "Authorize"
+msgstr ""
+
+msgctxt "#32155"
+msgid "Remind Me Later"
+msgstr ""
+
+msgctxt "#32156"
+msgid "No Thanks"
+msgstr ""
+
+msgctxt "#32157"
+msgid "Account Authorization"
+msgstr ""
+
+# empty string with id 32158
+msgctxt "#32159"
+msgid "Visit {0} or scan the QR code."
+msgstr ""
+
+msgctxt "#32162"
+msgid "The trakt addon CAN NOT be used without authorizing it to access your trakt.tv account."
+msgstr ""
+
 msgctxt "#32163"
 msgid "User"
 msgstr "Korisnik"
+
+msgctxt "#32164"
+msgid "Fallback to Title/Year matching if necessary"
+msgstr ""
+
+msgctxt "#32165"
+msgid "Trakt - Added to watchlist"
+msgstr ""
+
+msgctxt "#32166"
+msgid "Trakt - Failed adding to watchlist"
+msgstr ""
+
+msgctxt "#32167"
+msgid "Offset scrobble start by X minutes"
+msgstr ""
+
+msgctxt "#32168"
+msgid "Sync ratings"
+msgstr ""
+
+msgctxt "#32169"
+msgid "Kodi movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32170"
+msgid "%i movie(s) ratings will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32171"
+msgid "Updating %i of %i movie ratings in Kodi"
+msgstr ""
+
+msgctxt "#32172"
+msgid "Ratings updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32173"
+msgid "Kodi episode ratings are up to date"
+msgstr ""
+
+msgctxt "#32174"
+msgid "Updating %i of %i episode ratings in Kodi"
+msgstr ""
+
+msgctxt "#32175"
+msgid "Ratings updated for %i episode(s) in Kodi"
+msgstr ""
+
+msgctxt "#32176"
+msgid "Kodi show ratings are up to date"
+msgstr ""
+
+msgctxt "#32177"
+msgid "Updating %i of %i show ratings in Kodi"
+msgstr ""
+
+msgctxt "#32178"
+msgid "Ratings updated for %i show(s) in Kodi"
+msgstr ""
+
+msgctxt "#32179"
+msgid "Trakt movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32180"
+msgid "%i movie ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32181"
+msgid "Trakt show ratings are up to date"
+msgstr ""
+
+msgctxt "#32182"
+msgid "%i show ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32183"
+msgid "Attempt to scrobble MythTV PVR recordings"
+msgstr ""
+
+msgctxt "#32184"
+msgid "Attempt secondary show title search"
+msgstr ""
+
+msgctxt "#32185"
+msgid "Exclude Plugins"
+msgstr ""
+
+msgctxt "#32186"
+msgid "Allow script exclusions"
+msgstr ""

--- a/script.trakt/resources/language/resource.language.hu_HU/strings.po
+++ b/script.trakt/resources/language/resource.language.hu_HU/strings.po
@@ -10,10 +10,10 @@ msgstr ""
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Kodi Translation Team\n"
 "Language-Team: Hungarian (http://www.transifex.com/projects/p/xbmc-addons/language/hu/)\n"
+"Language: hu\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: hu\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 msgctxt "#32000"
@@ -256,9 +256,33 @@ msgctxt "#32066"
 msgid "Movie Sync Complete"
 msgstr "Film szinkronizáció kész"
 
+msgctxt "#32067"
+msgid "Going to add %i show(s) to Trakt collection"
+msgstr ""
+
+msgctxt "#32068"
+msgid "Checking for episodes missing from Trakt collection"
+msgstr ""
+
+msgctxt "#32069"
+msgid "%i of %i show(s) have episodes added to Trakt collection"
+msgstr ""
+
+msgctxt "#32070"
+msgid "Going to update %i show(s) missing watched status"
+msgstr ""
+
 msgctxt "#32071"
 msgid "Checking watched episodes on Trakt"
 msgstr "Megnézett sorozat részek ellenőrzése Trakt-on"
+
+msgctxt "#32072"
+msgid "%i show(s) had missing watched status"
+msgstr ""
+
+msgctxt "#32073"
+msgid "%i episodes are being updated"
+msgstr ""
 
 msgctxt "#32074"
 msgid "Checking watched episodes on Kodi"
@@ -267,6 +291,10 @@ msgstr "Megnézett sorozat részek ellenőrzése"
 msgctxt "#32075"
 msgid "Episode Sync Complete"
 msgstr "Epizód szinkronizáció kész"
+
+msgctxt "#32076"
+msgid "%i movie(s) will be removed from Trakt collection"
+msgstr ""
 
 msgctxt "#32077"
 msgid "Cleaning Trakt TV show collection"
@@ -284,6 +312,134 @@ msgctxt "#32080"
 msgid "Movies loaded from Kodi"
 msgstr "Filmek betöltve"
 
+msgctxt "#32081"
+msgid "Retrieving movie collection from Trakt"
+msgstr ""
+
+msgctxt "#32082"
+msgid "Retrieving watched movies from Trakt"
+msgstr ""
+
+msgctxt "#32083"
+msgid "Retrieved movie data from Trakt"
+msgstr ""
+
+msgctxt "#32084"
+msgid "Trakt movie collection is up to date, no movies to add"
+msgstr ""
+
+msgctxt "#32085"
+msgid "%i movie(s) were added to your Trakt collection"
+msgstr ""
+
+msgctxt "#32086"
+msgid "Trakt movie playcounts are up to date"
+msgstr ""
+
+msgctxt "#32087"
+msgid "Playcounts updated for %i movie(s) on Trakt"
+msgstr ""
+
+msgctxt "#32088"
+msgid "Kodi movie playcounts are up to date"
+msgstr ""
+
+msgctxt "#32089"
+msgid "Updating %i of %i movie playcount(s) in Kodi"
+msgstr ""
+
+msgctxt "#32090"
+msgid "Playcounts updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32091"
+msgid "Trakt movie collection is up to date, no movies removed"
+msgstr ""
+
+msgctxt "#32092"
+msgid "%i movie(s) were removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32093"
+msgid "Updating %i of %i movie playcount(s) on Trakt"
+msgstr ""
+
+msgctxt "#32094"
+msgid "Loading episode data from Kodi"
+msgstr ""
+
+msgctxt "#32095"
+msgid "Loading shows from Kodi"
+msgstr ""
+
+msgctxt "#32096"
+msgid "Shows loaded from Kodi"
+msgstr ""
+
+msgctxt "#32097"
+msgid "Parsing %i of %i episode data from Kodi"
+msgstr ""
+
+msgctxt "#32098"
+msgid "Loaded episode data from Kodi"
+msgstr ""
+
+msgctxt "#32099"
+msgid "Loading episode data from Trakt"
+msgstr ""
+
+msgctxt "#32100"
+msgid "Retrieving episode collection from Trakt"
+msgstr ""
+
+msgctxt "#32101"
+msgid "Retrieving watched episodes from Trakt"
+msgstr ""
+
+msgctxt "#32102"
+msgid "Parsing episode data %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32103"
+msgid "Retrieved episode data from Trakt"
+msgstr ""
+
+msgctxt "#32104"
+msgid "Trakt episode collection is up to date, no episodes to add"
+msgstr ""
+
+msgctxt "#32105"
+msgid "%i episode(s) were added to your Trakt collection"
+msgstr ""
+
+msgctxt "#32106"
+msgid "Trakt episode playcounts are up to date"
+msgstr ""
+
+msgctxt "#32107"
+msgid "Kodi episode playcounts are up to date"
+msgstr ""
+
+msgctxt "#32108"
+msgid "Updating %i of %i episode playcount(s) in Kodi"
+msgstr ""
+
+msgctxt "#32109"
+msgid "Playcounts updated for %i show(s) in Kodi"
+msgstr ""
+
+msgctxt "#32110"
+msgid "Trakt episode collection is clean, no episodes to remove"
+msgstr ""
+
+msgctxt "#32111"
+msgid "%i episode(s) are being removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32112"
+msgid "%i episode(s) were removed from your Trakt collection"
+msgstr ""
+
 msgctxt "#32113"
 msgid "Trakt - Marked as watched"
 msgstr "Trakt - Megnézettként megjelöl"
@@ -291,6 +447,10 @@ msgstr "Trakt - Megnézettként megjelöl"
 msgctxt "#32114"
 msgid "Trakt - Failed marking as watched"
 msgstr "Trakt - Megnézettként megjelölés sikertelen"
+
+msgctxt "#32115"
+msgid "%d episode(s) of '%s'"
+msgstr ""
 
 msgctxt "#32116"
 msgid "Enable debug mode"
@@ -308,6 +468,10 @@ msgctxt "#32119"
 msgid "Retrieving episode playback progress from Trakt"
 msgstr "Sorozat rész lejátszási folyamat letöltése a Trakt-ról"
 
+msgctxt "#32120"
+msgid "Parsing episode playback progress %i of %i from Trakt"
+msgstr ""
+
 msgctxt "#32121"
 msgid "Retrieved episode playback progress from Trakt"
 msgstr "Sorozat rész lejátszási folyamat letöltve a Trakt-ról"
@@ -315,6 +479,10 @@ msgstr "Sorozat rész lejátszási folyamat letöltve a Trakt-ról"
 msgctxt "#32122"
 msgid "Retrieving movie playback progress from Trakt"
 msgstr "Film lejátszási folyamat letöltése a Trakt-ról"
+
+msgctxt "#32123"
+msgid "Parsing movie playback progress %i of %i from Trakt"
+msgstr ""
 
 msgctxt "#32124"
 msgid "Retrieved movie playback progress from Trakt"
@@ -440,17 +608,10 @@ msgctxt "#32157"
 msgid "Account Authorization"
 msgstr "Fiók hitelesítése"
 
+# empty string with id 32158
 msgctxt "#32159"
-msgid "Visit {0} or scan the QR Code below."
-msgstr "Látogass el a {0} oldalra, vagy olvasd be a QR kódot."
-
-msgctxt "#32160"
-msgid "Authorize the trakt addon to access your account."
-msgstr "Hitelesítsd a kiegszítőt, hogy hozzáférjen a fiókodhoz."
-
-msgctxt "#32161"
-msgid "Enter the PIN provided in the box below."
-msgstr "Írd be a kapott PIN kódot."
+msgid "Visit {0} or scan the QR code."
+msgstr ""
 
 msgctxt "#32162"
 msgid "The trakt addon CAN NOT be used without authorizing it to access your trakt.tv account."
@@ -471,3 +632,95 @@ msgstr "Trakt - Figyelési listához adva"
 msgctxt "#32166"
 msgid "Trakt - Failed adding to watchlist"
 msgstr "Trakt - Figyelési listához adás sikertelen"
+
+msgctxt "#32167"
+msgid "Offset scrobble start by X minutes"
+msgstr ""
+
+msgctxt "#32168"
+msgid "Sync ratings"
+msgstr ""
+
+msgctxt "#32169"
+msgid "Kodi movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32170"
+msgid "%i movie(s) ratings will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32171"
+msgid "Updating %i of %i movie ratings in Kodi"
+msgstr ""
+
+msgctxt "#32172"
+msgid "Ratings updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32173"
+msgid "Kodi episode ratings are up to date"
+msgstr ""
+
+msgctxt "#32174"
+msgid "Updating %i of %i episode ratings in Kodi"
+msgstr ""
+
+msgctxt "#32175"
+msgid "Ratings updated for %i episode(s) in Kodi"
+msgstr ""
+
+msgctxt "#32176"
+msgid "Kodi show ratings are up to date"
+msgstr ""
+
+msgctxt "#32177"
+msgid "Updating %i of %i show ratings in Kodi"
+msgstr ""
+
+msgctxt "#32178"
+msgid "Ratings updated for %i show(s) in Kodi"
+msgstr ""
+
+msgctxt "#32179"
+msgid "Trakt movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32180"
+msgid "%i movie ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32181"
+msgid "Trakt show ratings are up to date"
+msgstr ""
+
+msgctxt "#32182"
+msgid "%i show ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32183"
+msgid "Attempt to scrobble MythTV PVR recordings"
+msgstr ""
+
+msgctxt "#32184"
+msgid "Attempt secondary show title search"
+msgstr ""
+
+msgctxt "#32185"
+msgid "Exclude Plugins"
+msgstr ""
+
+msgctxt "#32186"
+msgid "Allow script exclusions"
+msgstr ""
+
+#~ msgctxt "#32159"
+#~ msgid "Visit {0} or scan the QR Code below."
+#~ msgstr "Látogass el a {0} oldalra, vagy olvasd be a QR kódot."
+
+#~ msgctxt "#32160"
+#~ msgid "Authorize the trakt addon to access your account."
+#~ msgstr "Hitelesítsd a kiegszítőt, hogy hozzáférjen a fiókodhoz."
+
+#~ msgctxt "#32161"
+#~ msgid "Enter the PIN provided in the box below."
+#~ msgstr "Írd be a kapott PIN kódot."

--- a/script.trakt/resources/language/resource.language.hy_AM/strings.po
+++ b/script.trakt/resources/language/resource.language.hy_AM/strings.po
@@ -10,32 +10,712 @@ msgstr ""
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Kodi Translation Team\n"
 "Language-Team: Armenian (http://www.transifex.com/projects/p/xbmc-addons/language/hy/)\n"
+"Language: hy\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: hy\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 msgctxt "#32000"
 msgid "General"
 msgstr "Գլխավոր"
 
+# empty strings from id 32001 to 32002
+msgctxt "#32003"
+msgid "Startup Delay"
+msgstr ""
+
 msgctxt "#32004"
 msgid "Rating"
 msgstr "Գնահատական"
+
+msgctxt "#32005"
+msgid "Rate Movie after watching"
+msgstr ""
+
+msgctxt "#32006"
+msgid "Rate TV show Episode after watching"
+msgstr ""
+
+msgctxt "#32008"
+msgid "Minimum percent watched to display rating dialog"
+msgstr ""
+
+msgctxt "#32009"
+msgid "Allow re-rating of media"
+msgstr ""
+
+msgctxt "#32010"
+msgid "Default rating"
+msgstr ""
+
+# Scrobbling Settings
+msgctxt "#32011"
+msgid "Scrobbling"
+msgstr ""
+
+msgctxt "#32012"
+msgid "Scrobble movies"
+msgstr ""
+
+msgctxt "#32013"
+msgid "Scrobble TV show episodes"
+msgstr ""
+
+msgctxt "#32014"
+msgid "Show notification on scrobble"
+msgstr ""
+
+msgctxt "#32015"
+msgid "Trakt - Scrobbled successfully"
+msgstr ""
+
+msgctxt "#32016"
+msgid "Exclusions"
+msgstr ""
+
+msgctxt "#32017"
+msgid "Exclude Live TV"
+msgstr ""
+
+msgctxt "#32018"
+msgid "Exclude HTTP sources"
+msgstr ""
+
+msgctxt "#32019"
+msgid "Exclude path"
+msgstr ""
+
+msgctxt "#32020"
+msgid "Folder's path (including subfolders)"
+msgstr ""
+
+# empty strings from id 32021 to 32022
+msgctxt "#32023"
+msgid "Can not connect to Trakt"
+msgstr ""
 
 msgctxt "#32024"
 msgid "Error"
 msgstr "Սխալ"
 
+# empty string with id 32025
+msgctxt "#32026"
+msgid "What Did You Think?"
+msgstr ""
+
+msgctxt "#32027"
+msgid "Totally Ninja!"
+msgstr ""
+
+msgctxt "#32028"
+msgid "Weak Sauce :("
+msgstr ""
+
+msgctxt "#32029"
+msgid "Terrible"
+msgstr ""
+
+msgctxt "#32030"
+msgid "Bad"
+msgstr ""
+
+msgctxt "#32031"
+msgid "Poor"
+msgstr ""
+
+msgctxt "#32032"
+msgid "Meh"
+msgstr ""
+
 msgctxt "#32033"
 msgid "Fair"
 msgstr "Պարզ"
+
+msgctxt "#32034"
+msgid "Good"
+msgstr ""
+
+msgctxt "#32035"
+msgid "Great"
+msgstr ""
+
+msgctxt "#32036"
+msgid "Superb"
+msgstr ""
+
+msgctxt "#32037"
+msgid "Unrate this movie"
+msgstr ""
+
+msgctxt "#32038"
+msgid "Unrate this show"
+msgstr ""
+
+msgctxt "#32039"
+msgid "Unrate this episode"
+msgstr ""
+
+msgctxt "#32040"
+msgid "Trakt - Rating submitted successfully"
+msgstr ""
+
+msgctxt "#32041"
+msgid "Trakt - Already rated"
+msgstr ""
+
+msgctxt "#32042"
+msgid "Trakt - Unrated successfully"
+msgstr ""
+
+msgctxt "#32043"
+msgid "Trakt - Already has the same rating"
+msgstr ""
+
+msgctxt "#32044"
+msgid "Trakt - Problem submitting rating"
+msgstr ""
+
+msgctxt "#32045"
+msgid "Synchronize"
+msgstr ""
 
 msgctxt "#32046"
 msgid "Movies"
 msgstr "Ֆիլմեր"
 
+msgctxt "#32047"
+msgid "Add new movies to Trakt collection"
+msgstr ""
+
+msgctxt "#32048"
+msgid "Add watched movies to Trakt history"
+msgstr ""
+
+msgctxt "#32049"
+msgid "Mark movies from Trakt history as watched in Kodi"
+msgstr ""
+
+msgctxt "#32050"
+msgid "TV Episodes"
+msgstr ""
+
+msgctxt "#32051"
+msgid "Add new TV episodes to Trakt collection"
+msgstr ""
+
+msgctxt "#32052"
+msgid "Add watched TV episodes to Trakt history"
+msgstr ""
+
+msgctxt "#32053"
+msgid "Mark TV episodes from Trakt history as watched in Kodi"
+msgstr ""
+
 msgctxt "#32054"
 msgid "Service"
 msgstr "Ծառայություն"
+
+msgctxt "#32055"
+msgid "Sync collection on library update or cleaning"
+msgstr ""
+
+msgctxt "#32056"
+msgid "Show sync notifications"
+msgstr ""
+
+msgctxt "#32057"
+msgid "Remove deleted movies from Trakt collection"
+msgstr ""
+
+msgctxt "#32058"
+msgid "Remove deleted TV episodes from Trakt collection"
+msgstr ""
+
+# empty string with id 32059
+msgctxt "#32060"
+msgid "Hide notifications during playback"
+msgstr ""
+
+msgctxt "#32061"
+msgid "Sync started"
+msgstr ""
+
+msgctxt "#32062"
+msgid "Sync complete"
+msgstr ""
+
+msgctxt "#32063"
+msgid "%i movie(s) will be added to Trakt collection"
+msgstr ""
+
+msgctxt "#32064"
+msgid "%i movie playcount(s) will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32065"
+msgid "%i movie(s) playcount will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32066"
+msgid "Movie Sync Complete"
+msgstr ""
+
+msgctxt "#32067"
+msgid "Going to add %i show(s) to Trakt collection"
+msgstr ""
+
+msgctxt "#32068"
+msgid "Checking for episodes missing from Trakt collection"
+msgstr ""
+
+msgctxt "#32069"
+msgid "%i of %i show(s) have episodes added to Trakt collection"
+msgstr ""
+
+msgctxt "#32070"
+msgid "Going to update %i show(s) missing watched status"
+msgstr ""
+
+msgctxt "#32071"
+msgid "Checking watched episodes on Trakt"
+msgstr ""
+
+msgctxt "#32072"
+msgid "%i show(s) had missing watched status"
+msgstr ""
+
+msgctxt "#32073"
+msgid "%i episodes are being updated"
+msgstr ""
+
+msgctxt "#32074"
+msgid "Checking watched episodes on Kodi"
+msgstr ""
+
+msgctxt "#32075"
+msgid "Episode Sync Complete"
+msgstr ""
+
+msgctxt "#32076"
+msgid "%i movie(s) will be removed from Trakt collection"
+msgstr ""
+
+msgctxt "#32077"
+msgid "Cleaning Trakt TV show collection"
+msgstr ""
+
+msgctxt "#32078"
+msgid "episodes are being removed"
+msgstr ""
+
+msgctxt "#32079"
+msgid "Loading movies from Kodi"
+msgstr ""
+
+msgctxt "#32080"
+msgid "Movies loaded from Kodi"
+msgstr ""
+
+msgctxt "#32081"
+msgid "Retrieving movie collection from Trakt"
+msgstr ""
+
+msgctxt "#32082"
+msgid "Retrieving watched movies from Trakt"
+msgstr ""
+
+msgctxt "#32083"
+msgid "Retrieved movie data from Trakt"
+msgstr ""
+
+msgctxt "#32084"
+msgid "Trakt movie collection is up to date, no movies to add"
+msgstr ""
+
+msgctxt "#32085"
+msgid "%i movie(s) were added to your Trakt collection"
+msgstr ""
+
+msgctxt "#32086"
+msgid "Trakt movie playcounts are up to date"
+msgstr ""
+
+msgctxt "#32087"
+msgid "Playcounts updated for %i movie(s) on Trakt"
+msgstr ""
+
+msgctxt "#32088"
+msgid "Kodi movie playcounts are up to date"
+msgstr ""
+
+msgctxt "#32089"
+msgid "Updating %i of %i movie playcount(s) in Kodi"
+msgstr ""
+
+msgctxt "#32090"
+msgid "Playcounts updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32091"
+msgid "Trakt movie collection is up to date, no movies removed"
+msgstr ""
+
+msgctxt "#32092"
+msgid "%i movie(s) were removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32093"
+msgid "Updating %i of %i movie playcount(s) on Trakt"
+msgstr ""
+
+msgctxt "#32094"
+msgid "Loading episode data from Kodi"
+msgstr ""
+
+msgctxt "#32095"
+msgid "Loading shows from Kodi"
+msgstr ""
+
+msgctxt "#32096"
+msgid "Shows loaded from Kodi"
+msgstr ""
+
+msgctxt "#32097"
+msgid "Parsing %i of %i episode data from Kodi"
+msgstr ""
+
+msgctxt "#32098"
+msgid "Loaded episode data from Kodi"
+msgstr ""
+
+msgctxt "#32099"
+msgid "Loading episode data from Trakt"
+msgstr ""
+
+msgctxt "#32100"
+msgid "Retrieving episode collection from Trakt"
+msgstr ""
+
+msgctxt "#32101"
+msgid "Retrieving watched episodes from Trakt"
+msgstr ""
+
+msgctxt "#32102"
+msgid "Parsing episode data %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32103"
+msgid "Retrieved episode data from Trakt"
+msgstr ""
+
+msgctxt "#32104"
+msgid "Trakt episode collection is up to date, no episodes to add"
+msgstr ""
+
+msgctxt "#32105"
+msgid "%i episode(s) were added to your Trakt collection"
+msgstr ""
+
+msgctxt "#32106"
+msgid "Trakt episode playcounts are up to date"
+msgstr ""
+
+msgctxt "#32107"
+msgid "Kodi episode playcounts are up to date"
+msgstr ""
+
+msgctxt "#32108"
+msgid "Updating %i of %i episode playcount(s) in Kodi"
+msgstr ""
+
+msgctxt "#32109"
+msgid "Playcounts updated for %i show(s) in Kodi"
+msgstr ""
+
+msgctxt "#32110"
+msgid "Trakt episode collection is clean, no episodes to remove"
+msgstr ""
+
+msgctxt "#32111"
+msgid "%i episode(s) are being removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32112"
+msgid "%i episode(s) were removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32113"
+msgid "Trakt - Marked as watched"
+msgstr ""
+
+msgctxt "#32114"
+msgid "Trakt - Failed marking as watched"
+msgstr ""
+
+msgctxt "#32115"
+msgid "%d episode(s) of '%s'"
+msgstr ""
+
+msgctxt "#32116"
+msgid "Enable debug mode"
+msgstr ""
+
+msgctxt "#32117"
+msgid "Sync movie playback progress to Kodi"
+msgstr ""
+
+msgctxt "#32118"
+msgid "Sync episode playback progress to Kodi"
+msgstr ""
+
+msgctxt "#32119"
+msgid "Retrieving episode playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32120"
+msgid "Parsing episode playback progress %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32121"
+msgid "Retrieved episode playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32122"
+msgid "Retrieving movie playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32123"
+msgid "Parsing movie playback progress %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32124"
+msgid "Retrieved movie playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32125"
+msgid "Kodi movie playback progress is up to date"
+msgstr ""
+
+msgctxt "#32126"
+msgid "%i movie(s) playback progress will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32127"
+msgid "Updating %i of %i movie(s) playback progress in Kodi"
+msgstr ""
+
+msgctxt "#32128"
+msgid "Playback progress updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32129"
+msgid "Kodi episode playback progress is up to date"
+msgstr ""
+
+msgctxt "#32130"
+msgid "Updating %i of %i episode(s) playback progress in Kodi"
+msgstr ""
+
+msgctxt "#32131"
+msgid "Playback progress updated for %i episode(s) in Kodi"
+msgstr ""
+
+msgctxt "#32132"
+msgid "Unrate this season"
+msgstr ""
+
+msgctxt "#32133"
+msgid "Manage Movie's Lists"
+msgstr ""
+
+msgctxt "#32134"
+msgid "Manage Show's Lists"
+msgstr ""
+
+msgctxt "#32135"
+msgid "Remove from Watchlist"
+msgstr ""
+
+msgctxt "#32136"
+msgid "Add to watchlist"
+msgstr ""
+
+msgctxt "#32137"
+msgid "Rate this movie"
+msgstr ""
+
+msgctxt "#32138"
+msgid "Rate this show"
+msgstr ""
+
+msgctxt "#32139"
+msgid "Rate this episode"
+msgstr ""
+
+msgctxt "#32140"
+msgid "Toggle watched"
+msgstr ""
+
+msgctxt "#32141"
+msgid "Manage all lists"
+msgstr ""
+
+msgctxt "#32142"
+msgid "Update all tags"
+msgstr ""
+
+msgctxt "#32143"
+msgid "Synchronize library"
+msgstr ""
+
+msgctxt "#32144"
+msgid "How do I authorize the trakt addon to access my trakt.tv account?"
+msgstr ""
+
+# empty strings from id 32145 to 32146
+msgctxt "#32147"
+msgid "Trakt.tv PIN Authorization Failed"
+msgstr ""
+
+# empty string with id 32148
+msgctxt "#32149"
+msgid "Rate this Season"
+msgstr ""
+
+msgctxt "#32150"
+msgid "You will be reminded in 24 hours"
+msgstr ""
+
+msgctxt "#32151"
+msgid "Use Addon Settings later if you change your mind"
+msgstr ""
+
+msgctxt "#32152"
+msgid "Trakt Authorization Complete"
+msgstr ""
+
+msgctxt "#32153"
+msgid "Trakt Account Authorization"
+msgstr ""
+
+msgctxt "#32154"
+msgid "Authorize"
+msgstr ""
+
+msgctxt "#32155"
+msgid "Remind Me Later"
+msgstr ""
+
+msgctxt "#32156"
+msgid "No Thanks"
+msgstr ""
+
+msgctxt "#32157"
+msgid "Account Authorization"
+msgstr ""
+
+# empty string with id 32158
+msgctxt "#32159"
+msgid "Visit {0} or scan the QR code."
+msgstr ""
+
+msgctxt "#32162"
+msgid "The trakt addon CAN NOT be used without authorizing it to access your trakt.tv account."
+msgstr ""
+
+msgctxt "#32163"
+msgid "User"
+msgstr ""
+
+msgctxt "#32164"
+msgid "Fallback to Title/Year matching if necessary"
+msgstr ""
+
+msgctxt "#32165"
+msgid "Trakt - Added to watchlist"
+msgstr ""
+
+msgctxt "#32166"
+msgid "Trakt - Failed adding to watchlist"
+msgstr ""
+
+msgctxt "#32167"
+msgid "Offset scrobble start by X minutes"
+msgstr ""
+
+msgctxt "#32168"
+msgid "Sync ratings"
+msgstr ""
+
+msgctxt "#32169"
+msgid "Kodi movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32170"
+msgid "%i movie(s) ratings will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32171"
+msgid "Updating %i of %i movie ratings in Kodi"
+msgstr ""
+
+msgctxt "#32172"
+msgid "Ratings updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32173"
+msgid "Kodi episode ratings are up to date"
+msgstr ""
+
+msgctxt "#32174"
+msgid "Updating %i of %i episode ratings in Kodi"
+msgstr ""
+
+msgctxt "#32175"
+msgid "Ratings updated for %i episode(s) in Kodi"
+msgstr ""
+
+msgctxt "#32176"
+msgid "Kodi show ratings are up to date"
+msgstr ""
+
+msgctxt "#32177"
+msgid "Updating %i of %i show ratings in Kodi"
+msgstr ""
+
+msgctxt "#32178"
+msgid "Ratings updated for %i show(s) in Kodi"
+msgstr ""
+
+msgctxt "#32179"
+msgid "Trakt movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32180"
+msgid "%i movie ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32181"
+msgid "Trakt show ratings are up to date"
+msgstr ""
+
+msgctxt "#32182"
+msgid "%i show ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32183"
+msgid "Attempt to scrobble MythTV PVR recordings"
+msgstr ""
+
+msgctxt "#32184"
+msgid "Attempt secondary show title search"
+msgstr ""
+
+msgctxt "#32185"
+msgid "Exclude Plugins"
+msgstr ""
+
+msgctxt "#32186"
+msgid "Allow script exclusions"
+msgstr ""

--- a/script.trakt/resources/language/resource.language.id_ID/strings.po
+++ b/script.trakt/resources/language/resource.language.id_ID/strings.po
@@ -10,32 +10,712 @@ msgstr ""
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Kodi Translation Team\n"
 "Language-Team: Indonesian (http://www.transifex.com/projects/p/xbmc-addons/language/id/)\n"
+"Language: id\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: id\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 msgctxt "#32000"
 msgid "General"
 msgstr "Umum"
 
+# empty strings from id 32001 to 32002
+msgctxt "#32003"
+msgid "Startup Delay"
+msgstr ""
+
 msgctxt "#32004"
 msgid "Rating"
 msgstr "Rating"
+
+msgctxt "#32005"
+msgid "Rate Movie after watching"
+msgstr ""
+
+msgctxt "#32006"
+msgid "Rate TV show Episode after watching"
+msgstr ""
+
+msgctxt "#32008"
+msgid "Minimum percent watched to display rating dialog"
+msgstr ""
+
+msgctxt "#32009"
+msgid "Allow re-rating of media"
+msgstr ""
+
+msgctxt "#32010"
+msgid "Default rating"
+msgstr ""
+
+# Scrobbling Settings
+msgctxt "#32011"
+msgid "Scrobbling"
+msgstr ""
+
+msgctxt "#32012"
+msgid "Scrobble movies"
+msgstr ""
+
+msgctxt "#32013"
+msgid "Scrobble TV show episodes"
+msgstr ""
+
+msgctxt "#32014"
+msgid "Show notification on scrobble"
+msgstr ""
+
+msgctxt "#32015"
+msgid "Trakt - Scrobbled successfully"
+msgstr ""
+
+msgctxt "#32016"
+msgid "Exclusions"
+msgstr ""
+
+msgctxt "#32017"
+msgid "Exclude Live TV"
+msgstr ""
+
+msgctxt "#32018"
+msgid "Exclude HTTP sources"
+msgstr ""
+
+msgctxt "#32019"
+msgid "Exclude path"
+msgstr ""
+
+msgctxt "#32020"
+msgid "Folder's path (including subfolders)"
+msgstr ""
+
+# empty strings from id 32021 to 32022
+msgctxt "#32023"
+msgid "Can not connect to Trakt"
+msgstr ""
 
 msgctxt "#32024"
 msgid "Error"
 msgstr "Galat"
 
+# empty string with id 32025
+msgctxt "#32026"
+msgid "What Did You Think?"
+msgstr ""
+
+msgctxt "#32027"
+msgid "Totally Ninja!"
+msgstr ""
+
+msgctxt "#32028"
+msgid "Weak Sauce :("
+msgstr ""
+
+msgctxt "#32029"
+msgid "Terrible"
+msgstr ""
+
+msgctxt "#32030"
+msgid "Bad"
+msgstr ""
+
+msgctxt "#32031"
+msgid "Poor"
+msgstr ""
+
+msgctxt "#32032"
+msgid "Meh"
+msgstr ""
+
 msgctxt "#32033"
 msgid "Fair"
 msgstr "Cukup"
+
+msgctxt "#32034"
+msgid "Good"
+msgstr ""
+
+msgctxt "#32035"
+msgid "Great"
+msgstr ""
+
+msgctxt "#32036"
+msgid "Superb"
+msgstr ""
+
+msgctxt "#32037"
+msgid "Unrate this movie"
+msgstr ""
+
+msgctxt "#32038"
+msgid "Unrate this show"
+msgstr ""
+
+msgctxt "#32039"
+msgid "Unrate this episode"
+msgstr ""
+
+msgctxt "#32040"
+msgid "Trakt - Rating submitted successfully"
+msgstr ""
+
+msgctxt "#32041"
+msgid "Trakt - Already rated"
+msgstr ""
+
+msgctxt "#32042"
+msgid "Trakt - Unrated successfully"
+msgstr ""
+
+msgctxt "#32043"
+msgid "Trakt - Already has the same rating"
+msgstr ""
+
+msgctxt "#32044"
+msgid "Trakt - Problem submitting rating"
+msgstr ""
+
+msgctxt "#32045"
+msgid "Synchronize"
+msgstr ""
 
 msgctxt "#32046"
 msgid "Movies"
 msgstr "Film"
 
+msgctxt "#32047"
+msgid "Add new movies to Trakt collection"
+msgstr ""
+
+msgctxt "#32048"
+msgid "Add watched movies to Trakt history"
+msgstr ""
+
+msgctxt "#32049"
+msgid "Mark movies from Trakt history as watched in Kodi"
+msgstr ""
+
+msgctxt "#32050"
+msgid "TV Episodes"
+msgstr ""
+
+msgctxt "#32051"
+msgid "Add new TV episodes to Trakt collection"
+msgstr ""
+
+msgctxt "#32052"
+msgid "Add watched TV episodes to Trakt history"
+msgstr ""
+
+msgctxt "#32053"
+msgid "Mark TV episodes from Trakt history as watched in Kodi"
+msgstr ""
+
 msgctxt "#32054"
 msgid "Service"
 msgstr "Layanan"
+
+msgctxt "#32055"
+msgid "Sync collection on library update or cleaning"
+msgstr ""
+
+msgctxt "#32056"
+msgid "Show sync notifications"
+msgstr ""
+
+msgctxt "#32057"
+msgid "Remove deleted movies from Trakt collection"
+msgstr ""
+
+msgctxt "#32058"
+msgid "Remove deleted TV episodes from Trakt collection"
+msgstr ""
+
+# empty string with id 32059
+msgctxt "#32060"
+msgid "Hide notifications during playback"
+msgstr ""
+
+msgctxt "#32061"
+msgid "Sync started"
+msgstr ""
+
+msgctxt "#32062"
+msgid "Sync complete"
+msgstr ""
+
+msgctxt "#32063"
+msgid "%i movie(s) will be added to Trakt collection"
+msgstr ""
+
+msgctxt "#32064"
+msgid "%i movie playcount(s) will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32065"
+msgid "%i movie(s) playcount will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32066"
+msgid "Movie Sync Complete"
+msgstr ""
+
+msgctxt "#32067"
+msgid "Going to add %i show(s) to Trakt collection"
+msgstr ""
+
+msgctxt "#32068"
+msgid "Checking for episodes missing from Trakt collection"
+msgstr ""
+
+msgctxt "#32069"
+msgid "%i of %i show(s) have episodes added to Trakt collection"
+msgstr ""
+
+msgctxt "#32070"
+msgid "Going to update %i show(s) missing watched status"
+msgstr ""
+
+msgctxt "#32071"
+msgid "Checking watched episodes on Trakt"
+msgstr ""
+
+msgctxt "#32072"
+msgid "%i show(s) had missing watched status"
+msgstr ""
+
+msgctxt "#32073"
+msgid "%i episodes are being updated"
+msgstr ""
+
+msgctxt "#32074"
+msgid "Checking watched episodes on Kodi"
+msgstr ""
+
+msgctxt "#32075"
+msgid "Episode Sync Complete"
+msgstr ""
+
+msgctxt "#32076"
+msgid "%i movie(s) will be removed from Trakt collection"
+msgstr ""
+
+msgctxt "#32077"
+msgid "Cleaning Trakt TV show collection"
+msgstr ""
+
+msgctxt "#32078"
+msgid "episodes are being removed"
+msgstr ""
+
+msgctxt "#32079"
+msgid "Loading movies from Kodi"
+msgstr ""
+
+msgctxt "#32080"
+msgid "Movies loaded from Kodi"
+msgstr ""
+
+msgctxt "#32081"
+msgid "Retrieving movie collection from Trakt"
+msgstr ""
+
+msgctxt "#32082"
+msgid "Retrieving watched movies from Trakt"
+msgstr ""
+
+msgctxt "#32083"
+msgid "Retrieved movie data from Trakt"
+msgstr ""
+
+msgctxt "#32084"
+msgid "Trakt movie collection is up to date, no movies to add"
+msgstr ""
+
+msgctxt "#32085"
+msgid "%i movie(s) were added to your Trakt collection"
+msgstr ""
+
+msgctxt "#32086"
+msgid "Trakt movie playcounts are up to date"
+msgstr ""
+
+msgctxt "#32087"
+msgid "Playcounts updated for %i movie(s) on Trakt"
+msgstr ""
+
+msgctxt "#32088"
+msgid "Kodi movie playcounts are up to date"
+msgstr ""
+
+msgctxt "#32089"
+msgid "Updating %i of %i movie playcount(s) in Kodi"
+msgstr ""
+
+msgctxt "#32090"
+msgid "Playcounts updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32091"
+msgid "Trakt movie collection is up to date, no movies removed"
+msgstr ""
+
+msgctxt "#32092"
+msgid "%i movie(s) were removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32093"
+msgid "Updating %i of %i movie playcount(s) on Trakt"
+msgstr ""
+
+msgctxt "#32094"
+msgid "Loading episode data from Kodi"
+msgstr ""
+
+msgctxt "#32095"
+msgid "Loading shows from Kodi"
+msgstr ""
+
+msgctxt "#32096"
+msgid "Shows loaded from Kodi"
+msgstr ""
+
+msgctxt "#32097"
+msgid "Parsing %i of %i episode data from Kodi"
+msgstr ""
+
+msgctxt "#32098"
+msgid "Loaded episode data from Kodi"
+msgstr ""
+
+msgctxt "#32099"
+msgid "Loading episode data from Trakt"
+msgstr ""
+
+msgctxt "#32100"
+msgid "Retrieving episode collection from Trakt"
+msgstr ""
+
+msgctxt "#32101"
+msgid "Retrieving watched episodes from Trakt"
+msgstr ""
+
+msgctxt "#32102"
+msgid "Parsing episode data %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32103"
+msgid "Retrieved episode data from Trakt"
+msgstr ""
+
+msgctxt "#32104"
+msgid "Trakt episode collection is up to date, no episodes to add"
+msgstr ""
+
+msgctxt "#32105"
+msgid "%i episode(s) were added to your Trakt collection"
+msgstr ""
+
+msgctxt "#32106"
+msgid "Trakt episode playcounts are up to date"
+msgstr ""
+
+msgctxt "#32107"
+msgid "Kodi episode playcounts are up to date"
+msgstr ""
+
+msgctxt "#32108"
+msgid "Updating %i of %i episode playcount(s) in Kodi"
+msgstr ""
+
+msgctxt "#32109"
+msgid "Playcounts updated for %i show(s) in Kodi"
+msgstr ""
+
+msgctxt "#32110"
+msgid "Trakt episode collection is clean, no episodes to remove"
+msgstr ""
+
+msgctxt "#32111"
+msgid "%i episode(s) are being removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32112"
+msgid "%i episode(s) were removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32113"
+msgid "Trakt - Marked as watched"
+msgstr ""
+
+msgctxt "#32114"
+msgid "Trakt - Failed marking as watched"
+msgstr ""
+
+msgctxt "#32115"
+msgid "%d episode(s) of '%s'"
+msgstr ""
+
+msgctxt "#32116"
+msgid "Enable debug mode"
+msgstr ""
+
+msgctxt "#32117"
+msgid "Sync movie playback progress to Kodi"
+msgstr ""
+
+msgctxt "#32118"
+msgid "Sync episode playback progress to Kodi"
+msgstr ""
+
+msgctxt "#32119"
+msgid "Retrieving episode playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32120"
+msgid "Parsing episode playback progress %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32121"
+msgid "Retrieved episode playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32122"
+msgid "Retrieving movie playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32123"
+msgid "Parsing movie playback progress %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32124"
+msgid "Retrieved movie playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32125"
+msgid "Kodi movie playback progress is up to date"
+msgstr ""
+
+msgctxt "#32126"
+msgid "%i movie(s) playback progress will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32127"
+msgid "Updating %i of %i movie(s) playback progress in Kodi"
+msgstr ""
+
+msgctxt "#32128"
+msgid "Playback progress updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32129"
+msgid "Kodi episode playback progress is up to date"
+msgstr ""
+
+msgctxt "#32130"
+msgid "Updating %i of %i episode(s) playback progress in Kodi"
+msgstr ""
+
+msgctxt "#32131"
+msgid "Playback progress updated for %i episode(s) in Kodi"
+msgstr ""
+
+msgctxt "#32132"
+msgid "Unrate this season"
+msgstr ""
+
+msgctxt "#32133"
+msgid "Manage Movie's Lists"
+msgstr ""
+
+msgctxt "#32134"
+msgid "Manage Show's Lists"
+msgstr ""
+
+msgctxt "#32135"
+msgid "Remove from Watchlist"
+msgstr ""
+
+msgctxt "#32136"
+msgid "Add to watchlist"
+msgstr ""
+
+msgctxt "#32137"
+msgid "Rate this movie"
+msgstr ""
+
+msgctxt "#32138"
+msgid "Rate this show"
+msgstr ""
+
+msgctxt "#32139"
+msgid "Rate this episode"
+msgstr ""
+
+msgctxt "#32140"
+msgid "Toggle watched"
+msgstr ""
+
+msgctxt "#32141"
+msgid "Manage all lists"
+msgstr ""
+
+msgctxt "#32142"
+msgid "Update all tags"
+msgstr ""
+
+msgctxt "#32143"
+msgid "Synchronize library"
+msgstr ""
+
+msgctxt "#32144"
+msgid "How do I authorize the trakt addon to access my trakt.tv account?"
+msgstr ""
+
+# empty strings from id 32145 to 32146
+msgctxt "#32147"
+msgid "Trakt.tv PIN Authorization Failed"
+msgstr ""
+
+# empty string with id 32148
+msgctxt "#32149"
+msgid "Rate this Season"
+msgstr ""
+
+msgctxt "#32150"
+msgid "You will be reminded in 24 hours"
+msgstr ""
+
+msgctxt "#32151"
+msgid "Use Addon Settings later if you change your mind"
+msgstr ""
+
+msgctxt "#32152"
+msgid "Trakt Authorization Complete"
+msgstr ""
+
+msgctxt "#32153"
+msgid "Trakt Account Authorization"
+msgstr ""
+
+msgctxt "#32154"
+msgid "Authorize"
+msgstr ""
+
+msgctxt "#32155"
+msgid "Remind Me Later"
+msgstr ""
+
+msgctxt "#32156"
+msgid "No Thanks"
+msgstr ""
+
+msgctxt "#32157"
+msgid "Account Authorization"
+msgstr ""
+
+# empty string with id 32158
+msgctxt "#32159"
+msgid "Visit {0} or scan the QR code."
+msgstr ""
+
+msgctxt "#32162"
+msgid "The trakt addon CAN NOT be used without authorizing it to access your trakt.tv account."
+msgstr ""
+
+msgctxt "#32163"
+msgid "User"
+msgstr ""
+
+msgctxt "#32164"
+msgid "Fallback to Title/Year matching if necessary"
+msgstr ""
+
+msgctxt "#32165"
+msgid "Trakt - Added to watchlist"
+msgstr ""
+
+msgctxt "#32166"
+msgid "Trakt - Failed adding to watchlist"
+msgstr ""
+
+msgctxt "#32167"
+msgid "Offset scrobble start by X minutes"
+msgstr ""
+
+msgctxt "#32168"
+msgid "Sync ratings"
+msgstr ""
+
+msgctxt "#32169"
+msgid "Kodi movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32170"
+msgid "%i movie(s) ratings will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32171"
+msgid "Updating %i of %i movie ratings in Kodi"
+msgstr ""
+
+msgctxt "#32172"
+msgid "Ratings updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32173"
+msgid "Kodi episode ratings are up to date"
+msgstr ""
+
+msgctxt "#32174"
+msgid "Updating %i of %i episode ratings in Kodi"
+msgstr ""
+
+msgctxt "#32175"
+msgid "Ratings updated for %i episode(s) in Kodi"
+msgstr ""
+
+msgctxt "#32176"
+msgid "Kodi show ratings are up to date"
+msgstr ""
+
+msgctxt "#32177"
+msgid "Updating %i of %i show ratings in Kodi"
+msgstr ""
+
+msgctxt "#32178"
+msgid "Ratings updated for %i show(s) in Kodi"
+msgstr ""
+
+msgctxt "#32179"
+msgid "Trakt movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32180"
+msgid "%i movie ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32181"
+msgid "Trakt show ratings are up to date"
+msgstr ""
+
+msgctxt "#32182"
+msgid "%i show ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32183"
+msgid "Attempt to scrobble MythTV PVR recordings"
+msgstr ""
+
+msgctxt "#32184"
+msgid "Attempt secondary show title search"
+msgstr ""
+
+msgctxt "#32185"
+msgid "Exclude Plugins"
+msgstr ""
+
+msgctxt "#32186"
+msgid "Allow script exclusions"
+msgstr ""

--- a/script.trakt/resources/language/resource.language.is_IS/strings.po
+++ b/script.trakt/resources/language/resource.language.is_IS/strings.po
@@ -10,32 +10,712 @@ msgstr ""
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Kodi Translation Team\n"
 "Language-Team: Icelandic (http://www.transifex.com/projects/p/xbmc-addons/language/is/)\n"
+"Language: is\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: is\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 msgctxt "#32000"
 msgid "General"
 msgstr "Almennt"
 
+# empty strings from id 32001 to 32002
+msgctxt "#32003"
+msgid "Startup Delay"
+msgstr ""
+
 msgctxt "#32004"
 msgid "Rating"
 msgstr "Stjörnugjöf"
+
+msgctxt "#32005"
+msgid "Rate Movie after watching"
+msgstr ""
+
+msgctxt "#32006"
+msgid "Rate TV show Episode after watching"
+msgstr ""
+
+msgctxt "#32008"
+msgid "Minimum percent watched to display rating dialog"
+msgstr ""
+
+msgctxt "#32009"
+msgid "Allow re-rating of media"
+msgstr ""
+
+msgctxt "#32010"
+msgid "Default rating"
+msgstr ""
+
+# Scrobbling Settings
+msgctxt "#32011"
+msgid "Scrobbling"
+msgstr ""
+
+msgctxt "#32012"
+msgid "Scrobble movies"
+msgstr ""
+
+msgctxt "#32013"
+msgid "Scrobble TV show episodes"
+msgstr ""
+
+msgctxt "#32014"
+msgid "Show notification on scrobble"
+msgstr ""
+
+msgctxt "#32015"
+msgid "Trakt - Scrobbled successfully"
+msgstr ""
+
+msgctxt "#32016"
+msgid "Exclusions"
+msgstr ""
+
+msgctxt "#32017"
+msgid "Exclude Live TV"
+msgstr ""
+
+msgctxt "#32018"
+msgid "Exclude HTTP sources"
+msgstr ""
+
+msgctxt "#32019"
+msgid "Exclude path"
+msgstr ""
+
+msgctxt "#32020"
+msgid "Folder's path (including subfolders)"
+msgstr ""
+
+# empty strings from id 32021 to 32022
+msgctxt "#32023"
+msgid "Can not connect to Trakt"
+msgstr ""
 
 msgctxt "#32024"
 msgid "Error"
 msgstr "VillaVilla"
 
+# empty string with id 32025
+msgctxt "#32026"
+msgid "What Did You Think?"
+msgstr ""
+
+msgctxt "#32027"
+msgid "Totally Ninja!"
+msgstr ""
+
+msgctxt "#32028"
+msgid "Weak Sauce :("
+msgstr ""
+
+msgctxt "#32029"
+msgid "Terrible"
+msgstr ""
+
+msgctxt "#32030"
+msgid "Bad"
+msgstr ""
+
+msgctxt "#32031"
+msgid "Poor"
+msgstr ""
+
+msgctxt "#32032"
+msgid "Meh"
+msgstr ""
+
 msgctxt "#32033"
 msgid "Fair"
 msgstr "Létt"
+
+msgctxt "#32034"
+msgid "Good"
+msgstr ""
+
+msgctxt "#32035"
+msgid "Great"
+msgstr ""
+
+msgctxt "#32036"
+msgid "Superb"
+msgstr ""
+
+msgctxt "#32037"
+msgid "Unrate this movie"
+msgstr ""
+
+msgctxt "#32038"
+msgid "Unrate this show"
+msgstr ""
+
+msgctxt "#32039"
+msgid "Unrate this episode"
+msgstr ""
+
+msgctxt "#32040"
+msgid "Trakt - Rating submitted successfully"
+msgstr ""
+
+msgctxt "#32041"
+msgid "Trakt - Already rated"
+msgstr ""
+
+msgctxt "#32042"
+msgid "Trakt - Unrated successfully"
+msgstr ""
+
+msgctxt "#32043"
+msgid "Trakt - Already has the same rating"
+msgstr ""
+
+msgctxt "#32044"
+msgid "Trakt - Problem submitting rating"
+msgstr ""
+
+msgctxt "#32045"
+msgid "Synchronize"
+msgstr ""
 
 msgctxt "#32046"
 msgid "Movies"
 msgstr "Kvikmyndir"
 
+msgctxt "#32047"
+msgid "Add new movies to Trakt collection"
+msgstr ""
+
+msgctxt "#32048"
+msgid "Add watched movies to Trakt history"
+msgstr ""
+
+msgctxt "#32049"
+msgid "Mark movies from Trakt history as watched in Kodi"
+msgstr ""
+
+msgctxt "#32050"
+msgid "TV Episodes"
+msgstr ""
+
+msgctxt "#32051"
+msgid "Add new TV episodes to Trakt collection"
+msgstr ""
+
+msgctxt "#32052"
+msgid "Add watched TV episodes to Trakt history"
+msgstr ""
+
+msgctxt "#32053"
+msgid "Mark TV episodes from Trakt history as watched in Kodi"
+msgstr ""
+
 msgctxt "#32054"
 msgid "Service"
 msgstr "Þjónusta"
+
+msgctxt "#32055"
+msgid "Sync collection on library update or cleaning"
+msgstr ""
+
+msgctxt "#32056"
+msgid "Show sync notifications"
+msgstr ""
+
+msgctxt "#32057"
+msgid "Remove deleted movies from Trakt collection"
+msgstr ""
+
+msgctxt "#32058"
+msgid "Remove deleted TV episodes from Trakt collection"
+msgstr ""
+
+# empty string with id 32059
+msgctxt "#32060"
+msgid "Hide notifications during playback"
+msgstr ""
+
+msgctxt "#32061"
+msgid "Sync started"
+msgstr ""
+
+msgctxt "#32062"
+msgid "Sync complete"
+msgstr ""
+
+msgctxt "#32063"
+msgid "%i movie(s) will be added to Trakt collection"
+msgstr ""
+
+msgctxt "#32064"
+msgid "%i movie playcount(s) will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32065"
+msgid "%i movie(s) playcount will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32066"
+msgid "Movie Sync Complete"
+msgstr ""
+
+msgctxt "#32067"
+msgid "Going to add %i show(s) to Trakt collection"
+msgstr ""
+
+msgctxt "#32068"
+msgid "Checking for episodes missing from Trakt collection"
+msgstr ""
+
+msgctxt "#32069"
+msgid "%i of %i show(s) have episodes added to Trakt collection"
+msgstr ""
+
+msgctxt "#32070"
+msgid "Going to update %i show(s) missing watched status"
+msgstr ""
+
+msgctxt "#32071"
+msgid "Checking watched episodes on Trakt"
+msgstr ""
+
+msgctxt "#32072"
+msgid "%i show(s) had missing watched status"
+msgstr ""
+
+msgctxt "#32073"
+msgid "%i episodes are being updated"
+msgstr ""
+
+msgctxt "#32074"
+msgid "Checking watched episodes on Kodi"
+msgstr ""
+
+msgctxt "#32075"
+msgid "Episode Sync Complete"
+msgstr ""
+
+msgctxt "#32076"
+msgid "%i movie(s) will be removed from Trakt collection"
+msgstr ""
+
+msgctxt "#32077"
+msgid "Cleaning Trakt TV show collection"
+msgstr ""
+
+msgctxt "#32078"
+msgid "episodes are being removed"
+msgstr ""
+
+msgctxt "#32079"
+msgid "Loading movies from Kodi"
+msgstr ""
+
+msgctxt "#32080"
+msgid "Movies loaded from Kodi"
+msgstr ""
+
+msgctxt "#32081"
+msgid "Retrieving movie collection from Trakt"
+msgstr ""
+
+msgctxt "#32082"
+msgid "Retrieving watched movies from Trakt"
+msgstr ""
+
+msgctxt "#32083"
+msgid "Retrieved movie data from Trakt"
+msgstr ""
+
+msgctxt "#32084"
+msgid "Trakt movie collection is up to date, no movies to add"
+msgstr ""
+
+msgctxt "#32085"
+msgid "%i movie(s) were added to your Trakt collection"
+msgstr ""
+
+msgctxt "#32086"
+msgid "Trakt movie playcounts are up to date"
+msgstr ""
+
+msgctxt "#32087"
+msgid "Playcounts updated for %i movie(s) on Trakt"
+msgstr ""
+
+msgctxt "#32088"
+msgid "Kodi movie playcounts are up to date"
+msgstr ""
+
+msgctxt "#32089"
+msgid "Updating %i of %i movie playcount(s) in Kodi"
+msgstr ""
+
+msgctxt "#32090"
+msgid "Playcounts updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32091"
+msgid "Trakt movie collection is up to date, no movies removed"
+msgstr ""
+
+msgctxt "#32092"
+msgid "%i movie(s) were removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32093"
+msgid "Updating %i of %i movie playcount(s) on Trakt"
+msgstr ""
+
+msgctxt "#32094"
+msgid "Loading episode data from Kodi"
+msgstr ""
+
+msgctxt "#32095"
+msgid "Loading shows from Kodi"
+msgstr ""
+
+msgctxt "#32096"
+msgid "Shows loaded from Kodi"
+msgstr ""
+
+msgctxt "#32097"
+msgid "Parsing %i of %i episode data from Kodi"
+msgstr ""
+
+msgctxt "#32098"
+msgid "Loaded episode data from Kodi"
+msgstr ""
+
+msgctxt "#32099"
+msgid "Loading episode data from Trakt"
+msgstr ""
+
+msgctxt "#32100"
+msgid "Retrieving episode collection from Trakt"
+msgstr ""
+
+msgctxt "#32101"
+msgid "Retrieving watched episodes from Trakt"
+msgstr ""
+
+msgctxt "#32102"
+msgid "Parsing episode data %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32103"
+msgid "Retrieved episode data from Trakt"
+msgstr ""
+
+msgctxt "#32104"
+msgid "Trakt episode collection is up to date, no episodes to add"
+msgstr ""
+
+msgctxt "#32105"
+msgid "%i episode(s) were added to your Trakt collection"
+msgstr ""
+
+msgctxt "#32106"
+msgid "Trakt episode playcounts are up to date"
+msgstr ""
+
+msgctxt "#32107"
+msgid "Kodi episode playcounts are up to date"
+msgstr ""
+
+msgctxt "#32108"
+msgid "Updating %i of %i episode playcount(s) in Kodi"
+msgstr ""
+
+msgctxt "#32109"
+msgid "Playcounts updated for %i show(s) in Kodi"
+msgstr ""
+
+msgctxt "#32110"
+msgid "Trakt episode collection is clean, no episodes to remove"
+msgstr ""
+
+msgctxt "#32111"
+msgid "%i episode(s) are being removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32112"
+msgid "%i episode(s) were removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32113"
+msgid "Trakt - Marked as watched"
+msgstr ""
+
+msgctxt "#32114"
+msgid "Trakt - Failed marking as watched"
+msgstr ""
+
+msgctxt "#32115"
+msgid "%d episode(s) of '%s'"
+msgstr ""
+
+msgctxt "#32116"
+msgid "Enable debug mode"
+msgstr ""
+
+msgctxt "#32117"
+msgid "Sync movie playback progress to Kodi"
+msgstr ""
+
+msgctxt "#32118"
+msgid "Sync episode playback progress to Kodi"
+msgstr ""
+
+msgctxt "#32119"
+msgid "Retrieving episode playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32120"
+msgid "Parsing episode playback progress %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32121"
+msgid "Retrieved episode playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32122"
+msgid "Retrieving movie playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32123"
+msgid "Parsing movie playback progress %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32124"
+msgid "Retrieved movie playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32125"
+msgid "Kodi movie playback progress is up to date"
+msgstr ""
+
+msgctxt "#32126"
+msgid "%i movie(s) playback progress will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32127"
+msgid "Updating %i of %i movie(s) playback progress in Kodi"
+msgstr ""
+
+msgctxt "#32128"
+msgid "Playback progress updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32129"
+msgid "Kodi episode playback progress is up to date"
+msgstr ""
+
+msgctxt "#32130"
+msgid "Updating %i of %i episode(s) playback progress in Kodi"
+msgstr ""
+
+msgctxt "#32131"
+msgid "Playback progress updated for %i episode(s) in Kodi"
+msgstr ""
+
+msgctxt "#32132"
+msgid "Unrate this season"
+msgstr ""
+
+msgctxt "#32133"
+msgid "Manage Movie's Lists"
+msgstr ""
+
+msgctxt "#32134"
+msgid "Manage Show's Lists"
+msgstr ""
+
+msgctxt "#32135"
+msgid "Remove from Watchlist"
+msgstr ""
+
+msgctxt "#32136"
+msgid "Add to watchlist"
+msgstr ""
+
+msgctxt "#32137"
+msgid "Rate this movie"
+msgstr ""
+
+msgctxt "#32138"
+msgid "Rate this show"
+msgstr ""
+
+msgctxt "#32139"
+msgid "Rate this episode"
+msgstr ""
+
+msgctxt "#32140"
+msgid "Toggle watched"
+msgstr ""
+
+msgctxt "#32141"
+msgid "Manage all lists"
+msgstr ""
+
+msgctxt "#32142"
+msgid "Update all tags"
+msgstr ""
+
+msgctxt "#32143"
+msgid "Synchronize library"
+msgstr ""
+
+msgctxt "#32144"
+msgid "How do I authorize the trakt addon to access my trakt.tv account?"
+msgstr ""
+
+# empty strings from id 32145 to 32146
+msgctxt "#32147"
+msgid "Trakt.tv PIN Authorization Failed"
+msgstr ""
+
+# empty string with id 32148
+msgctxt "#32149"
+msgid "Rate this Season"
+msgstr ""
+
+msgctxt "#32150"
+msgid "You will be reminded in 24 hours"
+msgstr ""
+
+msgctxt "#32151"
+msgid "Use Addon Settings later if you change your mind"
+msgstr ""
+
+msgctxt "#32152"
+msgid "Trakt Authorization Complete"
+msgstr ""
+
+msgctxt "#32153"
+msgid "Trakt Account Authorization"
+msgstr ""
+
+msgctxt "#32154"
+msgid "Authorize"
+msgstr ""
+
+msgctxt "#32155"
+msgid "Remind Me Later"
+msgstr ""
+
+msgctxt "#32156"
+msgid "No Thanks"
+msgstr ""
+
+msgctxt "#32157"
+msgid "Account Authorization"
+msgstr ""
+
+# empty string with id 32158
+msgctxt "#32159"
+msgid "Visit {0} or scan the QR code."
+msgstr ""
+
+msgctxt "#32162"
+msgid "The trakt addon CAN NOT be used without authorizing it to access your trakt.tv account."
+msgstr ""
+
+msgctxt "#32163"
+msgid "User"
+msgstr ""
+
+msgctxt "#32164"
+msgid "Fallback to Title/Year matching if necessary"
+msgstr ""
+
+msgctxt "#32165"
+msgid "Trakt - Added to watchlist"
+msgstr ""
+
+msgctxt "#32166"
+msgid "Trakt - Failed adding to watchlist"
+msgstr ""
+
+msgctxt "#32167"
+msgid "Offset scrobble start by X minutes"
+msgstr ""
+
+msgctxt "#32168"
+msgid "Sync ratings"
+msgstr ""
+
+msgctxt "#32169"
+msgid "Kodi movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32170"
+msgid "%i movie(s) ratings will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32171"
+msgid "Updating %i of %i movie ratings in Kodi"
+msgstr ""
+
+msgctxt "#32172"
+msgid "Ratings updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32173"
+msgid "Kodi episode ratings are up to date"
+msgstr ""
+
+msgctxt "#32174"
+msgid "Updating %i of %i episode ratings in Kodi"
+msgstr ""
+
+msgctxt "#32175"
+msgid "Ratings updated for %i episode(s) in Kodi"
+msgstr ""
+
+msgctxt "#32176"
+msgid "Kodi show ratings are up to date"
+msgstr ""
+
+msgctxt "#32177"
+msgid "Updating %i of %i show ratings in Kodi"
+msgstr ""
+
+msgctxt "#32178"
+msgid "Ratings updated for %i show(s) in Kodi"
+msgstr ""
+
+msgctxt "#32179"
+msgid "Trakt movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32180"
+msgid "%i movie ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32181"
+msgid "Trakt show ratings are up to date"
+msgstr ""
+
+msgctxt "#32182"
+msgid "%i show ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32183"
+msgid "Attempt to scrobble MythTV PVR recordings"
+msgstr ""
+
+msgctxt "#32184"
+msgid "Attempt secondary show title search"
+msgstr ""
+
+msgctxt "#32185"
+msgid "Exclude Plugins"
+msgstr ""
+
+msgctxt "#32186"
+msgid "Allow script exclusions"
+msgstr ""

--- a/script.trakt/resources/language/resource.language.it_IT/strings.po
+++ b/script.trakt/resources/language/resource.language.it_IT/strings.po
@@ -10,10 +10,10 @@ msgstr ""
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Kodi Translation Team\n"
 "Language-Team: Italian (http://www.transifex.com/projects/p/xbmc-addons/language/it/)\n"
+"Language: it\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: it\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 msgctxt "#32000"
@@ -608,17 +608,10 @@ msgctxt "#32157"
 msgid "Account Authorization"
 msgstr "Autorizzazione account"
 
+# empty string with id 32158
 msgctxt "#32159"
-msgid "Visit {0} or scan the QR Code below."
-msgstr "Visita {0} o scansiona il QR Code qui sotto."
-
-msgctxt "#32160"
-msgid "Authorize the trakt addon to access your account."
-msgstr "Autorizza l'addon trakt ad accedere al tuo account"
-
-msgctxt "#32161"
-msgid "Enter the PIN provided in the box below."
-msgstr "Inserisci il PIN fornito nello spazio sottostante"
+msgid "Visit {0} or scan the QR code."
+msgstr ""
 
 msgctxt "#32162"
 msgid "The trakt addon CAN NOT be used without authorizing it to access your trakt.tv account."
@@ -639,3 +632,95 @@ msgstr "Trakt - Aggiunto a lista da guardare"
 msgctxt "#32166"
 msgid "Trakt - Failed adding to watchlist"
 msgstr "Trakt - Impossibile aggiungere a lista da guardare"
+
+msgctxt "#32167"
+msgid "Offset scrobble start by X minutes"
+msgstr ""
+
+msgctxt "#32168"
+msgid "Sync ratings"
+msgstr ""
+
+msgctxt "#32169"
+msgid "Kodi movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32170"
+msgid "%i movie(s) ratings will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32171"
+msgid "Updating %i of %i movie ratings in Kodi"
+msgstr ""
+
+msgctxt "#32172"
+msgid "Ratings updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32173"
+msgid "Kodi episode ratings are up to date"
+msgstr ""
+
+msgctxt "#32174"
+msgid "Updating %i of %i episode ratings in Kodi"
+msgstr ""
+
+msgctxt "#32175"
+msgid "Ratings updated for %i episode(s) in Kodi"
+msgstr ""
+
+msgctxt "#32176"
+msgid "Kodi show ratings are up to date"
+msgstr ""
+
+msgctxt "#32177"
+msgid "Updating %i of %i show ratings in Kodi"
+msgstr ""
+
+msgctxt "#32178"
+msgid "Ratings updated for %i show(s) in Kodi"
+msgstr ""
+
+msgctxt "#32179"
+msgid "Trakt movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32180"
+msgid "%i movie ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32181"
+msgid "Trakt show ratings are up to date"
+msgstr ""
+
+msgctxt "#32182"
+msgid "%i show ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32183"
+msgid "Attempt to scrobble MythTV PVR recordings"
+msgstr ""
+
+msgctxt "#32184"
+msgid "Attempt secondary show title search"
+msgstr ""
+
+msgctxt "#32185"
+msgid "Exclude Plugins"
+msgstr ""
+
+msgctxt "#32186"
+msgid "Allow script exclusions"
+msgstr ""
+
+#~ msgctxt "#32159"
+#~ msgid "Visit {0} or scan the QR Code below."
+#~ msgstr "Visita {0} o scansiona il QR Code qui sotto."
+
+#~ msgctxt "#32160"
+#~ msgid "Authorize the trakt addon to access your account."
+#~ msgstr "Autorizza l'addon trakt ad accedere al tuo account"
+
+#~ msgctxt "#32161"
+#~ msgid "Enter the PIN provided in the box below."
+#~ msgstr "Inserisci il PIN fornito nello spazio sottostante"

--- a/script.trakt/resources/language/resource.language.ja_JP/strings.po
+++ b/script.trakt/resources/language/resource.language.ja_JP/strings.po
@@ -10,32 +10,712 @@ msgstr ""
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Kodi Translation Team\n"
 "Language-Team: Japanese (http://www.transifex.com/projects/p/xbmc-addons/language/ja/)\n"
+"Language: ja\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: ja\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 msgctxt "#32000"
 msgid "General"
 msgstr "一般"
 
+# empty strings from id 32001 to 32002
+msgctxt "#32003"
+msgid "Startup Delay"
+msgstr ""
+
 msgctxt "#32004"
 msgid "Rating"
 msgstr "評価"
+
+msgctxt "#32005"
+msgid "Rate Movie after watching"
+msgstr ""
+
+msgctxt "#32006"
+msgid "Rate TV show Episode after watching"
+msgstr ""
+
+msgctxt "#32008"
+msgid "Minimum percent watched to display rating dialog"
+msgstr ""
+
+msgctxt "#32009"
+msgid "Allow re-rating of media"
+msgstr ""
+
+msgctxt "#32010"
+msgid "Default rating"
+msgstr ""
+
+# Scrobbling Settings
+msgctxt "#32011"
+msgid "Scrobbling"
+msgstr ""
+
+msgctxt "#32012"
+msgid "Scrobble movies"
+msgstr ""
+
+msgctxt "#32013"
+msgid "Scrobble TV show episodes"
+msgstr ""
+
+msgctxt "#32014"
+msgid "Show notification on scrobble"
+msgstr ""
+
+msgctxt "#32015"
+msgid "Trakt - Scrobbled successfully"
+msgstr ""
+
+msgctxt "#32016"
+msgid "Exclusions"
+msgstr ""
+
+msgctxt "#32017"
+msgid "Exclude Live TV"
+msgstr ""
+
+msgctxt "#32018"
+msgid "Exclude HTTP sources"
+msgstr ""
+
+msgctxt "#32019"
+msgid "Exclude path"
+msgstr ""
+
+msgctxt "#32020"
+msgid "Folder's path (including subfolders)"
+msgstr ""
+
+# empty strings from id 32021 to 32022
+msgctxt "#32023"
+msgid "Can not connect to Trakt"
+msgstr ""
 
 msgctxt "#32024"
 msgid "Error"
 msgstr "エラー"
 
+# empty string with id 32025
+msgctxt "#32026"
+msgid "What Did You Think?"
+msgstr ""
+
+msgctxt "#32027"
+msgid "Totally Ninja!"
+msgstr ""
+
+msgctxt "#32028"
+msgid "Weak Sauce :("
+msgstr ""
+
+msgctxt "#32029"
+msgid "Terrible"
+msgstr ""
+
+msgctxt "#32030"
+msgid "Bad"
+msgstr ""
+
+msgctxt "#32031"
+msgid "Poor"
+msgstr ""
+
+msgctxt "#32032"
+msgid "Meh"
+msgstr ""
+
 msgctxt "#32033"
 msgid "Fair"
 msgstr "好天"
+
+msgctxt "#32034"
+msgid "Good"
+msgstr ""
+
+msgctxt "#32035"
+msgid "Great"
+msgstr ""
+
+msgctxt "#32036"
+msgid "Superb"
+msgstr ""
+
+msgctxt "#32037"
+msgid "Unrate this movie"
+msgstr ""
+
+msgctxt "#32038"
+msgid "Unrate this show"
+msgstr ""
+
+msgctxt "#32039"
+msgid "Unrate this episode"
+msgstr ""
+
+msgctxt "#32040"
+msgid "Trakt - Rating submitted successfully"
+msgstr ""
+
+msgctxt "#32041"
+msgid "Trakt - Already rated"
+msgstr ""
+
+msgctxt "#32042"
+msgid "Trakt - Unrated successfully"
+msgstr ""
+
+msgctxt "#32043"
+msgid "Trakt - Already has the same rating"
+msgstr ""
+
+msgctxt "#32044"
+msgid "Trakt - Problem submitting rating"
+msgstr ""
+
+msgctxt "#32045"
+msgid "Synchronize"
+msgstr ""
 
 msgctxt "#32046"
 msgid "Movies"
 msgstr "ムービー"
 
+msgctxt "#32047"
+msgid "Add new movies to Trakt collection"
+msgstr ""
+
+msgctxt "#32048"
+msgid "Add watched movies to Trakt history"
+msgstr ""
+
+msgctxt "#32049"
+msgid "Mark movies from Trakt history as watched in Kodi"
+msgstr ""
+
+msgctxt "#32050"
+msgid "TV Episodes"
+msgstr ""
+
+msgctxt "#32051"
+msgid "Add new TV episodes to Trakt collection"
+msgstr ""
+
+msgctxt "#32052"
+msgid "Add watched TV episodes to Trakt history"
+msgstr ""
+
+msgctxt "#32053"
+msgid "Mark TV episodes from Trakt history as watched in Kodi"
+msgstr ""
+
 msgctxt "#32054"
 msgid "Service"
 msgstr "サービス"
+
+msgctxt "#32055"
+msgid "Sync collection on library update or cleaning"
+msgstr ""
+
+msgctxt "#32056"
+msgid "Show sync notifications"
+msgstr ""
+
+msgctxt "#32057"
+msgid "Remove deleted movies from Trakt collection"
+msgstr ""
+
+msgctxt "#32058"
+msgid "Remove deleted TV episodes from Trakt collection"
+msgstr ""
+
+# empty string with id 32059
+msgctxt "#32060"
+msgid "Hide notifications during playback"
+msgstr ""
+
+msgctxt "#32061"
+msgid "Sync started"
+msgstr ""
+
+msgctxt "#32062"
+msgid "Sync complete"
+msgstr ""
+
+msgctxt "#32063"
+msgid "%i movie(s) will be added to Trakt collection"
+msgstr ""
+
+msgctxt "#32064"
+msgid "%i movie playcount(s) will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32065"
+msgid "%i movie(s) playcount will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32066"
+msgid "Movie Sync Complete"
+msgstr ""
+
+msgctxt "#32067"
+msgid "Going to add %i show(s) to Trakt collection"
+msgstr ""
+
+msgctxt "#32068"
+msgid "Checking for episodes missing from Trakt collection"
+msgstr ""
+
+msgctxt "#32069"
+msgid "%i of %i show(s) have episodes added to Trakt collection"
+msgstr ""
+
+msgctxt "#32070"
+msgid "Going to update %i show(s) missing watched status"
+msgstr ""
+
+msgctxt "#32071"
+msgid "Checking watched episodes on Trakt"
+msgstr ""
+
+msgctxt "#32072"
+msgid "%i show(s) had missing watched status"
+msgstr ""
+
+msgctxt "#32073"
+msgid "%i episodes are being updated"
+msgstr ""
+
+msgctxt "#32074"
+msgid "Checking watched episodes on Kodi"
+msgstr ""
+
+msgctxt "#32075"
+msgid "Episode Sync Complete"
+msgstr ""
+
+msgctxt "#32076"
+msgid "%i movie(s) will be removed from Trakt collection"
+msgstr ""
+
+msgctxt "#32077"
+msgid "Cleaning Trakt TV show collection"
+msgstr ""
+
+msgctxt "#32078"
+msgid "episodes are being removed"
+msgstr ""
+
+msgctxt "#32079"
+msgid "Loading movies from Kodi"
+msgstr ""
+
+msgctxt "#32080"
+msgid "Movies loaded from Kodi"
+msgstr ""
+
+msgctxt "#32081"
+msgid "Retrieving movie collection from Trakt"
+msgstr ""
+
+msgctxt "#32082"
+msgid "Retrieving watched movies from Trakt"
+msgstr ""
+
+msgctxt "#32083"
+msgid "Retrieved movie data from Trakt"
+msgstr ""
+
+msgctxt "#32084"
+msgid "Trakt movie collection is up to date, no movies to add"
+msgstr ""
+
+msgctxt "#32085"
+msgid "%i movie(s) were added to your Trakt collection"
+msgstr ""
+
+msgctxt "#32086"
+msgid "Trakt movie playcounts are up to date"
+msgstr ""
+
+msgctxt "#32087"
+msgid "Playcounts updated for %i movie(s) on Trakt"
+msgstr ""
+
+msgctxt "#32088"
+msgid "Kodi movie playcounts are up to date"
+msgstr ""
+
+msgctxt "#32089"
+msgid "Updating %i of %i movie playcount(s) in Kodi"
+msgstr ""
+
+msgctxt "#32090"
+msgid "Playcounts updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32091"
+msgid "Trakt movie collection is up to date, no movies removed"
+msgstr ""
+
+msgctxt "#32092"
+msgid "%i movie(s) were removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32093"
+msgid "Updating %i of %i movie playcount(s) on Trakt"
+msgstr ""
+
+msgctxt "#32094"
+msgid "Loading episode data from Kodi"
+msgstr ""
+
+msgctxt "#32095"
+msgid "Loading shows from Kodi"
+msgstr ""
+
+msgctxt "#32096"
+msgid "Shows loaded from Kodi"
+msgstr ""
+
+msgctxt "#32097"
+msgid "Parsing %i of %i episode data from Kodi"
+msgstr ""
+
+msgctxt "#32098"
+msgid "Loaded episode data from Kodi"
+msgstr ""
+
+msgctxt "#32099"
+msgid "Loading episode data from Trakt"
+msgstr ""
+
+msgctxt "#32100"
+msgid "Retrieving episode collection from Trakt"
+msgstr ""
+
+msgctxt "#32101"
+msgid "Retrieving watched episodes from Trakt"
+msgstr ""
+
+msgctxt "#32102"
+msgid "Parsing episode data %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32103"
+msgid "Retrieved episode data from Trakt"
+msgstr ""
+
+msgctxt "#32104"
+msgid "Trakt episode collection is up to date, no episodes to add"
+msgstr ""
+
+msgctxt "#32105"
+msgid "%i episode(s) were added to your Trakt collection"
+msgstr ""
+
+msgctxt "#32106"
+msgid "Trakt episode playcounts are up to date"
+msgstr ""
+
+msgctxt "#32107"
+msgid "Kodi episode playcounts are up to date"
+msgstr ""
+
+msgctxt "#32108"
+msgid "Updating %i of %i episode playcount(s) in Kodi"
+msgstr ""
+
+msgctxt "#32109"
+msgid "Playcounts updated for %i show(s) in Kodi"
+msgstr ""
+
+msgctxt "#32110"
+msgid "Trakt episode collection is clean, no episodes to remove"
+msgstr ""
+
+msgctxt "#32111"
+msgid "%i episode(s) are being removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32112"
+msgid "%i episode(s) were removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32113"
+msgid "Trakt - Marked as watched"
+msgstr ""
+
+msgctxt "#32114"
+msgid "Trakt - Failed marking as watched"
+msgstr ""
+
+msgctxt "#32115"
+msgid "%d episode(s) of '%s'"
+msgstr ""
+
+msgctxt "#32116"
+msgid "Enable debug mode"
+msgstr ""
+
+msgctxt "#32117"
+msgid "Sync movie playback progress to Kodi"
+msgstr ""
+
+msgctxt "#32118"
+msgid "Sync episode playback progress to Kodi"
+msgstr ""
+
+msgctxt "#32119"
+msgid "Retrieving episode playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32120"
+msgid "Parsing episode playback progress %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32121"
+msgid "Retrieved episode playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32122"
+msgid "Retrieving movie playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32123"
+msgid "Parsing movie playback progress %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32124"
+msgid "Retrieved movie playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32125"
+msgid "Kodi movie playback progress is up to date"
+msgstr ""
+
+msgctxt "#32126"
+msgid "%i movie(s) playback progress will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32127"
+msgid "Updating %i of %i movie(s) playback progress in Kodi"
+msgstr ""
+
+msgctxt "#32128"
+msgid "Playback progress updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32129"
+msgid "Kodi episode playback progress is up to date"
+msgstr ""
+
+msgctxt "#32130"
+msgid "Updating %i of %i episode(s) playback progress in Kodi"
+msgstr ""
+
+msgctxt "#32131"
+msgid "Playback progress updated for %i episode(s) in Kodi"
+msgstr ""
+
+msgctxt "#32132"
+msgid "Unrate this season"
+msgstr ""
+
+msgctxt "#32133"
+msgid "Manage Movie's Lists"
+msgstr ""
+
+msgctxt "#32134"
+msgid "Manage Show's Lists"
+msgstr ""
+
+msgctxt "#32135"
+msgid "Remove from Watchlist"
+msgstr ""
+
+msgctxt "#32136"
+msgid "Add to watchlist"
+msgstr ""
+
+msgctxt "#32137"
+msgid "Rate this movie"
+msgstr ""
+
+msgctxt "#32138"
+msgid "Rate this show"
+msgstr ""
+
+msgctxt "#32139"
+msgid "Rate this episode"
+msgstr ""
+
+msgctxt "#32140"
+msgid "Toggle watched"
+msgstr ""
+
+msgctxt "#32141"
+msgid "Manage all lists"
+msgstr ""
+
+msgctxt "#32142"
+msgid "Update all tags"
+msgstr ""
+
+msgctxt "#32143"
+msgid "Synchronize library"
+msgstr ""
+
+msgctxt "#32144"
+msgid "How do I authorize the trakt addon to access my trakt.tv account?"
+msgstr ""
+
+# empty strings from id 32145 to 32146
+msgctxt "#32147"
+msgid "Trakt.tv PIN Authorization Failed"
+msgstr ""
+
+# empty string with id 32148
+msgctxt "#32149"
+msgid "Rate this Season"
+msgstr ""
+
+msgctxt "#32150"
+msgid "You will be reminded in 24 hours"
+msgstr ""
+
+msgctxt "#32151"
+msgid "Use Addon Settings later if you change your mind"
+msgstr ""
+
+msgctxt "#32152"
+msgid "Trakt Authorization Complete"
+msgstr ""
+
+msgctxt "#32153"
+msgid "Trakt Account Authorization"
+msgstr ""
+
+msgctxt "#32154"
+msgid "Authorize"
+msgstr ""
+
+msgctxt "#32155"
+msgid "Remind Me Later"
+msgstr ""
+
+msgctxt "#32156"
+msgid "No Thanks"
+msgstr ""
+
+msgctxt "#32157"
+msgid "Account Authorization"
+msgstr ""
+
+# empty string with id 32158
+msgctxt "#32159"
+msgid "Visit {0} or scan the QR code."
+msgstr ""
+
+msgctxt "#32162"
+msgid "The trakt addon CAN NOT be used without authorizing it to access your trakt.tv account."
+msgstr ""
+
+msgctxt "#32163"
+msgid "User"
+msgstr ""
+
+msgctxt "#32164"
+msgid "Fallback to Title/Year matching if necessary"
+msgstr ""
+
+msgctxt "#32165"
+msgid "Trakt - Added to watchlist"
+msgstr ""
+
+msgctxt "#32166"
+msgid "Trakt - Failed adding to watchlist"
+msgstr ""
+
+msgctxt "#32167"
+msgid "Offset scrobble start by X minutes"
+msgstr ""
+
+msgctxt "#32168"
+msgid "Sync ratings"
+msgstr ""
+
+msgctxt "#32169"
+msgid "Kodi movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32170"
+msgid "%i movie(s) ratings will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32171"
+msgid "Updating %i of %i movie ratings in Kodi"
+msgstr ""
+
+msgctxt "#32172"
+msgid "Ratings updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32173"
+msgid "Kodi episode ratings are up to date"
+msgstr ""
+
+msgctxt "#32174"
+msgid "Updating %i of %i episode ratings in Kodi"
+msgstr ""
+
+msgctxt "#32175"
+msgid "Ratings updated for %i episode(s) in Kodi"
+msgstr ""
+
+msgctxt "#32176"
+msgid "Kodi show ratings are up to date"
+msgstr ""
+
+msgctxt "#32177"
+msgid "Updating %i of %i show ratings in Kodi"
+msgstr ""
+
+msgctxt "#32178"
+msgid "Ratings updated for %i show(s) in Kodi"
+msgstr ""
+
+msgctxt "#32179"
+msgid "Trakt movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32180"
+msgid "%i movie ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32181"
+msgid "Trakt show ratings are up to date"
+msgstr ""
+
+msgctxt "#32182"
+msgid "%i show ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32183"
+msgid "Attempt to scrobble MythTV PVR recordings"
+msgstr ""
+
+msgctxt "#32184"
+msgid "Attempt secondary show title search"
+msgstr ""
+
+msgctxt "#32185"
+msgid "Exclude Plugins"
+msgstr ""
+
+msgctxt "#32186"
+msgid "Allow script exclusions"
+msgstr ""

--- a/script.trakt/resources/language/resource.language.kn_in/strings.po
+++ b/script.trakt/resources/language/resource.language.kn_in/strings.po
@@ -1,0 +1,722 @@
+# Kodi Media Center language file
+# Addon Name: Trakt
+# Addon id: script.trakt
+# Addon Provider: Trakt.tv, Razze
+msgid ""
+msgstr ""
+"Project-Id-Version: XBMC Addons\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
+"POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: kn_in\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n > 1;\n"
+
+# General Settings
+msgctxt "#32000"
+msgid "General"
+msgstr ""
+
+# empty strings from id 32001 to 32002
+msgctxt "#32003"
+msgid "Startup Delay"
+msgstr ""
+
+msgctxt "#32004"
+msgid "Rating"
+msgstr ""
+
+msgctxt "#32005"
+msgid "Rate Movie after watching"
+msgstr ""
+
+msgctxt "#32006"
+msgid "Rate TV show Episode after watching"
+msgstr ""
+
+msgctxt "#32008"
+msgid "Minimum percent watched to display rating dialog"
+msgstr ""
+
+msgctxt "#32009"
+msgid "Allow re-rating of media"
+msgstr ""
+
+msgctxt "#32010"
+msgid "Default rating"
+msgstr ""
+
+# Scrobbling Settings
+msgctxt "#32011"
+msgid "Scrobbling"
+msgstr ""
+
+msgctxt "#32012"
+msgid "Scrobble movies"
+msgstr ""
+
+msgctxt "#32013"
+msgid "Scrobble TV show episodes"
+msgstr ""
+
+msgctxt "#32014"
+msgid "Show notification on scrobble"
+msgstr ""
+
+msgctxt "#32015"
+msgid "Trakt - Scrobbled successfully"
+msgstr ""
+
+msgctxt "#32016"
+msgid "Exclusions"
+msgstr ""
+
+msgctxt "#32017"
+msgid "Exclude Live TV"
+msgstr ""
+
+msgctxt "#32018"
+msgid "Exclude HTTP sources"
+msgstr ""
+
+msgctxt "#32019"
+msgid "Exclude path"
+msgstr ""
+
+msgctxt "#32020"
+msgid "Folder's path (including subfolders)"
+msgstr ""
+
+# empty strings from id 32021 to 32022
+msgctxt "#32023"
+msgid "Can not connect to Trakt"
+msgstr ""
+
+msgctxt "#32024"
+msgid "Error"
+msgstr ""
+
+# empty string with id 32025
+msgctxt "#32026"
+msgid "What Did You Think?"
+msgstr ""
+
+msgctxt "#32027"
+msgid "Totally Ninja!"
+msgstr ""
+
+msgctxt "#32028"
+msgid "Weak Sauce :("
+msgstr ""
+
+msgctxt "#32029"
+msgid "Terrible"
+msgstr ""
+
+msgctxt "#32030"
+msgid "Bad"
+msgstr ""
+
+msgctxt "#32031"
+msgid "Poor"
+msgstr ""
+
+msgctxt "#32032"
+msgid "Meh"
+msgstr ""
+
+msgctxt "#32033"
+msgid "Fair"
+msgstr ""
+
+msgctxt "#32034"
+msgid "Good"
+msgstr ""
+
+msgctxt "#32035"
+msgid "Great"
+msgstr ""
+
+msgctxt "#32036"
+msgid "Superb"
+msgstr ""
+
+msgctxt "#32037"
+msgid "Unrate this movie"
+msgstr ""
+
+msgctxt "#32038"
+msgid "Unrate this show"
+msgstr ""
+
+msgctxt "#32039"
+msgid "Unrate this episode"
+msgstr ""
+
+msgctxt "#32040"
+msgid "Trakt - Rating submitted successfully"
+msgstr ""
+
+msgctxt "#32041"
+msgid "Trakt - Already rated"
+msgstr ""
+
+msgctxt "#32042"
+msgid "Trakt - Unrated successfully"
+msgstr ""
+
+msgctxt "#32043"
+msgid "Trakt - Already has the same rating"
+msgstr ""
+
+msgctxt "#32044"
+msgid "Trakt - Problem submitting rating"
+msgstr ""
+
+msgctxt "#32045"
+msgid "Synchronize"
+msgstr ""
+
+msgctxt "#32046"
+msgid "Movies"
+msgstr ""
+
+msgctxt "#32047"
+msgid "Add new movies to Trakt collection"
+msgstr ""
+
+msgctxt "#32048"
+msgid "Add watched movies to Trakt history"
+msgstr ""
+
+msgctxt "#32049"
+msgid "Mark movies from Trakt history as watched in Kodi"
+msgstr ""
+
+msgctxt "#32050"
+msgid "TV Episodes"
+msgstr ""
+
+msgctxt "#32051"
+msgid "Add new TV episodes to Trakt collection"
+msgstr ""
+
+msgctxt "#32052"
+msgid "Add watched TV episodes to Trakt history"
+msgstr ""
+
+msgctxt "#32053"
+msgid "Mark TV episodes from Trakt history as watched in Kodi"
+msgstr ""
+
+msgctxt "#32054"
+msgid "Service"
+msgstr ""
+
+msgctxt "#32055"
+msgid "Sync collection on library update or cleaning"
+msgstr ""
+
+msgctxt "#32056"
+msgid "Show sync notifications"
+msgstr ""
+
+msgctxt "#32057"
+msgid "Remove deleted movies from Trakt collection"
+msgstr ""
+
+msgctxt "#32058"
+msgid "Remove deleted TV episodes from Trakt collection"
+msgstr ""
+
+# empty string with id 32059
+msgctxt "#32060"
+msgid "Hide notifications during playback"
+msgstr ""
+
+msgctxt "#32061"
+msgid "Sync started"
+msgstr ""
+
+msgctxt "#32062"
+msgid "Sync complete"
+msgstr ""
+
+msgctxt "#32063"
+msgid "%i movie(s) will be added to Trakt collection"
+msgstr ""
+
+msgctxt "#32064"
+msgid "%i movie playcount(s) will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32065"
+msgid "%i movie(s) playcount will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32066"
+msgid "Movie Sync Complete"
+msgstr ""
+
+msgctxt "#32067"
+msgid "Going to add %i show(s) to Trakt collection"
+msgstr ""
+
+msgctxt "#32068"
+msgid "Checking for episodes missing from Trakt collection"
+msgstr ""
+
+msgctxt "#32069"
+msgid "%i of %i show(s) have episodes added to Trakt collection"
+msgstr ""
+
+msgctxt "#32070"
+msgid "Going to update %i show(s) missing watched status"
+msgstr ""
+
+msgctxt "#32071"
+msgid "Checking watched episodes on Trakt"
+msgstr ""
+
+msgctxt "#32072"
+msgid "%i show(s) had missing watched status"
+msgstr ""
+
+msgctxt "#32073"
+msgid "%i episodes are being updated"
+msgstr ""
+
+msgctxt "#32074"
+msgid "Checking watched episodes on Kodi"
+msgstr ""
+
+msgctxt "#32075"
+msgid "Episode Sync Complete"
+msgstr ""
+
+msgctxt "#32076"
+msgid "%i movie(s) will be removed from Trakt collection"
+msgstr ""
+
+msgctxt "#32077"
+msgid "Cleaning Trakt TV show collection"
+msgstr ""
+
+msgctxt "#32078"
+msgid "episodes are being removed"
+msgstr ""
+
+msgctxt "#32079"
+msgid "Loading movies from Kodi"
+msgstr ""
+
+msgctxt "#32080"
+msgid "Movies loaded from Kodi"
+msgstr ""
+
+msgctxt "#32081"
+msgid "Retrieving movie collection from Trakt"
+msgstr ""
+
+msgctxt "#32082"
+msgid "Retrieving watched movies from Trakt"
+msgstr ""
+
+msgctxt "#32083"
+msgid "Retrieved movie data from Trakt"
+msgstr ""
+
+msgctxt "#32084"
+msgid "Trakt movie collection is up to date, no movies to add"
+msgstr ""
+
+msgctxt "#32085"
+msgid "%i movie(s) were added to your Trakt collection"
+msgstr ""
+
+msgctxt "#32086"
+msgid "Trakt movie playcounts are up to date"
+msgstr ""
+
+msgctxt "#32087"
+msgid "Playcounts updated for %i movie(s) on Trakt"
+msgstr ""
+
+msgctxt "#32088"
+msgid "Kodi movie playcounts are up to date"
+msgstr ""
+
+msgctxt "#32089"
+msgid "Updating %i of %i movie playcount(s) in Kodi"
+msgstr ""
+
+msgctxt "#32090"
+msgid "Playcounts updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32091"
+msgid "Trakt movie collection is up to date, no movies removed"
+msgstr ""
+
+msgctxt "#32092"
+msgid "%i movie(s) were removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32093"
+msgid "Updating %i of %i movie playcount(s) on Trakt"
+msgstr ""
+
+msgctxt "#32094"
+msgid "Loading episode data from Kodi"
+msgstr ""
+
+msgctxt "#32095"
+msgid "Loading shows from Kodi"
+msgstr ""
+
+msgctxt "#32096"
+msgid "Shows loaded from Kodi"
+msgstr ""
+
+msgctxt "#32097"
+msgid "Parsing %i of %i episode data from Kodi"
+msgstr ""
+
+msgctxt "#32098"
+msgid "Loaded episode data from Kodi"
+msgstr ""
+
+msgctxt "#32099"
+msgid "Loading episode data from Trakt"
+msgstr ""
+
+msgctxt "#32100"
+msgid "Retrieving episode collection from Trakt"
+msgstr ""
+
+msgctxt "#32101"
+msgid "Retrieving watched episodes from Trakt"
+msgstr ""
+
+msgctxt "#32102"
+msgid "Parsing episode data %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32103"
+msgid "Retrieved episode data from Trakt"
+msgstr ""
+
+msgctxt "#32104"
+msgid "Trakt episode collection is up to date, no episodes to add"
+msgstr ""
+
+msgctxt "#32105"
+msgid "%i episode(s) were added to your Trakt collection"
+msgstr ""
+
+msgctxt "#32106"
+msgid "Trakt episode playcounts are up to date"
+msgstr ""
+
+msgctxt "#32107"
+msgid "Kodi episode playcounts are up to date"
+msgstr ""
+
+msgctxt "#32108"
+msgid "Updating %i of %i episode playcount(s) in Kodi"
+msgstr ""
+
+msgctxt "#32109"
+msgid "Playcounts updated for %i show(s) in Kodi"
+msgstr ""
+
+msgctxt "#32110"
+msgid "Trakt episode collection is clean, no episodes to remove"
+msgstr ""
+
+msgctxt "#32111"
+msgid "%i episode(s) are being removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32112"
+msgid "%i episode(s) were removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32113"
+msgid "Trakt - Marked as watched"
+msgstr ""
+
+msgctxt "#32114"
+msgid "Trakt - Failed marking as watched"
+msgstr ""
+
+msgctxt "#32115"
+msgid "%d episode(s) of '%s'"
+msgstr ""
+
+msgctxt "#32116"
+msgid "Enable debug mode"
+msgstr ""
+
+msgctxt "#32117"
+msgid "Sync movie playback progress to Kodi"
+msgstr ""
+
+msgctxt "#32118"
+msgid "Sync episode playback progress to Kodi"
+msgstr ""
+
+msgctxt "#32119"
+msgid "Retrieving episode playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32120"
+msgid "Parsing episode playback progress %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32121"
+msgid "Retrieved episode playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32122"
+msgid "Retrieving movie playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32123"
+msgid "Parsing movie playback progress %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32124"
+msgid "Retrieved movie playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32125"
+msgid "Kodi movie playback progress is up to date"
+msgstr ""
+
+msgctxt "#32126"
+msgid "%i movie(s) playback progress will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32127"
+msgid "Updating %i of %i movie(s) playback progress in Kodi"
+msgstr ""
+
+msgctxt "#32128"
+msgid "Playback progress updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32129"
+msgid "Kodi episode playback progress is up to date"
+msgstr ""
+
+msgctxt "#32130"
+msgid "Updating %i of %i episode(s) playback progress in Kodi"
+msgstr ""
+
+msgctxt "#32131"
+msgid "Playback progress updated for %i episode(s) in Kodi"
+msgstr ""
+
+msgctxt "#32132"
+msgid "Unrate this season"
+msgstr ""
+
+msgctxt "#32133"
+msgid "Manage Movie's Lists"
+msgstr ""
+
+msgctxt "#32134"
+msgid "Manage Show's Lists"
+msgstr ""
+
+msgctxt "#32135"
+msgid "Remove from Watchlist"
+msgstr ""
+
+msgctxt "#32136"
+msgid "Add to watchlist"
+msgstr ""
+
+msgctxt "#32137"
+msgid "Rate this movie"
+msgstr ""
+
+msgctxt "#32138"
+msgid "Rate this show"
+msgstr ""
+
+msgctxt "#32139"
+msgid "Rate this episode"
+msgstr ""
+
+msgctxt "#32140"
+msgid "Toggle watched"
+msgstr ""
+
+msgctxt "#32141"
+msgid "Manage all lists"
+msgstr ""
+
+msgctxt "#32142"
+msgid "Update all tags"
+msgstr ""
+
+msgctxt "#32143"
+msgid "Synchronize library"
+msgstr ""
+
+msgctxt "#32144"
+msgid "How do I authorize the trakt addon to access my trakt.tv account?"
+msgstr ""
+
+# empty strings from id 32145 to 32146
+msgctxt "#32147"
+msgid "Trakt.tv PIN Authorization Failed"
+msgstr ""
+
+# empty string with id 32148
+msgctxt "#32149"
+msgid "Rate this Season"
+msgstr ""
+
+msgctxt "#32150"
+msgid "You will be reminded in 24 hours"
+msgstr ""
+
+msgctxt "#32151"
+msgid "Use Addon Settings later if you change your mind"
+msgstr ""
+
+msgctxt "#32152"
+msgid "Trakt Authorization Complete"
+msgstr ""
+
+msgctxt "#32153"
+msgid "Trakt Account Authorization"
+msgstr ""
+
+msgctxt "#32154"
+msgid "Authorize"
+msgstr ""
+
+msgctxt "#32155"
+msgid "Remind Me Later"
+msgstr ""
+
+msgctxt "#32156"
+msgid "No Thanks"
+msgstr ""
+
+msgctxt "#32157"
+msgid "Account Authorization"
+msgstr ""
+
+# empty string with id 32158
+msgctxt "#32159"
+msgid "Visit {0} or scan the QR code."
+msgstr ""
+
+msgctxt "#32162"
+msgid "The trakt addon CAN NOT be used without authorizing it to access your trakt.tv account."
+msgstr ""
+
+msgctxt "#32163"
+msgid "User"
+msgstr ""
+
+msgctxt "#32164"
+msgid "Fallback to Title/Year matching if necessary"
+msgstr ""
+
+msgctxt "#32165"
+msgid "Trakt - Added to watchlist"
+msgstr ""
+
+msgctxt "#32166"
+msgid "Trakt - Failed adding to watchlist"
+msgstr ""
+
+msgctxt "#32167"
+msgid "Offset scrobble start by X minutes"
+msgstr ""
+
+msgctxt "#32168"
+msgid "Sync ratings"
+msgstr ""
+
+msgctxt "#32169"
+msgid "Kodi movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32170"
+msgid "%i movie(s) ratings will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32171"
+msgid "Updating %i of %i movie ratings in Kodi"
+msgstr ""
+
+msgctxt "#32172"
+msgid "Ratings updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32173"
+msgid "Kodi episode ratings are up to date"
+msgstr ""
+
+msgctxt "#32174"
+msgid "Updating %i of %i episode ratings in Kodi"
+msgstr ""
+
+msgctxt "#32175"
+msgid "Ratings updated for %i episode(s) in Kodi"
+msgstr ""
+
+msgctxt "#32176"
+msgid "Kodi show ratings are up to date"
+msgstr ""
+
+msgctxt "#32177"
+msgid "Updating %i of %i show ratings in Kodi"
+msgstr ""
+
+msgctxt "#32178"
+msgid "Ratings updated for %i show(s) in Kodi"
+msgstr ""
+
+msgctxt "#32179"
+msgid "Trakt movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32180"
+msgid "%i movie ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32181"
+msgid "Trakt show ratings are up to date"
+msgstr ""
+
+msgctxt "#32182"
+msgid "%i show ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32183"
+msgid "Attempt to scrobble MythTV PVR recordings"
+msgstr ""
+
+msgctxt "#32184"
+msgid "Attempt secondary show title search"
+msgstr ""
+
+msgctxt "#32185"
+msgid "Exclude Plugins"
+msgstr ""
+
+msgctxt "#32186"
+msgid "Allow script exclusions"
+msgstr ""

--- a/script.trakt/resources/language/resource.language.ko_KR/strings.po
+++ b/script.trakt/resources/language/resource.language.ko_KR/strings.po
@@ -7,14 +7,15 @@ msgstr ""
 "Project-Id-Version: XBMC Addons\n"
 "Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: Kodi Translation Team\n"
-"Language-Team: Korean (http://www.transifex.com/projects/p/xbmc-addons/language/ko/)\n"
+"PO-Revision-Date: 2021-03-20 15:56+0000\n"
+"Last-Translator: Christian Gade <gade@kodi.tv>\n"
+"Language-Team: Korean <https://kodi.weblate.cloud/projects/kodi-add-ons-scripts/script-trakt/ko_kr/>\n"
+"Language: ko_KR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: ko\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
+"X-Generator: Weblate 4.5.1\n"
 
 msgctxt "#32000"
 msgid "General"
@@ -262,7 +263,7 @@ msgstr "%i TV 쇼를 Trakt 컬렉션에 추가합니다"
 
 msgctxt "#32068"
 msgid "Checking for episodes missing from Trakt collection"
-msgstr "Trakt 컬렉션에서 누락된 에피소드 확인 중 "
+msgstr "Trakt 컬렉션에서 누락된 에피소드 확인 중"
 
 msgctxt "#32069"
 msgid "%i of %i show(s) have episodes added to Trakt collection"
@@ -450,7 +451,7 @@ msgstr "Trakt - 시청함으로 표시하는 데 실패하였습니다"
 
 msgctxt "#32115"
 msgid "%d episode(s) of '%s'"
-msgstr "'%s'의 %d 에피소드 "
+msgstr "'%s'의 %d 에피소드"
 
 msgctxt "#32116"
 msgid "Enable debug mode"
@@ -474,7 +475,7 @@ msgstr "trakt의 에피소드 재생 진생 상태 분석 중 (%i / %i)"
 
 msgctxt "#32121"
 msgid "Retrieved episode playback progress from Trakt"
-msgstr "trakt에서 에피소드 재생  진행 상태를 가져왔습니다"
+msgstr "trakt에서 에피소드 재생 진행 상태를 가져왔습니다"
 
 msgctxt "#32122"
 msgid "Retrieving movie playback progress from Trakt"
@@ -486,7 +487,7 @@ msgstr "trakt의 영화 재생 진생 상태 분석 중 (%i / %i)"
 
 msgctxt "#32124"
 msgid "Retrieved movie playback progress from Trakt"
-msgstr "trakt에서 영화 재생  진행 상태를 가져왔습니다"
+msgstr "trakt에서 영화 재생 진행 상태를 가져왔습니다"
 
 msgctxt "#32125"
 msgid "Kodi movie playback progress is up to date"
@@ -580,6 +581,10 @@ msgctxt "#32150"
 msgid "You will be reminded in 24 hours"
 msgstr "24시간 후에 알려줍니다"
 
+msgctxt "#32151"
+msgid "Use Addon Settings later if you change your mind"
+msgstr ""
+
 msgctxt "#32152"
 msgid "Trakt Authorization Complete"
 msgstr "Trakt 인증 완료"
@@ -604,17 +609,10 @@ msgctxt "#32157"
 msgid "Account Authorization"
 msgstr "계정 인증"
 
+# empty string with id 32158
 msgctxt "#32159"
-msgid "Visit {0} or scan the QR Code below."
-msgstr "{0} 을 방문하거나 아래의 QR 코드를 스캔하세요."
-
-msgctxt "#32160"
-msgid "Authorize the trakt addon to access your account."
-msgstr "trakt 애드온이 계정에 접속할 수 있게 인증하세요."
-
-msgctxt "#32161"
-msgid "Enter the PIN provided in the box below."
-msgstr "아래의 상자에서 제공되는 PIN 번호를 입력하세요."
+msgid "Visit {0} or scan the QR code."
+msgstr ""
 
 msgctxt "#32162"
 msgid "The trakt addon CAN NOT be used without authorizing it to access your trakt.tv account."
@@ -624,6 +622,10 @@ msgctxt "#32163"
 msgid "User"
 msgstr "사용자"
 
+msgctxt "#32164"
+msgid "Fallback to Title/Year matching if necessary"
+msgstr ""
+
 msgctxt "#32165"
 msgid "Trakt - Added to watchlist"
 msgstr "Trakt - watchlist에 추가됨"
@@ -631,3 +633,95 @@ msgstr "Trakt - watchlist에 추가됨"
 msgctxt "#32166"
 msgid "Trakt - Failed adding to watchlist"
 msgstr "Trakt - watchlist에 추가 실패"
+
+msgctxt "#32167"
+msgid "Offset scrobble start by X minutes"
+msgstr ""
+
+msgctxt "#32168"
+msgid "Sync ratings"
+msgstr ""
+
+msgctxt "#32169"
+msgid "Kodi movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32170"
+msgid "%i movie(s) ratings will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32171"
+msgid "Updating %i of %i movie ratings in Kodi"
+msgstr ""
+
+msgctxt "#32172"
+msgid "Ratings updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32173"
+msgid "Kodi episode ratings are up to date"
+msgstr ""
+
+msgctxt "#32174"
+msgid "Updating %i of %i episode ratings in Kodi"
+msgstr ""
+
+msgctxt "#32175"
+msgid "Ratings updated for %i episode(s) in Kodi"
+msgstr ""
+
+msgctxt "#32176"
+msgid "Kodi show ratings are up to date"
+msgstr ""
+
+msgctxt "#32177"
+msgid "Updating %i of %i show ratings in Kodi"
+msgstr ""
+
+msgctxt "#32178"
+msgid "Ratings updated for %i show(s) in Kodi"
+msgstr ""
+
+msgctxt "#32179"
+msgid "Trakt movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32180"
+msgid "%i movie ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32181"
+msgid "Trakt show ratings are up to date"
+msgstr ""
+
+msgctxt "#32182"
+msgid "%i show ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32183"
+msgid "Attempt to scrobble MythTV PVR recordings"
+msgstr ""
+
+msgctxt "#32184"
+msgid "Attempt secondary show title search"
+msgstr ""
+
+msgctxt "#32185"
+msgid "Exclude Plugins"
+msgstr ""
+
+msgctxt "#32186"
+msgid "Allow script exclusions"
+msgstr ""
+
+#~ msgctxt "#32159"
+#~ msgid "Visit {0} or scan the QR Code below."
+#~ msgstr "{0} 을 방문하거나 아래의 QR 코드를 스캔하세요."
+
+#~ msgctxt "#32160"
+#~ msgid "Authorize the trakt addon to access your account."
+#~ msgstr "trakt 애드온이 계정에 접속할 수 있게 인증하세요."
+
+#~ msgctxt "#32161"
+#~ msgid "Enter the PIN provided in the box below."
+#~ msgstr "아래의 상자에서 제공되는 PIN 번호를 입력하세요."

--- a/script.trakt/resources/language/resource.language.lt_LT/strings.po
+++ b/script.trakt/resources/language/resource.language.lt_LT/strings.po
@@ -10,10 +10,10 @@ msgstr ""
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Kodi Translation Team\n"
 "Language-Team: Lithuanian (http://www.transifex.com/projects/p/xbmc-addons/language/lt/)\n"
+"Language: lt\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: lt\n"
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 
 msgctxt "#32000"
@@ -608,17 +608,10 @@ msgctxt "#32157"
 msgid "Account Authorization"
 msgstr "Paskyros autorizacija"
 
+# empty string with id 32158
 msgctxt "#32159"
-msgid "Visit {0} or scan the QR Code below."
-msgstr "Apsilankykite {0} arba nuskaitykite žemiau esantį QR kodą.."
-
-msgctxt "#32160"
-msgid "Authorize the trakt addon to access your account."
-msgstr "Autorizuoti Trakt priedą, kad jis galėtų pasiekti jūsų paskyrą."
-
-msgctxt "#32161"
-msgid "Enter the PIN provided in the box below."
-msgstr "Įveskite žemiau pateiktą PIN kodą."
+msgid "Visit {0} or scan the QR code."
+msgstr ""
 
 msgctxt "#32162"
 msgid "The trakt addon CAN NOT be used without authorizing it to access your trakt.tv account."
@@ -639,3 +632,95 @@ msgstr "Trakt - pridėta į peržiūros sąrašą"
 msgctxt "#32166"
 msgid "Trakt - Failed adding to watchlist"
 msgstr "Trakt - nepavyko pridėti į peržiūros sąrašą"
+
+msgctxt "#32167"
+msgid "Offset scrobble start by X minutes"
+msgstr ""
+
+msgctxt "#32168"
+msgid "Sync ratings"
+msgstr ""
+
+msgctxt "#32169"
+msgid "Kodi movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32170"
+msgid "%i movie(s) ratings will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32171"
+msgid "Updating %i of %i movie ratings in Kodi"
+msgstr ""
+
+msgctxt "#32172"
+msgid "Ratings updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32173"
+msgid "Kodi episode ratings are up to date"
+msgstr ""
+
+msgctxt "#32174"
+msgid "Updating %i of %i episode ratings in Kodi"
+msgstr ""
+
+msgctxt "#32175"
+msgid "Ratings updated for %i episode(s) in Kodi"
+msgstr ""
+
+msgctxt "#32176"
+msgid "Kodi show ratings are up to date"
+msgstr ""
+
+msgctxt "#32177"
+msgid "Updating %i of %i show ratings in Kodi"
+msgstr ""
+
+msgctxt "#32178"
+msgid "Ratings updated for %i show(s) in Kodi"
+msgstr ""
+
+msgctxt "#32179"
+msgid "Trakt movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32180"
+msgid "%i movie ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32181"
+msgid "Trakt show ratings are up to date"
+msgstr ""
+
+msgctxt "#32182"
+msgid "%i show ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32183"
+msgid "Attempt to scrobble MythTV PVR recordings"
+msgstr ""
+
+msgctxt "#32184"
+msgid "Attempt secondary show title search"
+msgstr ""
+
+msgctxt "#32185"
+msgid "Exclude Plugins"
+msgstr ""
+
+msgctxt "#32186"
+msgid "Allow script exclusions"
+msgstr ""
+
+#~ msgctxt "#32159"
+#~ msgid "Visit {0} or scan the QR Code below."
+#~ msgstr "Apsilankykite {0} arba nuskaitykite žemiau esantį QR kodą.."
+
+#~ msgctxt "#32160"
+#~ msgid "Authorize the trakt addon to access your account."
+#~ msgstr "Autorizuoti Trakt priedą, kad jis galėtų pasiekti jūsų paskyrą."
+
+#~ msgctxt "#32161"
+#~ msgid "Enter the PIN provided in the box below."
+#~ msgstr "Įveskite žemiau pateiktą PIN kodą."

--- a/script.trakt/resources/language/resource.language.lv_LV/strings.po
+++ b/script.trakt/resources/language/resource.language.lv_LV/strings.po
@@ -10,36 +10,712 @@ msgstr ""
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Kodi Translation Team\n"
 "Language-Team: Latvian (http://www.transifex.com/projects/p/xbmc-addons/language/lv/)\n"
+"Language: lv\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: lv\n"
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n != 0 ? 1 : 2);\n"
 
 msgctxt "#32000"
 msgid "General"
 msgstr "Vispārīgi"
 
+# empty strings from id 32001 to 32002
+msgctxt "#32003"
+msgid "Startup Delay"
+msgstr ""
+
 msgctxt "#32004"
 msgid "Rating"
 msgstr "Reitings"
+
+msgctxt "#32005"
+msgid "Rate Movie after watching"
+msgstr ""
+
+msgctxt "#32006"
+msgid "Rate TV show Episode after watching"
+msgstr ""
+
+msgctxt "#32008"
+msgid "Minimum percent watched to display rating dialog"
+msgstr ""
+
+msgctxt "#32009"
+msgid "Allow re-rating of media"
+msgstr ""
+
+msgctxt "#32010"
+msgid "Default rating"
+msgstr ""
+
+# Scrobbling Settings
+msgctxt "#32011"
+msgid "Scrobbling"
+msgstr ""
+
+msgctxt "#32012"
+msgid "Scrobble movies"
+msgstr ""
+
+msgctxt "#32013"
+msgid "Scrobble TV show episodes"
+msgstr ""
+
+msgctxt "#32014"
+msgid "Show notification on scrobble"
+msgstr ""
+
+msgctxt "#32015"
+msgid "Trakt - Scrobbled successfully"
+msgstr ""
+
+msgctxt "#32016"
+msgid "Exclusions"
+msgstr ""
+
+msgctxt "#32017"
+msgid "Exclude Live TV"
+msgstr ""
+
+msgctxt "#32018"
+msgid "Exclude HTTP sources"
+msgstr ""
+
+msgctxt "#32019"
+msgid "Exclude path"
+msgstr ""
+
+msgctxt "#32020"
+msgid "Folder's path (including subfolders)"
+msgstr ""
+
+# empty strings from id 32021 to 32022
+msgctxt "#32023"
+msgid "Can not connect to Trakt"
+msgstr ""
 
 msgctxt "#32024"
 msgid "Error"
 msgstr "Kļūda"
 
+# empty string with id 32025
+msgctxt "#32026"
+msgid "What Did You Think?"
+msgstr ""
+
+msgctxt "#32027"
+msgid "Totally Ninja!"
+msgstr ""
+
+msgctxt "#32028"
+msgid "Weak Sauce :("
+msgstr ""
+
+msgctxt "#32029"
+msgid "Terrible"
+msgstr ""
+
+msgctxt "#32030"
+msgid "Bad"
+msgstr ""
+
+msgctxt "#32031"
+msgid "Poor"
+msgstr ""
+
+msgctxt "#32032"
+msgid "Meh"
+msgstr ""
+
 msgctxt "#32033"
 msgid "Fair"
 msgstr "Vājš"
+
+msgctxt "#32034"
+msgid "Good"
+msgstr ""
+
+msgctxt "#32035"
+msgid "Great"
+msgstr ""
+
+msgctxt "#32036"
+msgid "Superb"
+msgstr ""
+
+msgctxt "#32037"
+msgid "Unrate this movie"
+msgstr ""
+
+msgctxt "#32038"
+msgid "Unrate this show"
+msgstr ""
+
+msgctxt "#32039"
+msgid "Unrate this episode"
+msgstr ""
+
+msgctxt "#32040"
+msgid "Trakt - Rating submitted successfully"
+msgstr ""
+
+msgctxt "#32041"
+msgid "Trakt - Already rated"
+msgstr ""
+
+msgctxt "#32042"
+msgid "Trakt - Unrated successfully"
+msgstr ""
+
+msgctxt "#32043"
+msgid "Trakt - Already has the same rating"
+msgstr ""
+
+msgctxt "#32044"
+msgid "Trakt - Problem submitting rating"
+msgstr ""
+
+msgctxt "#32045"
+msgid "Synchronize"
+msgstr ""
 
 msgctxt "#32046"
 msgid "Movies"
 msgstr "Filmas"
 
+msgctxt "#32047"
+msgid "Add new movies to Trakt collection"
+msgstr ""
+
+msgctxt "#32048"
+msgid "Add watched movies to Trakt history"
+msgstr ""
+
+msgctxt "#32049"
+msgid "Mark movies from Trakt history as watched in Kodi"
+msgstr ""
+
+msgctxt "#32050"
+msgid "TV Episodes"
+msgstr ""
+
+msgctxt "#32051"
+msgid "Add new TV episodes to Trakt collection"
+msgstr ""
+
+msgctxt "#32052"
+msgid "Add watched TV episodes to Trakt history"
+msgstr ""
+
+msgctxt "#32053"
+msgid "Mark TV episodes from Trakt history as watched in Kodi"
+msgstr ""
+
 msgctxt "#32054"
 msgid "Service"
 msgstr "Pakalpojums"
 
+msgctxt "#32055"
+msgid "Sync collection on library update or cleaning"
+msgstr ""
+
+msgctxt "#32056"
+msgid "Show sync notifications"
+msgstr ""
+
+msgctxt "#32057"
+msgid "Remove deleted movies from Trakt collection"
+msgstr ""
+
+msgctxt "#32058"
+msgid "Remove deleted TV episodes from Trakt collection"
+msgstr ""
+
+# empty string with id 32059
+msgctxt "#32060"
+msgid "Hide notifications during playback"
+msgstr ""
+
+msgctxt "#32061"
+msgid "Sync started"
+msgstr ""
+
+msgctxt "#32062"
+msgid "Sync complete"
+msgstr ""
+
+msgctxt "#32063"
+msgid "%i movie(s) will be added to Trakt collection"
+msgstr ""
+
+msgctxt "#32064"
+msgid "%i movie playcount(s) will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32065"
+msgid "%i movie(s) playcount will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32066"
+msgid "Movie Sync Complete"
+msgstr ""
+
+msgctxt "#32067"
+msgid "Going to add %i show(s) to Trakt collection"
+msgstr ""
+
+msgctxt "#32068"
+msgid "Checking for episodes missing from Trakt collection"
+msgstr ""
+
+msgctxt "#32069"
+msgid "%i of %i show(s) have episodes added to Trakt collection"
+msgstr ""
+
+msgctxt "#32070"
+msgid "Going to update %i show(s) missing watched status"
+msgstr ""
+
+msgctxt "#32071"
+msgid "Checking watched episodes on Trakt"
+msgstr ""
+
+msgctxt "#32072"
+msgid "%i show(s) had missing watched status"
+msgstr ""
+
+msgctxt "#32073"
+msgid "%i episodes are being updated"
+msgstr ""
+
+msgctxt "#32074"
+msgid "Checking watched episodes on Kodi"
+msgstr ""
+
+msgctxt "#32075"
+msgid "Episode Sync Complete"
+msgstr ""
+
+msgctxt "#32076"
+msgid "%i movie(s) will be removed from Trakt collection"
+msgstr ""
+
+msgctxt "#32077"
+msgid "Cleaning Trakt TV show collection"
+msgstr ""
+
+msgctxt "#32078"
+msgid "episodes are being removed"
+msgstr ""
+
+msgctxt "#32079"
+msgid "Loading movies from Kodi"
+msgstr ""
+
+msgctxt "#32080"
+msgid "Movies loaded from Kodi"
+msgstr ""
+
+msgctxt "#32081"
+msgid "Retrieving movie collection from Trakt"
+msgstr ""
+
+msgctxt "#32082"
+msgid "Retrieving watched movies from Trakt"
+msgstr ""
+
+msgctxt "#32083"
+msgid "Retrieved movie data from Trakt"
+msgstr ""
+
+msgctxt "#32084"
+msgid "Trakt movie collection is up to date, no movies to add"
+msgstr ""
+
+msgctxt "#32085"
+msgid "%i movie(s) were added to your Trakt collection"
+msgstr ""
+
+msgctxt "#32086"
+msgid "Trakt movie playcounts are up to date"
+msgstr ""
+
+msgctxt "#32087"
+msgid "Playcounts updated for %i movie(s) on Trakt"
+msgstr ""
+
+msgctxt "#32088"
+msgid "Kodi movie playcounts are up to date"
+msgstr ""
+
+msgctxt "#32089"
+msgid "Updating %i of %i movie playcount(s) in Kodi"
+msgstr ""
+
+msgctxt "#32090"
+msgid "Playcounts updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32091"
+msgid "Trakt movie collection is up to date, no movies removed"
+msgstr ""
+
+msgctxt "#32092"
+msgid "%i movie(s) were removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32093"
+msgid "Updating %i of %i movie playcount(s) on Trakt"
+msgstr ""
+
+msgctxt "#32094"
+msgid "Loading episode data from Kodi"
+msgstr ""
+
+msgctxt "#32095"
+msgid "Loading shows from Kodi"
+msgstr ""
+
+msgctxt "#32096"
+msgid "Shows loaded from Kodi"
+msgstr ""
+
+msgctxt "#32097"
+msgid "Parsing %i of %i episode data from Kodi"
+msgstr ""
+
+msgctxt "#32098"
+msgid "Loaded episode data from Kodi"
+msgstr ""
+
+msgctxt "#32099"
+msgid "Loading episode data from Trakt"
+msgstr ""
+
+msgctxt "#32100"
+msgid "Retrieving episode collection from Trakt"
+msgstr ""
+
+msgctxt "#32101"
+msgid "Retrieving watched episodes from Trakt"
+msgstr ""
+
+msgctxt "#32102"
+msgid "Parsing episode data %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32103"
+msgid "Retrieved episode data from Trakt"
+msgstr ""
+
+msgctxt "#32104"
+msgid "Trakt episode collection is up to date, no episodes to add"
+msgstr ""
+
+msgctxt "#32105"
+msgid "%i episode(s) were added to your Trakt collection"
+msgstr ""
+
+msgctxt "#32106"
+msgid "Trakt episode playcounts are up to date"
+msgstr ""
+
+msgctxt "#32107"
+msgid "Kodi episode playcounts are up to date"
+msgstr ""
+
+msgctxt "#32108"
+msgid "Updating %i of %i episode playcount(s) in Kodi"
+msgstr ""
+
+msgctxt "#32109"
+msgid "Playcounts updated for %i show(s) in Kodi"
+msgstr ""
+
+msgctxt "#32110"
+msgid "Trakt episode collection is clean, no episodes to remove"
+msgstr ""
+
+msgctxt "#32111"
+msgid "%i episode(s) are being removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32112"
+msgid "%i episode(s) were removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32113"
+msgid "Trakt - Marked as watched"
+msgstr ""
+
+msgctxt "#32114"
+msgid "Trakt - Failed marking as watched"
+msgstr ""
+
+msgctxt "#32115"
+msgid "%d episode(s) of '%s'"
+msgstr ""
+
+msgctxt "#32116"
+msgid "Enable debug mode"
+msgstr ""
+
+msgctxt "#32117"
+msgid "Sync movie playback progress to Kodi"
+msgstr ""
+
+msgctxt "#32118"
+msgid "Sync episode playback progress to Kodi"
+msgstr ""
+
+msgctxt "#32119"
+msgid "Retrieving episode playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32120"
+msgid "Parsing episode playback progress %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32121"
+msgid "Retrieved episode playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32122"
+msgid "Retrieving movie playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32123"
+msgid "Parsing movie playback progress %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32124"
+msgid "Retrieved movie playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32125"
+msgid "Kodi movie playback progress is up to date"
+msgstr ""
+
+msgctxt "#32126"
+msgid "%i movie(s) playback progress will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32127"
+msgid "Updating %i of %i movie(s) playback progress in Kodi"
+msgstr ""
+
+msgctxt "#32128"
+msgid "Playback progress updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32129"
+msgid "Kodi episode playback progress is up to date"
+msgstr ""
+
+msgctxt "#32130"
+msgid "Updating %i of %i episode(s) playback progress in Kodi"
+msgstr ""
+
+msgctxt "#32131"
+msgid "Playback progress updated for %i episode(s) in Kodi"
+msgstr ""
+
+msgctxt "#32132"
+msgid "Unrate this season"
+msgstr ""
+
+msgctxt "#32133"
+msgid "Manage Movie's Lists"
+msgstr ""
+
+msgctxt "#32134"
+msgid "Manage Show's Lists"
+msgstr ""
+
+msgctxt "#32135"
+msgid "Remove from Watchlist"
+msgstr ""
+
+msgctxt "#32136"
+msgid "Add to watchlist"
+msgstr ""
+
+msgctxt "#32137"
+msgid "Rate this movie"
+msgstr ""
+
+msgctxt "#32138"
+msgid "Rate this show"
+msgstr ""
+
+msgctxt "#32139"
+msgid "Rate this episode"
+msgstr ""
+
+msgctxt "#32140"
+msgid "Toggle watched"
+msgstr ""
+
+msgctxt "#32141"
+msgid "Manage all lists"
+msgstr ""
+
+msgctxt "#32142"
+msgid "Update all tags"
+msgstr ""
+
+msgctxt "#32143"
+msgid "Synchronize library"
+msgstr ""
+
+msgctxt "#32144"
+msgid "How do I authorize the trakt addon to access my trakt.tv account?"
+msgstr ""
+
+# empty strings from id 32145 to 32146
+msgctxt "#32147"
+msgid "Trakt.tv PIN Authorization Failed"
+msgstr ""
+
+# empty string with id 32148
+msgctxt "#32149"
+msgid "Rate this Season"
+msgstr ""
+
+msgctxt "#32150"
+msgid "You will be reminded in 24 hours"
+msgstr ""
+
+msgctxt "#32151"
+msgid "Use Addon Settings later if you change your mind"
+msgstr ""
+
+msgctxt "#32152"
+msgid "Trakt Authorization Complete"
+msgstr ""
+
+msgctxt "#32153"
+msgid "Trakt Account Authorization"
+msgstr ""
+
+msgctxt "#32154"
+msgid "Authorize"
+msgstr ""
+
+msgctxt "#32155"
+msgid "Remind Me Later"
+msgstr ""
+
+msgctxt "#32156"
+msgid "No Thanks"
+msgstr ""
+
+msgctxt "#32157"
+msgid "Account Authorization"
+msgstr ""
+
+# empty string with id 32158
+msgctxt "#32159"
+msgid "Visit {0} or scan the QR code."
+msgstr ""
+
+msgctxt "#32162"
+msgid "The trakt addon CAN NOT be used without authorizing it to access your trakt.tv account."
+msgstr ""
+
 msgctxt "#32163"
 msgid "User"
 msgstr "Lietotājs"
+
+msgctxt "#32164"
+msgid "Fallback to Title/Year matching if necessary"
+msgstr ""
+
+msgctxt "#32165"
+msgid "Trakt - Added to watchlist"
+msgstr ""
+
+msgctxt "#32166"
+msgid "Trakt - Failed adding to watchlist"
+msgstr ""
+
+msgctxt "#32167"
+msgid "Offset scrobble start by X minutes"
+msgstr ""
+
+msgctxt "#32168"
+msgid "Sync ratings"
+msgstr ""
+
+msgctxt "#32169"
+msgid "Kodi movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32170"
+msgid "%i movie(s) ratings will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32171"
+msgid "Updating %i of %i movie ratings in Kodi"
+msgstr ""
+
+msgctxt "#32172"
+msgid "Ratings updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32173"
+msgid "Kodi episode ratings are up to date"
+msgstr ""
+
+msgctxt "#32174"
+msgid "Updating %i of %i episode ratings in Kodi"
+msgstr ""
+
+msgctxt "#32175"
+msgid "Ratings updated for %i episode(s) in Kodi"
+msgstr ""
+
+msgctxt "#32176"
+msgid "Kodi show ratings are up to date"
+msgstr ""
+
+msgctxt "#32177"
+msgid "Updating %i of %i show ratings in Kodi"
+msgstr ""
+
+msgctxt "#32178"
+msgid "Ratings updated for %i show(s) in Kodi"
+msgstr ""
+
+msgctxt "#32179"
+msgid "Trakt movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32180"
+msgid "%i movie ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32181"
+msgid "Trakt show ratings are up to date"
+msgstr ""
+
+msgctxt "#32182"
+msgid "%i show ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32183"
+msgid "Attempt to scrobble MythTV PVR recordings"
+msgstr ""
+
+msgctxt "#32184"
+msgid "Attempt secondary show title search"
+msgstr ""
+
+msgctxt "#32185"
+msgid "Exclude Plugins"
+msgstr ""
+
+msgctxt "#32186"
+msgid "Allow script exclusions"
+msgstr ""

--- a/script.trakt/resources/language/resource.language.mi/strings.po
+++ b/script.trakt/resources/language/resource.language.mi/strings.po
@@ -1,0 +1,722 @@
+# Kodi Media Center language file
+# Addon Name: Trakt
+# Addon id: script.trakt
+# Addon Provider: Trakt.tv, Razze
+msgid ""
+msgstr ""
+"Project-Id-Version: XBMC Addons\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
+"POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: mi\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n > 1;\n"
+
+# General Settings
+msgctxt "#32000"
+msgid "General"
+msgstr ""
+
+# empty strings from id 32001 to 32002
+msgctxt "#32003"
+msgid "Startup Delay"
+msgstr ""
+
+msgctxt "#32004"
+msgid "Rating"
+msgstr ""
+
+msgctxt "#32005"
+msgid "Rate Movie after watching"
+msgstr ""
+
+msgctxt "#32006"
+msgid "Rate TV show Episode after watching"
+msgstr ""
+
+msgctxt "#32008"
+msgid "Minimum percent watched to display rating dialog"
+msgstr ""
+
+msgctxt "#32009"
+msgid "Allow re-rating of media"
+msgstr ""
+
+msgctxt "#32010"
+msgid "Default rating"
+msgstr ""
+
+# Scrobbling Settings
+msgctxt "#32011"
+msgid "Scrobbling"
+msgstr ""
+
+msgctxt "#32012"
+msgid "Scrobble movies"
+msgstr ""
+
+msgctxt "#32013"
+msgid "Scrobble TV show episodes"
+msgstr ""
+
+msgctxt "#32014"
+msgid "Show notification on scrobble"
+msgstr ""
+
+msgctxt "#32015"
+msgid "Trakt - Scrobbled successfully"
+msgstr ""
+
+msgctxt "#32016"
+msgid "Exclusions"
+msgstr ""
+
+msgctxt "#32017"
+msgid "Exclude Live TV"
+msgstr ""
+
+msgctxt "#32018"
+msgid "Exclude HTTP sources"
+msgstr ""
+
+msgctxt "#32019"
+msgid "Exclude path"
+msgstr ""
+
+msgctxt "#32020"
+msgid "Folder's path (including subfolders)"
+msgstr ""
+
+# empty strings from id 32021 to 32022
+msgctxt "#32023"
+msgid "Can not connect to Trakt"
+msgstr ""
+
+msgctxt "#32024"
+msgid "Error"
+msgstr ""
+
+# empty string with id 32025
+msgctxt "#32026"
+msgid "What Did You Think?"
+msgstr ""
+
+msgctxt "#32027"
+msgid "Totally Ninja!"
+msgstr ""
+
+msgctxt "#32028"
+msgid "Weak Sauce :("
+msgstr ""
+
+msgctxt "#32029"
+msgid "Terrible"
+msgstr ""
+
+msgctxt "#32030"
+msgid "Bad"
+msgstr ""
+
+msgctxt "#32031"
+msgid "Poor"
+msgstr ""
+
+msgctxt "#32032"
+msgid "Meh"
+msgstr ""
+
+msgctxt "#32033"
+msgid "Fair"
+msgstr ""
+
+msgctxt "#32034"
+msgid "Good"
+msgstr ""
+
+msgctxt "#32035"
+msgid "Great"
+msgstr ""
+
+msgctxt "#32036"
+msgid "Superb"
+msgstr ""
+
+msgctxt "#32037"
+msgid "Unrate this movie"
+msgstr ""
+
+msgctxt "#32038"
+msgid "Unrate this show"
+msgstr ""
+
+msgctxt "#32039"
+msgid "Unrate this episode"
+msgstr ""
+
+msgctxt "#32040"
+msgid "Trakt - Rating submitted successfully"
+msgstr ""
+
+msgctxt "#32041"
+msgid "Trakt - Already rated"
+msgstr ""
+
+msgctxt "#32042"
+msgid "Trakt - Unrated successfully"
+msgstr ""
+
+msgctxt "#32043"
+msgid "Trakt - Already has the same rating"
+msgstr ""
+
+msgctxt "#32044"
+msgid "Trakt - Problem submitting rating"
+msgstr ""
+
+msgctxt "#32045"
+msgid "Synchronize"
+msgstr ""
+
+msgctxt "#32046"
+msgid "Movies"
+msgstr ""
+
+msgctxt "#32047"
+msgid "Add new movies to Trakt collection"
+msgstr ""
+
+msgctxt "#32048"
+msgid "Add watched movies to Trakt history"
+msgstr ""
+
+msgctxt "#32049"
+msgid "Mark movies from Trakt history as watched in Kodi"
+msgstr ""
+
+msgctxt "#32050"
+msgid "TV Episodes"
+msgstr ""
+
+msgctxt "#32051"
+msgid "Add new TV episodes to Trakt collection"
+msgstr ""
+
+msgctxt "#32052"
+msgid "Add watched TV episodes to Trakt history"
+msgstr ""
+
+msgctxt "#32053"
+msgid "Mark TV episodes from Trakt history as watched in Kodi"
+msgstr ""
+
+msgctxt "#32054"
+msgid "Service"
+msgstr ""
+
+msgctxt "#32055"
+msgid "Sync collection on library update or cleaning"
+msgstr ""
+
+msgctxt "#32056"
+msgid "Show sync notifications"
+msgstr ""
+
+msgctxt "#32057"
+msgid "Remove deleted movies from Trakt collection"
+msgstr ""
+
+msgctxt "#32058"
+msgid "Remove deleted TV episodes from Trakt collection"
+msgstr ""
+
+# empty string with id 32059
+msgctxt "#32060"
+msgid "Hide notifications during playback"
+msgstr ""
+
+msgctxt "#32061"
+msgid "Sync started"
+msgstr ""
+
+msgctxt "#32062"
+msgid "Sync complete"
+msgstr ""
+
+msgctxt "#32063"
+msgid "%i movie(s) will be added to Trakt collection"
+msgstr ""
+
+msgctxt "#32064"
+msgid "%i movie playcount(s) will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32065"
+msgid "%i movie(s) playcount will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32066"
+msgid "Movie Sync Complete"
+msgstr ""
+
+msgctxt "#32067"
+msgid "Going to add %i show(s) to Trakt collection"
+msgstr ""
+
+msgctxt "#32068"
+msgid "Checking for episodes missing from Trakt collection"
+msgstr ""
+
+msgctxt "#32069"
+msgid "%i of %i show(s) have episodes added to Trakt collection"
+msgstr ""
+
+msgctxt "#32070"
+msgid "Going to update %i show(s) missing watched status"
+msgstr ""
+
+msgctxt "#32071"
+msgid "Checking watched episodes on Trakt"
+msgstr ""
+
+msgctxt "#32072"
+msgid "%i show(s) had missing watched status"
+msgstr ""
+
+msgctxt "#32073"
+msgid "%i episodes are being updated"
+msgstr ""
+
+msgctxt "#32074"
+msgid "Checking watched episodes on Kodi"
+msgstr ""
+
+msgctxt "#32075"
+msgid "Episode Sync Complete"
+msgstr ""
+
+msgctxt "#32076"
+msgid "%i movie(s) will be removed from Trakt collection"
+msgstr ""
+
+msgctxt "#32077"
+msgid "Cleaning Trakt TV show collection"
+msgstr ""
+
+msgctxt "#32078"
+msgid "episodes are being removed"
+msgstr ""
+
+msgctxt "#32079"
+msgid "Loading movies from Kodi"
+msgstr ""
+
+msgctxt "#32080"
+msgid "Movies loaded from Kodi"
+msgstr ""
+
+msgctxt "#32081"
+msgid "Retrieving movie collection from Trakt"
+msgstr ""
+
+msgctxt "#32082"
+msgid "Retrieving watched movies from Trakt"
+msgstr ""
+
+msgctxt "#32083"
+msgid "Retrieved movie data from Trakt"
+msgstr ""
+
+msgctxt "#32084"
+msgid "Trakt movie collection is up to date, no movies to add"
+msgstr ""
+
+msgctxt "#32085"
+msgid "%i movie(s) were added to your Trakt collection"
+msgstr ""
+
+msgctxt "#32086"
+msgid "Trakt movie playcounts are up to date"
+msgstr ""
+
+msgctxt "#32087"
+msgid "Playcounts updated for %i movie(s) on Trakt"
+msgstr ""
+
+msgctxt "#32088"
+msgid "Kodi movie playcounts are up to date"
+msgstr ""
+
+msgctxt "#32089"
+msgid "Updating %i of %i movie playcount(s) in Kodi"
+msgstr ""
+
+msgctxt "#32090"
+msgid "Playcounts updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32091"
+msgid "Trakt movie collection is up to date, no movies removed"
+msgstr ""
+
+msgctxt "#32092"
+msgid "%i movie(s) were removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32093"
+msgid "Updating %i of %i movie playcount(s) on Trakt"
+msgstr ""
+
+msgctxt "#32094"
+msgid "Loading episode data from Kodi"
+msgstr ""
+
+msgctxt "#32095"
+msgid "Loading shows from Kodi"
+msgstr ""
+
+msgctxt "#32096"
+msgid "Shows loaded from Kodi"
+msgstr ""
+
+msgctxt "#32097"
+msgid "Parsing %i of %i episode data from Kodi"
+msgstr ""
+
+msgctxt "#32098"
+msgid "Loaded episode data from Kodi"
+msgstr ""
+
+msgctxt "#32099"
+msgid "Loading episode data from Trakt"
+msgstr ""
+
+msgctxt "#32100"
+msgid "Retrieving episode collection from Trakt"
+msgstr ""
+
+msgctxt "#32101"
+msgid "Retrieving watched episodes from Trakt"
+msgstr ""
+
+msgctxt "#32102"
+msgid "Parsing episode data %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32103"
+msgid "Retrieved episode data from Trakt"
+msgstr ""
+
+msgctxt "#32104"
+msgid "Trakt episode collection is up to date, no episodes to add"
+msgstr ""
+
+msgctxt "#32105"
+msgid "%i episode(s) were added to your Trakt collection"
+msgstr ""
+
+msgctxt "#32106"
+msgid "Trakt episode playcounts are up to date"
+msgstr ""
+
+msgctxt "#32107"
+msgid "Kodi episode playcounts are up to date"
+msgstr ""
+
+msgctxt "#32108"
+msgid "Updating %i of %i episode playcount(s) in Kodi"
+msgstr ""
+
+msgctxt "#32109"
+msgid "Playcounts updated for %i show(s) in Kodi"
+msgstr ""
+
+msgctxt "#32110"
+msgid "Trakt episode collection is clean, no episodes to remove"
+msgstr ""
+
+msgctxt "#32111"
+msgid "%i episode(s) are being removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32112"
+msgid "%i episode(s) were removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32113"
+msgid "Trakt - Marked as watched"
+msgstr ""
+
+msgctxt "#32114"
+msgid "Trakt - Failed marking as watched"
+msgstr ""
+
+msgctxt "#32115"
+msgid "%d episode(s) of '%s'"
+msgstr ""
+
+msgctxt "#32116"
+msgid "Enable debug mode"
+msgstr ""
+
+msgctxt "#32117"
+msgid "Sync movie playback progress to Kodi"
+msgstr ""
+
+msgctxt "#32118"
+msgid "Sync episode playback progress to Kodi"
+msgstr ""
+
+msgctxt "#32119"
+msgid "Retrieving episode playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32120"
+msgid "Parsing episode playback progress %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32121"
+msgid "Retrieved episode playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32122"
+msgid "Retrieving movie playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32123"
+msgid "Parsing movie playback progress %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32124"
+msgid "Retrieved movie playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32125"
+msgid "Kodi movie playback progress is up to date"
+msgstr ""
+
+msgctxt "#32126"
+msgid "%i movie(s) playback progress will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32127"
+msgid "Updating %i of %i movie(s) playback progress in Kodi"
+msgstr ""
+
+msgctxt "#32128"
+msgid "Playback progress updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32129"
+msgid "Kodi episode playback progress is up to date"
+msgstr ""
+
+msgctxt "#32130"
+msgid "Updating %i of %i episode(s) playback progress in Kodi"
+msgstr ""
+
+msgctxt "#32131"
+msgid "Playback progress updated for %i episode(s) in Kodi"
+msgstr ""
+
+msgctxt "#32132"
+msgid "Unrate this season"
+msgstr ""
+
+msgctxt "#32133"
+msgid "Manage Movie's Lists"
+msgstr ""
+
+msgctxt "#32134"
+msgid "Manage Show's Lists"
+msgstr ""
+
+msgctxt "#32135"
+msgid "Remove from Watchlist"
+msgstr ""
+
+msgctxt "#32136"
+msgid "Add to watchlist"
+msgstr ""
+
+msgctxt "#32137"
+msgid "Rate this movie"
+msgstr ""
+
+msgctxt "#32138"
+msgid "Rate this show"
+msgstr ""
+
+msgctxt "#32139"
+msgid "Rate this episode"
+msgstr ""
+
+msgctxt "#32140"
+msgid "Toggle watched"
+msgstr ""
+
+msgctxt "#32141"
+msgid "Manage all lists"
+msgstr ""
+
+msgctxt "#32142"
+msgid "Update all tags"
+msgstr ""
+
+msgctxt "#32143"
+msgid "Synchronize library"
+msgstr ""
+
+msgctxt "#32144"
+msgid "How do I authorize the trakt addon to access my trakt.tv account?"
+msgstr ""
+
+# empty strings from id 32145 to 32146
+msgctxt "#32147"
+msgid "Trakt.tv PIN Authorization Failed"
+msgstr ""
+
+# empty string with id 32148
+msgctxt "#32149"
+msgid "Rate this Season"
+msgstr ""
+
+msgctxt "#32150"
+msgid "You will be reminded in 24 hours"
+msgstr ""
+
+msgctxt "#32151"
+msgid "Use Addon Settings later if you change your mind"
+msgstr ""
+
+msgctxt "#32152"
+msgid "Trakt Authorization Complete"
+msgstr ""
+
+msgctxt "#32153"
+msgid "Trakt Account Authorization"
+msgstr ""
+
+msgctxt "#32154"
+msgid "Authorize"
+msgstr ""
+
+msgctxt "#32155"
+msgid "Remind Me Later"
+msgstr ""
+
+msgctxt "#32156"
+msgid "No Thanks"
+msgstr ""
+
+msgctxt "#32157"
+msgid "Account Authorization"
+msgstr ""
+
+# empty string with id 32158
+msgctxt "#32159"
+msgid "Visit {0} or scan the QR code."
+msgstr ""
+
+msgctxt "#32162"
+msgid "The trakt addon CAN NOT be used without authorizing it to access your trakt.tv account."
+msgstr ""
+
+msgctxt "#32163"
+msgid "User"
+msgstr ""
+
+msgctxt "#32164"
+msgid "Fallback to Title/Year matching if necessary"
+msgstr ""
+
+msgctxt "#32165"
+msgid "Trakt - Added to watchlist"
+msgstr ""
+
+msgctxt "#32166"
+msgid "Trakt - Failed adding to watchlist"
+msgstr ""
+
+msgctxt "#32167"
+msgid "Offset scrobble start by X minutes"
+msgstr ""
+
+msgctxt "#32168"
+msgid "Sync ratings"
+msgstr ""
+
+msgctxt "#32169"
+msgid "Kodi movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32170"
+msgid "%i movie(s) ratings will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32171"
+msgid "Updating %i of %i movie ratings in Kodi"
+msgstr ""
+
+msgctxt "#32172"
+msgid "Ratings updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32173"
+msgid "Kodi episode ratings are up to date"
+msgstr ""
+
+msgctxt "#32174"
+msgid "Updating %i of %i episode ratings in Kodi"
+msgstr ""
+
+msgctxt "#32175"
+msgid "Ratings updated for %i episode(s) in Kodi"
+msgstr ""
+
+msgctxt "#32176"
+msgid "Kodi show ratings are up to date"
+msgstr ""
+
+msgctxt "#32177"
+msgid "Updating %i of %i show ratings in Kodi"
+msgstr ""
+
+msgctxt "#32178"
+msgid "Ratings updated for %i show(s) in Kodi"
+msgstr ""
+
+msgctxt "#32179"
+msgid "Trakt movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32180"
+msgid "%i movie ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32181"
+msgid "Trakt show ratings are up to date"
+msgstr ""
+
+msgctxt "#32182"
+msgid "%i show ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32183"
+msgid "Attempt to scrobble MythTV PVR recordings"
+msgstr ""
+
+msgctxt "#32184"
+msgid "Attempt secondary show title search"
+msgstr ""
+
+msgctxt "#32185"
+msgid "Exclude Plugins"
+msgstr ""
+
+msgctxt "#32186"
+msgid "Allow script exclusions"
+msgstr ""

--- a/script.trakt/resources/language/resource.language.mk_MK/strings.po
+++ b/script.trakt/resources/language/resource.language.mk_MK/strings.po
@@ -10,32 +10,712 @@ msgstr ""
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Kodi Translation Team\n"
 "Language-Team: Macedonian (http://www.transifex.com/projects/p/xbmc-addons/language/mk/)\n"
+"Language: mk\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: mk\n"
 "Plural-Forms: nplurals=2; plural=(n % 10 == 1 && n % 100 != 11) ? 0 : 1;\n"
 
 msgctxt "#32000"
 msgid "General"
 msgstr "Општо"
 
+# empty strings from id 32001 to 32002
+msgctxt "#32003"
+msgid "Startup Delay"
+msgstr ""
+
 msgctxt "#32004"
 msgid "Rating"
 msgstr "Оценка"
+
+msgctxt "#32005"
+msgid "Rate Movie after watching"
+msgstr ""
+
+msgctxt "#32006"
+msgid "Rate TV show Episode after watching"
+msgstr ""
+
+msgctxt "#32008"
+msgid "Minimum percent watched to display rating dialog"
+msgstr ""
+
+msgctxt "#32009"
+msgid "Allow re-rating of media"
+msgstr ""
+
+msgctxt "#32010"
+msgid "Default rating"
+msgstr ""
+
+# Scrobbling Settings
+msgctxt "#32011"
+msgid "Scrobbling"
+msgstr ""
+
+msgctxt "#32012"
+msgid "Scrobble movies"
+msgstr ""
+
+msgctxt "#32013"
+msgid "Scrobble TV show episodes"
+msgstr ""
+
+msgctxt "#32014"
+msgid "Show notification on scrobble"
+msgstr ""
+
+msgctxt "#32015"
+msgid "Trakt - Scrobbled successfully"
+msgstr ""
+
+msgctxt "#32016"
+msgid "Exclusions"
+msgstr ""
+
+msgctxt "#32017"
+msgid "Exclude Live TV"
+msgstr ""
+
+msgctxt "#32018"
+msgid "Exclude HTTP sources"
+msgstr ""
+
+msgctxt "#32019"
+msgid "Exclude path"
+msgstr ""
+
+msgctxt "#32020"
+msgid "Folder's path (including subfolders)"
+msgstr ""
+
+# empty strings from id 32021 to 32022
+msgctxt "#32023"
+msgid "Can not connect to Trakt"
+msgstr ""
 
 msgctxt "#32024"
 msgid "Error"
 msgstr "Грешка"
 
+# empty string with id 32025
+msgctxt "#32026"
+msgid "What Did You Think?"
+msgstr ""
+
+msgctxt "#32027"
+msgid "Totally Ninja!"
+msgstr ""
+
+msgctxt "#32028"
+msgid "Weak Sauce :("
+msgstr ""
+
+msgctxt "#32029"
+msgid "Terrible"
+msgstr ""
+
+msgctxt "#32030"
+msgid "Bad"
+msgstr ""
+
+msgctxt "#32031"
+msgid "Poor"
+msgstr ""
+
+msgctxt "#32032"
+msgid "Meh"
+msgstr ""
+
 msgctxt "#32033"
 msgid "Fair"
 msgstr "умерено"
+
+msgctxt "#32034"
+msgid "Good"
+msgstr ""
+
+msgctxt "#32035"
+msgid "Great"
+msgstr ""
+
+msgctxt "#32036"
+msgid "Superb"
+msgstr ""
+
+msgctxt "#32037"
+msgid "Unrate this movie"
+msgstr ""
+
+msgctxt "#32038"
+msgid "Unrate this show"
+msgstr ""
+
+msgctxt "#32039"
+msgid "Unrate this episode"
+msgstr ""
+
+msgctxt "#32040"
+msgid "Trakt - Rating submitted successfully"
+msgstr ""
+
+msgctxt "#32041"
+msgid "Trakt - Already rated"
+msgstr ""
+
+msgctxt "#32042"
+msgid "Trakt - Unrated successfully"
+msgstr ""
+
+msgctxt "#32043"
+msgid "Trakt - Already has the same rating"
+msgstr ""
+
+msgctxt "#32044"
+msgid "Trakt - Problem submitting rating"
+msgstr ""
+
+msgctxt "#32045"
+msgid "Synchronize"
+msgstr ""
 
 msgctxt "#32046"
 msgid "Movies"
 msgstr "Филмови"
 
+msgctxt "#32047"
+msgid "Add new movies to Trakt collection"
+msgstr ""
+
+msgctxt "#32048"
+msgid "Add watched movies to Trakt history"
+msgstr ""
+
+msgctxt "#32049"
+msgid "Mark movies from Trakt history as watched in Kodi"
+msgstr ""
+
+msgctxt "#32050"
+msgid "TV Episodes"
+msgstr ""
+
+msgctxt "#32051"
+msgid "Add new TV episodes to Trakt collection"
+msgstr ""
+
+msgctxt "#32052"
+msgid "Add watched TV episodes to Trakt history"
+msgstr ""
+
+msgctxt "#32053"
+msgid "Mark TV episodes from Trakt history as watched in Kodi"
+msgstr ""
+
 msgctxt "#32054"
 msgid "Service"
 msgstr "Сервис"
+
+msgctxt "#32055"
+msgid "Sync collection on library update or cleaning"
+msgstr ""
+
+msgctxt "#32056"
+msgid "Show sync notifications"
+msgstr ""
+
+msgctxt "#32057"
+msgid "Remove deleted movies from Trakt collection"
+msgstr ""
+
+msgctxt "#32058"
+msgid "Remove deleted TV episodes from Trakt collection"
+msgstr ""
+
+# empty string with id 32059
+msgctxt "#32060"
+msgid "Hide notifications during playback"
+msgstr ""
+
+msgctxt "#32061"
+msgid "Sync started"
+msgstr ""
+
+msgctxt "#32062"
+msgid "Sync complete"
+msgstr ""
+
+msgctxt "#32063"
+msgid "%i movie(s) will be added to Trakt collection"
+msgstr ""
+
+msgctxt "#32064"
+msgid "%i movie playcount(s) will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32065"
+msgid "%i movie(s) playcount will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32066"
+msgid "Movie Sync Complete"
+msgstr ""
+
+msgctxt "#32067"
+msgid "Going to add %i show(s) to Trakt collection"
+msgstr ""
+
+msgctxt "#32068"
+msgid "Checking for episodes missing from Trakt collection"
+msgstr ""
+
+msgctxt "#32069"
+msgid "%i of %i show(s) have episodes added to Trakt collection"
+msgstr ""
+
+msgctxt "#32070"
+msgid "Going to update %i show(s) missing watched status"
+msgstr ""
+
+msgctxt "#32071"
+msgid "Checking watched episodes on Trakt"
+msgstr ""
+
+msgctxt "#32072"
+msgid "%i show(s) had missing watched status"
+msgstr ""
+
+msgctxt "#32073"
+msgid "%i episodes are being updated"
+msgstr ""
+
+msgctxt "#32074"
+msgid "Checking watched episodes on Kodi"
+msgstr ""
+
+msgctxt "#32075"
+msgid "Episode Sync Complete"
+msgstr ""
+
+msgctxt "#32076"
+msgid "%i movie(s) will be removed from Trakt collection"
+msgstr ""
+
+msgctxt "#32077"
+msgid "Cleaning Trakt TV show collection"
+msgstr ""
+
+msgctxt "#32078"
+msgid "episodes are being removed"
+msgstr ""
+
+msgctxt "#32079"
+msgid "Loading movies from Kodi"
+msgstr ""
+
+msgctxt "#32080"
+msgid "Movies loaded from Kodi"
+msgstr ""
+
+msgctxt "#32081"
+msgid "Retrieving movie collection from Trakt"
+msgstr ""
+
+msgctxt "#32082"
+msgid "Retrieving watched movies from Trakt"
+msgstr ""
+
+msgctxt "#32083"
+msgid "Retrieved movie data from Trakt"
+msgstr ""
+
+msgctxt "#32084"
+msgid "Trakt movie collection is up to date, no movies to add"
+msgstr ""
+
+msgctxt "#32085"
+msgid "%i movie(s) were added to your Trakt collection"
+msgstr ""
+
+msgctxt "#32086"
+msgid "Trakt movie playcounts are up to date"
+msgstr ""
+
+msgctxt "#32087"
+msgid "Playcounts updated for %i movie(s) on Trakt"
+msgstr ""
+
+msgctxt "#32088"
+msgid "Kodi movie playcounts are up to date"
+msgstr ""
+
+msgctxt "#32089"
+msgid "Updating %i of %i movie playcount(s) in Kodi"
+msgstr ""
+
+msgctxt "#32090"
+msgid "Playcounts updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32091"
+msgid "Trakt movie collection is up to date, no movies removed"
+msgstr ""
+
+msgctxt "#32092"
+msgid "%i movie(s) were removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32093"
+msgid "Updating %i of %i movie playcount(s) on Trakt"
+msgstr ""
+
+msgctxt "#32094"
+msgid "Loading episode data from Kodi"
+msgstr ""
+
+msgctxt "#32095"
+msgid "Loading shows from Kodi"
+msgstr ""
+
+msgctxt "#32096"
+msgid "Shows loaded from Kodi"
+msgstr ""
+
+msgctxt "#32097"
+msgid "Parsing %i of %i episode data from Kodi"
+msgstr ""
+
+msgctxt "#32098"
+msgid "Loaded episode data from Kodi"
+msgstr ""
+
+msgctxt "#32099"
+msgid "Loading episode data from Trakt"
+msgstr ""
+
+msgctxt "#32100"
+msgid "Retrieving episode collection from Trakt"
+msgstr ""
+
+msgctxt "#32101"
+msgid "Retrieving watched episodes from Trakt"
+msgstr ""
+
+msgctxt "#32102"
+msgid "Parsing episode data %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32103"
+msgid "Retrieved episode data from Trakt"
+msgstr ""
+
+msgctxt "#32104"
+msgid "Trakt episode collection is up to date, no episodes to add"
+msgstr ""
+
+msgctxt "#32105"
+msgid "%i episode(s) were added to your Trakt collection"
+msgstr ""
+
+msgctxt "#32106"
+msgid "Trakt episode playcounts are up to date"
+msgstr ""
+
+msgctxt "#32107"
+msgid "Kodi episode playcounts are up to date"
+msgstr ""
+
+msgctxt "#32108"
+msgid "Updating %i of %i episode playcount(s) in Kodi"
+msgstr ""
+
+msgctxt "#32109"
+msgid "Playcounts updated for %i show(s) in Kodi"
+msgstr ""
+
+msgctxt "#32110"
+msgid "Trakt episode collection is clean, no episodes to remove"
+msgstr ""
+
+msgctxt "#32111"
+msgid "%i episode(s) are being removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32112"
+msgid "%i episode(s) were removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32113"
+msgid "Trakt - Marked as watched"
+msgstr ""
+
+msgctxt "#32114"
+msgid "Trakt - Failed marking as watched"
+msgstr ""
+
+msgctxt "#32115"
+msgid "%d episode(s) of '%s'"
+msgstr ""
+
+msgctxt "#32116"
+msgid "Enable debug mode"
+msgstr ""
+
+msgctxt "#32117"
+msgid "Sync movie playback progress to Kodi"
+msgstr ""
+
+msgctxt "#32118"
+msgid "Sync episode playback progress to Kodi"
+msgstr ""
+
+msgctxt "#32119"
+msgid "Retrieving episode playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32120"
+msgid "Parsing episode playback progress %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32121"
+msgid "Retrieved episode playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32122"
+msgid "Retrieving movie playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32123"
+msgid "Parsing movie playback progress %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32124"
+msgid "Retrieved movie playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32125"
+msgid "Kodi movie playback progress is up to date"
+msgstr ""
+
+msgctxt "#32126"
+msgid "%i movie(s) playback progress will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32127"
+msgid "Updating %i of %i movie(s) playback progress in Kodi"
+msgstr ""
+
+msgctxt "#32128"
+msgid "Playback progress updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32129"
+msgid "Kodi episode playback progress is up to date"
+msgstr ""
+
+msgctxt "#32130"
+msgid "Updating %i of %i episode(s) playback progress in Kodi"
+msgstr ""
+
+msgctxt "#32131"
+msgid "Playback progress updated for %i episode(s) in Kodi"
+msgstr ""
+
+msgctxt "#32132"
+msgid "Unrate this season"
+msgstr ""
+
+msgctxt "#32133"
+msgid "Manage Movie's Lists"
+msgstr ""
+
+msgctxt "#32134"
+msgid "Manage Show's Lists"
+msgstr ""
+
+msgctxt "#32135"
+msgid "Remove from Watchlist"
+msgstr ""
+
+msgctxt "#32136"
+msgid "Add to watchlist"
+msgstr ""
+
+msgctxt "#32137"
+msgid "Rate this movie"
+msgstr ""
+
+msgctxt "#32138"
+msgid "Rate this show"
+msgstr ""
+
+msgctxt "#32139"
+msgid "Rate this episode"
+msgstr ""
+
+msgctxt "#32140"
+msgid "Toggle watched"
+msgstr ""
+
+msgctxt "#32141"
+msgid "Manage all lists"
+msgstr ""
+
+msgctxt "#32142"
+msgid "Update all tags"
+msgstr ""
+
+msgctxt "#32143"
+msgid "Synchronize library"
+msgstr ""
+
+msgctxt "#32144"
+msgid "How do I authorize the trakt addon to access my trakt.tv account?"
+msgstr ""
+
+# empty strings from id 32145 to 32146
+msgctxt "#32147"
+msgid "Trakt.tv PIN Authorization Failed"
+msgstr ""
+
+# empty string with id 32148
+msgctxt "#32149"
+msgid "Rate this Season"
+msgstr ""
+
+msgctxt "#32150"
+msgid "You will be reminded in 24 hours"
+msgstr ""
+
+msgctxt "#32151"
+msgid "Use Addon Settings later if you change your mind"
+msgstr ""
+
+msgctxt "#32152"
+msgid "Trakt Authorization Complete"
+msgstr ""
+
+msgctxt "#32153"
+msgid "Trakt Account Authorization"
+msgstr ""
+
+msgctxt "#32154"
+msgid "Authorize"
+msgstr ""
+
+msgctxt "#32155"
+msgid "Remind Me Later"
+msgstr ""
+
+msgctxt "#32156"
+msgid "No Thanks"
+msgstr ""
+
+msgctxt "#32157"
+msgid "Account Authorization"
+msgstr ""
+
+# empty string with id 32158
+msgctxt "#32159"
+msgid "Visit {0} or scan the QR code."
+msgstr ""
+
+msgctxt "#32162"
+msgid "The trakt addon CAN NOT be used without authorizing it to access your trakt.tv account."
+msgstr ""
+
+msgctxt "#32163"
+msgid "User"
+msgstr ""
+
+msgctxt "#32164"
+msgid "Fallback to Title/Year matching if necessary"
+msgstr ""
+
+msgctxt "#32165"
+msgid "Trakt - Added to watchlist"
+msgstr ""
+
+msgctxt "#32166"
+msgid "Trakt - Failed adding to watchlist"
+msgstr ""
+
+msgctxt "#32167"
+msgid "Offset scrobble start by X minutes"
+msgstr ""
+
+msgctxt "#32168"
+msgid "Sync ratings"
+msgstr ""
+
+msgctxt "#32169"
+msgid "Kodi movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32170"
+msgid "%i movie(s) ratings will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32171"
+msgid "Updating %i of %i movie ratings in Kodi"
+msgstr ""
+
+msgctxt "#32172"
+msgid "Ratings updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32173"
+msgid "Kodi episode ratings are up to date"
+msgstr ""
+
+msgctxt "#32174"
+msgid "Updating %i of %i episode ratings in Kodi"
+msgstr ""
+
+msgctxt "#32175"
+msgid "Ratings updated for %i episode(s) in Kodi"
+msgstr ""
+
+msgctxt "#32176"
+msgid "Kodi show ratings are up to date"
+msgstr ""
+
+msgctxt "#32177"
+msgid "Updating %i of %i show ratings in Kodi"
+msgstr ""
+
+msgctxt "#32178"
+msgid "Ratings updated for %i show(s) in Kodi"
+msgstr ""
+
+msgctxt "#32179"
+msgid "Trakt movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32180"
+msgid "%i movie ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32181"
+msgid "Trakt show ratings are up to date"
+msgstr ""
+
+msgctxt "#32182"
+msgid "%i show ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32183"
+msgid "Attempt to scrobble MythTV PVR recordings"
+msgstr ""
+
+msgctxt "#32184"
+msgid "Attempt secondary show title search"
+msgstr ""
+
+msgctxt "#32185"
+msgid "Exclude Plugins"
+msgstr ""
+
+msgctxt "#32186"
+msgid "Allow script exclusions"
+msgstr ""

--- a/script.trakt/resources/language/resource.language.ml_IN/strings.po
+++ b/script.trakt/resources/language/resource.language.ml_IN/strings.po
@@ -10,12 +10,712 @@ msgstr ""
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Kodi Translation Team\n"
 "Language-Team: Malayalam (http://www.transifex.com/projects/p/xbmc-addons/language/ml/)\n"
+"Language: ml\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: ml\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 msgctxt "#32000"
 msgid "General"
 msgstr "പോതുവായത്"
+
+# empty strings from id 32001 to 32002
+msgctxt "#32003"
+msgid "Startup Delay"
+msgstr ""
+
+msgctxt "#32004"
+msgid "Rating"
+msgstr ""
+
+msgctxt "#32005"
+msgid "Rate Movie after watching"
+msgstr ""
+
+msgctxt "#32006"
+msgid "Rate TV show Episode after watching"
+msgstr ""
+
+msgctxt "#32008"
+msgid "Minimum percent watched to display rating dialog"
+msgstr ""
+
+msgctxt "#32009"
+msgid "Allow re-rating of media"
+msgstr ""
+
+msgctxt "#32010"
+msgid "Default rating"
+msgstr ""
+
+# Scrobbling Settings
+msgctxt "#32011"
+msgid "Scrobbling"
+msgstr ""
+
+msgctxt "#32012"
+msgid "Scrobble movies"
+msgstr ""
+
+msgctxt "#32013"
+msgid "Scrobble TV show episodes"
+msgstr ""
+
+msgctxt "#32014"
+msgid "Show notification on scrobble"
+msgstr ""
+
+msgctxt "#32015"
+msgid "Trakt - Scrobbled successfully"
+msgstr ""
+
+msgctxt "#32016"
+msgid "Exclusions"
+msgstr ""
+
+msgctxt "#32017"
+msgid "Exclude Live TV"
+msgstr ""
+
+msgctxt "#32018"
+msgid "Exclude HTTP sources"
+msgstr ""
+
+msgctxt "#32019"
+msgid "Exclude path"
+msgstr ""
+
+msgctxt "#32020"
+msgid "Folder's path (including subfolders)"
+msgstr ""
+
+# empty strings from id 32021 to 32022
+msgctxt "#32023"
+msgid "Can not connect to Trakt"
+msgstr ""
+
+msgctxt "#32024"
+msgid "Error"
+msgstr ""
+
+# empty string with id 32025
+msgctxt "#32026"
+msgid "What Did You Think?"
+msgstr ""
+
+msgctxt "#32027"
+msgid "Totally Ninja!"
+msgstr ""
+
+msgctxt "#32028"
+msgid "Weak Sauce :("
+msgstr ""
+
+msgctxt "#32029"
+msgid "Terrible"
+msgstr ""
+
+msgctxt "#32030"
+msgid "Bad"
+msgstr ""
+
+msgctxt "#32031"
+msgid "Poor"
+msgstr ""
+
+msgctxt "#32032"
+msgid "Meh"
+msgstr ""
+
+msgctxt "#32033"
+msgid "Fair"
+msgstr ""
+
+msgctxt "#32034"
+msgid "Good"
+msgstr ""
+
+msgctxt "#32035"
+msgid "Great"
+msgstr ""
+
+msgctxt "#32036"
+msgid "Superb"
+msgstr ""
+
+msgctxt "#32037"
+msgid "Unrate this movie"
+msgstr ""
+
+msgctxt "#32038"
+msgid "Unrate this show"
+msgstr ""
+
+msgctxt "#32039"
+msgid "Unrate this episode"
+msgstr ""
+
+msgctxt "#32040"
+msgid "Trakt - Rating submitted successfully"
+msgstr ""
+
+msgctxt "#32041"
+msgid "Trakt - Already rated"
+msgstr ""
+
+msgctxt "#32042"
+msgid "Trakt - Unrated successfully"
+msgstr ""
+
+msgctxt "#32043"
+msgid "Trakt - Already has the same rating"
+msgstr ""
+
+msgctxt "#32044"
+msgid "Trakt - Problem submitting rating"
+msgstr ""
+
+msgctxt "#32045"
+msgid "Synchronize"
+msgstr ""
+
+msgctxt "#32046"
+msgid "Movies"
+msgstr ""
+
+msgctxt "#32047"
+msgid "Add new movies to Trakt collection"
+msgstr ""
+
+msgctxt "#32048"
+msgid "Add watched movies to Trakt history"
+msgstr ""
+
+msgctxt "#32049"
+msgid "Mark movies from Trakt history as watched in Kodi"
+msgstr ""
+
+msgctxt "#32050"
+msgid "TV Episodes"
+msgstr ""
+
+msgctxt "#32051"
+msgid "Add new TV episodes to Trakt collection"
+msgstr ""
+
+msgctxt "#32052"
+msgid "Add watched TV episodes to Trakt history"
+msgstr ""
+
+msgctxt "#32053"
+msgid "Mark TV episodes from Trakt history as watched in Kodi"
+msgstr ""
+
+msgctxt "#32054"
+msgid "Service"
+msgstr ""
+
+msgctxt "#32055"
+msgid "Sync collection on library update or cleaning"
+msgstr ""
+
+msgctxt "#32056"
+msgid "Show sync notifications"
+msgstr ""
+
+msgctxt "#32057"
+msgid "Remove deleted movies from Trakt collection"
+msgstr ""
+
+msgctxt "#32058"
+msgid "Remove deleted TV episodes from Trakt collection"
+msgstr ""
+
+# empty string with id 32059
+msgctxt "#32060"
+msgid "Hide notifications during playback"
+msgstr ""
+
+msgctxt "#32061"
+msgid "Sync started"
+msgstr ""
+
+msgctxt "#32062"
+msgid "Sync complete"
+msgstr ""
+
+msgctxt "#32063"
+msgid "%i movie(s) will be added to Trakt collection"
+msgstr ""
+
+msgctxt "#32064"
+msgid "%i movie playcount(s) will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32065"
+msgid "%i movie(s) playcount will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32066"
+msgid "Movie Sync Complete"
+msgstr ""
+
+msgctxt "#32067"
+msgid "Going to add %i show(s) to Trakt collection"
+msgstr ""
+
+msgctxt "#32068"
+msgid "Checking for episodes missing from Trakt collection"
+msgstr ""
+
+msgctxt "#32069"
+msgid "%i of %i show(s) have episodes added to Trakt collection"
+msgstr ""
+
+msgctxt "#32070"
+msgid "Going to update %i show(s) missing watched status"
+msgstr ""
+
+msgctxt "#32071"
+msgid "Checking watched episodes on Trakt"
+msgstr ""
+
+msgctxt "#32072"
+msgid "%i show(s) had missing watched status"
+msgstr ""
+
+msgctxt "#32073"
+msgid "%i episodes are being updated"
+msgstr ""
+
+msgctxt "#32074"
+msgid "Checking watched episodes on Kodi"
+msgstr ""
+
+msgctxt "#32075"
+msgid "Episode Sync Complete"
+msgstr ""
+
+msgctxt "#32076"
+msgid "%i movie(s) will be removed from Trakt collection"
+msgstr ""
+
+msgctxt "#32077"
+msgid "Cleaning Trakt TV show collection"
+msgstr ""
+
+msgctxt "#32078"
+msgid "episodes are being removed"
+msgstr ""
+
+msgctxt "#32079"
+msgid "Loading movies from Kodi"
+msgstr ""
+
+msgctxt "#32080"
+msgid "Movies loaded from Kodi"
+msgstr ""
+
+msgctxt "#32081"
+msgid "Retrieving movie collection from Trakt"
+msgstr ""
+
+msgctxt "#32082"
+msgid "Retrieving watched movies from Trakt"
+msgstr ""
+
+msgctxt "#32083"
+msgid "Retrieved movie data from Trakt"
+msgstr ""
+
+msgctxt "#32084"
+msgid "Trakt movie collection is up to date, no movies to add"
+msgstr ""
+
+msgctxt "#32085"
+msgid "%i movie(s) were added to your Trakt collection"
+msgstr ""
+
+msgctxt "#32086"
+msgid "Trakt movie playcounts are up to date"
+msgstr ""
+
+msgctxt "#32087"
+msgid "Playcounts updated for %i movie(s) on Trakt"
+msgstr ""
+
+msgctxt "#32088"
+msgid "Kodi movie playcounts are up to date"
+msgstr ""
+
+msgctxt "#32089"
+msgid "Updating %i of %i movie playcount(s) in Kodi"
+msgstr ""
+
+msgctxt "#32090"
+msgid "Playcounts updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32091"
+msgid "Trakt movie collection is up to date, no movies removed"
+msgstr ""
+
+msgctxt "#32092"
+msgid "%i movie(s) were removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32093"
+msgid "Updating %i of %i movie playcount(s) on Trakt"
+msgstr ""
+
+msgctxt "#32094"
+msgid "Loading episode data from Kodi"
+msgstr ""
+
+msgctxt "#32095"
+msgid "Loading shows from Kodi"
+msgstr ""
+
+msgctxt "#32096"
+msgid "Shows loaded from Kodi"
+msgstr ""
+
+msgctxt "#32097"
+msgid "Parsing %i of %i episode data from Kodi"
+msgstr ""
+
+msgctxt "#32098"
+msgid "Loaded episode data from Kodi"
+msgstr ""
+
+msgctxt "#32099"
+msgid "Loading episode data from Trakt"
+msgstr ""
+
+msgctxt "#32100"
+msgid "Retrieving episode collection from Trakt"
+msgstr ""
+
+msgctxt "#32101"
+msgid "Retrieving watched episodes from Trakt"
+msgstr ""
+
+msgctxt "#32102"
+msgid "Parsing episode data %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32103"
+msgid "Retrieved episode data from Trakt"
+msgstr ""
+
+msgctxt "#32104"
+msgid "Trakt episode collection is up to date, no episodes to add"
+msgstr ""
+
+msgctxt "#32105"
+msgid "%i episode(s) were added to your Trakt collection"
+msgstr ""
+
+msgctxt "#32106"
+msgid "Trakt episode playcounts are up to date"
+msgstr ""
+
+msgctxt "#32107"
+msgid "Kodi episode playcounts are up to date"
+msgstr ""
+
+msgctxt "#32108"
+msgid "Updating %i of %i episode playcount(s) in Kodi"
+msgstr ""
+
+msgctxt "#32109"
+msgid "Playcounts updated for %i show(s) in Kodi"
+msgstr ""
+
+msgctxt "#32110"
+msgid "Trakt episode collection is clean, no episodes to remove"
+msgstr ""
+
+msgctxt "#32111"
+msgid "%i episode(s) are being removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32112"
+msgid "%i episode(s) were removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32113"
+msgid "Trakt - Marked as watched"
+msgstr ""
+
+msgctxt "#32114"
+msgid "Trakt - Failed marking as watched"
+msgstr ""
+
+msgctxt "#32115"
+msgid "%d episode(s) of '%s'"
+msgstr ""
+
+msgctxt "#32116"
+msgid "Enable debug mode"
+msgstr ""
+
+msgctxt "#32117"
+msgid "Sync movie playback progress to Kodi"
+msgstr ""
+
+msgctxt "#32118"
+msgid "Sync episode playback progress to Kodi"
+msgstr ""
+
+msgctxt "#32119"
+msgid "Retrieving episode playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32120"
+msgid "Parsing episode playback progress %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32121"
+msgid "Retrieved episode playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32122"
+msgid "Retrieving movie playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32123"
+msgid "Parsing movie playback progress %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32124"
+msgid "Retrieved movie playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32125"
+msgid "Kodi movie playback progress is up to date"
+msgstr ""
+
+msgctxt "#32126"
+msgid "%i movie(s) playback progress will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32127"
+msgid "Updating %i of %i movie(s) playback progress in Kodi"
+msgstr ""
+
+msgctxt "#32128"
+msgid "Playback progress updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32129"
+msgid "Kodi episode playback progress is up to date"
+msgstr ""
+
+msgctxt "#32130"
+msgid "Updating %i of %i episode(s) playback progress in Kodi"
+msgstr ""
+
+msgctxt "#32131"
+msgid "Playback progress updated for %i episode(s) in Kodi"
+msgstr ""
+
+msgctxt "#32132"
+msgid "Unrate this season"
+msgstr ""
+
+msgctxt "#32133"
+msgid "Manage Movie's Lists"
+msgstr ""
+
+msgctxt "#32134"
+msgid "Manage Show's Lists"
+msgstr ""
+
+msgctxt "#32135"
+msgid "Remove from Watchlist"
+msgstr ""
+
+msgctxt "#32136"
+msgid "Add to watchlist"
+msgstr ""
+
+msgctxt "#32137"
+msgid "Rate this movie"
+msgstr ""
+
+msgctxt "#32138"
+msgid "Rate this show"
+msgstr ""
+
+msgctxt "#32139"
+msgid "Rate this episode"
+msgstr ""
+
+msgctxt "#32140"
+msgid "Toggle watched"
+msgstr ""
+
+msgctxt "#32141"
+msgid "Manage all lists"
+msgstr ""
+
+msgctxt "#32142"
+msgid "Update all tags"
+msgstr ""
+
+msgctxt "#32143"
+msgid "Synchronize library"
+msgstr ""
+
+msgctxt "#32144"
+msgid "How do I authorize the trakt addon to access my trakt.tv account?"
+msgstr ""
+
+# empty strings from id 32145 to 32146
+msgctxt "#32147"
+msgid "Trakt.tv PIN Authorization Failed"
+msgstr ""
+
+# empty string with id 32148
+msgctxt "#32149"
+msgid "Rate this Season"
+msgstr ""
+
+msgctxt "#32150"
+msgid "You will be reminded in 24 hours"
+msgstr ""
+
+msgctxt "#32151"
+msgid "Use Addon Settings later if you change your mind"
+msgstr ""
+
+msgctxt "#32152"
+msgid "Trakt Authorization Complete"
+msgstr ""
+
+msgctxt "#32153"
+msgid "Trakt Account Authorization"
+msgstr ""
+
+msgctxt "#32154"
+msgid "Authorize"
+msgstr ""
+
+msgctxt "#32155"
+msgid "Remind Me Later"
+msgstr ""
+
+msgctxt "#32156"
+msgid "No Thanks"
+msgstr ""
+
+msgctxt "#32157"
+msgid "Account Authorization"
+msgstr ""
+
+# empty string with id 32158
+msgctxt "#32159"
+msgid "Visit {0} or scan the QR code."
+msgstr ""
+
+msgctxt "#32162"
+msgid "The trakt addon CAN NOT be used without authorizing it to access your trakt.tv account."
+msgstr ""
+
+msgctxt "#32163"
+msgid "User"
+msgstr ""
+
+msgctxt "#32164"
+msgid "Fallback to Title/Year matching if necessary"
+msgstr ""
+
+msgctxt "#32165"
+msgid "Trakt - Added to watchlist"
+msgstr ""
+
+msgctxt "#32166"
+msgid "Trakt - Failed adding to watchlist"
+msgstr ""
+
+msgctxt "#32167"
+msgid "Offset scrobble start by X minutes"
+msgstr ""
+
+msgctxt "#32168"
+msgid "Sync ratings"
+msgstr ""
+
+msgctxt "#32169"
+msgid "Kodi movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32170"
+msgid "%i movie(s) ratings will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32171"
+msgid "Updating %i of %i movie ratings in Kodi"
+msgstr ""
+
+msgctxt "#32172"
+msgid "Ratings updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32173"
+msgid "Kodi episode ratings are up to date"
+msgstr ""
+
+msgctxt "#32174"
+msgid "Updating %i of %i episode ratings in Kodi"
+msgstr ""
+
+msgctxt "#32175"
+msgid "Ratings updated for %i episode(s) in Kodi"
+msgstr ""
+
+msgctxt "#32176"
+msgid "Kodi show ratings are up to date"
+msgstr ""
+
+msgctxt "#32177"
+msgid "Updating %i of %i show ratings in Kodi"
+msgstr ""
+
+msgctxt "#32178"
+msgid "Ratings updated for %i show(s) in Kodi"
+msgstr ""
+
+msgctxt "#32179"
+msgid "Trakt movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32180"
+msgid "%i movie ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32181"
+msgid "Trakt show ratings are up to date"
+msgstr ""
+
+msgctxt "#32182"
+msgid "%i show ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32183"
+msgid "Attempt to scrobble MythTV PVR recordings"
+msgstr ""
+
+msgctxt "#32184"
+msgid "Attempt secondary show title search"
+msgstr ""
+
+msgctxt "#32185"
+msgid "Exclude Plugins"
+msgstr ""
+
+msgctxt "#32186"
+msgid "Allow script exclusions"
+msgstr ""

--- a/script.trakt/resources/language/resource.language.mn_MN/strings.po
+++ b/script.trakt/resources/language/resource.language.mn_MN/strings.po
@@ -10,16 +10,712 @@ msgstr ""
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Kodi Translation Team\n"
 "Language-Team: Mongolian (Mongolia) (http://www.transifex.com/projects/p/xbmc-addons/language/mn_MN/)\n"
+"Language: mn_MN\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: mn_MN\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 msgctxt "#32000"
 msgid "General"
 msgstr "Ерөнхий"
 
+# empty strings from id 32001 to 32002
+msgctxt "#32003"
+msgid "Startup Delay"
+msgstr ""
+
+msgctxt "#32004"
+msgid "Rating"
+msgstr ""
+
+msgctxt "#32005"
+msgid "Rate Movie after watching"
+msgstr ""
+
+msgctxt "#32006"
+msgid "Rate TV show Episode after watching"
+msgstr ""
+
+msgctxt "#32008"
+msgid "Minimum percent watched to display rating dialog"
+msgstr ""
+
+msgctxt "#32009"
+msgid "Allow re-rating of media"
+msgstr ""
+
+msgctxt "#32010"
+msgid "Default rating"
+msgstr ""
+
+# Scrobbling Settings
+msgctxt "#32011"
+msgid "Scrobbling"
+msgstr ""
+
+msgctxt "#32012"
+msgid "Scrobble movies"
+msgstr ""
+
+msgctxt "#32013"
+msgid "Scrobble TV show episodes"
+msgstr ""
+
+msgctxt "#32014"
+msgid "Show notification on scrobble"
+msgstr ""
+
+msgctxt "#32015"
+msgid "Trakt - Scrobbled successfully"
+msgstr ""
+
+msgctxt "#32016"
+msgid "Exclusions"
+msgstr ""
+
+msgctxt "#32017"
+msgid "Exclude Live TV"
+msgstr ""
+
+msgctxt "#32018"
+msgid "Exclude HTTP sources"
+msgstr ""
+
+msgctxt "#32019"
+msgid "Exclude path"
+msgstr ""
+
+msgctxt "#32020"
+msgid "Folder's path (including subfolders)"
+msgstr ""
+
+# empty strings from id 32021 to 32022
+msgctxt "#32023"
+msgid "Can not connect to Trakt"
+msgstr ""
+
 msgctxt "#32024"
 msgid "Error"
 msgstr "Алдаа"
+
+# empty string with id 32025
+msgctxt "#32026"
+msgid "What Did You Think?"
+msgstr ""
+
+msgctxt "#32027"
+msgid "Totally Ninja!"
+msgstr ""
+
+msgctxt "#32028"
+msgid "Weak Sauce :("
+msgstr ""
+
+msgctxt "#32029"
+msgid "Terrible"
+msgstr ""
+
+msgctxt "#32030"
+msgid "Bad"
+msgstr ""
+
+msgctxt "#32031"
+msgid "Poor"
+msgstr ""
+
+msgctxt "#32032"
+msgid "Meh"
+msgstr ""
+
+msgctxt "#32033"
+msgid "Fair"
+msgstr ""
+
+msgctxt "#32034"
+msgid "Good"
+msgstr ""
+
+msgctxt "#32035"
+msgid "Great"
+msgstr ""
+
+msgctxt "#32036"
+msgid "Superb"
+msgstr ""
+
+msgctxt "#32037"
+msgid "Unrate this movie"
+msgstr ""
+
+msgctxt "#32038"
+msgid "Unrate this show"
+msgstr ""
+
+msgctxt "#32039"
+msgid "Unrate this episode"
+msgstr ""
+
+msgctxt "#32040"
+msgid "Trakt - Rating submitted successfully"
+msgstr ""
+
+msgctxt "#32041"
+msgid "Trakt - Already rated"
+msgstr ""
+
+msgctxt "#32042"
+msgid "Trakt - Unrated successfully"
+msgstr ""
+
+msgctxt "#32043"
+msgid "Trakt - Already has the same rating"
+msgstr ""
+
+msgctxt "#32044"
+msgid "Trakt - Problem submitting rating"
+msgstr ""
+
+msgctxt "#32045"
+msgid "Synchronize"
+msgstr ""
+
+msgctxt "#32046"
+msgid "Movies"
+msgstr ""
+
+msgctxt "#32047"
+msgid "Add new movies to Trakt collection"
+msgstr ""
+
+msgctxt "#32048"
+msgid "Add watched movies to Trakt history"
+msgstr ""
+
+msgctxt "#32049"
+msgid "Mark movies from Trakt history as watched in Kodi"
+msgstr ""
+
+msgctxt "#32050"
+msgid "TV Episodes"
+msgstr ""
+
+msgctxt "#32051"
+msgid "Add new TV episodes to Trakt collection"
+msgstr ""
+
+msgctxt "#32052"
+msgid "Add watched TV episodes to Trakt history"
+msgstr ""
+
+msgctxt "#32053"
+msgid "Mark TV episodes from Trakt history as watched in Kodi"
+msgstr ""
+
+msgctxt "#32054"
+msgid "Service"
+msgstr ""
+
+msgctxt "#32055"
+msgid "Sync collection on library update or cleaning"
+msgstr ""
+
+msgctxt "#32056"
+msgid "Show sync notifications"
+msgstr ""
+
+msgctxt "#32057"
+msgid "Remove deleted movies from Trakt collection"
+msgstr ""
+
+msgctxt "#32058"
+msgid "Remove deleted TV episodes from Trakt collection"
+msgstr ""
+
+# empty string with id 32059
+msgctxt "#32060"
+msgid "Hide notifications during playback"
+msgstr ""
+
+msgctxt "#32061"
+msgid "Sync started"
+msgstr ""
+
+msgctxt "#32062"
+msgid "Sync complete"
+msgstr ""
+
+msgctxt "#32063"
+msgid "%i movie(s) will be added to Trakt collection"
+msgstr ""
+
+msgctxt "#32064"
+msgid "%i movie playcount(s) will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32065"
+msgid "%i movie(s) playcount will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32066"
+msgid "Movie Sync Complete"
+msgstr ""
+
+msgctxt "#32067"
+msgid "Going to add %i show(s) to Trakt collection"
+msgstr ""
+
+msgctxt "#32068"
+msgid "Checking for episodes missing from Trakt collection"
+msgstr ""
+
+msgctxt "#32069"
+msgid "%i of %i show(s) have episodes added to Trakt collection"
+msgstr ""
+
+msgctxt "#32070"
+msgid "Going to update %i show(s) missing watched status"
+msgstr ""
+
+msgctxt "#32071"
+msgid "Checking watched episodes on Trakt"
+msgstr ""
+
+msgctxt "#32072"
+msgid "%i show(s) had missing watched status"
+msgstr ""
+
+msgctxt "#32073"
+msgid "%i episodes are being updated"
+msgstr ""
+
+msgctxt "#32074"
+msgid "Checking watched episodes on Kodi"
+msgstr ""
+
+msgctxt "#32075"
+msgid "Episode Sync Complete"
+msgstr ""
+
+msgctxt "#32076"
+msgid "%i movie(s) will be removed from Trakt collection"
+msgstr ""
+
+msgctxt "#32077"
+msgid "Cleaning Trakt TV show collection"
+msgstr ""
+
+msgctxt "#32078"
+msgid "episodes are being removed"
+msgstr ""
+
+msgctxt "#32079"
+msgid "Loading movies from Kodi"
+msgstr ""
+
+msgctxt "#32080"
+msgid "Movies loaded from Kodi"
+msgstr ""
+
+msgctxt "#32081"
+msgid "Retrieving movie collection from Trakt"
+msgstr ""
+
+msgctxt "#32082"
+msgid "Retrieving watched movies from Trakt"
+msgstr ""
+
+msgctxt "#32083"
+msgid "Retrieved movie data from Trakt"
+msgstr ""
+
+msgctxt "#32084"
+msgid "Trakt movie collection is up to date, no movies to add"
+msgstr ""
+
+msgctxt "#32085"
+msgid "%i movie(s) were added to your Trakt collection"
+msgstr ""
+
+msgctxt "#32086"
+msgid "Trakt movie playcounts are up to date"
+msgstr ""
+
+msgctxt "#32087"
+msgid "Playcounts updated for %i movie(s) on Trakt"
+msgstr ""
+
+msgctxt "#32088"
+msgid "Kodi movie playcounts are up to date"
+msgstr ""
+
+msgctxt "#32089"
+msgid "Updating %i of %i movie playcount(s) in Kodi"
+msgstr ""
+
+msgctxt "#32090"
+msgid "Playcounts updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32091"
+msgid "Trakt movie collection is up to date, no movies removed"
+msgstr ""
+
+msgctxt "#32092"
+msgid "%i movie(s) were removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32093"
+msgid "Updating %i of %i movie playcount(s) on Trakt"
+msgstr ""
+
+msgctxt "#32094"
+msgid "Loading episode data from Kodi"
+msgstr ""
+
+msgctxt "#32095"
+msgid "Loading shows from Kodi"
+msgstr ""
+
+msgctxt "#32096"
+msgid "Shows loaded from Kodi"
+msgstr ""
+
+msgctxt "#32097"
+msgid "Parsing %i of %i episode data from Kodi"
+msgstr ""
+
+msgctxt "#32098"
+msgid "Loaded episode data from Kodi"
+msgstr ""
+
+msgctxt "#32099"
+msgid "Loading episode data from Trakt"
+msgstr ""
+
+msgctxt "#32100"
+msgid "Retrieving episode collection from Trakt"
+msgstr ""
+
+msgctxt "#32101"
+msgid "Retrieving watched episodes from Trakt"
+msgstr ""
+
+msgctxt "#32102"
+msgid "Parsing episode data %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32103"
+msgid "Retrieved episode data from Trakt"
+msgstr ""
+
+msgctxt "#32104"
+msgid "Trakt episode collection is up to date, no episodes to add"
+msgstr ""
+
+msgctxt "#32105"
+msgid "%i episode(s) were added to your Trakt collection"
+msgstr ""
+
+msgctxt "#32106"
+msgid "Trakt episode playcounts are up to date"
+msgstr ""
+
+msgctxt "#32107"
+msgid "Kodi episode playcounts are up to date"
+msgstr ""
+
+msgctxt "#32108"
+msgid "Updating %i of %i episode playcount(s) in Kodi"
+msgstr ""
+
+msgctxt "#32109"
+msgid "Playcounts updated for %i show(s) in Kodi"
+msgstr ""
+
+msgctxt "#32110"
+msgid "Trakt episode collection is clean, no episodes to remove"
+msgstr ""
+
+msgctxt "#32111"
+msgid "%i episode(s) are being removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32112"
+msgid "%i episode(s) were removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32113"
+msgid "Trakt - Marked as watched"
+msgstr ""
+
+msgctxt "#32114"
+msgid "Trakt - Failed marking as watched"
+msgstr ""
+
+msgctxt "#32115"
+msgid "%d episode(s) of '%s'"
+msgstr ""
+
+msgctxt "#32116"
+msgid "Enable debug mode"
+msgstr ""
+
+msgctxt "#32117"
+msgid "Sync movie playback progress to Kodi"
+msgstr ""
+
+msgctxt "#32118"
+msgid "Sync episode playback progress to Kodi"
+msgstr ""
+
+msgctxt "#32119"
+msgid "Retrieving episode playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32120"
+msgid "Parsing episode playback progress %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32121"
+msgid "Retrieved episode playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32122"
+msgid "Retrieving movie playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32123"
+msgid "Parsing movie playback progress %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32124"
+msgid "Retrieved movie playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32125"
+msgid "Kodi movie playback progress is up to date"
+msgstr ""
+
+msgctxt "#32126"
+msgid "%i movie(s) playback progress will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32127"
+msgid "Updating %i of %i movie(s) playback progress in Kodi"
+msgstr ""
+
+msgctxt "#32128"
+msgid "Playback progress updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32129"
+msgid "Kodi episode playback progress is up to date"
+msgstr ""
+
+msgctxt "#32130"
+msgid "Updating %i of %i episode(s) playback progress in Kodi"
+msgstr ""
+
+msgctxt "#32131"
+msgid "Playback progress updated for %i episode(s) in Kodi"
+msgstr ""
+
+msgctxt "#32132"
+msgid "Unrate this season"
+msgstr ""
+
+msgctxt "#32133"
+msgid "Manage Movie's Lists"
+msgstr ""
+
+msgctxt "#32134"
+msgid "Manage Show's Lists"
+msgstr ""
+
+msgctxt "#32135"
+msgid "Remove from Watchlist"
+msgstr ""
+
+msgctxt "#32136"
+msgid "Add to watchlist"
+msgstr ""
+
+msgctxt "#32137"
+msgid "Rate this movie"
+msgstr ""
+
+msgctxt "#32138"
+msgid "Rate this show"
+msgstr ""
+
+msgctxt "#32139"
+msgid "Rate this episode"
+msgstr ""
+
+msgctxt "#32140"
+msgid "Toggle watched"
+msgstr ""
+
+msgctxt "#32141"
+msgid "Manage all lists"
+msgstr ""
+
+msgctxt "#32142"
+msgid "Update all tags"
+msgstr ""
+
+msgctxt "#32143"
+msgid "Synchronize library"
+msgstr ""
+
+msgctxt "#32144"
+msgid "How do I authorize the trakt addon to access my trakt.tv account?"
+msgstr ""
+
+# empty strings from id 32145 to 32146
+msgctxt "#32147"
+msgid "Trakt.tv PIN Authorization Failed"
+msgstr ""
+
+# empty string with id 32148
+msgctxt "#32149"
+msgid "Rate this Season"
+msgstr ""
+
+msgctxt "#32150"
+msgid "You will be reminded in 24 hours"
+msgstr ""
+
+msgctxt "#32151"
+msgid "Use Addon Settings later if you change your mind"
+msgstr ""
+
+msgctxt "#32152"
+msgid "Trakt Authorization Complete"
+msgstr ""
+
+msgctxt "#32153"
+msgid "Trakt Account Authorization"
+msgstr ""
+
+msgctxt "#32154"
+msgid "Authorize"
+msgstr ""
+
+msgctxt "#32155"
+msgid "Remind Me Later"
+msgstr ""
+
+msgctxt "#32156"
+msgid "No Thanks"
+msgstr ""
+
+msgctxt "#32157"
+msgid "Account Authorization"
+msgstr ""
+
+# empty string with id 32158
+msgctxt "#32159"
+msgid "Visit {0} or scan the QR code."
+msgstr ""
+
+msgctxt "#32162"
+msgid "The trakt addon CAN NOT be used without authorizing it to access your trakt.tv account."
+msgstr ""
+
+msgctxt "#32163"
+msgid "User"
+msgstr ""
+
+msgctxt "#32164"
+msgid "Fallback to Title/Year matching if necessary"
+msgstr ""
+
+msgctxt "#32165"
+msgid "Trakt - Added to watchlist"
+msgstr ""
+
+msgctxt "#32166"
+msgid "Trakt - Failed adding to watchlist"
+msgstr ""
+
+msgctxt "#32167"
+msgid "Offset scrobble start by X minutes"
+msgstr ""
+
+msgctxt "#32168"
+msgid "Sync ratings"
+msgstr ""
+
+msgctxt "#32169"
+msgid "Kodi movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32170"
+msgid "%i movie(s) ratings will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32171"
+msgid "Updating %i of %i movie ratings in Kodi"
+msgstr ""
+
+msgctxt "#32172"
+msgid "Ratings updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32173"
+msgid "Kodi episode ratings are up to date"
+msgstr ""
+
+msgctxt "#32174"
+msgid "Updating %i of %i episode ratings in Kodi"
+msgstr ""
+
+msgctxt "#32175"
+msgid "Ratings updated for %i episode(s) in Kodi"
+msgstr ""
+
+msgctxt "#32176"
+msgid "Kodi show ratings are up to date"
+msgstr ""
+
+msgctxt "#32177"
+msgid "Updating %i of %i show ratings in Kodi"
+msgstr ""
+
+msgctxt "#32178"
+msgid "Ratings updated for %i show(s) in Kodi"
+msgstr ""
+
+msgctxt "#32179"
+msgid "Trakt movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32180"
+msgid "%i movie ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32181"
+msgid "Trakt show ratings are up to date"
+msgstr ""
+
+msgctxt "#32182"
+msgid "%i show ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32183"
+msgid "Attempt to scrobble MythTV PVR recordings"
+msgstr ""
+
+msgctxt "#32184"
+msgid "Attempt secondary show title search"
+msgstr ""
+
+msgctxt "#32185"
+msgid "Exclude Plugins"
+msgstr ""
+
+msgctxt "#32186"
+msgid "Allow script exclusions"
+msgstr ""

--- a/script.trakt/resources/language/resource.language.ms_MY/strings.po
+++ b/script.trakt/resources/language/resource.language.ms_MY/strings.po
@@ -10,36 +10,712 @@ msgstr ""
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Kodi Translation Team\n"
 "Language-Team: Malay (http://www.transifex.com/projects/p/xbmc-addons/language/ms/)\n"
+"Language: ms\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: ms\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 msgctxt "#32000"
 msgid "General"
 msgstr "Am"
 
+# empty strings from id 32001 to 32002
+msgctxt "#32003"
+msgid "Startup Delay"
+msgstr ""
+
 msgctxt "#32004"
 msgid "Rating"
 msgstr "Penarafan"
+
+msgctxt "#32005"
+msgid "Rate Movie after watching"
+msgstr ""
+
+msgctxt "#32006"
+msgid "Rate TV show Episode after watching"
+msgstr ""
+
+msgctxt "#32008"
+msgid "Minimum percent watched to display rating dialog"
+msgstr ""
+
+msgctxt "#32009"
+msgid "Allow re-rating of media"
+msgstr ""
+
+msgctxt "#32010"
+msgid "Default rating"
+msgstr ""
+
+# Scrobbling Settings
+msgctxt "#32011"
+msgid "Scrobbling"
+msgstr ""
+
+msgctxt "#32012"
+msgid "Scrobble movies"
+msgstr ""
+
+msgctxt "#32013"
+msgid "Scrobble TV show episodes"
+msgstr ""
+
+msgctxt "#32014"
+msgid "Show notification on scrobble"
+msgstr ""
+
+msgctxt "#32015"
+msgid "Trakt - Scrobbled successfully"
+msgstr ""
+
+msgctxt "#32016"
+msgid "Exclusions"
+msgstr ""
+
+msgctxt "#32017"
+msgid "Exclude Live TV"
+msgstr ""
+
+msgctxt "#32018"
+msgid "Exclude HTTP sources"
+msgstr ""
+
+msgctxt "#32019"
+msgid "Exclude path"
+msgstr ""
+
+msgctxt "#32020"
+msgid "Folder's path (including subfolders)"
+msgstr ""
+
+# empty strings from id 32021 to 32022
+msgctxt "#32023"
+msgid "Can not connect to Trakt"
+msgstr ""
 
 msgctxt "#32024"
 msgid "Error"
 msgstr "Ralat"
 
+# empty string with id 32025
+msgctxt "#32026"
+msgid "What Did You Think?"
+msgstr ""
+
+msgctxt "#32027"
+msgid "Totally Ninja!"
+msgstr ""
+
+msgctxt "#32028"
+msgid "Weak Sauce :("
+msgstr ""
+
+msgctxt "#32029"
+msgid "Terrible"
+msgstr ""
+
+msgctxt "#32030"
+msgid "Bad"
+msgstr ""
+
+msgctxt "#32031"
+msgid "Poor"
+msgstr ""
+
+msgctxt "#32032"
+msgid "Meh"
+msgstr ""
+
 msgctxt "#32033"
 msgid "Fair"
 msgstr "Sederhana"
+
+msgctxt "#32034"
+msgid "Good"
+msgstr ""
+
+msgctxt "#32035"
+msgid "Great"
+msgstr ""
+
+msgctxt "#32036"
+msgid "Superb"
+msgstr ""
+
+msgctxt "#32037"
+msgid "Unrate this movie"
+msgstr ""
+
+msgctxt "#32038"
+msgid "Unrate this show"
+msgstr ""
+
+msgctxt "#32039"
+msgid "Unrate this episode"
+msgstr ""
+
+msgctxt "#32040"
+msgid "Trakt - Rating submitted successfully"
+msgstr ""
+
+msgctxt "#32041"
+msgid "Trakt - Already rated"
+msgstr ""
+
+msgctxt "#32042"
+msgid "Trakt - Unrated successfully"
+msgstr ""
+
+msgctxt "#32043"
+msgid "Trakt - Already has the same rating"
+msgstr ""
+
+msgctxt "#32044"
+msgid "Trakt - Problem submitting rating"
+msgstr ""
+
+msgctxt "#32045"
+msgid "Synchronize"
+msgstr ""
 
 msgctxt "#32046"
 msgid "Movies"
 msgstr "Cereka"
 
+msgctxt "#32047"
+msgid "Add new movies to Trakt collection"
+msgstr ""
+
+msgctxt "#32048"
+msgid "Add watched movies to Trakt history"
+msgstr ""
+
+msgctxt "#32049"
+msgid "Mark movies from Trakt history as watched in Kodi"
+msgstr ""
+
+msgctxt "#32050"
+msgid "TV Episodes"
+msgstr ""
+
+msgctxt "#32051"
+msgid "Add new TV episodes to Trakt collection"
+msgstr ""
+
+msgctxt "#32052"
+msgid "Add watched TV episodes to Trakt history"
+msgstr ""
+
+msgctxt "#32053"
+msgid "Mark TV episodes from Trakt history as watched in Kodi"
+msgstr ""
+
 msgctxt "#32054"
 msgid "Service"
 msgstr "Perkhidmatan"
 
+msgctxt "#32055"
+msgid "Sync collection on library update or cleaning"
+msgstr ""
+
+msgctxt "#32056"
+msgid "Show sync notifications"
+msgstr ""
+
+msgctxt "#32057"
+msgid "Remove deleted movies from Trakt collection"
+msgstr ""
+
+msgctxt "#32058"
+msgid "Remove deleted TV episodes from Trakt collection"
+msgstr ""
+
+# empty string with id 32059
+msgctxt "#32060"
+msgid "Hide notifications during playback"
+msgstr ""
+
+msgctxt "#32061"
+msgid "Sync started"
+msgstr ""
+
+msgctxt "#32062"
+msgid "Sync complete"
+msgstr ""
+
+msgctxt "#32063"
+msgid "%i movie(s) will be added to Trakt collection"
+msgstr ""
+
+msgctxt "#32064"
+msgid "%i movie playcount(s) will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32065"
+msgid "%i movie(s) playcount will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32066"
+msgid "Movie Sync Complete"
+msgstr ""
+
+msgctxt "#32067"
+msgid "Going to add %i show(s) to Trakt collection"
+msgstr ""
+
+msgctxt "#32068"
+msgid "Checking for episodes missing from Trakt collection"
+msgstr ""
+
+msgctxt "#32069"
+msgid "%i of %i show(s) have episodes added to Trakt collection"
+msgstr ""
+
+msgctxt "#32070"
+msgid "Going to update %i show(s) missing watched status"
+msgstr ""
+
+msgctxt "#32071"
+msgid "Checking watched episodes on Trakt"
+msgstr ""
+
+msgctxt "#32072"
+msgid "%i show(s) had missing watched status"
+msgstr ""
+
+msgctxt "#32073"
+msgid "%i episodes are being updated"
+msgstr ""
+
+msgctxt "#32074"
+msgid "Checking watched episodes on Kodi"
+msgstr ""
+
+msgctxt "#32075"
+msgid "Episode Sync Complete"
+msgstr ""
+
+msgctxt "#32076"
+msgid "%i movie(s) will be removed from Trakt collection"
+msgstr ""
+
+msgctxt "#32077"
+msgid "Cleaning Trakt TV show collection"
+msgstr ""
+
+msgctxt "#32078"
+msgid "episodes are being removed"
+msgstr ""
+
+msgctxt "#32079"
+msgid "Loading movies from Kodi"
+msgstr ""
+
+msgctxt "#32080"
+msgid "Movies loaded from Kodi"
+msgstr ""
+
+msgctxt "#32081"
+msgid "Retrieving movie collection from Trakt"
+msgstr ""
+
+msgctxt "#32082"
+msgid "Retrieving watched movies from Trakt"
+msgstr ""
+
+msgctxt "#32083"
+msgid "Retrieved movie data from Trakt"
+msgstr ""
+
+msgctxt "#32084"
+msgid "Trakt movie collection is up to date, no movies to add"
+msgstr ""
+
+msgctxt "#32085"
+msgid "%i movie(s) were added to your Trakt collection"
+msgstr ""
+
+msgctxt "#32086"
+msgid "Trakt movie playcounts are up to date"
+msgstr ""
+
+msgctxt "#32087"
+msgid "Playcounts updated for %i movie(s) on Trakt"
+msgstr ""
+
+msgctxt "#32088"
+msgid "Kodi movie playcounts are up to date"
+msgstr ""
+
+msgctxt "#32089"
+msgid "Updating %i of %i movie playcount(s) in Kodi"
+msgstr ""
+
+msgctxt "#32090"
+msgid "Playcounts updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32091"
+msgid "Trakt movie collection is up to date, no movies removed"
+msgstr ""
+
+msgctxt "#32092"
+msgid "%i movie(s) were removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32093"
+msgid "Updating %i of %i movie playcount(s) on Trakt"
+msgstr ""
+
+msgctxt "#32094"
+msgid "Loading episode data from Kodi"
+msgstr ""
+
+msgctxt "#32095"
+msgid "Loading shows from Kodi"
+msgstr ""
+
+msgctxt "#32096"
+msgid "Shows loaded from Kodi"
+msgstr ""
+
+msgctxt "#32097"
+msgid "Parsing %i of %i episode data from Kodi"
+msgstr ""
+
+msgctxt "#32098"
+msgid "Loaded episode data from Kodi"
+msgstr ""
+
+msgctxt "#32099"
+msgid "Loading episode data from Trakt"
+msgstr ""
+
+msgctxt "#32100"
+msgid "Retrieving episode collection from Trakt"
+msgstr ""
+
+msgctxt "#32101"
+msgid "Retrieving watched episodes from Trakt"
+msgstr ""
+
+msgctxt "#32102"
+msgid "Parsing episode data %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32103"
+msgid "Retrieved episode data from Trakt"
+msgstr ""
+
+msgctxt "#32104"
+msgid "Trakt episode collection is up to date, no episodes to add"
+msgstr ""
+
+msgctxt "#32105"
+msgid "%i episode(s) were added to your Trakt collection"
+msgstr ""
+
+msgctxt "#32106"
+msgid "Trakt episode playcounts are up to date"
+msgstr ""
+
+msgctxt "#32107"
+msgid "Kodi episode playcounts are up to date"
+msgstr ""
+
+msgctxt "#32108"
+msgid "Updating %i of %i episode playcount(s) in Kodi"
+msgstr ""
+
+msgctxt "#32109"
+msgid "Playcounts updated for %i show(s) in Kodi"
+msgstr ""
+
+msgctxt "#32110"
+msgid "Trakt episode collection is clean, no episodes to remove"
+msgstr ""
+
+msgctxt "#32111"
+msgid "%i episode(s) are being removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32112"
+msgid "%i episode(s) were removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32113"
+msgid "Trakt - Marked as watched"
+msgstr ""
+
+msgctxt "#32114"
+msgid "Trakt - Failed marking as watched"
+msgstr ""
+
+msgctxt "#32115"
+msgid "%d episode(s) of '%s'"
+msgstr ""
+
+msgctxt "#32116"
+msgid "Enable debug mode"
+msgstr ""
+
+msgctxt "#32117"
+msgid "Sync movie playback progress to Kodi"
+msgstr ""
+
+msgctxt "#32118"
+msgid "Sync episode playback progress to Kodi"
+msgstr ""
+
+msgctxt "#32119"
+msgid "Retrieving episode playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32120"
+msgid "Parsing episode playback progress %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32121"
+msgid "Retrieved episode playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32122"
+msgid "Retrieving movie playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32123"
+msgid "Parsing movie playback progress %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32124"
+msgid "Retrieved movie playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32125"
+msgid "Kodi movie playback progress is up to date"
+msgstr ""
+
+msgctxt "#32126"
+msgid "%i movie(s) playback progress will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32127"
+msgid "Updating %i of %i movie(s) playback progress in Kodi"
+msgstr ""
+
+msgctxt "#32128"
+msgid "Playback progress updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32129"
+msgid "Kodi episode playback progress is up to date"
+msgstr ""
+
+msgctxt "#32130"
+msgid "Updating %i of %i episode(s) playback progress in Kodi"
+msgstr ""
+
+msgctxt "#32131"
+msgid "Playback progress updated for %i episode(s) in Kodi"
+msgstr ""
+
+msgctxt "#32132"
+msgid "Unrate this season"
+msgstr ""
+
+msgctxt "#32133"
+msgid "Manage Movie's Lists"
+msgstr ""
+
+msgctxt "#32134"
+msgid "Manage Show's Lists"
+msgstr ""
+
+msgctxt "#32135"
+msgid "Remove from Watchlist"
+msgstr ""
+
+msgctxt "#32136"
+msgid "Add to watchlist"
+msgstr ""
+
+msgctxt "#32137"
+msgid "Rate this movie"
+msgstr ""
+
+msgctxt "#32138"
+msgid "Rate this show"
+msgstr ""
+
+msgctxt "#32139"
+msgid "Rate this episode"
+msgstr ""
+
+msgctxt "#32140"
+msgid "Toggle watched"
+msgstr ""
+
+msgctxt "#32141"
+msgid "Manage all lists"
+msgstr ""
+
+msgctxt "#32142"
+msgid "Update all tags"
+msgstr ""
+
+msgctxt "#32143"
+msgid "Synchronize library"
+msgstr ""
+
+msgctxt "#32144"
+msgid "How do I authorize the trakt addon to access my trakt.tv account?"
+msgstr ""
+
+# empty strings from id 32145 to 32146
+msgctxt "#32147"
+msgid "Trakt.tv PIN Authorization Failed"
+msgstr ""
+
+# empty string with id 32148
+msgctxt "#32149"
+msgid "Rate this Season"
+msgstr ""
+
+msgctxt "#32150"
+msgid "You will be reminded in 24 hours"
+msgstr ""
+
+msgctxt "#32151"
+msgid "Use Addon Settings later if you change your mind"
+msgstr ""
+
+msgctxt "#32152"
+msgid "Trakt Authorization Complete"
+msgstr ""
+
+msgctxt "#32153"
+msgid "Trakt Account Authorization"
+msgstr ""
+
+msgctxt "#32154"
+msgid "Authorize"
+msgstr ""
+
+msgctxt "#32155"
+msgid "Remind Me Later"
+msgstr ""
+
+msgctxt "#32156"
+msgid "No Thanks"
+msgstr ""
+
+msgctxt "#32157"
+msgid "Account Authorization"
+msgstr ""
+
+# empty string with id 32158
+msgctxt "#32159"
+msgid "Visit {0} or scan the QR code."
+msgstr ""
+
+msgctxt "#32162"
+msgid "The trakt addon CAN NOT be used without authorizing it to access your trakt.tv account."
+msgstr ""
+
 msgctxt "#32163"
 msgid "User"
 msgstr "Pengguna"
+
+msgctxt "#32164"
+msgid "Fallback to Title/Year matching if necessary"
+msgstr ""
+
+msgctxt "#32165"
+msgid "Trakt - Added to watchlist"
+msgstr ""
+
+msgctxt "#32166"
+msgid "Trakt - Failed adding to watchlist"
+msgstr ""
+
+msgctxt "#32167"
+msgid "Offset scrobble start by X minutes"
+msgstr ""
+
+msgctxt "#32168"
+msgid "Sync ratings"
+msgstr ""
+
+msgctxt "#32169"
+msgid "Kodi movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32170"
+msgid "%i movie(s) ratings will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32171"
+msgid "Updating %i of %i movie ratings in Kodi"
+msgstr ""
+
+msgctxt "#32172"
+msgid "Ratings updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32173"
+msgid "Kodi episode ratings are up to date"
+msgstr ""
+
+msgctxt "#32174"
+msgid "Updating %i of %i episode ratings in Kodi"
+msgstr ""
+
+msgctxt "#32175"
+msgid "Ratings updated for %i episode(s) in Kodi"
+msgstr ""
+
+msgctxt "#32176"
+msgid "Kodi show ratings are up to date"
+msgstr ""
+
+msgctxt "#32177"
+msgid "Updating %i of %i show ratings in Kodi"
+msgstr ""
+
+msgctxt "#32178"
+msgid "Ratings updated for %i show(s) in Kodi"
+msgstr ""
+
+msgctxt "#32179"
+msgid "Trakt movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32180"
+msgid "%i movie ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32181"
+msgid "Trakt show ratings are up to date"
+msgstr ""
+
+msgctxt "#32182"
+msgid "%i show ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32183"
+msgid "Attempt to scrobble MythTV PVR recordings"
+msgstr ""
+
+msgctxt "#32184"
+msgid "Attempt secondary show title search"
+msgstr ""
+
+msgctxt "#32185"
+msgid "Exclude Plugins"
+msgstr ""
+
+msgctxt "#32186"
+msgid "Allow script exclusions"
+msgstr ""

--- a/script.trakt/resources/language/resource.language.mt_MT/strings.po
+++ b/script.trakt/resources/language/resource.language.mt_MT/strings.po
@@ -10,28 +10,712 @@ msgstr ""
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Kodi Translation Team\n"
 "Language-Team: Maltese (http://www.transifex.com/projects/p/xbmc-addons/language/mt/)\n"
+"Language: mt\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: mt\n"
 "Plural-Forms: nplurals=4; plural=(n==1 ? 0 : n==0 || ( n%100>1 && n%100<11) ? 1 : (n%100>10 && n%100<20 ) ? 2 : 3);\n"
 
 msgctxt "#32000"
 msgid "General"
 msgstr "Ġenerali"
 
+# empty strings from id 32001 to 32002
+msgctxt "#32003"
+msgid "Startup Delay"
+msgstr ""
+
 msgctxt "#32004"
 msgid "Rating"
 msgstr "Rating"
+
+msgctxt "#32005"
+msgid "Rate Movie after watching"
+msgstr ""
+
+msgctxt "#32006"
+msgid "Rate TV show Episode after watching"
+msgstr ""
+
+msgctxt "#32008"
+msgid "Minimum percent watched to display rating dialog"
+msgstr ""
+
+msgctxt "#32009"
+msgid "Allow re-rating of media"
+msgstr ""
+
+msgctxt "#32010"
+msgid "Default rating"
+msgstr ""
+
+# Scrobbling Settings
+msgctxt "#32011"
+msgid "Scrobbling"
+msgstr ""
+
+msgctxt "#32012"
+msgid "Scrobble movies"
+msgstr ""
+
+msgctxt "#32013"
+msgid "Scrobble TV show episodes"
+msgstr ""
+
+msgctxt "#32014"
+msgid "Show notification on scrobble"
+msgstr ""
+
+msgctxt "#32015"
+msgid "Trakt - Scrobbled successfully"
+msgstr ""
+
+msgctxt "#32016"
+msgid "Exclusions"
+msgstr ""
+
+msgctxt "#32017"
+msgid "Exclude Live TV"
+msgstr ""
+
+msgctxt "#32018"
+msgid "Exclude HTTP sources"
+msgstr ""
+
+msgctxt "#32019"
+msgid "Exclude path"
+msgstr ""
+
+msgctxt "#32020"
+msgid "Folder's path (including subfolders)"
+msgstr ""
+
+# empty strings from id 32021 to 32022
+msgctxt "#32023"
+msgid "Can not connect to Trakt"
+msgstr ""
 
 msgctxt "#32024"
 msgid "Error"
 msgstr "Problema"
 
+# empty string with id 32025
+msgctxt "#32026"
+msgid "What Did You Think?"
+msgstr ""
+
+msgctxt "#32027"
+msgid "Totally Ninja!"
+msgstr ""
+
+msgctxt "#32028"
+msgid "Weak Sauce :("
+msgstr ""
+
+msgctxt "#32029"
+msgid "Terrible"
+msgstr ""
+
+msgctxt "#32030"
+msgid "Bad"
+msgstr ""
+
+msgctxt "#32031"
+msgid "Poor"
+msgstr ""
+
+msgctxt "#32032"
+msgid "Meh"
+msgstr ""
+
 msgctxt "#32033"
 msgid "Fair"
 msgstr "Ħafif"
 
+msgctxt "#32034"
+msgid "Good"
+msgstr ""
+
+msgctxt "#32035"
+msgid "Great"
+msgstr ""
+
+msgctxt "#32036"
+msgid "Superb"
+msgstr ""
+
+msgctxt "#32037"
+msgid "Unrate this movie"
+msgstr ""
+
+msgctxt "#32038"
+msgid "Unrate this show"
+msgstr ""
+
+msgctxt "#32039"
+msgid "Unrate this episode"
+msgstr ""
+
+msgctxt "#32040"
+msgid "Trakt - Rating submitted successfully"
+msgstr ""
+
+msgctxt "#32041"
+msgid "Trakt - Already rated"
+msgstr ""
+
+msgctxt "#32042"
+msgid "Trakt - Unrated successfully"
+msgstr ""
+
+msgctxt "#32043"
+msgid "Trakt - Already has the same rating"
+msgstr ""
+
+msgctxt "#32044"
+msgid "Trakt - Problem submitting rating"
+msgstr ""
+
+msgctxt "#32045"
+msgid "Synchronize"
+msgstr ""
+
 msgctxt "#32046"
 msgid "Movies"
 msgstr "Filmati"
+
+msgctxt "#32047"
+msgid "Add new movies to Trakt collection"
+msgstr ""
+
+msgctxt "#32048"
+msgid "Add watched movies to Trakt history"
+msgstr ""
+
+msgctxt "#32049"
+msgid "Mark movies from Trakt history as watched in Kodi"
+msgstr ""
+
+msgctxt "#32050"
+msgid "TV Episodes"
+msgstr ""
+
+msgctxt "#32051"
+msgid "Add new TV episodes to Trakt collection"
+msgstr ""
+
+msgctxt "#32052"
+msgid "Add watched TV episodes to Trakt history"
+msgstr ""
+
+msgctxt "#32053"
+msgid "Mark TV episodes from Trakt history as watched in Kodi"
+msgstr ""
+
+msgctxt "#32054"
+msgid "Service"
+msgstr ""
+
+msgctxt "#32055"
+msgid "Sync collection on library update or cleaning"
+msgstr ""
+
+msgctxt "#32056"
+msgid "Show sync notifications"
+msgstr ""
+
+msgctxt "#32057"
+msgid "Remove deleted movies from Trakt collection"
+msgstr ""
+
+msgctxt "#32058"
+msgid "Remove deleted TV episodes from Trakt collection"
+msgstr ""
+
+# empty string with id 32059
+msgctxt "#32060"
+msgid "Hide notifications during playback"
+msgstr ""
+
+msgctxt "#32061"
+msgid "Sync started"
+msgstr ""
+
+msgctxt "#32062"
+msgid "Sync complete"
+msgstr ""
+
+msgctxt "#32063"
+msgid "%i movie(s) will be added to Trakt collection"
+msgstr ""
+
+msgctxt "#32064"
+msgid "%i movie playcount(s) will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32065"
+msgid "%i movie(s) playcount will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32066"
+msgid "Movie Sync Complete"
+msgstr ""
+
+msgctxt "#32067"
+msgid "Going to add %i show(s) to Trakt collection"
+msgstr ""
+
+msgctxt "#32068"
+msgid "Checking for episodes missing from Trakt collection"
+msgstr ""
+
+msgctxt "#32069"
+msgid "%i of %i show(s) have episodes added to Trakt collection"
+msgstr ""
+
+msgctxt "#32070"
+msgid "Going to update %i show(s) missing watched status"
+msgstr ""
+
+msgctxt "#32071"
+msgid "Checking watched episodes on Trakt"
+msgstr ""
+
+msgctxt "#32072"
+msgid "%i show(s) had missing watched status"
+msgstr ""
+
+msgctxt "#32073"
+msgid "%i episodes are being updated"
+msgstr ""
+
+msgctxt "#32074"
+msgid "Checking watched episodes on Kodi"
+msgstr ""
+
+msgctxt "#32075"
+msgid "Episode Sync Complete"
+msgstr ""
+
+msgctxt "#32076"
+msgid "%i movie(s) will be removed from Trakt collection"
+msgstr ""
+
+msgctxt "#32077"
+msgid "Cleaning Trakt TV show collection"
+msgstr ""
+
+msgctxt "#32078"
+msgid "episodes are being removed"
+msgstr ""
+
+msgctxt "#32079"
+msgid "Loading movies from Kodi"
+msgstr ""
+
+msgctxt "#32080"
+msgid "Movies loaded from Kodi"
+msgstr ""
+
+msgctxt "#32081"
+msgid "Retrieving movie collection from Trakt"
+msgstr ""
+
+msgctxt "#32082"
+msgid "Retrieving watched movies from Trakt"
+msgstr ""
+
+msgctxt "#32083"
+msgid "Retrieved movie data from Trakt"
+msgstr ""
+
+msgctxt "#32084"
+msgid "Trakt movie collection is up to date, no movies to add"
+msgstr ""
+
+msgctxt "#32085"
+msgid "%i movie(s) were added to your Trakt collection"
+msgstr ""
+
+msgctxt "#32086"
+msgid "Trakt movie playcounts are up to date"
+msgstr ""
+
+msgctxt "#32087"
+msgid "Playcounts updated for %i movie(s) on Trakt"
+msgstr ""
+
+msgctxt "#32088"
+msgid "Kodi movie playcounts are up to date"
+msgstr ""
+
+msgctxt "#32089"
+msgid "Updating %i of %i movie playcount(s) in Kodi"
+msgstr ""
+
+msgctxt "#32090"
+msgid "Playcounts updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32091"
+msgid "Trakt movie collection is up to date, no movies removed"
+msgstr ""
+
+msgctxt "#32092"
+msgid "%i movie(s) were removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32093"
+msgid "Updating %i of %i movie playcount(s) on Trakt"
+msgstr ""
+
+msgctxt "#32094"
+msgid "Loading episode data from Kodi"
+msgstr ""
+
+msgctxt "#32095"
+msgid "Loading shows from Kodi"
+msgstr ""
+
+msgctxt "#32096"
+msgid "Shows loaded from Kodi"
+msgstr ""
+
+msgctxt "#32097"
+msgid "Parsing %i of %i episode data from Kodi"
+msgstr ""
+
+msgctxt "#32098"
+msgid "Loaded episode data from Kodi"
+msgstr ""
+
+msgctxt "#32099"
+msgid "Loading episode data from Trakt"
+msgstr ""
+
+msgctxt "#32100"
+msgid "Retrieving episode collection from Trakt"
+msgstr ""
+
+msgctxt "#32101"
+msgid "Retrieving watched episodes from Trakt"
+msgstr ""
+
+msgctxt "#32102"
+msgid "Parsing episode data %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32103"
+msgid "Retrieved episode data from Trakt"
+msgstr ""
+
+msgctxt "#32104"
+msgid "Trakt episode collection is up to date, no episodes to add"
+msgstr ""
+
+msgctxt "#32105"
+msgid "%i episode(s) were added to your Trakt collection"
+msgstr ""
+
+msgctxt "#32106"
+msgid "Trakt episode playcounts are up to date"
+msgstr ""
+
+msgctxt "#32107"
+msgid "Kodi episode playcounts are up to date"
+msgstr ""
+
+msgctxt "#32108"
+msgid "Updating %i of %i episode playcount(s) in Kodi"
+msgstr ""
+
+msgctxt "#32109"
+msgid "Playcounts updated for %i show(s) in Kodi"
+msgstr ""
+
+msgctxt "#32110"
+msgid "Trakt episode collection is clean, no episodes to remove"
+msgstr ""
+
+msgctxt "#32111"
+msgid "%i episode(s) are being removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32112"
+msgid "%i episode(s) were removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32113"
+msgid "Trakt - Marked as watched"
+msgstr ""
+
+msgctxt "#32114"
+msgid "Trakt - Failed marking as watched"
+msgstr ""
+
+msgctxt "#32115"
+msgid "%d episode(s) of '%s'"
+msgstr ""
+
+msgctxt "#32116"
+msgid "Enable debug mode"
+msgstr ""
+
+msgctxt "#32117"
+msgid "Sync movie playback progress to Kodi"
+msgstr ""
+
+msgctxt "#32118"
+msgid "Sync episode playback progress to Kodi"
+msgstr ""
+
+msgctxt "#32119"
+msgid "Retrieving episode playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32120"
+msgid "Parsing episode playback progress %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32121"
+msgid "Retrieved episode playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32122"
+msgid "Retrieving movie playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32123"
+msgid "Parsing movie playback progress %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32124"
+msgid "Retrieved movie playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32125"
+msgid "Kodi movie playback progress is up to date"
+msgstr ""
+
+msgctxt "#32126"
+msgid "%i movie(s) playback progress will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32127"
+msgid "Updating %i of %i movie(s) playback progress in Kodi"
+msgstr ""
+
+msgctxt "#32128"
+msgid "Playback progress updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32129"
+msgid "Kodi episode playback progress is up to date"
+msgstr ""
+
+msgctxt "#32130"
+msgid "Updating %i of %i episode(s) playback progress in Kodi"
+msgstr ""
+
+msgctxt "#32131"
+msgid "Playback progress updated for %i episode(s) in Kodi"
+msgstr ""
+
+msgctxt "#32132"
+msgid "Unrate this season"
+msgstr ""
+
+msgctxt "#32133"
+msgid "Manage Movie's Lists"
+msgstr ""
+
+msgctxt "#32134"
+msgid "Manage Show's Lists"
+msgstr ""
+
+msgctxt "#32135"
+msgid "Remove from Watchlist"
+msgstr ""
+
+msgctxt "#32136"
+msgid "Add to watchlist"
+msgstr ""
+
+msgctxt "#32137"
+msgid "Rate this movie"
+msgstr ""
+
+msgctxt "#32138"
+msgid "Rate this show"
+msgstr ""
+
+msgctxt "#32139"
+msgid "Rate this episode"
+msgstr ""
+
+msgctxt "#32140"
+msgid "Toggle watched"
+msgstr ""
+
+msgctxt "#32141"
+msgid "Manage all lists"
+msgstr ""
+
+msgctxt "#32142"
+msgid "Update all tags"
+msgstr ""
+
+msgctxt "#32143"
+msgid "Synchronize library"
+msgstr ""
+
+msgctxt "#32144"
+msgid "How do I authorize the trakt addon to access my trakt.tv account?"
+msgstr ""
+
+# empty strings from id 32145 to 32146
+msgctxt "#32147"
+msgid "Trakt.tv PIN Authorization Failed"
+msgstr ""
+
+# empty string with id 32148
+msgctxt "#32149"
+msgid "Rate this Season"
+msgstr ""
+
+msgctxt "#32150"
+msgid "You will be reminded in 24 hours"
+msgstr ""
+
+msgctxt "#32151"
+msgid "Use Addon Settings later if you change your mind"
+msgstr ""
+
+msgctxt "#32152"
+msgid "Trakt Authorization Complete"
+msgstr ""
+
+msgctxt "#32153"
+msgid "Trakt Account Authorization"
+msgstr ""
+
+msgctxt "#32154"
+msgid "Authorize"
+msgstr ""
+
+msgctxt "#32155"
+msgid "Remind Me Later"
+msgstr ""
+
+msgctxt "#32156"
+msgid "No Thanks"
+msgstr ""
+
+msgctxt "#32157"
+msgid "Account Authorization"
+msgstr ""
+
+# empty string with id 32158
+msgctxt "#32159"
+msgid "Visit {0} or scan the QR code."
+msgstr ""
+
+msgctxt "#32162"
+msgid "The trakt addon CAN NOT be used without authorizing it to access your trakt.tv account."
+msgstr ""
+
+msgctxt "#32163"
+msgid "User"
+msgstr ""
+
+msgctxt "#32164"
+msgid "Fallback to Title/Year matching if necessary"
+msgstr ""
+
+msgctxt "#32165"
+msgid "Trakt - Added to watchlist"
+msgstr ""
+
+msgctxt "#32166"
+msgid "Trakt - Failed adding to watchlist"
+msgstr ""
+
+msgctxt "#32167"
+msgid "Offset scrobble start by X minutes"
+msgstr ""
+
+msgctxt "#32168"
+msgid "Sync ratings"
+msgstr ""
+
+msgctxt "#32169"
+msgid "Kodi movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32170"
+msgid "%i movie(s) ratings will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32171"
+msgid "Updating %i of %i movie ratings in Kodi"
+msgstr ""
+
+msgctxt "#32172"
+msgid "Ratings updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32173"
+msgid "Kodi episode ratings are up to date"
+msgstr ""
+
+msgctxt "#32174"
+msgid "Updating %i of %i episode ratings in Kodi"
+msgstr ""
+
+msgctxt "#32175"
+msgid "Ratings updated for %i episode(s) in Kodi"
+msgstr ""
+
+msgctxt "#32176"
+msgid "Kodi show ratings are up to date"
+msgstr ""
+
+msgctxt "#32177"
+msgid "Updating %i of %i show ratings in Kodi"
+msgstr ""
+
+msgctxt "#32178"
+msgid "Ratings updated for %i show(s) in Kodi"
+msgstr ""
+
+msgctxt "#32179"
+msgid "Trakt movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32180"
+msgid "%i movie ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32181"
+msgid "Trakt show ratings are up to date"
+msgstr ""
+
+msgctxt "#32182"
+msgid "%i show ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32183"
+msgid "Attempt to scrobble MythTV PVR recordings"
+msgstr ""
+
+msgctxt "#32184"
+msgid "Attempt secondary show title search"
+msgstr ""
+
+msgctxt "#32185"
+msgid "Exclude Plugins"
+msgstr ""
+
+msgctxt "#32186"
+msgid "Allow script exclusions"
+msgstr ""

--- a/script.trakt/resources/language/resource.language.my_MM/strings.po
+++ b/script.trakt/resources/language/resource.language.my_MM/strings.po
@@ -10,24 +10,712 @@ msgstr ""
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Kodi Translation Team\n"
 "Language-Team: Burmese (http://www.transifex.com/projects/p/xbmc-addons/language/my/)\n"
+"Language: my\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: my\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 msgctxt "#32000"
 msgid "General"
 msgstr "ယေဘုယျ"
 
+# empty strings from id 32001 to 32002
+msgctxt "#32003"
+msgid "Startup Delay"
+msgstr ""
+
 msgctxt "#32004"
 msgid "Rating"
 msgstr "အဆင့်သတ်မှတ်မှု့"
+
+msgctxt "#32005"
+msgid "Rate Movie after watching"
+msgstr ""
+
+msgctxt "#32006"
+msgid "Rate TV show Episode after watching"
+msgstr ""
+
+msgctxt "#32008"
+msgid "Minimum percent watched to display rating dialog"
+msgstr ""
+
+msgctxt "#32009"
+msgid "Allow re-rating of media"
+msgstr ""
+
+msgctxt "#32010"
+msgid "Default rating"
+msgstr ""
+
+# Scrobbling Settings
+msgctxt "#32011"
+msgid "Scrobbling"
+msgstr ""
+
+msgctxt "#32012"
+msgid "Scrobble movies"
+msgstr ""
+
+msgctxt "#32013"
+msgid "Scrobble TV show episodes"
+msgstr ""
+
+msgctxt "#32014"
+msgid "Show notification on scrobble"
+msgstr ""
+
+msgctxt "#32015"
+msgid "Trakt - Scrobbled successfully"
+msgstr ""
+
+msgctxt "#32016"
+msgid "Exclusions"
+msgstr ""
+
+msgctxt "#32017"
+msgid "Exclude Live TV"
+msgstr ""
+
+msgctxt "#32018"
+msgid "Exclude HTTP sources"
+msgstr ""
+
+msgctxt "#32019"
+msgid "Exclude path"
+msgstr ""
+
+msgctxt "#32020"
+msgid "Folder's path (including subfolders)"
+msgstr ""
+
+# empty strings from id 32021 to 32022
+msgctxt "#32023"
+msgid "Can not connect to Trakt"
+msgstr ""
 
 msgctxt "#32024"
 msgid "Error"
 msgstr "ချို့ယွင်းချက်"
 
+# empty string with id 32025
+msgctxt "#32026"
+msgid "What Did You Think?"
+msgstr ""
+
+msgctxt "#32027"
+msgid "Totally Ninja!"
+msgstr ""
+
+msgctxt "#32028"
+msgid "Weak Sauce :("
+msgstr ""
+
+msgctxt "#32029"
+msgid "Terrible"
+msgstr ""
+
+msgctxt "#32030"
+msgid "Bad"
+msgstr ""
+
+msgctxt "#32031"
+msgid "Poor"
+msgstr ""
+
+msgctxt "#32032"
+msgid "Meh"
+msgstr ""
+
+msgctxt "#32033"
+msgid "Fair"
+msgstr ""
+
+msgctxt "#32034"
+msgid "Good"
+msgstr ""
+
+msgctxt "#32035"
+msgid "Great"
+msgstr ""
+
+msgctxt "#32036"
+msgid "Superb"
+msgstr ""
+
+msgctxt "#32037"
+msgid "Unrate this movie"
+msgstr ""
+
+msgctxt "#32038"
+msgid "Unrate this show"
+msgstr ""
+
+msgctxt "#32039"
+msgid "Unrate this episode"
+msgstr ""
+
+msgctxt "#32040"
+msgid "Trakt - Rating submitted successfully"
+msgstr ""
+
+msgctxt "#32041"
+msgid "Trakt - Already rated"
+msgstr ""
+
+msgctxt "#32042"
+msgid "Trakt - Unrated successfully"
+msgstr ""
+
+msgctxt "#32043"
+msgid "Trakt - Already has the same rating"
+msgstr ""
+
+msgctxt "#32044"
+msgid "Trakt - Problem submitting rating"
+msgstr ""
+
+msgctxt "#32045"
+msgid "Synchronize"
+msgstr ""
+
 msgctxt "#32046"
 msgid "Movies"
 msgstr "ရုပ်ရှင်များ"
+
+msgctxt "#32047"
+msgid "Add new movies to Trakt collection"
+msgstr ""
+
+msgctxt "#32048"
+msgid "Add watched movies to Trakt history"
+msgstr ""
+
+msgctxt "#32049"
+msgid "Mark movies from Trakt history as watched in Kodi"
+msgstr ""
+
+msgctxt "#32050"
+msgid "TV Episodes"
+msgstr ""
+
+msgctxt "#32051"
+msgid "Add new TV episodes to Trakt collection"
+msgstr ""
+
+msgctxt "#32052"
+msgid "Add watched TV episodes to Trakt history"
+msgstr ""
+
+msgctxt "#32053"
+msgid "Mark TV episodes from Trakt history as watched in Kodi"
+msgstr ""
+
+msgctxt "#32054"
+msgid "Service"
+msgstr ""
+
+msgctxt "#32055"
+msgid "Sync collection on library update or cleaning"
+msgstr ""
+
+msgctxt "#32056"
+msgid "Show sync notifications"
+msgstr ""
+
+msgctxt "#32057"
+msgid "Remove deleted movies from Trakt collection"
+msgstr ""
+
+msgctxt "#32058"
+msgid "Remove deleted TV episodes from Trakt collection"
+msgstr ""
+
+# empty string with id 32059
+msgctxt "#32060"
+msgid "Hide notifications during playback"
+msgstr ""
+
+msgctxt "#32061"
+msgid "Sync started"
+msgstr ""
+
+msgctxt "#32062"
+msgid "Sync complete"
+msgstr ""
+
+msgctxt "#32063"
+msgid "%i movie(s) will be added to Trakt collection"
+msgstr ""
+
+msgctxt "#32064"
+msgid "%i movie playcount(s) will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32065"
+msgid "%i movie(s) playcount will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32066"
+msgid "Movie Sync Complete"
+msgstr ""
+
+msgctxt "#32067"
+msgid "Going to add %i show(s) to Trakt collection"
+msgstr ""
+
+msgctxt "#32068"
+msgid "Checking for episodes missing from Trakt collection"
+msgstr ""
+
+msgctxt "#32069"
+msgid "%i of %i show(s) have episodes added to Trakt collection"
+msgstr ""
+
+msgctxt "#32070"
+msgid "Going to update %i show(s) missing watched status"
+msgstr ""
+
+msgctxt "#32071"
+msgid "Checking watched episodes on Trakt"
+msgstr ""
+
+msgctxt "#32072"
+msgid "%i show(s) had missing watched status"
+msgstr ""
+
+msgctxt "#32073"
+msgid "%i episodes are being updated"
+msgstr ""
+
+msgctxt "#32074"
+msgid "Checking watched episodes on Kodi"
+msgstr ""
+
+msgctxt "#32075"
+msgid "Episode Sync Complete"
+msgstr ""
+
+msgctxt "#32076"
+msgid "%i movie(s) will be removed from Trakt collection"
+msgstr ""
+
+msgctxt "#32077"
+msgid "Cleaning Trakt TV show collection"
+msgstr ""
+
+msgctxt "#32078"
+msgid "episodes are being removed"
+msgstr ""
+
+msgctxt "#32079"
+msgid "Loading movies from Kodi"
+msgstr ""
+
+msgctxt "#32080"
+msgid "Movies loaded from Kodi"
+msgstr ""
+
+msgctxt "#32081"
+msgid "Retrieving movie collection from Trakt"
+msgstr ""
+
+msgctxt "#32082"
+msgid "Retrieving watched movies from Trakt"
+msgstr ""
+
+msgctxt "#32083"
+msgid "Retrieved movie data from Trakt"
+msgstr ""
+
+msgctxt "#32084"
+msgid "Trakt movie collection is up to date, no movies to add"
+msgstr ""
+
+msgctxt "#32085"
+msgid "%i movie(s) were added to your Trakt collection"
+msgstr ""
+
+msgctxt "#32086"
+msgid "Trakt movie playcounts are up to date"
+msgstr ""
+
+msgctxt "#32087"
+msgid "Playcounts updated for %i movie(s) on Trakt"
+msgstr ""
+
+msgctxt "#32088"
+msgid "Kodi movie playcounts are up to date"
+msgstr ""
+
+msgctxt "#32089"
+msgid "Updating %i of %i movie playcount(s) in Kodi"
+msgstr ""
+
+msgctxt "#32090"
+msgid "Playcounts updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32091"
+msgid "Trakt movie collection is up to date, no movies removed"
+msgstr ""
+
+msgctxt "#32092"
+msgid "%i movie(s) were removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32093"
+msgid "Updating %i of %i movie playcount(s) on Trakt"
+msgstr ""
+
+msgctxt "#32094"
+msgid "Loading episode data from Kodi"
+msgstr ""
+
+msgctxt "#32095"
+msgid "Loading shows from Kodi"
+msgstr ""
+
+msgctxt "#32096"
+msgid "Shows loaded from Kodi"
+msgstr ""
+
+msgctxt "#32097"
+msgid "Parsing %i of %i episode data from Kodi"
+msgstr ""
+
+msgctxt "#32098"
+msgid "Loaded episode data from Kodi"
+msgstr ""
+
+msgctxt "#32099"
+msgid "Loading episode data from Trakt"
+msgstr ""
+
+msgctxt "#32100"
+msgid "Retrieving episode collection from Trakt"
+msgstr ""
+
+msgctxt "#32101"
+msgid "Retrieving watched episodes from Trakt"
+msgstr ""
+
+msgctxt "#32102"
+msgid "Parsing episode data %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32103"
+msgid "Retrieved episode data from Trakt"
+msgstr ""
+
+msgctxt "#32104"
+msgid "Trakt episode collection is up to date, no episodes to add"
+msgstr ""
+
+msgctxt "#32105"
+msgid "%i episode(s) were added to your Trakt collection"
+msgstr ""
+
+msgctxt "#32106"
+msgid "Trakt episode playcounts are up to date"
+msgstr ""
+
+msgctxt "#32107"
+msgid "Kodi episode playcounts are up to date"
+msgstr ""
+
+msgctxt "#32108"
+msgid "Updating %i of %i episode playcount(s) in Kodi"
+msgstr ""
+
+msgctxt "#32109"
+msgid "Playcounts updated for %i show(s) in Kodi"
+msgstr ""
+
+msgctxt "#32110"
+msgid "Trakt episode collection is clean, no episodes to remove"
+msgstr ""
+
+msgctxt "#32111"
+msgid "%i episode(s) are being removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32112"
+msgid "%i episode(s) were removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32113"
+msgid "Trakt - Marked as watched"
+msgstr ""
+
+msgctxt "#32114"
+msgid "Trakt - Failed marking as watched"
+msgstr ""
+
+msgctxt "#32115"
+msgid "%d episode(s) of '%s'"
+msgstr ""
+
+msgctxt "#32116"
+msgid "Enable debug mode"
+msgstr ""
+
+msgctxt "#32117"
+msgid "Sync movie playback progress to Kodi"
+msgstr ""
+
+msgctxt "#32118"
+msgid "Sync episode playback progress to Kodi"
+msgstr ""
+
+msgctxt "#32119"
+msgid "Retrieving episode playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32120"
+msgid "Parsing episode playback progress %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32121"
+msgid "Retrieved episode playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32122"
+msgid "Retrieving movie playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32123"
+msgid "Parsing movie playback progress %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32124"
+msgid "Retrieved movie playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32125"
+msgid "Kodi movie playback progress is up to date"
+msgstr ""
+
+msgctxt "#32126"
+msgid "%i movie(s) playback progress will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32127"
+msgid "Updating %i of %i movie(s) playback progress in Kodi"
+msgstr ""
+
+msgctxt "#32128"
+msgid "Playback progress updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32129"
+msgid "Kodi episode playback progress is up to date"
+msgstr ""
+
+msgctxt "#32130"
+msgid "Updating %i of %i episode(s) playback progress in Kodi"
+msgstr ""
+
+msgctxt "#32131"
+msgid "Playback progress updated for %i episode(s) in Kodi"
+msgstr ""
+
+msgctxt "#32132"
+msgid "Unrate this season"
+msgstr ""
+
+msgctxt "#32133"
+msgid "Manage Movie's Lists"
+msgstr ""
+
+msgctxt "#32134"
+msgid "Manage Show's Lists"
+msgstr ""
+
+msgctxt "#32135"
+msgid "Remove from Watchlist"
+msgstr ""
+
+msgctxt "#32136"
+msgid "Add to watchlist"
+msgstr ""
+
+msgctxt "#32137"
+msgid "Rate this movie"
+msgstr ""
+
+msgctxt "#32138"
+msgid "Rate this show"
+msgstr ""
+
+msgctxt "#32139"
+msgid "Rate this episode"
+msgstr ""
+
+msgctxt "#32140"
+msgid "Toggle watched"
+msgstr ""
+
+msgctxt "#32141"
+msgid "Manage all lists"
+msgstr ""
+
+msgctxt "#32142"
+msgid "Update all tags"
+msgstr ""
+
+msgctxt "#32143"
+msgid "Synchronize library"
+msgstr ""
+
+msgctxt "#32144"
+msgid "How do I authorize the trakt addon to access my trakt.tv account?"
+msgstr ""
+
+# empty strings from id 32145 to 32146
+msgctxt "#32147"
+msgid "Trakt.tv PIN Authorization Failed"
+msgstr ""
+
+# empty string with id 32148
+msgctxt "#32149"
+msgid "Rate this Season"
+msgstr ""
+
+msgctxt "#32150"
+msgid "You will be reminded in 24 hours"
+msgstr ""
+
+msgctxt "#32151"
+msgid "Use Addon Settings later if you change your mind"
+msgstr ""
+
+msgctxt "#32152"
+msgid "Trakt Authorization Complete"
+msgstr ""
+
+msgctxt "#32153"
+msgid "Trakt Account Authorization"
+msgstr ""
+
+msgctxt "#32154"
+msgid "Authorize"
+msgstr ""
+
+msgctxt "#32155"
+msgid "Remind Me Later"
+msgstr ""
+
+msgctxt "#32156"
+msgid "No Thanks"
+msgstr ""
+
+msgctxt "#32157"
+msgid "Account Authorization"
+msgstr ""
+
+# empty string with id 32158
+msgctxt "#32159"
+msgid "Visit {0} or scan the QR code."
+msgstr ""
+
+msgctxt "#32162"
+msgid "The trakt addon CAN NOT be used without authorizing it to access your trakt.tv account."
+msgstr ""
+
+msgctxt "#32163"
+msgid "User"
+msgstr ""
+
+msgctxt "#32164"
+msgid "Fallback to Title/Year matching if necessary"
+msgstr ""
+
+msgctxt "#32165"
+msgid "Trakt - Added to watchlist"
+msgstr ""
+
+msgctxt "#32166"
+msgid "Trakt - Failed adding to watchlist"
+msgstr ""
+
+msgctxt "#32167"
+msgid "Offset scrobble start by X minutes"
+msgstr ""
+
+msgctxt "#32168"
+msgid "Sync ratings"
+msgstr ""
+
+msgctxt "#32169"
+msgid "Kodi movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32170"
+msgid "%i movie(s) ratings will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32171"
+msgid "Updating %i of %i movie ratings in Kodi"
+msgstr ""
+
+msgctxt "#32172"
+msgid "Ratings updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32173"
+msgid "Kodi episode ratings are up to date"
+msgstr ""
+
+msgctxt "#32174"
+msgid "Updating %i of %i episode ratings in Kodi"
+msgstr ""
+
+msgctxt "#32175"
+msgid "Ratings updated for %i episode(s) in Kodi"
+msgstr ""
+
+msgctxt "#32176"
+msgid "Kodi show ratings are up to date"
+msgstr ""
+
+msgctxt "#32177"
+msgid "Updating %i of %i show ratings in Kodi"
+msgstr ""
+
+msgctxt "#32178"
+msgid "Ratings updated for %i show(s) in Kodi"
+msgstr ""
+
+msgctxt "#32179"
+msgid "Trakt movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32180"
+msgid "%i movie ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32181"
+msgid "Trakt show ratings are up to date"
+msgstr ""
+
+msgctxt "#32182"
+msgid "%i show ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32183"
+msgid "Attempt to scrobble MythTV PVR recordings"
+msgstr ""
+
+msgctxt "#32184"
+msgid "Attempt secondary show title search"
+msgstr ""
+
+msgctxt "#32185"
+msgid "Exclude Plugins"
+msgstr ""
+
+msgctxt "#32186"
+msgid "Allow script exclusions"
+msgstr ""

--- a/script.trakt/resources/language/resource.language.nb_NO/strings.po
+++ b/script.trakt/resources/language/resource.language.nb_NO/strings.po
@@ -10,10 +10,10 @@ msgstr ""
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Kodi Translation Team\n"
 "Language-Team: Norwegian (http://www.transifex.com/projects/p/xbmc-addons/language/no/)\n"
+"Language: no\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: no\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 msgctxt "#32000"
@@ -215,6 +215,10 @@ msgstr "Tjeneste"
 msgctxt "#32055"
 msgid "Sync collection on library update or cleaning"
 msgstr "Synkroniser samling når biblioteket oppdateres eller renses"
+
+msgctxt "#32056"
+msgid "Show sync notifications"
+msgstr ""
 
 msgctxt "#32057"
 msgid "Remove deleted movies from Trakt collection"
@@ -452,6 +456,261 @@ msgctxt "#32116"
 msgid "Enable debug mode"
 msgstr "Aktiver feilsøkingsmodus"
 
+msgctxt "#32117"
+msgid "Sync movie playback progress to Kodi"
+msgstr ""
+
+msgctxt "#32118"
+msgid "Sync episode playback progress to Kodi"
+msgstr ""
+
+msgctxt "#32119"
+msgid "Retrieving episode playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32120"
+msgid "Parsing episode playback progress %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32121"
+msgid "Retrieved episode playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32122"
+msgid "Retrieving movie playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32123"
+msgid "Parsing movie playback progress %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32124"
+msgid "Retrieved movie playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32125"
+msgid "Kodi movie playback progress is up to date"
+msgstr ""
+
+msgctxt "#32126"
+msgid "%i movie(s) playback progress will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32127"
+msgid "Updating %i of %i movie(s) playback progress in Kodi"
+msgstr ""
+
+msgctxt "#32128"
+msgid "Playback progress updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32129"
+msgid "Kodi episode playback progress is up to date"
+msgstr ""
+
+msgctxt "#32130"
+msgid "Updating %i of %i episode(s) playback progress in Kodi"
+msgstr ""
+
+msgctxt "#32131"
+msgid "Playback progress updated for %i episode(s) in Kodi"
+msgstr ""
+
+msgctxt "#32132"
+msgid "Unrate this season"
+msgstr ""
+
+msgctxt "#32133"
+msgid "Manage Movie's Lists"
+msgstr ""
+
+msgctxt "#32134"
+msgid "Manage Show's Lists"
+msgstr ""
+
+msgctxt "#32135"
+msgid "Remove from Watchlist"
+msgstr ""
+
+msgctxt "#32136"
+msgid "Add to watchlist"
+msgstr ""
+
+msgctxt "#32137"
+msgid "Rate this movie"
+msgstr ""
+
+msgctxt "#32138"
+msgid "Rate this show"
+msgstr ""
+
+msgctxt "#32139"
+msgid "Rate this episode"
+msgstr ""
+
+msgctxt "#32140"
+msgid "Toggle watched"
+msgstr ""
+
+msgctxt "#32141"
+msgid "Manage all lists"
+msgstr ""
+
+msgctxt "#32142"
+msgid "Update all tags"
+msgstr ""
+
+msgctxt "#32143"
+msgid "Synchronize library"
+msgstr ""
+
+msgctxt "#32144"
+msgid "How do I authorize the trakt addon to access my trakt.tv account?"
+msgstr ""
+
+# empty strings from id 32145 to 32146
+msgctxt "#32147"
+msgid "Trakt.tv PIN Authorization Failed"
+msgstr ""
+
+# empty string with id 32148
+msgctxt "#32149"
+msgid "Rate this Season"
+msgstr ""
+
+msgctxt "#32150"
+msgid "You will be reminded in 24 hours"
+msgstr ""
+
+msgctxt "#32151"
+msgid "Use Addon Settings later if you change your mind"
+msgstr ""
+
+msgctxt "#32152"
+msgid "Trakt Authorization Complete"
+msgstr ""
+
+msgctxt "#32153"
+msgid "Trakt Account Authorization"
+msgstr ""
+
+msgctxt "#32154"
+msgid "Authorize"
+msgstr ""
+
+msgctxt "#32155"
+msgid "Remind Me Later"
+msgstr ""
+
+msgctxt "#32156"
+msgid "No Thanks"
+msgstr ""
+
+msgctxt "#32157"
+msgid "Account Authorization"
+msgstr ""
+
+# empty string with id 32158
+msgctxt "#32159"
+msgid "Visit {0} or scan the QR code."
+msgstr ""
+
+msgctxt "#32162"
+msgid "The trakt addon CAN NOT be used without authorizing it to access your trakt.tv account."
+msgstr ""
+
 msgctxt "#32163"
 msgid "User"
 msgstr "Bruker"
+
+msgctxt "#32164"
+msgid "Fallback to Title/Year matching if necessary"
+msgstr ""
+
+msgctxt "#32165"
+msgid "Trakt - Added to watchlist"
+msgstr ""
+
+msgctxt "#32166"
+msgid "Trakt - Failed adding to watchlist"
+msgstr ""
+
+msgctxt "#32167"
+msgid "Offset scrobble start by X minutes"
+msgstr ""
+
+msgctxt "#32168"
+msgid "Sync ratings"
+msgstr ""
+
+msgctxt "#32169"
+msgid "Kodi movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32170"
+msgid "%i movie(s) ratings will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32171"
+msgid "Updating %i of %i movie ratings in Kodi"
+msgstr ""
+
+msgctxt "#32172"
+msgid "Ratings updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32173"
+msgid "Kodi episode ratings are up to date"
+msgstr ""
+
+msgctxt "#32174"
+msgid "Updating %i of %i episode ratings in Kodi"
+msgstr ""
+
+msgctxt "#32175"
+msgid "Ratings updated for %i episode(s) in Kodi"
+msgstr ""
+
+msgctxt "#32176"
+msgid "Kodi show ratings are up to date"
+msgstr ""
+
+msgctxt "#32177"
+msgid "Updating %i of %i show ratings in Kodi"
+msgstr ""
+
+msgctxt "#32178"
+msgid "Ratings updated for %i show(s) in Kodi"
+msgstr ""
+
+msgctxt "#32179"
+msgid "Trakt movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32180"
+msgid "%i movie ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32181"
+msgid "Trakt show ratings are up to date"
+msgstr ""
+
+msgctxt "#32182"
+msgid "%i show ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32183"
+msgid "Attempt to scrobble MythTV PVR recordings"
+msgstr ""
+
+msgctxt "#32184"
+msgid "Attempt secondary show title search"
+msgstr ""
+
+msgctxt "#32185"
+msgid "Exclude Plugins"
+msgstr ""
+
+msgctxt "#32186"
+msgid "Allow script exclusions"
+msgstr ""

--- a/script.trakt/resources/language/resource.language.nl_NL/strings.po
+++ b/script.trakt/resources/language/resource.language.nl_NL/strings.po
@@ -7,14 +7,15 @@ msgstr ""
 "Project-Id-Version: XBMC Addons\n"
 "Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: Kodi Translation Team\n"
-"Language-Team: Dutch (http://www.transifex.com/projects/p/xbmc-addons/language/nl/)\n"
+"PO-Revision-Date: 2021-03-20 15:56+0000\n"
+"Last-Translator: Christian Gade <gade@kodi.tv>\n"
+"Language-Team: Dutch <https://kodi.weblate.cloud/projects/kodi-add-ons-scripts/script-trakt/nl_nl/>\n"
+"Language: nl_NL\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: nl\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Generator: Weblate 4.5.1\n"
 
 msgctxt "#32000"
 msgid "General"
@@ -270,7 +271,7 @@ msgstr "%i van %i aflevering(en) zijn toegevoegd aan je Trakt-collectie"
 
 msgctxt "#32070"
 msgid "Going to update %i show(s) missing watched status"
-msgstr "%i  afleveringen zonder de status Bekeken gaan worden bijgewerkt"
+msgstr "%i afleveringen zonder de status Bekeken gaan worden bijgewerkt"
 
 msgctxt "#32071"
 msgid "Checking watched episodes on Trakt"
@@ -608,21 +609,14 @@ msgctxt "#32157"
 msgid "Account Authorization"
 msgstr "Account autorisatie"
 
+# empty string with id 32158
 msgctxt "#32159"
-msgid "Visit {0} or scan the QR Code below."
-msgstr "Bezoek {0} of scan de QR code beneden."
-
-msgctxt "#32160"
-msgid "Authorize the trakt addon to access your account."
-msgstr "Autoriseer de trakt add-on om toegang te krijgen tot jouw account."
-
-msgctxt "#32161"
-msgid "Enter the PIN provided in the box below."
-msgstr "Vul het wachtwoord in verkregen in de box beneden."
+msgid "Visit {0} or scan the QR code."
+msgstr ""
 
 msgctxt "#32162"
 msgid "The trakt addon CAN NOT be used without authorizing it to access your trakt.tv account."
-msgstr "De trakt add-on KAN NIET worden gebruikt zonder het te autoriseren naar jouw trakt.tv account.   "
+msgstr "De trakt add-on KAN NIET worden gebruikt zonder het te autoriseren naar jouw trakt.tv account."
 
 msgctxt "#32163"
 msgid "User"
@@ -639,3 +633,95 @@ msgstr "Trakt - Toegevoegd aan bekijklijst"
 msgctxt "#32166"
 msgid "Trakt - Failed adding to watchlist"
 msgstr "Trakt - Niet gelukt toe te voegen aan bekijklijst"
+
+msgctxt "#32167"
+msgid "Offset scrobble start by X minutes"
+msgstr ""
+
+msgctxt "#32168"
+msgid "Sync ratings"
+msgstr ""
+
+msgctxt "#32169"
+msgid "Kodi movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32170"
+msgid "%i movie(s) ratings will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32171"
+msgid "Updating %i of %i movie ratings in Kodi"
+msgstr ""
+
+msgctxt "#32172"
+msgid "Ratings updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32173"
+msgid "Kodi episode ratings are up to date"
+msgstr ""
+
+msgctxt "#32174"
+msgid "Updating %i of %i episode ratings in Kodi"
+msgstr ""
+
+msgctxt "#32175"
+msgid "Ratings updated for %i episode(s) in Kodi"
+msgstr ""
+
+msgctxt "#32176"
+msgid "Kodi show ratings are up to date"
+msgstr ""
+
+msgctxt "#32177"
+msgid "Updating %i of %i show ratings in Kodi"
+msgstr ""
+
+msgctxt "#32178"
+msgid "Ratings updated for %i show(s) in Kodi"
+msgstr ""
+
+msgctxt "#32179"
+msgid "Trakt movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32180"
+msgid "%i movie ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32181"
+msgid "Trakt show ratings are up to date"
+msgstr ""
+
+msgctxt "#32182"
+msgid "%i show ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32183"
+msgid "Attempt to scrobble MythTV PVR recordings"
+msgstr ""
+
+msgctxt "#32184"
+msgid "Attempt secondary show title search"
+msgstr ""
+
+msgctxt "#32185"
+msgid "Exclude Plugins"
+msgstr ""
+
+msgctxt "#32186"
+msgid "Allow script exclusions"
+msgstr ""
+
+#~ msgctxt "#32159"
+#~ msgid "Visit {0} or scan the QR Code below."
+#~ msgstr "Bezoek {0} of scan de QR code beneden."
+
+#~ msgctxt "#32160"
+#~ msgid "Authorize the trakt addon to access your account."
+#~ msgstr "Autoriseer de trakt add-on om toegang te krijgen tot jouw account."
+
+#~ msgctxt "#32161"
+#~ msgid "Enter the PIN provided in the box below."
+#~ msgstr "Vul het wachtwoord in verkregen in de box beneden."

--- a/script.trakt/resources/language/resource.language.os_os/strings.po
+++ b/script.trakt/resources/language/resource.language.os_os/strings.po
@@ -1,0 +1,722 @@
+# Kodi Media Center language file
+# Addon Name: Trakt
+# Addon id: script.trakt
+# Addon Provider: Trakt.tv, Razze
+msgid ""
+msgstr ""
+"Project-Id-Version: XBMC Addons\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
+"POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: os_os\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+
+# General Settings
+msgctxt "#32000"
+msgid "General"
+msgstr ""
+
+# empty strings from id 32001 to 32002
+msgctxt "#32003"
+msgid "Startup Delay"
+msgstr ""
+
+msgctxt "#32004"
+msgid "Rating"
+msgstr ""
+
+msgctxt "#32005"
+msgid "Rate Movie after watching"
+msgstr ""
+
+msgctxt "#32006"
+msgid "Rate TV show Episode after watching"
+msgstr ""
+
+msgctxt "#32008"
+msgid "Minimum percent watched to display rating dialog"
+msgstr ""
+
+msgctxt "#32009"
+msgid "Allow re-rating of media"
+msgstr ""
+
+msgctxt "#32010"
+msgid "Default rating"
+msgstr ""
+
+# Scrobbling Settings
+msgctxt "#32011"
+msgid "Scrobbling"
+msgstr ""
+
+msgctxt "#32012"
+msgid "Scrobble movies"
+msgstr ""
+
+msgctxt "#32013"
+msgid "Scrobble TV show episodes"
+msgstr ""
+
+msgctxt "#32014"
+msgid "Show notification on scrobble"
+msgstr ""
+
+msgctxt "#32015"
+msgid "Trakt - Scrobbled successfully"
+msgstr ""
+
+msgctxt "#32016"
+msgid "Exclusions"
+msgstr ""
+
+msgctxt "#32017"
+msgid "Exclude Live TV"
+msgstr ""
+
+msgctxt "#32018"
+msgid "Exclude HTTP sources"
+msgstr ""
+
+msgctxt "#32019"
+msgid "Exclude path"
+msgstr ""
+
+msgctxt "#32020"
+msgid "Folder's path (including subfolders)"
+msgstr ""
+
+# empty strings from id 32021 to 32022
+msgctxt "#32023"
+msgid "Can not connect to Trakt"
+msgstr ""
+
+msgctxt "#32024"
+msgid "Error"
+msgstr ""
+
+# empty string with id 32025
+msgctxt "#32026"
+msgid "What Did You Think?"
+msgstr ""
+
+msgctxt "#32027"
+msgid "Totally Ninja!"
+msgstr ""
+
+msgctxt "#32028"
+msgid "Weak Sauce :("
+msgstr ""
+
+msgctxt "#32029"
+msgid "Terrible"
+msgstr ""
+
+msgctxt "#32030"
+msgid "Bad"
+msgstr ""
+
+msgctxt "#32031"
+msgid "Poor"
+msgstr ""
+
+msgctxt "#32032"
+msgid "Meh"
+msgstr ""
+
+msgctxt "#32033"
+msgid "Fair"
+msgstr ""
+
+msgctxt "#32034"
+msgid "Good"
+msgstr ""
+
+msgctxt "#32035"
+msgid "Great"
+msgstr ""
+
+msgctxt "#32036"
+msgid "Superb"
+msgstr ""
+
+msgctxt "#32037"
+msgid "Unrate this movie"
+msgstr ""
+
+msgctxt "#32038"
+msgid "Unrate this show"
+msgstr ""
+
+msgctxt "#32039"
+msgid "Unrate this episode"
+msgstr ""
+
+msgctxt "#32040"
+msgid "Trakt - Rating submitted successfully"
+msgstr ""
+
+msgctxt "#32041"
+msgid "Trakt - Already rated"
+msgstr ""
+
+msgctxt "#32042"
+msgid "Trakt - Unrated successfully"
+msgstr ""
+
+msgctxt "#32043"
+msgid "Trakt - Already has the same rating"
+msgstr ""
+
+msgctxt "#32044"
+msgid "Trakt - Problem submitting rating"
+msgstr ""
+
+msgctxt "#32045"
+msgid "Synchronize"
+msgstr ""
+
+msgctxt "#32046"
+msgid "Movies"
+msgstr ""
+
+msgctxt "#32047"
+msgid "Add new movies to Trakt collection"
+msgstr ""
+
+msgctxt "#32048"
+msgid "Add watched movies to Trakt history"
+msgstr ""
+
+msgctxt "#32049"
+msgid "Mark movies from Trakt history as watched in Kodi"
+msgstr ""
+
+msgctxt "#32050"
+msgid "TV Episodes"
+msgstr ""
+
+msgctxt "#32051"
+msgid "Add new TV episodes to Trakt collection"
+msgstr ""
+
+msgctxt "#32052"
+msgid "Add watched TV episodes to Trakt history"
+msgstr ""
+
+msgctxt "#32053"
+msgid "Mark TV episodes from Trakt history as watched in Kodi"
+msgstr ""
+
+msgctxt "#32054"
+msgid "Service"
+msgstr ""
+
+msgctxt "#32055"
+msgid "Sync collection on library update or cleaning"
+msgstr ""
+
+msgctxt "#32056"
+msgid "Show sync notifications"
+msgstr ""
+
+msgctxt "#32057"
+msgid "Remove deleted movies from Trakt collection"
+msgstr ""
+
+msgctxt "#32058"
+msgid "Remove deleted TV episodes from Trakt collection"
+msgstr ""
+
+# empty string with id 32059
+msgctxt "#32060"
+msgid "Hide notifications during playback"
+msgstr ""
+
+msgctxt "#32061"
+msgid "Sync started"
+msgstr ""
+
+msgctxt "#32062"
+msgid "Sync complete"
+msgstr ""
+
+msgctxt "#32063"
+msgid "%i movie(s) will be added to Trakt collection"
+msgstr ""
+
+msgctxt "#32064"
+msgid "%i movie playcount(s) will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32065"
+msgid "%i movie(s) playcount will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32066"
+msgid "Movie Sync Complete"
+msgstr ""
+
+msgctxt "#32067"
+msgid "Going to add %i show(s) to Trakt collection"
+msgstr ""
+
+msgctxt "#32068"
+msgid "Checking for episodes missing from Trakt collection"
+msgstr ""
+
+msgctxt "#32069"
+msgid "%i of %i show(s) have episodes added to Trakt collection"
+msgstr ""
+
+msgctxt "#32070"
+msgid "Going to update %i show(s) missing watched status"
+msgstr ""
+
+msgctxt "#32071"
+msgid "Checking watched episodes on Trakt"
+msgstr ""
+
+msgctxt "#32072"
+msgid "%i show(s) had missing watched status"
+msgstr ""
+
+msgctxt "#32073"
+msgid "%i episodes are being updated"
+msgstr ""
+
+msgctxt "#32074"
+msgid "Checking watched episodes on Kodi"
+msgstr ""
+
+msgctxt "#32075"
+msgid "Episode Sync Complete"
+msgstr ""
+
+msgctxt "#32076"
+msgid "%i movie(s) will be removed from Trakt collection"
+msgstr ""
+
+msgctxt "#32077"
+msgid "Cleaning Trakt TV show collection"
+msgstr ""
+
+msgctxt "#32078"
+msgid "episodes are being removed"
+msgstr ""
+
+msgctxt "#32079"
+msgid "Loading movies from Kodi"
+msgstr ""
+
+msgctxt "#32080"
+msgid "Movies loaded from Kodi"
+msgstr ""
+
+msgctxt "#32081"
+msgid "Retrieving movie collection from Trakt"
+msgstr ""
+
+msgctxt "#32082"
+msgid "Retrieving watched movies from Trakt"
+msgstr ""
+
+msgctxt "#32083"
+msgid "Retrieved movie data from Trakt"
+msgstr ""
+
+msgctxt "#32084"
+msgid "Trakt movie collection is up to date, no movies to add"
+msgstr ""
+
+msgctxt "#32085"
+msgid "%i movie(s) were added to your Trakt collection"
+msgstr ""
+
+msgctxt "#32086"
+msgid "Trakt movie playcounts are up to date"
+msgstr ""
+
+msgctxt "#32087"
+msgid "Playcounts updated for %i movie(s) on Trakt"
+msgstr ""
+
+msgctxt "#32088"
+msgid "Kodi movie playcounts are up to date"
+msgstr ""
+
+msgctxt "#32089"
+msgid "Updating %i of %i movie playcount(s) in Kodi"
+msgstr ""
+
+msgctxt "#32090"
+msgid "Playcounts updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32091"
+msgid "Trakt movie collection is up to date, no movies removed"
+msgstr ""
+
+msgctxt "#32092"
+msgid "%i movie(s) were removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32093"
+msgid "Updating %i of %i movie playcount(s) on Trakt"
+msgstr ""
+
+msgctxt "#32094"
+msgid "Loading episode data from Kodi"
+msgstr ""
+
+msgctxt "#32095"
+msgid "Loading shows from Kodi"
+msgstr ""
+
+msgctxt "#32096"
+msgid "Shows loaded from Kodi"
+msgstr ""
+
+msgctxt "#32097"
+msgid "Parsing %i of %i episode data from Kodi"
+msgstr ""
+
+msgctxt "#32098"
+msgid "Loaded episode data from Kodi"
+msgstr ""
+
+msgctxt "#32099"
+msgid "Loading episode data from Trakt"
+msgstr ""
+
+msgctxt "#32100"
+msgid "Retrieving episode collection from Trakt"
+msgstr ""
+
+msgctxt "#32101"
+msgid "Retrieving watched episodes from Trakt"
+msgstr ""
+
+msgctxt "#32102"
+msgid "Parsing episode data %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32103"
+msgid "Retrieved episode data from Trakt"
+msgstr ""
+
+msgctxt "#32104"
+msgid "Trakt episode collection is up to date, no episodes to add"
+msgstr ""
+
+msgctxt "#32105"
+msgid "%i episode(s) were added to your Trakt collection"
+msgstr ""
+
+msgctxt "#32106"
+msgid "Trakt episode playcounts are up to date"
+msgstr ""
+
+msgctxt "#32107"
+msgid "Kodi episode playcounts are up to date"
+msgstr ""
+
+msgctxt "#32108"
+msgid "Updating %i of %i episode playcount(s) in Kodi"
+msgstr ""
+
+msgctxt "#32109"
+msgid "Playcounts updated for %i show(s) in Kodi"
+msgstr ""
+
+msgctxt "#32110"
+msgid "Trakt episode collection is clean, no episodes to remove"
+msgstr ""
+
+msgctxt "#32111"
+msgid "%i episode(s) are being removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32112"
+msgid "%i episode(s) were removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32113"
+msgid "Trakt - Marked as watched"
+msgstr ""
+
+msgctxt "#32114"
+msgid "Trakt - Failed marking as watched"
+msgstr ""
+
+msgctxt "#32115"
+msgid "%d episode(s) of '%s'"
+msgstr ""
+
+msgctxt "#32116"
+msgid "Enable debug mode"
+msgstr ""
+
+msgctxt "#32117"
+msgid "Sync movie playback progress to Kodi"
+msgstr ""
+
+msgctxt "#32118"
+msgid "Sync episode playback progress to Kodi"
+msgstr ""
+
+msgctxt "#32119"
+msgid "Retrieving episode playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32120"
+msgid "Parsing episode playback progress %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32121"
+msgid "Retrieved episode playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32122"
+msgid "Retrieving movie playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32123"
+msgid "Parsing movie playback progress %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32124"
+msgid "Retrieved movie playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32125"
+msgid "Kodi movie playback progress is up to date"
+msgstr ""
+
+msgctxt "#32126"
+msgid "%i movie(s) playback progress will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32127"
+msgid "Updating %i of %i movie(s) playback progress in Kodi"
+msgstr ""
+
+msgctxt "#32128"
+msgid "Playback progress updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32129"
+msgid "Kodi episode playback progress is up to date"
+msgstr ""
+
+msgctxt "#32130"
+msgid "Updating %i of %i episode(s) playback progress in Kodi"
+msgstr ""
+
+msgctxt "#32131"
+msgid "Playback progress updated for %i episode(s) in Kodi"
+msgstr ""
+
+msgctxt "#32132"
+msgid "Unrate this season"
+msgstr ""
+
+msgctxt "#32133"
+msgid "Manage Movie's Lists"
+msgstr ""
+
+msgctxt "#32134"
+msgid "Manage Show's Lists"
+msgstr ""
+
+msgctxt "#32135"
+msgid "Remove from Watchlist"
+msgstr ""
+
+msgctxt "#32136"
+msgid "Add to watchlist"
+msgstr ""
+
+msgctxt "#32137"
+msgid "Rate this movie"
+msgstr ""
+
+msgctxt "#32138"
+msgid "Rate this show"
+msgstr ""
+
+msgctxt "#32139"
+msgid "Rate this episode"
+msgstr ""
+
+msgctxt "#32140"
+msgid "Toggle watched"
+msgstr ""
+
+msgctxt "#32141"
+msgid "Manage all lists"
+msgstr ""
+
+msgctxt "#32142"
+msgid "Update all tags"
+msgstr ""
+
+msgctxt "#32143"
+msgid "Synchronize library"
+msgstr ""
+
+msgctxt "#32144"
+msgid "How do I authorize the trakt addon to access my trakt.tv account?"
+msgstr ""
+
+# empty strings from id 32145 to 32146
+msgctxt "#32147"
+msgid "Trakt.tv PIN Authorization Failed"
+msgstr ""
+
+# empty string with id 32148
+msgctxt "#32149"
+msgid "Rate this Season"
+msgstr ""
+
+msgctxt "#32150"
+msgid "You will be reminded in 24 hours"
+msgstr ""
+
+msgctxt "#32151"
+msgid "Use Addon Settings later if you change your mind"
+msgstr ""
+
+msgctxt "#32152"
+msgid "Trakt Authorization Complete"
+msgstr ""
+
+msgctxt "#32153"
+msgid "Trakt Account Authorization"
+msgstr ""
+
+msgctxt "#32154"
+msgid "Authorize"
+msgstr ""
+
+msgctxt "#32155"
+msgid "Remind Me Later"
+msgstr ""
+
+msgctxt "#32156"
+msgid "No Thanks"
+msgstr ""
+
+msgctxt "#32157"
+msgid "Account Authorization"
+msgstr ""
+
+# empty string with id 32158
+msgctxt "#32159"
+msgid "Visit {0} or scan the QR code."
+msgstr ""
+
+msgctxt "#32162"
+msgid "The trakt addon CAN NOT be used without authorizing it to access your trakt.tv account."
+msgstr ""
+
+msgctxt "#32163"
+msgid "User"
+msgstr ""
+
+msgctxt "#32164"
+msgid "Fallback to Title/Year matching if necessary"
+msgstr ""
+
+msgctxt "#32165"
+msgid "Trakt - Added to watchlist"
+msgstr ""
+
+msgctxt "#32166"
+msgid "Trakt - Failed adding to watchlist"
+msgstr ""
+
+msgctxt "#32167"
+msgid "Offset scrobble start by X minutes"
+msgstr ""
+
+msgctxt "#32168"
+msgid "Sync ratings"
+msgstr ""
+
+msgctxt "#32169"
+msgid "Kodi movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32170"
+msgid "%i movie(s) ratings will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32171"
+msgid "Updating %i of %i movie ratings in Kodi"
+msgstr ""
+
+msgctxt "#32172"
+msgid "Ratings updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32173"
+msgid "Kodi episode ratings are up to date"
+msgstr ""
+
+msgctxt "#32174"
+msgid "Updating %i of %i episode ratings in Kodi"
+msgstr ""
+
+msgctxt "#32175"
+msgid "Ratings updated for %i episode(s) in Kodi"
+msgstr ""
+
+msgctxt "#32176"
+msgid "Kodi show ratings are up to date"
+msgstr ""
+
+msgctxt "#32177"
+msgid "Updating %i of %i show ratings in Kodi"
+msgstr ""
+
+msgctxt "#32178"
+msgid "Ratings updated for %i show(s) in Kodi"
+msgstr ""
+
+msgctxt "#32179"
+msgid "Trakt movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32180"
+msgid "%i movie ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32181"
+msgid "Trakt show ratings are up to date"
+msgstr ""
+
+msgctxt "#32182"
+msgid "%i show ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32183"
+msgid "Attempt to scrobble MythTV PVR recordings"
+msgstr ""
+
+msgctxt "#32184"
+msgid "Attempt secondary show title search"
+msgstr ""
+
+msgctxt "#32185"
+msgid "Exclude Plugins"
+msgstr ""
+
+msgctxt "#32186"
+msgid "Allow script exclusions"
+msgstr ""

--- a/script.trakt/resources/language/resource.language.pl_PL/strings.po
+++ b/script.trakt/resources/language/resource.language.pl_PL/strings.po
@@ -7,14 +7,15 @@ msgstr ""
 "Project-Id-Version: XBMC Addons\n"
 "Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: Kodi Translation Team\n"
-"Language-Team: Polish (http://www.transifex.com/projects/p/xbmc-addons/language/pl/)\n"
+"PO-Revision-Date: 2021-03-20 15:56+0000\n"
+"Last-Translator: Christian Gade <gade@kodi.tv>\n"
+"Language-Team: Polish <https://kodi.weblate.cloud/projects/kodi-add-ons-scripts/script-trakt/pl_pl/>\n"
+"Language: pl_PL\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: pl\n"
-"Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+"Plural-Forms: nplurals=3; plural=n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"X-Generator: Weblate 4.5.1\n"
 
 msgctxt "#32000"
 msgid "General"
@@ -608,21 +609,14 @@ msgctxt "#32157"
 msgid "Account Authorization"
 msgstr "Autoryzacja konta"
 
+# empty string with id 32158
 msgctxt "#32159"
-msgid "Visit {0} or scan the QR Code below."
-msgstr "Odwiedź {0} lub zeskanuj kod QR poniżej."
-
-msgctxt "#32160"
-msgid "Authorize the trakt addon to access your account."
-msgstr "Umożliwia autoryzację dostępu dodatku do Twojego konta."
-
-msgctxt "#32161"
-msgid "Enter the PIN provided in the box below."
-msgstr "Wprowadź uzyskany kod PIN w polu poniżej."
+msgid "Visit {0} or scan the QR code."
+msgstr ""
 
 msgctxt "#32162"
 msgid "The trakt addon CAN NOT be used without authorizing it to access your trakt.tv account."
-msgstr "Dodatek Trakt wymaga do działania autoryzacji dostępu do Twojego konta w serwisie Trakt. "
+msgstr "Dodatek Trakt wymaga do działania autoryzacji dostępu do Twojego konta w serwisie Trakt."
 
 msgctxt "#32163"
 msgid "User"
@@ -639,3 +633,95 @@ msgstr "Trakt - Dodano do listy Do obejrzenia"
 msgctxt "#32166"
 msgid "Trakt - Failed adding to watchlist"
 msgstr "Trakt - Nieudane dodawanie do listy Do obejrzenia"
+
+msgctxt "#32167"
+msgid "Offset scrobble start by X minutes"
+msgstr ""
+
+msgctxt "#32168"
+msgid "Sync ratings"
+msgstr ""
+
+msgctxt "#32169"
+msgid "Kodi movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32170"
+msgid "%i movie(s) ratings will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32171"
+msgid "Updating %i of %i movie ratings in Kodi"
+msgstr ""
+
+msgctxt "#32172"
+msgid "Ratings updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32173"
+msgid "Kodi episode ratings are up to date"
+msgstr ""
+
+msgctxt "#32174"
+msgid "Updating %i of %i episode ratings in Kodi"
+msgstr ""
+
+msgctxt "#32175"
+msgid "Ratings updated for %i episode(s) in Kodi"
+msgstr ""
+
+msgctxt "#32176"
+msgid "Kodi show ratings are up to date"
+msgstr ""
+
+msgctxt "#32177"
+msgid "Updating %i of %i show ratings in Kodi"
+msgstr ""
+
+msgctxt "#32178"
+msgid "Ratings updated for %i show(s) in Kodi"
+msgstr ""
+
+msgctxt "#32179"
+msgid "Trakt movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32180"
+msgid "%i movie ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32181"
+msgid "Trakt show ratings are up to date"
+msgstr ""
+
+msgctxt "#32182"
+msgid "%i show ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32183"
+msgid "Attempt to scrobble MythTV PVR recordings"
+msgstr ""
+
+msgctxt "#32184"
+msgid "Attempt secondary show title search"
+msgstr ""
+
+msgctxt "#32185"
+msgid "Exclude Plugins"
+msgstr ""
+
+msgctxt "#32186"
+msgid "Allow script exclusions"
+msgstr ""
+
+#~ msgctxt "#32159"
+#~ msgid "Visit {0} or scan the QR Code below."
+#~ msgstr "Odwiedź {0} lub zeskanuj kod QR poniżej."
+
+#~ msgctxt "#32160"
+#~ msgid "Authorize the trakt addon to access your account."
+#~ msgstr "Umożliwia autoryzację dostępu dodatku do Twojego konta."
+
+#~ msgctxt "#32161"
+#~ msgid "Enter the PIN provided in the box below."
+#~ msgstr "Wprowadź uzyskany kod PIN w polu poniżej."

--- a/script.trakt/resources/language/resource.language.pt_BR/strings.po
+++ b/script.trakt/resources/language/resource.language.pt_BR/strings.po
@@ -7,14 +7,15 @@ msgstr ""
 "Project-Id-Version: XBMC Addons\n"
 "Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: Kodi Translation Team\n"
-"Language-Team: Portuguese (Brazil) (http://www.transifex.com/projects/p/xbmc-addons/language/pt_BR/)\n"
+"PO-Revision-Date: 2021-03-20 15:56+0000\n"
+"Last-Translator: Christian Gade <gade@kodi.tv>\n"
+"Language-Team: Portuguese (Brazil) <https://kodi.weblate.cloud/projects/kodi-add-ons-scripts/script-trakt/pt_br/>\n"
+"Language: pt_BR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: pt_BR\n"
-"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"Plural-Forms: nplurals=2; plural=n > 1;\n"
+"X-Generator: Weblate 4.5.1\n"
 
 msgctxt "#32000"
 msgid "General"
@@ -514,7 +515,7 @@ msgstr "Atualizando progresso de reprodução dos seriados (%i de %i) no Kodi"
 
 msgctxt "#32131"
 msgid "Playback progress updated for %i episode(s) in Kodi"
-msgstr "Progresso da reprodução atualizado para %i  episódio(s) no Kodi"
+msgstr "Progresso da reprodução atualizado para %i episódio(s) no Kodi"
 
 msgctxt "#32132"
 msgid "Unrate this season"
@@ -608,17 +609,10 @@ msgctxt "#32157"
 msgid "Account Authorization"
 msgstr "Autorização na Conta"
 
+# empty string with id 32158
 msgctxt "#32159"
-msgid "Visit {0} or scan the QR Code below."
-msgstr "Visite {0} ou escaneie o código QR abaixo."
-
-msgctxt "#32160"
-msgid "Authorize the trakt addon to access your account."
-msgstr "Autorize o addon do trakt acessar sua conta."
-
-msgctxt "#32161"
-msgid "Enter the PIN provided in the box below."
-msgstr "Entre com o PIN fornecido no campo abaixo."
+msgid "Visit {0} or scan the QR code."
+msgstr ""
 
 msgctxt "#32162"
 msgid "The trakt addon CAN NOT be used without authorizing it to access your trakt.tv account."
@@ -639,3 +633,95 @@ msgstr "Trakt - Adicionado para lista de por assistir"
 msgctxt "#32166"
 msgid "Trakt - Failed adding to watchlist"
 msgstr "Trakt - Falhou ao adicionar para lista de por assistir"
+
+msgctxt "#32167"
+msgid "Offset scrobble start by X minutes"
+msgstr ""
+
+msgctxt "#32168"
+msgid "Sync ratings"
+msgstr ""
+
+msgctxt "#32169"
+msgid "Kodi movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32170"
+msgid "%i movie(s) ratings will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32171"
+msgid "Updating %i of %i movie ratings in Kodi"
+msgstr ""
+
+msgctxt "#32172"
+msgid "Ratings updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32173"
+msgid "Kodi episode ratings are up to date"
+msgstr ""
+
+msgctxt "#32174"
+msgid "Updating %i of %i episode ratings in Kodi"
+msgstr ""
+
+msgctxt "#32175"
+msgid "Ratings updated for %i episode(s) in Kodi"
+msgstr ""
+
+msgctxt "#32176"
+msgid "Kodi show ratings are up to date"
+msgstr ""
+
+msgctxt "#32177"
+msgid "Updating %i of %i show ratings in Kodi"
+msgstr ""
+
+msgctxt "#32178"
+msgid "Ratings updated for %i show(s) in Kodi"
+msgstr ""
+
+msgctxt "#32179"
+msgid "Trakt movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32180"
+msgid "%i movie ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32181"
+msgid "Trakt show ratings are up to date"
+msgstr ""
+
+msgctxt "#32182"
+msgid "%i show ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32183"
+msgid "Attempt to scrobble MythTV PVR recordings"
+msgstr ""
+
+msgctxt "#32184"
+msgid "Attempt secondary show title search"
+msgstr ""
+
+msgctxt "#32185"
+msgid "Exclude Plugins"
+msgstr ""
+
+msgctxt "#32186"
+msgid "Allow script exclusions"
+msgstr ""
+
+#~ msgctxt "#32159"
+#~ msgid "Visit {0} or scan the QR Code below."
+#~ msgstr "Visite {0} ou escaneie o código QR abaixo."
+
+#~ msgctxt "#32160"
+#~ msgid "Authorize the trakt addon to access your account."
+#~ msgstr "Autorize o addon do trakt acessar sua conta."
+
+#~ msgctxt "#32161"
+#~ msgid "Enter the PIN provided in the box below."
+#~ msgstr "Entre com o PIN fornecido no campo abaixo."

--- a/script.trakt/resources/language/resource.language.pt_PT/strings.po
+++ b/script.trakt/resources/language/resource.language.pt_PT/strings.po
@@ -7,14 +7,15 @@ msgstr ""
 "Project-Id-Version: XBMC Addons\n"
 "Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: Kodi Translation Team\n"
-"Language-Team: Portuguese (http://www.transifex.com/projects/p/xbmc-addons/language/pt/)\n"
+"PO-Revision-Date: 2021-03-20 15:56+0000\n"
+"Last-Translator: Christian Gade <gade@kodi.tv>\n"
+"Language-Team: Portuguese (Portugal) <https://kodi.weblate.cloud/projects/kodi-add-ons-scripts/script-trakt/pt_pt/>\n"
+"Language: pt_PT\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: pt\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Weblate 4.5.1\n"
 
 msgctxt "#32000"
 msgid "General"
@@ -514,7 +515,7 @@ msgstr "A actualizar progresso de reprodução das séries (%i de %i) no Kodi"
 
 msgctxt "#32131"
 msgid "Playback progress updated for %i episode(s) in Kodi"
-msgstr "Progresso da reprodução actualizado para %i  episódio(s) no Kodi"
+msgstr "Progresso da reprodução actualizado para %i episódio(s) no Kodi"
 
 msgctxt "#32132"
 msgid "Unrate this season"
@@ -564,6 +565,36 @@ msgctxt "#32143"
 msgid "Synchronize library"
 msgstr "Sincronizar Biblioteca"
 
+msgctxt "#32144"
+msgid "How do I authorize the trakt addon to access my trakt.tv account?"
+msgstr ""
+
+# empty strings from id 32145 to 32146
+msgctxt "#32147"
+msgid "Trakt.tv PIN Authorization Failed"
+msgstr ""
+
+# empty string with id 32148
+msgctxt "#32149"
+msgid "Rate this Season"
+msgstr ""
+
+msgctxt "#32150"
+msgid "You will be reminded in 24 hours"
+msgstr ""
+
+msgctxt "#32151"
+msgid "Use Addon Settings later if you change your mind"
+msgstr ""
+
+msgctxt "#32152"
+msgid "Trakt Authorization Complete"
+msgstr ""
+
+msgctxt "#32153"
+msgid "Trakt Account Authorization"
+msgstr ""
+
 msgctxt "#32154"
 msgid "Authorize"
 msgstr "Autorizar"
@@ -580,13 +611,22 @@ msgctxt "#32157"
 msgid "Account Authorization"
 msgstr "Autorização de Conta"
 
+# empty string with id 32158
 msgctxt "#32159"
-msgid "Visit {0} or scan the QR Code below."
-msgstr "Visitar {0} ou digitalizar código QR abaixo."
+msgid "Visit {0} or scan the QR code."
+msgstr ""
+
+msgctxt "#32162"
+msgid "The trakt addon CAN NOT be used without authorizing it to access your trakt.tv account."
+msgstr ""
 
 msgctxt "#32163"
 msgid "User"
 msgstr "Utilizador"
+
+msgctxt "#32164"
+msgid "Fallback to Title/Year matching if necessary"
+msgstr ""
 
 msgctxt "#32165"
 msgid "Trakt - Added to watchlist"
@@ -595,3 +635,87 @@ msgstr "Trakt - Adicionado à Watchlist"
 msgctxt "#32166"
 msgid "Trakt - Failed adding to watchlist"
 msgstr "Trakt - Falhou a Adicionar à Watchlist"
+
+msgctxt "#32167"
+msgid "Offset scrobble start by X minutes"
+msgstr ""
+
+msgctxt "#32168"
+msgid "Sync ratings"
+msgstr ""
+
+msgctxt "#32169"
+msgid "Kodi movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32170"
+msgid "%i movie(s) ratings will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32171"
+msgid "Updating %i of %i movie ratings in Kodi"
+msgstr ""
+
+msgctxt "#32172"
+msgid "Ratings updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32173"
+msgid "Kodi episode ratings are up to date"
+msgstr ""
+
+msgctxt "#32174"
+msgid "Updating %i of %i episode ratings in Kodi"
+msgstr ""
+
+msgctxt "#32175"
+msgid "Ratings updated for %i episode(s) in Kodi"
+msgstr ""
+
+msgctxt "#32176"
+msgid "Kodi show ratings are up to date"
+msgstr ""
+
+msgctxt "#32177"
+msgid "Updating %i of %i show ratings in Kodi"
+msgstr ""
+
+msgctxt "#32178"
+msgid "Ratings updated for %i show(s) in Kodi"
+msgstr ""
+
+msgctxt "#32179"
+msgid "Trakt movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32180"
+msgid "%i movie ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32181"
+msgid "Trakt show ratings are up to date"
+msgstr ""
+
+msgctxt "#32182"
+msgid "%i show ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32183"
+msgid "Attempt to scrobble MythTV PVR recordings"
+msgstr ""
+
+msgctxt "#32184"
+msgid "Attempt secondary show title search"
+msgstr ""
+
+msgctxt "#32185"
+msgid "Exclude Plugins"
+msgstr ""
+
+msgctxt "#32186"
+msgid "Allow script exclusions"
+msgstr ""
+
+#~ msgctxt "#32159"
+#~ msgid "Visit {0} or scan the QR Code below."
+#~ msgstr "Visitar {0} ou digitalizar código QR abaixo."

--- a/script.trakt/resources/language/resource.language.ro_RO/strings.po
+++ b/script.trakt/resources/language/resource.language.ro_RO/strings.po
@@ -10,28 +10,712 @@ msgstr ""
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Kodi Translation Team\n"
 "Language-Team: Romanian (http://www.transifex.com/projects/p/xbmc-addons/language/ro/)\n"
+"Language: ro\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: ro\n"
 "Plural-Forms: nplurals=3; plural=(n==1?0:(((n%100>19)||((n%100==0)&&(n!=0)))?2:1));\n"
 
 msgctxt "#32000"
 msgid "General"
 msgstr "General"
 
+# empty strings from id 32001 to 32002
+msgctxt "#32003"
+msgid "Startup Delay"
+msgstr ""
+
 msgctxt "#32004"
 msgid "Rating"
 msgstr "Notă"
+
+msgctxt "#32005"
+msgid "Rate Movie after watching"
+msgstr ""
+
+msgctxt "#32006"
+msgid "Rate TV show Episode after watching"
+msgstr ""
+
+msgctxt "#32008"
+msgid "Minimum percent watched to display rating dialog"
+msgstr ""
+
+msgctxt "#32009"
+msgid "Allow re-rating of media"
+msgstr ""
+
+msgctxt "#32010"
+msgid "Default rating"
+msgstr ""
+
+# Scrobbling Settings
+msgctxt "#32011"
+msgid "Scrobbling"
+msgstr ""
+
+msgctxt "#32012"
+msgid "Scrobble movies"
+msgstr ""
+
+msgctxt "#32013"
+msgid "Scrobble TV show episodes"
+msgstr ""
+
+msgctxt "#32014"
+msgid "Show notification on scrobble"
+msgstr ""
+
+msgctxt "#32015"
+msgid "Trakt - Scrobbled successfully"
+msgstr ""
+
+msgctxt "#32016"
+msgid "Exclusions"
+msgstr ""
+
+msgctxt "#32017"
+msgid "Exclude Live TV"
+msgstr ""
+
+msgctxt "#32018"
+msgid "Exclude HTTP sources"
+msgstr ""
+
+msgctxt "#32019"
+msgid "Exclude path"
+msgstr ""
+
+msgctxt "#32020"
+msgid "Folder's path (including subfolders)"
+msgstr ""
+
+# empty strings from id 32021 to 32022
+msgctxt "#32023"
+msgid "Can not connect to Trakt"
+msgstr ""
 
 msgctxt "#32024"
 msgid "Error"
 msgstr "Eroare"
 
+# empty string with id 32025
+msgctxt "#32026"
+msgid "What Did You Think?"
+msgstr ""
+
+msgctxt "#32027"
+msgid "Totally Ninja!"
+msgstr ""
+
+msgctxt "#32028"
+msgid "Weak Sauce :("
+msgstr ""
+
+msgctxt "#32029"
+msgid "Terrible"
+msgstr ""
+
+msgctxt "#32030"
+msgid "Bad"
+msgstr ""
+
+msgctxt "#32031"
+msgid "Poor"
+msgstr ""
+
+msgctxt "#32032"
+msgid "Meh"
+msgstr ""
+
 msgctxt "#32033"
 msgid "Fair"
 msgstr "senin"
 
+msgctxt "#32034"
+msgid "Good"
+msgstr ""
+
+msgctxt "#32035"
+msgid "Great"
+msgstr ""
+
+msgctxt "#32036"
+msgid "Superb"
+msgstr ""
+
+msgctxt "#32037"
+msgid "Unrate this movie"
+msgstr ""
+
+msgctxt "#32038"
+msgid "Unrate this show"
+msgstr ""
+
+msgctxt "#32039"
+msgid "Unrate this episode"
+msgstr ""
+
+msgctxt "#32040"
+msgid "Trakt - Rating submitted successfully"
+msgstr ""
+
+msgctxt "#32041"
+msgid "Trakt - Already rated"
+msgstr ""
+
+msgctxt "#32042"
+msgid "Trakt - Unrated successfully"
+msgstr ""
+
+msgctxt "#32043"
+msgid "Trakt - Already has the same rating"
+msgstr ""
+
+msgctxt "#32044"
+msgid "Trakt - Problem submitting rating"
+msgstr ""
+
+msgctxt "#32045"
+msgid "Synchronize"
+msgstr ""
+
 msgctxt "#32046"
 msgid "Movies"
 msgstr "Filme"
+
+msgctxt "#32047"
+msgid "Add new movies to Trakt collection"
+msgstr ""
+
+msgctxt "#32048"
+msgid "Add watched movies to Trakt history"
+msgstr ""
+
+msgctxt "#32049"
+msgid "Mark movies from Trakt history as watched in Kodi"
+msgstr ""
+
+msgctxt "#32050"
+msgid "TV Episodes"
+msgstr ""
+
+msgctxt "#32051"
+msgid "Add new TV episodes to Trakt collection"
+msgstr ""
+
+msgctxt "#32052"
+msgid "Add watched TV episodes to Trakt history"
+msgstr ""
+
+msgctxt "#32053"
+msgid "Mark TV episodes from Trakt history as watched in Kodi"
+msgstr ""
+
+msgctxt "#32054"
+msgid "Service"
+msgstr ""
+
+msgctxt "#32055"
+msgid "Sync collection on library update or cleaning"
+msgstr ""
+
+msgctxt "#32056"
+msgid "Show sync notifications"
+msgstr ""
+
+msgctxt "#32057"
+msgid "Remove deleted movies from Trakt collection"
+msgstr ""
+
+msgctxt "#32058"
+msgid "Remove deleted TV episodes from Trakt collection"
+msgstr ""
+
+# empty string with id 32059
+msgctxt "#32060"
+msgid "Hide notifications during playback"
+msgstr ""
+
+msgctxt "#32061"
+msgid "Sync started"
+msgstr ""
+
+msgctxt "#32062"
+msgid "Sync complete"
+msgstr ""
+
+msgctxt "#32063"
+msgid "%i movie(s) will be added to Trakt collection"
+msgstr ""
+
+msgctxt "#32064"
+msgid "%i movie playcount(s) will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32065"
+msgid "%i movie(s) playcount will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32066"
+msgid "Movie Sync Complete"
+msgstr ""
+
+msgctxt "#32067"
+msgid "Going to add %i show(s) to Trakt collection"
+msgstr ""
+
+msgctxt "#32068"
+msgid "Checking for episodes missing from Trakt collection"
+msgstr ""
+
+msgctxt "#32069"
+msgid "%i of %i show(s) have episodes added to Trakt collection"
+msgstr ""
+
+msgctxt "#32070"
+msgid "Going to update %i show(s) missing watched status"
+msgstr ""
+
+msgctxt "#32071"
+msgid "Checking watched episodes on Trakt"
+msgstr ""
+
+msgctxt "#32072"
+msgid "%i show(s) had missing watched status"
+msgstr ""
+
+msgctxt "#32073"
+msgid "%i episodes are being updated"
+msgstr ""
+
+msgctxt "#32074"
+msgid "Checking watched episodes on Kodi"
+msgstr ""
+
+msgctxt "#32075"
+msgid "Episode Sync Complete"
+msgstr ""
+
+msgctxt "#32076"
+msgid "%i movie(s) will be removed from Trakt collection"
+msgstr ""
+
+msgctxt "#32077"
+msgid "Cleaning Trakt TV show collection"
+msgstr ""
+
+msgctxt "#32078"
+msgid "episodes are being removed"
+msgstr ""
+
+msgctxt "#32079"
+msgid "Loading movies from Kodi"
+msgstr ""
+
+msgctxt "#32080"
+msgid "Movies loaded from Kodi"
+msgstr ""
+
+msgctxt "#32081"
+msgid "Retrieving movie collection from Trakt"
+msgstr ""
+
+msgctxt "#32082"
+msgid "Retrieving watched movies from Trakt"
+msgstr ""
+
+msgctxt "#32083"
+msgid "Retrieved movie data from Trakt"
+msgstr ""
+
+msgctxt "#32084"
+msgid "Trakt movie collection is up to date, no movies to add"
+msgstr ""
+
+msgctxt "#32085"
+msgid "%i movie(s) were added to your Trakt collection"
+msgstr ""
+
+msgctxt "#32086"
+msgid "Trakt movie playcounts are up to date"
+msgstr ""
+
+msgctxt "#32087"
+msgid "Playcounts updated for %i movie(s) on Trakt"
+msgstr ""
+
+msgctxt "#32088"
+msgid "Kodi movie playcounts are up to date"
+msgstr ""
+
+msgctxt "#32089"
+msgid "Updating %i of %i movie playcount(s) in Kodi"
+msgstr ""
+
+msgctxt "#32090"
+msgid "Playcounts updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32091"
+msgid "Trakt movie collection is up to date, no movies removed"
+msgstr ""
+
+msgctxt "#32092"
+msgid "%i movie(s) were removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32093"
+msgid "Updating %i of %i movie playcount(s) on Trakt"
+msgstr ""
+
+msgctxt "#32094"
+msgid "Loading episode data from Kodi"
+msgstr ""
+
+msgctxt "#32095"
+msgid "Loading shows from Kodi"
+msgstr ""
+
+msgctxt "#32096"
+msgid "Shows loaded from Kodi"
+msgstr ""
+
+msgctxt "#32097"
+msgid "Parsing %i of %i episode data from Kodi"
+msgstr ""
+
+msgctxt "#32098"
+msgid "Loaded episode data from Kodi"
+msgstr ""
+
+msgctxt "#32099"
+msgid "Loading episode data from Trakt"
+msgstr ""
+
+msgctxt "#32100"
+msgid "Retrieving episode collection from Trakt"
+msgstr ""
+
+msgctxt "#32101"
+msgid "Retrieving watched episodes from Trakt"
+msgstr ""
+
+msgctxt "#32102"
+msgid "Parsing episode data %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32103"
+msgid "Retrieved episode data from Trakt"
+msgstr ""
+
+msgctxt "#32104"
+msgid "Trakt episode collection is up to date, no episodes to add"
+msgstr ""
+
+msgctxt "#32105"
+msgid "%i episode(s) were added to your Trakt collection"
+msgstr ""
+
+msgctxt "#32106"
+msgid "Trakt episode playcounts are up to date"
+msgstr ""
+
+msgctxt "#32107"
+msgid "Kodi episode playcounts are up to date"
+msgstr ""
+
+msgctxt "#32108"
+msgid "Updating %i of %i episode playcount(s) in Kodi"
+msgstr ""
+
+msgctxt "#32109"
+msgid "Playcounts updated for %i show(s) in Kodi"
+msgstr ""
+
+msgctxt "#32110"
+msgid "Trakt episode collection is clean, no episodes to remove"
+msgstr ""
+
+msgctxt "#32111"
+msgid "%i episode(s) are being removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32112"
+msgid "%i episode(s) were removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32113"
+msgid "Trakt - Marked as watched"
+msgstr ""
+
+msgctxt "#32114"
+msgid "Trakt - Failed marking as watched"
+msgstr ""
+
+msgctxt "#32115"
+msgid "%d episode(s) of '%s'"
+msgstr ""
+
+msgctxt "#32116"
+msgid "Enable debug mode"
+msgstr ""
+
+msgctxt "#32117"
+msgid "Sync movie playback progress to Kodi"
+msgstr ""
+
+msgctxt "#32118"
+msgid "Sync episode playback progress to Kodi"
+msgstr ""
+
+msgctxt "#32119"
+msgid "Retrieving episode playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32120"
+msgid "Parsing episode playback progress %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32121"
+msgid "Retrieved episode playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32122"
+msgid "Retrieving movie playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32123"
+msgid "Parsing movie playback progress %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32124"
+msgid "Retrieved movie playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32125"
+msgid "Kodi movie playback progress is up to date"
+msgstr ""
+
+msgctxt "#32126"
+msgid "%i movie(s) playback progress will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32127"
+msgid "Updating %i of %i movie(s) playback progress in Kodi"
+msgstr ""
+
+msgctxt "#32128"
+msgid "Playback progress updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32129"
+msgid "Kodi episode playback progress is up to date"
+msgstr ""
+
+msgctxt "#32130"
+msgid "Updating %i of %i episode(s) playback progress in Kodi"
+msgstr ""
+
+msgctxt "#32131"
+msgid "Playback progress updated for %i episode(s) in Kodi"
+msgstr ""
+
+msgctxt "#32132"
+msgid "Unrate this season"
+msgstr ""
+
+msgctxt "#32133"
+msgid "Manage Movie's Lists"
+msgstr ""
+
+msgctxt "#32134"
+msgid "Manage Show's Lists"
+msgstr ""
+
+msgctxt "#32135"
+msgid "Remove from Watchlist"
+msgstr ""
+
+msgctxt "#32136"
+msgid "Add to watchlist"
+msgstr ""
+
+msgctxt "#32137"
+msgid "Rate this movie"
+msgstr ""
+
+msgctxt "#32138"
+msgid "Rate this show"
+msgstr ""
+
+msgctxt "#32139"
+msgid "Rate this episode"
+msgstr ""
+
+msgctxt "#32140"
+msgid "Toggle watched"
+msgstr ""
+
+msgctxt "#32141"
+msgid "Manage all lists"
+msgstr ""
+
+msgctxt "#32142"
+msgid "Update all tags"
+msgstr ""
+
+msgctxt "#32143"
+msgid "Synchronize library"
+msgstr ""
+
+msgctxt "#32144"
+msgid "How do I authorize the trakt addon to access my trakt.tv account?"
+msgstr ""
+
+# empty strings from id 32145 to 32146
+msgctxt "#32147"
+msgid "Trakt.tv PIN Authorization Failed"
+msgstr ""
+
+# empty string with id 32148
+msgctxt "#32149"
+msgid "Rate this Season"
+msgstr ""
+
+msgctxt "#32150"
+msgid "You will be reminded in 24 hours"
+msgstr ""
+
+msgctxt "#32151"
+msgid "Use Addon Settings later if you change your mind"
+msgstr ""
+
+msgctxt "#32152"
+msgid "Trakt Authorization Complete"
+msgstr ""
+
+msgctxt "#32153"
+msgid "Trakt Account Authorization"
+msgstr ""
+
+msgctxt "#32154"
+msgid "Authorize"
+msgstr ""
+
+msgctxt "#32155"
+msgid "Remind Me Later"
+msgstr ""
+
+msgctxt "#32156"
+msgid "No Thanks"
+msgstr ""
+
+msgctxt "#32157"
+msgid "Account Authorization"
+msgstr ""
+
+# empty string with id 32158
+msgctxt "#32159"
+msgid "Visit {0} or scan the QR code."
+msgstr ""
+
+msgctxt "#32162"
+msgid "The trakt addon CAN NOT be used without authorizing it to access your trakt.tv account."
+msgstr ""
+
+msgctxt "#32163"
+msgid "User"
+msgstr ""
+
+msgctxt "#32164"
+msgid "Fallback to Title/Year matching if necessary"
+msgstr ""
+
+msgctxt "#32165"
+msgid "Trakt - Added to watchlist"
+msgstr ""
+
+msgctxt "#32166"
+msgid "Trakt - Failed adding to watchlist"
+msgstr ""
+
+msgctxt "#32167"
+msgid "Offset scrobble start by X minutes"
+msgstr ""
+
+msgctxt "#32168"
+msgid "Sync ratings"
+msgstr ""
+
+msgctxt "#32169"
+msgid "Kodi movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32170"
+msgid "%i movie(s) ratings will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32171"
+msgid "Updating %i of %i movie ratings in Kodi"
+msgstr ""
+
+msgctxt "#32172"
+msgid "Ratings updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32173"
+msgid "Kodi episode ratings are up to date"
+msgstr ""
+
+msgctxt "#32174"
+msgid "Updating %i of %i episode ratings in Kodi"
+msgstr ""
+
+msgctxt "#32175"
+msgid "Ratings updated for %i episode(s) in Kodi"
+msgstr ""
+
+msgctxt "#32176"
+msgid "Kodi show ratings are up to date"
+msgstr ""
+
+msgctxt "#32177"
+msgid "Updating %i of %i show ratings in Kodi"
+msgstr ""
+
+msgctxt "#32178"
+msgid "Ratings updated for %i show(s) in Kodi"
+msgstr ""
+
+msgctxt "#32179"
+msgid "Trakt movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32180"
+msgid "%i movie ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32181"
+msgid "Trakt show ratings are up to date"
+msgstr ""
+
+msgctxt "#32182"
+msgid "%i show ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32183"
+msgid "Attempt to scrobble MythTV PVR recordings"
+msgstr ""
+
+msgctxt "#32184"
+msgid "Attempt secondary show title search"
+msgstr ""
+
+msgctxt "#32185"
+msgid "Exclude Plugins"
+msgstr ""
+
+msgctxt "#32186"
+msgid "Allow script exclusions"
+msgstr ""

--- a/script.trakt/resources/language/resource.language.ro_md/strings.po
+++ b/script.trakt/resources/language/resource.language.ro_md/strings.po
@@ -1,0 +1,723 @@
+# Kodi Media Center language file
+# Addon Name: Trakt
+# Addon id: script.trakt
+# Addon Provider: Trakt.tv, Razze
+msgid ""
+msgstr ""
+"Project-Id-Version: XBMC Addons\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
+"POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: ro_md\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n == 1) ? 0 : ((n == 0 || n % 100 >= 2 && "
+"n % 100 <= 19) ? 1 : 2);\n"
+
+# General Settings
+msgctxt "#32000"
+msgid "General"
+msgstr ""
+
+# empty strings from id 32001 to 32002
+msgctxt "#32003"
+msgid "Startup Delay"
+msgstr ""
+
+msgctxt "#32004"
+msgid "Rating"
+msgstr ""
+
+msgctxt "#32005"
+msgid "Rate Movie after watching"
+msgstr ""
+
+msgctxt "#32006"
+msgid "Rate TV show Episode after watching"
+msgstr ""
+
+msgctxt "#32008"
+msgid "Minimum percent watched to display rating dialog"
+msgstr ""
+
+msgctxt "#32009"
+msgid "Allow re-rating of media"
+msgstr ""
+
+msgctxt "#32010"
+msgid "Default rating"
+msgstr ""
+
+# Scrobbling Settings
+msgctxt "#32011"
+msgid "Scrobbling"
+msgstr ""
+
+msgctxt "#32012"
+msgid "Scrobble movies"
+msgstr ""
+
+msgctxt "#32013"
+msgid "Scrobble TV show episodes"
+msgstr ""
+
+msgctxt "#32014"
+msgid "Show notification on scrobble"
+msgstr ""
+
+msgctxt "#32015"
+msgid "Trakt - Scrobbled successfully"
+msgstr ""
+
+msgctxt "#32016"
+msgid "Exclusions"
+msgstr ""
+
+msgctxt "#32017"
+msgid "Exclude Live TV"
+msgstr ""
+
+msgctxt "#32018"
+msgid "Exclude HTTP sources"
+msgstr ""
+
+msgctxt "#32019"
+msgid "Exclude path"
+msgstr ""
+
+msgctxt "#32020"
+msgid "Folder's path (including subfolders)"
+msgstr ""
+
+# empty strings from id 32021 to 32022
+msgctxt "#32023"
+msgid "Can not connect to Trakt"
+msgstr ""
+
+msgctxt "#32024"
+msgid "Error"
+msgstr ""
+
+# empty string with id 32025
+msgctxt "#32026"
+msgid "What Did You Think?"
+msgstr ""
+
+msgctxt "#32027"
+msgid "Totally Ninja!"
+msgstr ""
+
+msgctxt "#32028"
+msgid "Weak Sauce :("
+msgstr ""
+
+msgctxt "#32029"
+msgid "Terrible"
+msgstr ""
+
+msgctxt "#32030"
+msgid "Bad"
+msgstr ""
+
+msgctxt "#32031"
+msgid "Poor"
+msgstr ""
+
+msgctxt "#32032"
+msgid "Meh"
+msgstr ""
+
+msgctxt "#32033"
+msgid "Fair"
+msgstr ""
+
+msgctxt "#32034"
+msgid "Good"
+msgstr ""
+
+msgctxt "#32035"
+msgid "Great"
+msgstr ""
+
+msgctxt "#32036"
+msgid "Superb"
+msgstr ""
+
+msgctxt "#32037"
+msgid "Unrate this movie"
+msgstr ""
+
+msgctxt "#32038"
+msgid "Unrate this show"
+msgstr ""
+
+msgctxt "#32039"
+msgid "Unrate this episode"
+msgstr ""
+
+msgctxt "#32040"
+msgid "Trakt - Rating submitted successfully"
+msgstr ""
+
+msgctxt "#32041"
+msgid "Trakt - Already rated"
+msgstr ""
+
+msgctxt "#32042"
+msgid "Trakt - Unrated successfully"
+msgstr ""
+
+msgctxt "#32043"
+msgid "Trakt - Already has the same rating"
+msgstr ""
+
+msgctxt "#32044"
+msgid "Trakt - Problem submitting rating"
+msgstr ""
+
+msgctxt "#32045"
+msgid "Synchronize"
+msgstr ""
+
+msgctxt "#32046"
+msgid "Movies"
+msgstr ""
+
+msgctxt "#32047"
+msgid "Add new movies to Trakt collection"
+msgstr ""
+
+msgctxt "#32048"
+msgid "Add watched movies to Trakt history"
+msgstr ""
+
+msgctxt "#32049"
+msgid "Mark movies from Trakt history as watched in Kodi"
+msgstr ""
+
+msgctxt "#32050"
+msgid "TV Episodes"
+msgstr ""
+
+msgctxt "#32051"
+msgid "Add new TV episodes to Trakt collection"
+msgstr ""
+
+msgctxt "#32052"
+msgid "Add watched TV episodes to Trakt history"
+msgstr ""
+
+msgctxt "#32053"
+msgid "Mark TV episodes from Trakt history as watched in Kodi"
+msgstr ""
+
+msgctxt "#32054"
+msgid "Service"
+msgstr ""
+
+msgctxt "#32055"
+msgid "Sync collection on library update or cleaning"
+msgstr ""
+
+msgctxt "#32056"
+msgid "Show sync notifications"
+msgstr ""
+
+msgctxt "#32057"
+msgid "Remove deleted movies from Trakt collection"
+msgstr ""
+
+msgctxt "#32058"
+msgid "Remove deleted TV episodes from Trakt collection"
+msgstr ""
+
+# empty string with id 32059
+msgctxt "#32060"
+msgid "Hide notifications during playback"
+msgstr ""
+
+msgctxt "#32061"
+msgid "Sync started"
+msgstr ""
+
+msgctxt "#32062"
+msgid "Sync complete"
+msgstr ""
+
+msgctxt "#32063"
+msgid "%i movie(s) will be added to Trakt collection"
+msgstr ""
+
+msgctxt "#32064"
+msgid "%i movie playcount(s) will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32065"
+msgid "%i movie(s) playcount will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32066"
+msgid "Movie Sync Complete"
+msgstr ""
+
+msgctxt "#32067"
+msgid "Going to add %i show(s) to Trakt collection"
+msgstr ""
+
+msgctxt "#32068"
+msgid "Checking for episodes missing from Trakt collection"
+msgstr ""
+
+msgctxt "#32069"
+msgid "%i of %i show(s) have episodes added to Trakt collection"
+msgstr ""
+
+msgctxt "#32070"
+msgid "Going to update %i show(s) missing watched status"
+msgstr ""
+
+msgctxt "#32071"
+msgid "Checking watched episodes on Trakt"
+msgstr ""
+
+msgctxt "#32072"
+msgid "%i show(s) had missing watched status"
+msgstr ""
+
+msgctxt "#32073"
+msgid "%i episodes are being updated"
+msgstr ""
+
+msgctxt "#32074"
+msgid "Checking watched episodes on Kodi"
+msgstr ""
+
+msgctxt "#32075"
+msgid "Episode Sync Complete"
+msgstr ""
+
+msgctxt "#32076"
+msgid "%i movie(s) will be removed from Trakt collection"
+msgstr ""
+
+msgctxt "#32077"
+msgid "Cleaning Trakt TV show collection"
+msgstr ""
+
+msgctxt "#32078"
+msgid "episodes are being removed"
+msgstr ""
+
+msgctxt "#32079"
+msgid "Loading movies from Kodi"
+msgstr ""
+
+msgctxt "#32080"
+msgid "Movies loaded from Kodi"
+msgstr ""
+
+msgctxt "#32081"
+msgid "Retrieving movie collection from Trakt"
+msgstr ""
+
+msgctxt "#32082"
+msgid "Retrieving watched movies from Trakt"
+msgstr ""
+
+msgctxt "#32083"
+msgid "Retrieved movie data from Trakt"
+msgstr ""
+
+msgctxt "#32084"
+msgid "Trakt movie collection is up to date, no movies to add"
+msgstr ""
+
+msgctxt "#32085"
+msgid "%i movie(s) were added to your Trakt collection"
+msgstr ""
+
+msgctxt "#32086"
+msgid "Trakt movie playcounts are up to date"
+msgstr ""
+
+msgctxt "#32087"
+msgid "Playcounts updated for %i movie(s) on Trakt"
+msgstr ""
+
+msgctxt "#32088"
+msgid "Kodi movie playcounts are up to date"
+msgstr ""
+
+msgctxt "#32089"
+msgid "Updating %i of %i movie playcount(s) in Kodi"
+msgstr ""
+
+msgctxt "#32090"
+msgid "Playcounts updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32091"
+msgid "Trakt movie collection is up to date, no movies removed"
+msgstr ""
+
+msgctxt "#32092"
+msgid "%i movie(s) were removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32093"
+msgid "Updating %i of %i movie playcount(s) on Trakt"
+msgstr ""
+
+msgctxt "#32094"
+msgid "Loading episode data from Kodi"
+msgstr ""
+
+msgctxt "#32095"
+msgid "Loading shows from Kodi"
+msgstr ""
+
+msgctxt "#32096"
+msgid "Shows loaded from Kodi"
+msgstr ""
+
+msgctxt "#32097"
+msgid "Parsing %i of %i episode data from Kodi"
+msgstr ""
+
+msgctxt "#32098"
+msgid "Loaded episode data from Kodi"
+msgstr ""
+
+msgctxt "#32099"
+msgid "Loading episode data from Trakt"
+msgstr ""
+
+msgctxt "#32100"
+msgid "Retrieving episode collection from Trakt"
+msgstr ""
+
+msgctxt "#32101"
+msgid "Retrieving watched episodes from Trakt"
+msgstr ""
+
+msgctxt "#32102"
+msgid "Parsing episode data %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32103"
+msgid "Retrieved episode data from Trakt"
+msgstr ""
+
+msgctxt "#32104"
+msgid "Trakt episode collection is up to date, no episodes to add"
+msgstr ""
+
+msgctxt "#32105"
+msgid "%i episode(s) were added to your Trakt collection"
+msgstr ""
+
+msgctxt "#32106"
+msgid "Trakt episode playcounts are up to date"
+msgstr ""
+
+msgctxt "#32107"
+msgid "Kodi episode playcounts are up to date"
+msgstr ""
+
+msgctxt "#32108"
+msgid "Updating %i of %i episode playcount(s) in Kodi"
+msgstr ""
+
+msgctxt "#32109"
+msgid "Playcounts updated for %i show(s) in Kodi"
+msgstr ""
+
+msgctxt "#32110"
+msgid "Trakt episode collection is clean, no episodes to remove"
+msgstr ""
+
+msgctxt "#32111"
+msgid "%i episode(s) are being removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32112"
+msgid "%i episode(s) were removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32113"
+msgid "Trakt - Marked as watched"
+msgstr ""
+
+msgctxt "#32114"
+msgid "Trakt - Failed marking as watched"
+msgstr ""
+
+msgctxt "#32115"
+msgid "%d episode(s) of '%s'"
+msgstr ""
+
+msgctxt "#32116"
+msgid "Enable debug mode"
+msgstr ""
+
+msgctxt "#32117"
+msgid "Sync movie playback progress to Kodi"
+msgstr ""
+
+msgctxt "#32118"
+msgid "Sync episode playback progress to Kodi"
+msgstr ""
+
+msgctxt "#32119"
+msgid "Retrieving episode playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32120"
+msgid "Parsing episode playback progress %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32121"
+msgid "Retrieved episode playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32122"
+msgid "Retrieving movie playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32123"
+msgid "Parsing movie playback progress %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32124"
+msgid "Retrieved movie playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32125"
+msgid "Kodi movie playback progress is up to date"
+msgstr ""
+
+msgctxt "#32126"
+msgid "%i movie(s) playback progress will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32127"
+msgid "Updating %i of %i movie(s) playback progress in Kodi"
+msgstr ""
+
+msgctxt "#32128"
+msgid "Playback progress updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32129"
+msgid "Kodi episode playback progress is up to date"
+msgstr ""
+
+msgctxt "#32130"
+msgid "Updating %i of %i episode(s) playback progress in Kodi"
+msgstr ""
+
+msgctxt "#32131"
+msgid "Playback progress updated for %i episode(s) in Kodi"
+msgstr ""
+
+msgctxt "#32132"
+msgid "Unrate this season"
+msgstr ""
+
+msgctxt "#32133"
+msgid "Manage Movie's Lists"
+msgstr ""
+
+msgctxt "#32134"
+msgid "Manage Show's Lists"
+msgstr ""
+
+msgctxt "#32135"
+msgid "Remove from Watchlist"
+msgstr ""
+
+msgctxt "#32136"
+msgid "Add to watchlist"
+msgstr ""
+
+msgctxt "#32137"
+msgid "Rate this movie"
+msgstr ""
+
+msgctxt "#32138"
+msgid "Rate this show"
+msgstr ""
+
+msgctxt "#32139"
+msgid "Rate this episode"
+msgstr ""
+
+msgctxt "#32140"
+msgid "Toggle watched"
+msgstr ""
+
+msgctxt "#32141"
+msgid "Manage all lists"
+msgstr ""
+
+msgctxt "#32142"
+msgid "Update all tags"
+msgstr ""
+
+msgctxt "#32143"
+msgid "Synchronize library"
+msgstr ""
+
+msgctxt "#32144"
+msgid "How do I authorize the trakt addon to access my trakt.tv account?"
+msgstr ""
+
+# empty strings from id 32145 to 32146
+msgctxt "#32147"
+msgid "Trakt.tv PIN Authorization Failed"
+msgstr ""
+
+# empty string with id 32148
+msgctxt "#32149"
+msgid "Rate this Season"
+msgstr ""
+
+msgctxt "#32150"
+msgid "You will be reminded in 24 hours"
+msgstr ""
+
+msgctxt "#32151"
+msgid "Use Addon Settings later if you change your mind"
+msgstr ""
+
+msgctxt "#32152"
+msgid "Trakt Authorization Complete"
+msgstr ""
+
+msgctxt "#32153"
+msgid "Trakt Account Authorization"
+msgstr ""
+
+msgctxt "#32154"
+msgid "Authorize"
+msgstr ""
+
+msgctxt "#32155"
+msgid "Remind Me Later"
+msgstr ""
+
+msgctxt "#32156"
+msgid "No Thanks"
+msgstr ""
+
+msgctxt "#32157"
+msgid "Account Authorization"
+msgstr ""
+
+# empty string with id 32158
+msgctxt "#32159"
+msgid "Visit {0} or scan the QR code."
+msgstr ""
+
+msgctxt "#32162"
+msgid "The trakt addon CAN NOT be used without authorizing it to access your trakt.tv account."
+msgstr ""
+
+msgctxt "#32163"
+msgid "User"
+msgstr ""
+
+msgctxt "#32164"
+msgid "Fallback to Title/Year matching if necessary"
+msgstr ""
+
+msgctxt "#32165"
+msgid "Trakt - Added to watchlist"
+msgstr ""
+
+msgctxt "#32166"
+msgid "Trakt - Failed adding to watchlist"
+msgstr ""
+
+msgctxt "#32167"
+msgid "Offset scrobble start by X minutes"
+msgstr ""
+
+msgctxt "#32168"
+msgid "Sync ratings"
+msgstr ""
+
+msgctxt "#32169"
+msgid "Kodi movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32170"
+msgid "%i movie(s) ratings will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32171"
+msgid "Updating %i of %i movie ratings in Kodi"
+msgstr ""
+
+msgctxt "#32172"
+msgid "Ratings updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32173"
+msgid "Kodi episode ratings are up to date"
+msgstr ""
+
+msgctxt "#32174"
+msgid "Updating %i of %i episode ratings in Kodi"
+msgstr ""
+
+msgctxt "#32175"
+msgid "Ratings updated for %i episode(s) in Kodi"
+msgstr ""
+
+msgctxt "#32176"
+msgid "Kodi show ratings are up to date"
+msgstr ""
+
+msgctxt "#32177"
+msgid "Updating %i of %i show ratings in Kodi"
+msgstr ""
+
+msgctxt "#32178"
+msgid "Ratings updated for %i show(s) in Kodi"
+msgstr ""
+
+msgctxt "#32179"
+msgid "Trakt movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32180"
+msgid "%i movie ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32181"
+msgid "Trakt show ratings are up to date"
+msgstr ""
+
+msgctxt "#32182"
+msgid "%i show ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32183"
+msgid "Attempt to scrobble MythTV PVR recordings"
+msgstr ""
+
+msgctxt "#32184"
+msgid "Attempt secondary show title search"
+msgstr ""
+
+msgctxt "#32185"
+msgid "Exclude Plugins"
+msgstr ""
+
+msgctxt "#32186"
+msgid "Allow script exclusions"
+msgstr ""

--- a/script.trakt/resources/language/resource.language.ru_RU/strings.po
+++ b/script.trakt/resources/language/resource.language.ru_RU/strings.po
@@ -10,36 +10,712 @@ msgstr ""
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Kodi Translation Team\n"
 "Language-Team: Russian (http://www.transifex.com/projects/p/xbmc-addons/language/ru/)\n"
+"Language: ru\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: ru\n"
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 
 msgctxt "#32000"
 msgid "General"
 msgstr "Основное"
 
+# empty strings from id 32001 to 32002
+msgctxt "#32003"
+msgid "Startup Delay"
+msgstr ""
+
 msgctxt "#32004"
 msgid "Rating"
 msgstr "Рейтинг"
+
+msgctxt "#32005"
+msgid "Rate Movie after watching"
+msgstr ""
+
+msgctxt "#32006"
+msgid "Rate TV show Episode after watching"
+msgstr ""
+
+msgctxt "#32008"
+msgid "Minimum percent watched to display rating dialog"
+msgstr ""
+
+msgctxt "#32009"
+msgid "Allow re-rating of media"
+msgstr ""
+
+msgctxt "#32010"
+msgid "Default rating"
+msgstr ""
+
+# Scrobbling Settings
+msgctxt "#32011"
+msgid "Scrobbling"
+msgstr ""
+
+msgctxt "#32012"
+msgid "Scrobble movies"
+msgstr ""
+
+msgctxt "#32013"
+msgid "Scrobble TV show episodes"
+msgstr ""
+
+msgctxt "#32014"
+msgid "Show notification on scrobble"
+msgstr ""
+
+msgctxt "#32015"
+msgid "Trakt - Scrobbled successfully"
+msgstr ""
+
+msgctxt "#32016"
+msgid "Exclusions"
+msgstr ""
+
+msgctxt "#32017"
+msgid "Exclude Live TV"
+msgstr ""
+
+msgctxt "#32018"
+msgid "Exclude HTTP sources"
+msgstr ""
+
+msgctxt "#32019"
+msgid "Exclude path"
+msgstr ""
+
+msgctxt "#32020"
+msgid "Folder's path (including subfolders)"
+msgstr ""
+
+# empty strings from id 32021 to 32022
+msgctxt "#32023"
+msgid "Can not connect to Trakt"
+msgstr ""
 
 msgctxt "#32024"
 msgid "Error"
 msgstr "Ошибка"
 
+# empty string with id 32025
+msgctxt "#32026"
+msgid "What Did You Think?"
+msgstr ""
+
+msgctxt "#32027"
+msgid "Totally Ninja!"
+msgstr ""
+
+msgctxt "#32028"
+msgid "Weak Sauce :("
+msgstr ""
+
+msgctxt "#32029"
+msgid "Terrible"
+msgstr ""
+
+msgctxt "#32030"
+msgid "Bad"
+msgstr ""
+
+msgctxt "#32031"
+msgid "Poor"
+msgstr ""
+
+msgctxt "#32032"
+msgid "Meh"
+msgstr ""
+
 msgctxt "#32033"
 msgid "Fair"
 msgstr "безоблачно"
+
+msgctxt "#32034"
+msgid "Good"
+msgstr ""
+
+msgctxt "#32035"
+msgid "Great"
+msgstr ""
+
+msgctxt "#32036"
+msgid "Superb"
+msgstr ""
+
+msgctxt "#32037"
+msgid "Unrate this movie"
+msgstr ""
+
+msgctxt "#32038"
+msgid "Unrate this show"
+msgstr ""
+
+msgctxt "#32039"
+msgid "Unrate this episode"
+msgstr ""
+
+msgctxt "#32040"
+msgid "Trakt - Rating submitted successfully"
+msgstr ""
+
+msgctxt "#32041"
+msgid "Trakt - Already rated"
+msgstr ""
+
+msgctxt "#32042"
+msgid "Trakt - Unrated successfully"
+msgstr ""
+
+msgctxt "#32043"
+msgid "Trakt - Already has the same rating"
+msgstr ""
+
+msgctxt "#32044"
+msgid "Trakt - Problem submitting rating"
+msgstr ""
+
+msgctxt "#32045"
+msgid "Synchronize"
+msgstr ""
 
 msgctxt "#32046"
 msgid "Movies"
 msgstr "Фильмы"
 
+msgctxt "#32047"
+msgid "Add new movies to Trakt collection"
+msgstr ""
+
+msgctxt "#32048"
+msgid "Add watched movies to Trakt history"
+msgstr ""
+
+msgctxt "#32049"
+msgid "Mark movies from Trakt history as watched in Kodi"
+msgstr ""
+
+msgctxt "#32050"
+msgid "TV Episodes"
+msgstr ""
+
+msgctxt "#32051"
+msgid "Add new TV episodes to Trakt collection"
+msgstr ""
+
+msgctxt "#32052"
+msgid "Add watched TV episodes to Trakt history"
+msgstr ""
+
+msgctxt "#32053"
+msgid "Mark TV episodes from Trakt history as watched in Kodi"
+msgstr ""
+
 msgctxt "#32054"
 msgid "Service"
 msgstr "Служба"
 
+msgctxt "#32055"
+msgid "Sync collection on library update or cleaning"
+msgstr ""
+
+msgctxt "#32056"
+msgid "Show sync notifications"
+msgstr ""
+
+msgctxt "#32057"
+msgid "Remove deleted movies from Trakt collection"
+msgstr ""
+
+msgctxt "#32058"
+msgid "Remove deleted TV episodes from Trakt collection"
+msgstr ""
+
+# empty string with id 32059
+msgctxt "#32060"
+msgid "Hide notifications during playback"
+msgstr ""
+
+msgctxt "#32061"
+msgid "Sync started"
+msgstr ""
+
+msgctxt "#32062"
+msgid "Sync complete"
+msgstr ""
+
+msgctxt "#32063"
+msgid "%i movie(s) will be added to Trakt collection"
+msgstr ""
+
+msgctxt "#32064"
+msgid "%i movie playcount(s) will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32065"
+msgid "%i movie(s) playcount will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32066"
+msgid "Movie Sync Complete"
+msgstr ""
+
+msgctxt "#32067"
+msgid "Going to add %i show(s) to Trakt collection"
+msgstr ""
+
+msgctxt "#32068"
+msgid "Checking for episodes missing from Trakt collection"
+msgstr ""
+
+msgctxt "#32069"
+msgid "%i of %i show(s) have episodes added to Trakt collection"
+msgstr ""
+
+msgctxt "#32070"
+msgid "Going to update %i show(s) missing watched status"
+msgstr ""
+
+msgctxt "#32071"
+msgid "Checking watched episodes on Trakt"
+msgstr ""
+
+msgctxt "#32072"
+msgid "%i show(s) had missing watched status"
+msgstr ""
+
+msgctxt "#32073"
+msgid "%i episodes are being updated"
+msgstr ""
+
+msgctxt "#32074"
+msgid "Checking watched episodes on Kodi"
+msgstr ""
+
+msgctxt "#32075"
+msgid "Episode Sync Complete"
+msgstr ""
+
+msgctxt "#32076"
+msgid "%i movie(s) will be removed from Trakt collection"
+msgstr ""
+
+msgctxt "#32077"
+msgid "Cleaning Trakt TV show collection"
+msgstr ""
+
+msgctxt "#32078"
+msgid "episodes are being removed"
+msgstr ""
+
+msgctxt "#32079"
+msgid "Loading movies from Kodi"
+msgstr ""
+
+msgctxt "#32080"
+msgid "Movies loaded from Kodi"
+msgstr ""
+
+msgctxt "#32081"
+msgid "Retrieving movie collection from Trakt"
+msgstr ""
+
+msgctxt "#32082"
+msgid "Retrieving watched movies from Trakt"
+msgstr ""
+
+msgctxt "#32083"
+msgid "Retrieved movie data from Trakt"
+msgstr ""
+
+msgctxt "#32084"
+msgid "Trakt movie collection is up to date, no movies to add"
+msgstr ""
+
+msgctxt "#32085"
+msgid "%i movie(s) were added to your Trakt collection"
+msgstr ""
+
+msgctxt "#32086"
+msgid "Trakt movie playcounts are up to date"
+msgstr ""
+
+msgctxt "#32087"
+msgid "Playcounts updated for %i movie(s) on Trakt"
+msgstr ""
+
+msgctxt "#32088"
+msgid "Kodi movie playcounts are up to date"
+msgstr ""
+
+msgctxt "#32089"
+msgid "Updating %i of %i movie playcount(s) in Kodi"
+msgstr ""
+
+msgctxt "#32090"
+msgid "Playcounts updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32091"
+msgid "Trakt movie collection is up to date, no movies removed"
+msgstr ""
+
+msgctxt "#32092"
+msgid "%i movie(s) were removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32093"
+msgid "Updating %i of %i movie playcount(s) on Trakt"
+msgstr ""
+
+msgctxt "#32094"
+msgid "Loading episode data from Kodi"
+msgstr ""
+
+msgctxt "#32095"
+msgid "Loading shows from Kodi"
+msgstr ""
+
+msgctxt "#32096"
+msgid "Shows loaded from Kodi"
+msgstr ""
+
+msgctxt "#32097"
+msgid "Parsing %i of %i episode data from Kodi"
+msgstr ""
+
+msgctxt "#32098"
+msgid "Loaded episode data from Kodi"
+msgstr ""
+
+msgctxt "#32099"
+msgid "Loading episode data from Trakt"
+msgstr ""
+
+msgctxt "#32100"
+msgid "Retrieving episode collection from Trakt"
+msgstr ""
+
+msgctxt "#32101"
+msgid "Retrieving watched episodes from Trakt"
+msgstr ""
+
+msgctxt "#32102"
+msgid "Parsing episode data %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32103"
+msgid "Retrieved episode data from Trakt"
+msgstr ""
+
+msgctxt "#32104"
+msgid "Trakt episode collection is up to date, no episodes to add"
+msgstr ""
+
+msgctxt "#32105"
+msgid "%i episode(s) were added to your Trakt collection"
+msgstr ""
+
+msgctxt "#32106"
+msgid "Trakt episode playcounts are up to date"
+msgstr ""
+
+msgctxt "#32107"
+msgid "Kodi episode playcounts are up to date"
+msgstr ""
+
+msgctxt "#32108"
+msgid "Updating %i of %i episode playcount(s) in Kodi"
+msgstr ""
+
+msgctxt "#32109"
+msgid "Playcounts updated for %i show(s) in Kodi"
+msgstr ""
+
+msgctxt "#32110"
+msgid "Trakt episode collection is clean, no episodes to remove"
+msgstr ""
+
+msgctxt "#32111"
+msgid "%i episode(s) are being removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32112"
+msgid "%i episode(s) were removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32113"
+msgid "Trakt - Marked as watched"
+msgstr ""
+
+msgctxt "#32114"
+msgid "Trakt - Failed marking as watched"
+msgstr ""
+
+msgctxt "#32115"
+msgid "%d episode(s) of '%s'"
+msgstr ""
+
+msgctxt "#32116"
+msgid "Enable debug mode"
+msgstr ""
+
+msgctxt "#32117"
+msgid "Sync movie playback progress to Kodi"
+msgstr ""
+
+msgctxt "#32118"
+msgid "Sync episode playback progress to Kodi"
+msgstr ""
+
+msgctxt "#32119"
+msgid "Retrieving episode playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32120"
+msgid "Parsing episode playback progress %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32121"
+msgid "Retrieved episode playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32122"
+msgid "Retrieving movie playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32123"
+msgid "Parsing movie playback progress %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32124"
+msgid "Retrieved movie playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32125"
+msgid "Kodi movie playback progress is up to date"
+msgstr ""
+
+msgctxt "#32126"
+msgid "%i movie(s) playback progress will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32127"
+msgid "Updating %i of %i movie(s) playback progress in Kodi"
+msgstr ""
+
+msgctxt "#32128"
+msgid "Playback progress updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32129"
+msgid "Kodi episode playback progress is up to date"
+msgstr ""
+
+msgctxt "#32130"
+msgid "Updating %i of %i episode(s) playback progress in Kodi"
+msgstr ""
+
+msgctxt "#32131"
+msgid "Playback progress updated for %i episode(s) in Kodi"
+msgstr ""
+
+msgctxt "#32132"
+msgid "Unrate this season"
+msgstr ""
+
+msgctxt "#32133"
+msgid "Manage Movie's Lists"
+msgstr ""
+
+msgctxt "#32134"
+msgid "Manage Show's Lists"
+msgstr ""
+
+msgctxt "#32135"
+msgid "Remove from Watchlist"
+msgstr ""
+
+msgctxt "#32136"
+msgid "Add to watchlist"
+msgstr ""
+
+msgctxt "#32137"
+msgid "Rate this movie"
+msgstr ""
+
+msgctxt "#32138"
+msgid "Rate this show"
+msgstr ""
+
+msgctxt "#32139"
+msgid "Rate this episode"
+msgstr ""
+
+msgctxt "#32140"
+msgid "Toggle watched"
+msgstr ""
+
+msgctxt "#32141"
+msgid "Manage all lists"
+msgstr ""
+
+msgctxt "#32142"
+msgid "Update all tags"
+msgstr ""
+
+msgctxt "#32143"
+msgid "Synchronize library"
+msgstr ""
+
+msgctxt "#32144"
+msgid "How do I authorize the trakt addon to access my trakt.tv account?"
+msgstr ""
+
+# empty strings from id 32145 to 32146
+msgctxt "#32147"
+msgid "Trakt.tv PIN Authorization Failed"
+msgstr ""
+
+# empty string with id 32148
+msgctxt "#32149"
+msgid "Rate this Season"
+msgstr ""
+
+msgctxt "#32150"
+msgid "You will be reminded in 24 hours"
+msgstr ""
+
+msgctxt "#32151"
+msgid "Use Addon Settings later if you change your mind"
+msgstr ""
+
+msgctxt "#32152"
+msgid "Trakt Authorization Complete"
+msgstr ""
+
+msgctxt "#32153"
+msgid "Trakt Account Authorization"
+msgstr ""
+
+msgctxt "#32154"
+msgid "Authorize"
+msgstr ""
+
+msgctxt "#32155"
+msgid "Remind Me Later"
+msgstr ""
+
+msgctxt "#32156"
+msgid "No Thanks"
+msgstr ""
+
+msgctxt "#32157"
+msgid "Account Authorization"
+msgstr ""
+
+# empty string with id 32158
+msgctxt "#32159"
+msgid "Visit {0} or scan the QR code."
+msgstr ""
+
+msgctxt "#32162"
+msgid "The trakt addon CAN NOT be used without authorizing it to access your trakt.tv account."
+msgstr ""
+
 msgctxt "#32163"
 msgid "User"
 msgstr "Пользователь"
+
+msgctxt "#32164"
+msgid "Fallback to Title/Year matching if necessary"
+msgstr ""
+
+msgctxt "#32165"
+msgid "Trakt - Added to watchlist"
+msgstr ""
+
+msgctxt "#32166"
+msgid "Trakt - Failed adding to watchlist"
+msgstr ""
+
+msgctxt "#32167"
+msgid "Offset scrobble start by X minutes"
+msgstr ""
+
+msgctxt "#32168"
+msgid "Sync ratings"
+msgstr ""
+
+msgctxt "#32169"
+msgid "Kodi movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32170"
+msgid "%i movie(s) ratings will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32171"
+msgid "Updating %i of %i movie ratings in Kodi"
+msgstr ""
+
+msgctxt "#32172"
+msgid "Ratings updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32173"
+msgid "Kodi episode ratings are up to date"
+msgstr ""
+
+msgctxt "#32174"
+msgid "Updating %i of %i episode ratings in Kodi"
+msgstr ""
+
+msgctxt "#32175"
+msgid "Ratings updated for %i episode(s) in Kodi"
+msgstr ""
+
+msgctxt "#32176"
+msgid "Kodi show ratings are up to date"
+msgstr ""
+
+msgctxt "#32177"
+msgid "Updating %i of %i show ratings in Kodi"
+msgstr ""
+
+msgctxt "#32178"
+msgid "Ratings updated for %i show(s) in Kodi"
+msgstr ""
+
+msgctxt "#32179"
+msgid "Trakt movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32180"
+msgid "%i movie ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32181"
+msgid "Trakt show ratings are up to date"
+msgstr ""
+
+msgctxt "#32182"
+msgid "%i show ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32183"
+msgid "Attempt to scrobble MythTV PVR recordings"
+msgstr ""
+
+msgctxt "#32184"
+msgid "Attempt secondary show title search"
+msgstr ""
+
+msgctxt "#32185"
+msgid "Exclude Plugins"
+msgstr ""
+
+msgctxt "#32186"
+msgid "Allow script exclusions"
+msgstr ""

--- a/script.trakt/resources/language/resource.language.scn/strings.po
+++ b/script.trakt/resources/language/resource.language.scn/strings.po
@@ -1,0 +1,722 @@
+# Kodi Media Center language file
+# Addon Name: Trakt
+# Addon id: script.trakt
+# Addon Provider: Trakt.tv, Razze
+msgid ""
+msgstr ""
+"Project-Id-Version: XBMC Addons\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
+"POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: scn\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+
+# General Settings
+msgctxt "#32000"
+msgid "General"
+msgstr ""
+
+# empty strings from id 32001 to 32002
+msgctxt "#32003"
+msgid "Startup Delay"
+msgstr ""
+
+msgctxt "#32004"
+msgid "Rating"
+msgstr ""
+
+msgctxt "#32005"
+msgid "Rate Movie after watching"
+msgstr ""
+
+msgctxt "#32006"
+msgid "Rate TV show Episode after watching"
+msgstr ""
+
+msgctxt "#32008"
+msgid "Minimum percent watched to display rating dialog"
+msgstr ""
+
+msgctxt "#32009"
+msgid "Allow re-rating of media"
+msgstr ""
+
+msgctxt "#32010"
+msgid "Default rating"
+msgstr ""
+
+# Scrobbling Settings
+msgctxt "#32011"
+msgid "Scrobbling"
+msgstr ""
+
+msgctxt "#32012"
+msgid "Scrobble movies"
+msgstr ""
+
+msgctxt "#32013"
+msgid "Scrobble TV show episodes"
+msgstr ""
+
+msgctxt "#32014"
+msgid "Show notification on scrobble"
+msgstr ""
+
+msgctxt "#32015"
+msgid "Trakt - Scrobbled successfully"
+msgstr ""
+
+msgctxt "#32016"
+msgid "Exclusions"
+msgstr ""
+
+msgctxt "#32017"
+msgid "Exclude Live TV"
+msgstr ""
+
+msgctxt "#32018"
+msgid "Exclude HTTP sources"
+msgstr ""
+
+msgctxt "#32019"
+msgid "Exclude path"
+msgstr ""
+
+msgctxt "#32020"
+msgid "Folder's path (including subfolders)"
+msgstr ""
+
+# empty strings from id 32021 to 32022
+msgctxt "#32023"
+msgid "Can not connect to Trakt"
+msgstr ""
+
+msgctxt "#32024"
+msgid "Error"
+msgstr ""
+
+# empty string with id 32025
+msgctxt "#32026"
+msgid "What Did You Think?"
+msgstr ""
+
+msgctxt "#32027"
+msgid "Totally Ninja!"
+msgstr ""
+
+msgctxt "#32028"
+msgid "Weak Sauce :("
+msgstr ""
+
+msgctxt "#32029"
+msgid "Terrible"
+msgstr ""
+
+msgctxt "#32030"
+msgid "Bad"
+msgstr ""
+
+msgctxt "#32031"
+msgid "Poor"
+msgstr ""
+
+msgctxt "#32032"
+msgid "Meh"
+msgstr ""
+
+msgctxt "#32033"
+msgid "Fair"
+msgstr ""
+
+msgctxt "#32034"
+msgid "Good"
+msgstr ""
+
+msgctxt "#32035"
+msgid "Great"
+msgstr ""
+
+msgctxt "#32036"
+msgid "Superb"
+msgstr ""
+
+msgctxt "#32037"
+msgid "Unrate this movie"
+msgstr ""
+
+msgctxt "#32038"
+msgid "Unrate this show"
+msgstr ""
+
+msgctxt "#32039"
+msgid "Unrate this episode"
+msgstr ""
+
+msgctxt "#32040"
+msgid "Trakt - Rating submitted successfully"
+msgstr ""
+
+msgctxt "#32041"
+msgid "Trakt - Already rated"
+msgstr ""
+
+msgctxt "#32042"
+msgid "Trakt - Unrated successfully"
+msgstr ""
+
+msgctxt "#32043"
+msgid "Trakt - Already has the same rating"
+msgstr ""
+
+msgctxt "#32044"
+msgid "Trakt - Problem submitting rating"
+msgstr ""
+
+msgctxt "#32045"
+msgid "Synchronize"
+msgstr ""
+
+msgctxt "#32046"
+msgid "Movies"
+msgstr ""
+
+msgctxt "#32047"
+msgid "Add new movies to Trakt collection"
+msgstr ""
+
+msgctxt "#32048"
+msgid "Add watched movies to Trakt history"
+msgstr ""
+
+msgctxt "#32049"
+msgid "Mark movies from Trakt history as watched in Kodi"
+msgstr ""
+
+msgctxt "#32050"
+msgid "TV Episodes"
+msgstr ""
+
+msgctxt "#32051"
+msgid "Add new TV episodes to Trakt collection"
+msgstr ""
+
+msgctxt "#32052"
+msgid "Add watched TV episodes to Trakt history"
+msgstr ""
+
+msgctxt "#32053"
+msgid "Mark TV episodes from Trakt history as watched in Kodi"
+msgstr ""
+
+msgctxt "#32054"
+msgid "Service"
+msgstr ""
+
+msgctxt "#32055"
+msgid "Sync collection on library update or cleaning"
+msgstr ""
+
+msgctxt "#32056"
+msgid "Show sync notifications"
+msgstr ""
+
+msgctxt "#32057"
+msgid "Remove deleted movies from Trakt collection"
+msgstr ""
+
+msgctxt "#32058"
+msgid "Remove deleted TV episodes from Trakt collection"
+msgstr ""
+
+# empty string with id 32059
+msgctxt "#32060"
+msgid "Hide notifications during playback"
+msgstr ""
+
+msgctxt "#32061"
+msgid "Sync started"
+msgstr ""
+
+msgctxt "#32062"
+msgid "Sync complete"
+msgstr ""
+
+msgctxt "#32063"
+msgid "%i movie(s) will be added to Trakt collection"
+msgstr ""
+
+msgctxt "#32064"
+msgid "%i movie playcount(s) will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32065"
+msgid "%i movie(s) playcount will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32066"
+msgid "Movie Sync Complete"
+msgstr ""
+
+msgctxt "#32067"
+msgid "Going to add %i show(s) to Trakt collection"
+msgstr ""
+
+msgctxt "#32068"
+msgid "Checking for episodes missing from Trakt collection"
+msgstr ""
+
+msgctxt "#32069"
+msgid "%i of %i show(s) have episodes added to Trakt collection"
+msgstr ""
+
+msgctxt "#32070"
+msgid "Going to update %i show(s) missing watched status"
+msgstr ""
+
+msgctxt "#32071"
+msgid "Checking watched episodes on Trakt"
+msgstr ""
+
+msgctxt "#32072"
+msgid "%i show(s) had missing watched status"
+msgstr ""
+
+msgctxt "#32073"
+msgid "%i episodes are being updated"
+msgstr ""
+
+msgctxt "#32074"
+msgid "Checking watched episodes on Kodi"
+msgstr ""
+
+msgctxt "#32075"
+msgid "Episode Sync Complete"
+msgstr ""
+
+msgctxt "#32076"
+msgid "%i movie(s) will be removed from Trakt collection"
+msgstr ""
+
+msgctxt "#32077"
+msgid "Cleaning Trakt TV show collection"
+msgstr ""
+
+msgctxt "#32078"
+msgid "episodes are being removed"
+msgstr ""
+
+msgctxt "#32079"
+msgid "Loading movies from Kodi"
+msgstr ""
+
+msgctxt "#32080"
+msgid "Movies loaded from Kodi"
+msgstr ""
+
+msgctxt "#32081"
+msgid "Retrieving movie collection from Trakt"
+msgstr ""
+
+msgctxt "#32082"
+msgid "Retrieving watched movies from Trakt"
+msgstr ""
+
+msgctxt "#32083"
+msgid "Retrieved movie data from Trakt"
+msgstr ""
+
+msgctxt "#32084"
+msgid "Trakt movie collection is up to date, no movies to add"
+msgstr ""
+
+msgctxt "#32085"
+msgid "%i movie(s) were added to your Trakt collection"
+msgstr ""
+
+msgctxt "#32086"
+msgid "Trakt movie playcounts are up to date"
+msgstr ""
+
+msgctxt "#32087"
+msgid "Playcounts updated for %i movie(s) on Trakt"
+msgstr ""
+
+msgctxt "#32088"
+msgid "Kodi movie playcounts are up to date"
+msgstr ""
+
+msgctxt "#32089"
+msgid "Updating %i of %i movie playcount(s) in Kodi"
+msgstr ""
+
+msgctxt "#32090"
+msgid "Playcounts updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32091"
+msgid "Trakt movie collection is up to date, no movies removed"
+msgstr ""
+
+msgctxt "#32092"
+msgid "%i movie(s) were removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32093"
+msgid "Updating %i of %i movie playcount(s) on Trakt"
+msgstr ""
+
+msgctxt "#32094"
+msgid "Loading episode data from Kodi"
+msgstr ""
+
+msgctxt "#32095"
+msgid "Loading shows from Kodi"
+msgstr ""
+
+msgctxt "#32096"
+msgid "Shows loaded from Kodi"
+msgstr ""
+
+msgctxt "#32097"
+msgid "Parsing %i of %i episode data from Kodi"
+msgstr ""
+
+msgctxt "#32098"
+msgid "Loaded episode data from Kodi"
+msgstr ""
+
+msgctxt "#32099"
+msgid "Loading episode data from Trakt"
+msgstr ""
+
+msgctxt "#32100"
+msgid "Retrieving episode collection from Trakt"
+msgstr ""
+
+msgctxt "#32101"
+msgid "Retrieving watched episodes from Trakt"
+msgstr ""
+
+msgctxt "#32102"
+msgid "Parsing episode data %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32103"
+msgid "Retrieved episode data from Trakt"
+msgstr ""
+
+msgctxt "#32104"
+msgid "Trakt episode collection is up to date, no episodes to add"
+msgstr ""
+
+msgctxt "#32105"
+msgid "%i episode(s) were added to your Trakt collection"
+msgstr ""
+
+msgctxt "#32106"
+msgid "Trakt episode playcounts are up to date"
+msgstr ""
+
+msgctxt "#32107"
+msgid "Kodi episode playcounts are up to date"
+msgstr ""
+
+msgctxt "#32108"
+msgid "Updating %i of %i episode playcount(s) in Kodi"
+msgstr ""
+
+msgctxt "#32109"
+msgid "Playcounts updated for %i show(s) in Kodi"
+msgstr ""
+
+msgctxt "#32110"
+msgid "Trakt episode collection is clean, no episodes to remove"
+msgstr ""
+
+msgctxt "#32111"
+msgid "%i episode(s) are being removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32112"
+msgid "%i episode(s) were removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32113"
+msgid "Trakt - Marked as watched"
+msgstr ""
+
+msgctxt "#32114"
+msgid "Trakt - Failed marking as watched"
+msgstr ""
+
+msgctxt "#32115"
+msgid "%d episode(s) of '%s'"
+msgstr ""
+
+msgctxt "#32116"
+msgid "Enable debug mode"
+msgstr ""
+
+msgctxt "#32117"
+msgid "Sync movie playback progress to Kodi"
+msgstr ""
+
+msgctxt "#32118"
+msgid "Sync episode playback progress to Kodi"
+msgstr ""
+
+msgctxt "#32119"
+msgid "Retrieving episode playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32120"
+msgid "Parsing episode playback progress %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32121"
+msgid "Retrieved episode playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32122"
+msgid "Retrieving movie playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32123"
+msgid "Parsing movie playback progress %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32124"
+msgid "Retrieved movie playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32125"
+msgid "Kodi movie playback progress is up to date"
+msgstr ""
+
+msgctxt "#32126"
+msgid "%i movie(s) playback progress will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32127"
+msgid "Updating %i of %i movie(s) playback progress in Kodi"
+msgstr ""
+
+msgctxt "#32128"
+msgid "Playback progress updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32129"
+msgid "Kodi episode playback progress is up to date"
+msgstr ""
+
+msgctxt "#32130"
+msgid "Updating %i of %i episode(s) playback progress in Kodi"
+msgstr ""
+
+msgctxt "#32131"
+msgid "Playback progress updated for %i episode(s) in Kodi"
+msgstr ""
+
+msgctxt "#32132"
+msgid "Unrate this season"
+msgstr ""
+
+msgctxt "#32133"
+msgid "Manage Movie's Lists"
+msgstr ""
+
+msgctxt "#32134"
+msgid "Manage Show's Lists"
+msgstr ""
+
+msgctxt "#32135"
+msgid "Remove from Watchlist"
+msgstr ""
+
+msgctxt "#32136"
+msgid "Add to watchlist"
+msgstr ""
+
+msgctxt "#32137"
+msgid "Rate this movie"
+msgstr ""
+
+msgctxt "#32138"
+msgid "Rate this show"
+msgstr ""
+
+msgctxt "#32139"
+msgid "Rate this episode"
+msgstr ""
+
+msgctxt "#32140"
+msgid "Toggle watched"
+msgstr ""
+
+msgctxt "#32141"
+msgid "Manage all lists"
+msgstr ""
+
+msgctxt "#32142"
+msgid "Update all tags"
+msgstr ""
+
+msgctxt "#32143"
+msgid "Synchronize library"
+msgstr ""
+
+msgctxt "#32144"
+msgid "How do I authorize the trakt addon to access my trakt.tv account?"
+msgstr ""
+
+# empty strings from id 32145 to 32146
+msgctxt "#32147"
+msgid "Trakt.tv PIN Authorization Failed"
+msgstr ""
+
+# empty string with id 32148
+msgctxt "#32149"
+msgid "Rate this Season"
+msgstr ""
+
+msgctxt "#32150"
+msgid "You will be reminded in 24 hours"
+msgstr ""
+
+msgctxt "#32151"
+msgid "Use Addon Settings later if you change your mind"
+msgstr ""
+
+msgctxt "#32152"
+msgid "Trakt Authorization Complete"
+msgstr ""
+
+msgctxt "#32153"
+msgid "Trakt Account Authorization"
+msgstr ""
+
+msgctxt "#32154"
+msgid "Authorize"
+msgstr ""
+
+msgctxt "#32155"
+msgid "Remind Me Later"
+msgstr ""
+
+msgctxt "#32156"
+msgid "No Thanks"
+msgstr ""
+
+msgctxt "#32157"
+msgid "Account Authorization"
+msgstr ""
+
+# empty string with id 32158
+msgctxt "#32159"
+msgid "Visit {0} or scan the QR code."
+msgstr ""
+
+msgctxt "#32162"
+msgid "The trakt addon CAN NOT be used without authorizing it to access your trakt.tv account."
+msgstr ""
+
+msgctxt "#32163"
+msgid "User"
+msgstr ""
+
+msgctxt "#32164"
+msgid "Fallback to Title/Year matching if necessary"
+msgstr ""
+
+msgctxt "#32165"
+msgid "Trakt - Added to watchlist"
+msgstr ""
+
+msgctxt "#32166"
+msgid "Trakt - Failed adding to watchlist"
+msgstr ""
+
+msgctxt "#32167"
+msgid "Offset scrobble start by X minutes"
+msgstr ""
+
+msgctxt "#32168"
+msgid "Sync ratings"
+msgstr ""
+
+msgctxt "#32169"
+msgid "Kodi movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32170"
+msgid "%i movie(s) ratings will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32171"
+msgid "Updating %i of %i movie ratings in Kodi"
+msgstr ""
+
+msgctxt "#32172"
+msgid "Ratings updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32173"
+msgid "Kodi episode ratings are up to date"
+msgstr ""
+
+msgctxt "#32174"
+msgid "Updating %i of %i episode ratings in Kodi"
+msgstr ""
+
+msgctxt "#32175"
+msgid "Ratings updated for %i episode(s) in Kodi"
+msgstr ""
+
+msgctxt "#32176"
+msgid "Kodi show ratings are up to date"
+msgstr ""
+
+msgctxt "#32177"
+msgid "Updating %i of %i show ratings in Kodi"
+msgstr ""
+
+msgctxt "#32178"
+msgid "Ratings updated for %i show(s) in Kodi"
+msgstr ""
+
+msgctxt "#32179"
+msgid "Trakt movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32180"
+msgid "%i movie ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32181"
+msgid "Trakt show ratings are up to date"
+msgstr ""
+
+msgctxt "#32182"
+msgid "%i show ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32183"
+msgid "Attempt to scrobble MythTV PVR recordings"
+msgstr ""
+
+msgctxt "#32184"
+msgid "Attempt secondary show title search"
+msgstr ""
+
+msgctxt "#32185"
+msgid "Exclude Plugins"
+msgstr ""
+
+msgctxt "#32186"
+msgid "Allow script exclusions"
+msgstr ""

--- a/script.trakt/resources/language/resource.language.si_lk/strings.po
+++ b/script.trakt/resources/language/resource.language.si_lk/strings.po
@@ -1,0 +1,722 @@
+# Kodi Media Center language file
+# Addon Name: Trakt
+# Addon id: script.trakt
+# Addon Provider: Trakt.tv, Razze
+msgid ""
+msgstr ""
+"Project-Id-Version: XBMC Addons\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
+"POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: si_lk\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n > 1;\n"
+
+# General Settings
+msgctxt "#32000"
+msgid "General"
+msgstr ""
+
+# empty strings from id 32001 to 32002
+msgctxt "#32003"
+msgid "Startup Delay"
+msgstr ""
+
+msgctxt "#32004"
+msgid "Rating"
+msgstr ""
+
+msgctxt "#32005"
+msgid "Rate Movie after watching"
+msgstr ""
+
+msgctxt "#32006"
+msgid "Rate TV show Episode after watching"
+msgstr ""
+
+msgctxt "#32008"
+msgid "Minimum percent watched to display rating dialog"
+msgstr ""
+
+msgctxt "#32009"
+msgid "Allow re-rating of media"
+msgstr ""
+
+msgctxt "#32010"
+msgid "Default rating"
+msgstr ""
+
+# Scrobbling Settings
+msgctxt "#32011"
+msgid "Scrobbling"
+msgstr ""
+
+msgctxt "#32012"
+msgid "Scrobble movies"
+msgstr ""
+
+msgctxt "#32013"
+msgid "Scrobble TV show episodes"
+msgstr ""
+
+msgctxt "#32014"
+msgid "Show notification on scrobble"
+msgstr ""
+
+msgctxt "#32015"
+msgid "Trakt - Scrobbled successfully"
+msgstr ""
+
+msgctxt "#32016"
+msgid "Exclusions"
+msgstr ""
+
+msgctxt "#32017"
+msgid "Exclude Live TV"
+msgstr ""
+
+msgctxt "#32018"
+msgid "Exclude HTTP sources"
+msgstr ""
+
+msgctxt "#32019"
+msgid "Exclude path"
+msgstr ""
+
+msgctxt "#32020"
+msgid "Folder's path (including subfolders)"
+msgstr ""
+
+# empty strings from id 32021 to 32022
+msgctxt "#32023"
+msgid "Can not connect to Trakt"
+msgstr ""
+
+msgctxt "#32024"
+msgid "Error"
+msgstr ""
+
+# empty string with id 32025
+msgctxt "#32026"
+msgid "What Did You Think?"
+msgstr ""
+
+msgctxt "#32027"
+msgid "Totally Ninja!"
+msgstr ""
+
+msgctxt "#32028"
+msgid "Weak Sauce :("
+msgstr ""
+
+msgctxt "#32029"
+msgid "Terrible"
+msgstr ""
+
+msgctxt "#32030"
+msgid "Bad"
+msgstr ""
+
+msgctxt "#32031"
+msgid "Poor"
+msgstr ""
+
+msgctxt "#32032"
+msgid "Meh"
+msgstr ""
+
+msgctxt "#32033"
+msgid "Fair"
+msgstr ""
+
+msgctxt "#32034"
+msgid "Good"
+msgstr ""
+
+msgctxt "#32035"
+msgid "Great"
+msgstr ""
+
+msgctxt "#32036"
+msgid "Superb"
+msgstr ""
+
+msgctxt "#32037"
+msgid "Unrate this movie"
+msgstr ""
+
+msgctxt "#32038"
+msgid "Unrate this show"
+msgstr ""
+
+msgctxt "#32039"
+msgid "Unrate this episode"
+msgstr ""
+
+msgctxt "#32040"
+msgid "Trakt - Rating submitted successfully"
+msgstr ""
+
+msgctxt "#32041"
+msgid "Trakt - Already rated"
+msgstr ""
+
+msgctxt "#32042"
+msgid "Trakt - Unrated successfully"
+msgstr ""
+
+msgctxt "#32043"
+msgid "Trakt - Already has the same rating"
+msgstr ""
+
+msgctxt "#32044"
+msgid "Trakt - Problem submitting rating"
+msgstr ""
+
+msgctxt "#32045"
+msgid "Synchronize"
+msgstr ""
+
+msgctxt "#32046"
+msgid "Movies"
+msgstr ""
+
+msgctxt "#32047"
+msgid "Add new movies to Trakt collection"
+msgstr ""
+
+msgctxt "#32048"
+msgid "Add watched movies to Trakt history"
+msgstr ""
+
+msgctxt "#32049"
+msgid "Mark movies from Trakt history as watched in Kodi"
+msgstr ""
+
+msgctxt "#32050"
+msgid "TV Episodes"
+msgstr ""
+
+msgctxt "#32051"
+msgid "Add new TV episodes to Trakt collection"
+msgstr ""
+
+msgctxt "#32052"
+msgid "Add watched TV episodes to Trakt history"
+msgstr ""
+
+msgctxt "#32053"
+msgid "Mark TV episodes from Trakt history as watched in Kodi"
+msgstr ""
+
+msgctxt "#32054"
+msgid "Service"
+msgstr ""
+
+msgctxt "#32055"
+msgid "Sync collection on library update or cleaning"
+msgstr ""
+
+msgctxt "#32056"
+msgid "Show sync notifications"
+msgstr ""
+
+msgctxt "#32057"
+msgid "Remove deleted movies from Trakt collection"
+msgstr ""
+
+msgctxt "#32058"
+msgid "Remove deleted TV episodes from Trakt collection"
+msgstr ""
+
+# empty string with id 32059
+msgctxt "#32060"
+msgid "Hide notifications during playback"
+msgstr ""
+
+msgctxt "#32061"
+msgid "Sync started"
+msgstr ""
+
+msgctxt "#32062"
+msgid "Sync complete"
+msgstr ""
+
+msgctxt "#32063"
+msgid "%i movie(s) will be added to Trakt collection"
+msgstr ""
+
+msgctxt "#32064"
+msgid "%i movie playcount(s) will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32065"
+msgid "%i movie(s) playcount will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32066"
+msgid "Movie Sync Complete"
+msgstr ""
+
+msgctxt "#32067"
+msgid "Going to add %i show(s) to Trakt collection"
+msgstr ""
+
+msgctxt "#32068"
+msgid "Checking for episodes missing from Trakt collection"
+msgstr ""
+
+msgctxt "#32069"
+msgid "%i of %i show(s) have episodes added to Trakt collection"
+msgstr ""
+
+msgctxt "#32070"
+msgid "Going to update %i show(s) missing watched status"
+msgstr ""
+
+msgctxt "#32071"
+msgid "Checking watched episodes on Trakt"
+msgstr ""
+
+msgctxt "#32072"
+msgid "%i show(s) had missing watched status"
+msgstr ""
+
+msgctxt "#32073"
+msgid "%i episodes are being updated"
+msgstr ""
+
+msgctxt "#32074"
+msgid "Checking watched episodes on Kodi"
+msgstr ""
+
+msgctxt "#32075"
+msgid "Episode Sync Complete"
+msgstr ""
+
+msgctxt "#32076"
+msgid "%i movie(s) will be removed from Trakt collection"
+msgstr ""
+
+msgctxt "#32077"
+msgid "Cleaning Trakt TV show collection"
+msgstr ""
+
+msgctxt "#32078"
+msgid "episodes are being removed"
+msgstr ""
+
+msgctxt "#32079"
+msgid "Loading movies from Kodi"
+msgstr ""
+
+msgctxt "#32080"
+msgid "Movies loaded from Kodi"
+msgstr ""
+
+msgctxt "#32081"
+msgid "Retrieving movie collection from Trakt"
+msgstr ""
+
+msgctxt "#32082"
+msgid "Retrieving watched movies from Trakt"
+msgstr ""
+
+msgctxt "#32083"
+msgid "Retrieved movie data from Trakt"
+msgstr ""
+
+msgctxt "#32084"
+msgid "Trakt movie collection is up to date, no movies to add"
+msgstr ""
+
+msgctxt "#32085"
+msgid "%i movie(s) were added to your Trakt collection"
+msgstr ""
+
+msgctxt "#32086"
+msgid "Trakt movie playcounts are up to date"
+msgstr ""
+
+msgctxt "#32087"
+msgid "Playcounts updated for %i movie(s) on Trakt"
+msgstr ""
+
+msgctxt "#32088"
+msgid "Kodi movie playcounts are up to date"
+msgstr ""
+
+msgctxt "#32089"
+msgid "Updating %i of %i movie playcount(s) in Kodi"
+msgstr ""
+
+msgctxt "#32090"
+msgid "Playcounts updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32091"
+msgid "Trakt movie collection is up to date, no movies removed"
+msgstr ""
+
+msgctxt "#32092"
+msgid "%i movie(s) were removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32093"
+msgid "Updating %i of %i movie playcount(s) on Trakt"
+msgstr ""
+
+msgctxt "#32094"
+msgid "Loading episode data from Kodi"
+msgstr ""
+
+msgctxt "#32095"
+msgid "Loading shows from Kodi"
+msgstr ""
+
+msgctxt "#32096"
+msgid "Shows loaded from Kodi"
+msgstr ""
+
+msgctxt "#32097"
+msgid "Parsing %i of %i episode data from Kodi"
+msgstr ""
+
+msgctxt "#32098"
+msgid "Loaded episode data from Kodi"
+msgstr ""
+
+msgctxt "#32099"
+msgid "Loading episode data from Trakt"
+msgstr ""
+
+msgctxt "#32100"
+msgid "Retrieving episode collection from Trakt"
+msgstr ""
+
+msgctxt "#32101"
+msgid "Retrieving watched episodes from Trakt"
+msgstr ""
+
+msgctxt "#32102"
+msgid "Parsing episode data %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32103"
+msgid "Retrieved episode data from Trakt"
+msgstr ""
+
+msgctxt "#32104"
+msgid "Trakt episode collection is up to date, no episodes to add"
+msgstr ""
+
+msgctxt "#32105"
+msgid "%i episode(s) were added to your Trakt collection"
+msgstr ""
+
+msgctxt "#32106"
+msgid "Trakt episode playcounts are up to date"
+msgstr ""
+
+msgctxt "#32107"
+msgid "Kodi episode playcounts are up to date"
+msgstr ""
+
+msgctxt "#32108"
+msgid "Updating %i of %i episode playcount(s) in Kodi"
+msgstr ""
+
+msgctxt "#32109"
+msgid "Playcounts updated for %i show(s) in Kodi"
+msgstr ""
+
+msgctxt "#32110"
+msgid "Trakt episode collection is clean, no episodes to remove"
+msgstr ""
+
+msgctxt "#32111"
+msgid "%i episode(s) are being removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32112"
+msgid "%i episode(s) were removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32113"
+msgid "Trakt - Marked as watched"
+msgstr ""
+
+msgctxt "#32114"
+msgid "Trakt - Failed marking as watched"
+msgstr ""
+
+msgctxt "#32115"
+msgid "%d episode(s) of '%s'"
+msgstr ""
+
+msgctxt "#32116"
+msgid "Enable debug mode"
+msgstr ""
+
+msgctxt "#32117"
+msgid "Sync movie playback progress to Kodi"
+msgstr ""
+
+msgctxt "#32118"
+msgid "Sync episode playback progress to Kodi"
+msgstr ""
+
+msgctxt "#32119"
+msgid "Retrieving episode playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32120"
+msgid "Parsing episode playback progress %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32121"
+msgid "Retrieved episode playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32122"
+msgid "Retrieving movie playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32123"
+msgid "Parsing movie playback progress %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32124"
+msgid "Retrieved movie playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32125"
+msgid "Kodi movie playback progress is up to date"
+msgstr ""
+
+msgctxt "#32126"
+msgid "%i movie(s) playback progress will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32127"
+msgid "Updating %i of %i movie(s) playback progress in Kodi"
+msgstr ""
+
+msgctxt "#32128"
+msgid "Playback progress updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32129"
+msgid "Kodi episode playback progress is up to date"
+msgstr ""
+
+msgctxt "#32130"
+msgid "Updating %i of %i episode(s) playback progress in Kodi"
+msgstr ""
+
+msgctxt "#32131"
+msgid "Playback progress updated for %i episode(s) in Kodi"
+msgstr ""
+
+msgctxt "#32132"
+msgid "Unrate this season"
+msgstr ""
+
+msgctxt "#32133"
+msgid "Manage Movie's Lists"
+msgstr ""
+
+msgctxt "#32134"
+msgid "Manage Show's Lists"
+msgstr ""
+
+msgctxt "#32135"
+msgid "Remove from Watchlist"
+msgstr ""
+
+msgctxt "#32136"
+msgid "Add to watchlist"
+msgstr ""
+
+msgctxt "#32137"
+msgid "Rate this movie"
+msgstr ""
+
+msgctxt "#32138"
+msgid "Rate this show"
+msgstr ""
+
+msgctxt "#32139"
+msgid "Rate this episode"
+msgstr ""
+
+msgctxt "#32140"
+msgid "Toggle watched"
+msgstr ""
+
+msgctxt "#32141"
+msgid "Manage all lists"
+msgstr ""
+
+msgctxt "#32142"
+msgid "Update all tags"
+msgstr ""
+
+msgctxt "#32143"
+msgid "Synchronize library"
+msgstr ""
+
+msgctxt "#32144"
+msgid "How do I authorize the trakt addon to access my trakt.tv account?"
+msgstr ""
+
+# empty strings from id 32145 to 32146
+msgctxt "#32147"
+msgid "Trakt.tv PIN Authorization Failed"
+msgstr ""
+
+# empty string with id 32148
+msgctxt "#32149"
+msgid "Rate this Season"
+msgstr ""
+
+msgctxt "#32150"
+msgid "You will be reminded in 24 hours"
+msgstr ""
+
+msgctxt "#32151"
+msgid "Use Addon Settings later if you change your mind"
+msgstr ""
+
+msgctxt "#32152"
+msgid "Trakt Authorization Complete"
+msgstr ""
+
+msgctxt "#32153"
+msgid "Trakt Account Authorization"
+msgstr ""
+
+msgctxt "#32154"
+msgid "Authorize"
+msgstr ""
+
+msgctxt "#32155"
+msgid "Remind Me Later"
+msgstr ""
+
+msgctxt "#32156"
+msgid "No Thanks"
+msgstr ""
+
+msgctxt "#32157"
+msgid "Account Authorization"
+msgstr ""
+
+# empty string with id 32158
+msgctxt "#32159"
+msgid "Visit {0} or scan the QR code."
+msgstr ""
+
+msgctxt "#32162"
+msgid "The trakt addon CAN NOT be used without authorizing it to access your trakt.tv account."
+msgstr ""
+
+msgctxt "#32163"
+msgid "User"
+msgstr ""
+
+msgctxt "#32164"
+msgid "Fallback to Title/Year matching if necessary"
+msgstr ""
+
+msgctxt "#32165"
+msgid "Trakt - Added to watchlist"
+msgstr ""
+
+msgctxt "#32166"
+msgid "Trakt - Failed adding to watchlist"
+msgstr ""
+
+msgctxt "#32167"
+msgid "Offset scrobble start by X minutes"
+msgstr ""
+
+msgctxt "#32168"
+msgid "Sync ratings"
+msgstr ""
+
+msgctxt "#32169"
+msgid "Kodi movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32170"
+msgid "%i movie(s) ratings will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32171"
+msgid "Updating %i of %i movie ratings in Kodi"
+msgstr ""
+
+msgctxt "#32172"
+msgid "Ratings updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32173"
+msgid "Kodi episode ratings are up to date"
+msgstr ""
+
+msgctxt "#32174"
+msgid "Updating %i of %i episode ratings in Kodi"
+msgstr ""
+
+msgctxt "#32175"
+msgid "Ratings updated for %i episode(s) in Kodi"
+msgstr ""
+
+msgctxt "#32176"
+msgid "Kodi show ratings are up to date"
+msgstr ""
+
+msgctxt "#32177"
+msgid "Updating %i of %i show ratings in Kodi"
+msgstr ""
+
+msgctxt "#32178"
+msgid "Ratings updated for %i show(s) in Kodi"
+msgstr ""
+
+msgctxt "#32179"
+msgid "Trakt movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32180"
+msgid "%i movie ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32181"
+msgid "Trakt show ratings are up to date"
+msgstr ""
+
+msgctxt "#32182"
+msgid "%i show ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32183"
+msgid "Attempt to scrobble MythTV PVR recordings"
+msgstr ""
+
+msgctxt "#32184"
+msgid "Attempt secondary show title search"
+msgstr ""
+
+msgctxt "#32185"
+msgid "Exclude Plugins"
+msgstr ""
+
+msgctxt "#32186"
+msgid "Allow script exclusions"
+msgstr ""

--- a/script.trakt/resources/language/resource.language.sk_SK/strings.po
+++ b/script.trakt/resources/language/resource.language.sk_SK/strings.po
@@ -10,10 +10,10 @@ msgstr ""
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Kodi Translation Team\n"
 "Language-Team: Slovak (http://www.transifex.com/projects/p/xbmc-addons/language/sk/)\n"
+"Language: sk\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: sk\n"
 "Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
 
 msgctxt "#32000"
@@ -608,17 +608,10 @@ msgctxt "#32157"
 msgid "Account Authorization"
 msgstr "Autorizácia účtu"
 
+# empty string with id 32158
 msgctxt "#32159"
-msgid "Visit {0} or scan the QR Code below."
-msgstr "Navštívte {0} alebo naskenujte QR kód"
-
-msgctxt "#32160"
-msgid "Authorize the trakt addon to access your account."
-msgstr "Autorizujte Trakt doplnok pre prístup k vášmu účtu"
-
-msgctxt "#32161"
-msgid "Enter the PIN provided in the box below."
-msgstr "Zadajte vygenerovaný PIN do poľa nižšie"
+msgid "Visit {0} or scan the QR code."
+msgstr ""
 
 msgctxt "#32162"
 msgid "The trakt addon CAN NOT be used without authorizing it to access your trakt.tv account."
@@ -639,3 +632,95 @@ msgstr "Trakt - Pridané do zoznamu na pozretie"
 msgctxt "#32166"
 msgid "Trakt - Failed adding to watchlist"
 msgstr "Trakt - Pri pridávaní do zoznamu na pozretie nastala chyba"
+
+msgctxt "#32167"
+msgid "Offset scrobble start by X minutes"
+msgstr ""
+
+msgctxt "#32168"
+msgid "Sync ratings"
+msgstr ""
+
+msgctxt "#32169"
+msgid "Kodi movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32170"
+msgid "%i movie(s) ratings will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32171"
+msgid "Updating %i of %i movie ratings in Kodi"
+msgstr ""
+
+msgctxt "#32172"
+msgid "Ratings updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32173"
+msgid "Kodi episode ratings are up to date"
+msgstr ""
+
+msgctxt "#32174"
+msgid "Updating %i of %i episode ratings in Kodi"
+msgstr ""
+
+msgctxt "#32175"
+msgid "Ratings updated for %i episode(s) in Kodi"
+msgstr ""
+
+msgctxt "#32176"
+msgid "Kodi show ratings are up to date"
+msgstr ""
+
+msgctxt "#32177"
+msgid "Updating %i of %i show ratings in Kodi"
+msgstr ""
+
+msgctxt "#32178"
+msgid "Ratings updated for %i show(s) in Kodi"
+msgstr ""
+
+msgctxt "#32179"
+msgid "Trakt movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32180"
+msgid "%i movie ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32181"
+msgid "Trakt show ratings are up to date"
+msgstr ""
+
+msgctxt "#32182"
+msgid "%i show ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32183"
+msgid "Attempt to scrobble MythTV PVR recordings"
+msgstr ""
+
+msgctxt "#32184"
+msgid "Attempt secondary show title search"
+msgstr ""
+
+msgctxt "#32185"
+msgid "Exclude Plugins"
+msgstr ""
+
+msgctxt "#32186"
+msgid "Allow script exclusions"
+msgstr ""
+
+#~ msgctxt "#32159"
+#~ msgid "Visit {0} or scan the QR Code below."
+#~ msgstr "Navštívte {0} alebo naskenujte QR kód"
+
+#~ msgctxt "#32160"
+#~ msgid "Authorize the trakt addon to access your account."
+#~ msgstr "Autorizujte Trakt doplnok pre prístup k vášmu účtu"
+
+#~ msgctxt "#32161"
+#~ msgid "Enter the PIN provided in the box below."
+#~ msgstr "Zadajte vygenerovaný PIN do poľa nižšie"

--- a/script.trakt/resources/language/resource.language.sl_SI/strings.po
+++ b/script.trakt/resources/language/resource.language.sl_SI/strings.po
@@ -10,32 +10,712 @@ msgstr ""
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Kodi Translation Team\n"
 "Language-Team: Slovenian (http://www.transifex.com/projects/p/xbmc-addons/language/sl/)\n"
+"Language: sl\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: sl\n"
 "Plural-Forms: nplurals=4; plural=(n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || n%100==4 ? 2 : 3);\n"
 
 msgctxt "#32000"
 msgid "General"
 msgstr "Splošno"
 
+# empty strings from id 32001 to 32002
+msgctxt "#32003"
+msgid "Startup Delay"
+msgstr ""
+
 msgctxt "#32004"
 msgid "Rating"
 msgstr "Ocena"
+
+msgctxt "#32005"
+msgid "Rate Movie after watching"
+msgstr ""
+
+msgctxt "#32006"
+msgid "Rate TV show Episode after watching"
+msgstr ""
+
+msgctxt "#32008"
+msgid "Minimum percent watched to display rating dialog"
+msgstr ""
+
+msgctxt "#32009"
+msgid "Allow re-rating of media"
+msgstr ""
+
+msgctxt "#32010"
+msgid "Default rating"
+msgstr ""
+
+# Scrobbling Settings
+msgctxt "#32011"
+msgid "Scrobbling"
+msgstr ""
+
+msgctxt "#32012"
+msgid "Scrobble movies"
+msgstr ""
+
+msgctxt "#32013"
+msgid "Scrobble TV show episodes"
+msgstr ""
+
+msgctxt "#32014"
+msgid "Show notification on scrobble"
+msgstr ""
+
+msgctxt "#32015"
+msgid "Trakt - Scrobbled successfully"
+msgstr ""
+
+msgctxt "#32016"
+msgid "Exclusions"
+msgstr ""
+
+msgctxt "#32017"
+msgid "Exclude Live TV"
+msgstr ""
+
+msgctxt "#32018"
+msgid "Exclude HTTP sources"
+msgstr ""
+
+msgctxt "#32019"
+msgid "Exclude path"
+msgstr ""
+
+msgctxt "#32020"
+msgid "Folder's path (including subfolders)"
+msgstr ""
+
+# empty strings from id 32021 to 32022
+msgctxt "#32023"
+msgid "Can not connect to Trakt"
+msgstr ""
 
 msgctxt "#32024"
 msgid "Error"
 msgstr "Napaka"
 
+# empty string with id 32025
+msgctxt "#32026"
+msgid "What Did You Think?"
+msgstr ""
+
+msgctxt "#32027"
+msgid "Totally Ninja!"
+msgstr ""
+
+msgctxt "#32028"
+msgid "Weak Sauce :("
+msgstr ""
+
+msgctxt "#32029"
+msgid "Terrible"
+msgstr ""
+
+msgctxt "#32030"
+msgid "Bad"
+msgstr ""
+
+msgctxt "#32031"
+msgid "Poor"
+msgstr ""
+
+msgctxt "#32032"
+msgid "Meh"
+msgstr ""
+
 msgctxt "#32033"
 msgid "Fair"
 msgstr "Šibak"
+
+msgctxt "#32034"
+msgid "Good"
+msgstr ""
+
+msgctxt "#32035"
+msgid "Great"
+msgstr ""
+
+msgctxt "#32036"
+msgid "Superb"
+msgstr ""
+
+msgctxt "#32037"
+msgid "Unrate this movie"
+msgstr ""
+
+msgctxt "#32038"
+msgid "Unrate this show"
+msgstr ""
+
+msgctxt "#32039"
+msgid "Unrate this episode"
+msgstr ""
+
+msgctxt "#32040"
+msgid "Trakt - Rating submitted successfully"
+msgstr ""
+
+msgctxt "#32041"
+msgid "Trakt - Already rated"
+msgstr ""
+
+msgctxt "#32042"
+msgid "Trakt - Unrated successfully"
+msgstr ""
+
+msgctxt "#32043"
+msgid "Trakt - Already has the same rating"
+msgstr ""
+
+msgctxt "#32044"
+msgid "Trakt - Problem submitting rating"
+msgstr ""
+
+msgctxt "#32045"
+msgid "Synchronize"
+msgstr ""
 
 msgctxt "#32046"
 msgid "Movies"
 msgstr "Filmi"
 
+msgctxt "#32047"
+msgid "Add new movies to Trakt collection"
+msgstr ""
+
+msgctxt "#32048"
+msgid "Add watched movies to Trakt history"
+msgstr ""
+
+msgctxt "#32049"
+msgid "Mark movies from Trakt history as watched in Kodi"
+msgstr ""
+
+msgctxt "#32050"
+msgid "TV Episodes"
+msgstr ""
+
+msgctxt "#32051"
+msgid "Add new TV episodes to Trakt collection"
+msgstr ""
+
+msgctxt "#32052"
+msgid "Add watched TV episodes to Trakt history"
+msgstr ""
+
+msgctxt "#32053"
+msgid "Mark TV episodes from Trakt history as watched in Kodi"
+msgstr ""
+
 msgctxt "#32054"
 msgid "Service"
 msgstr "Storitev"
+
+msgctxt "#32055"
+msgid "Sync collection on library update or cleaning"
+msgstr ""
+
+msgctxt "#32056"
+msgid "Show sync notifications"
+msgstr ""
+
+msgctxt "#32057"
+msgid "Remove deleted movies from Trakt collection"
+msgstr ""
+
+msgctxt "#32058"
+msgid "Remove deleted TV episodes from Trakt collection"
+msgstr ""
+
+# empty string with id 32059
+msgctxt "#32060"
+msgid "Hide notifications during playback"
+msgstr ""
+
+msgctxt "#32061"
+msgid "Sync started"
+msgstr ""
+
+msgctxt "#32062"
+msgid "Sync complete"
+msgstr ""
+
+msgctxt "#32063"
+msgid "%i movie(s) will be added to Trakt collection"
+msgstr ""
+
+msgctxt "#32064"
+msgid "%i movie playcount(s) will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32065"
+msgid "%i movie(s) playcount will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32066"
+msgid "Movie Sync Complete"
+msgstr ""
+
+msgctxt "#32067"
+msgid "Going to add %i show(s) to Trakt collection"
+msgstr ""
+
+msgctxt "#32068"
+msgid "Checking for episodes missing from Trakt collection"
+msgstr ""
+
+msgctxt "#32069"
+msgid "%i of %i show(s) have episodes added to Trakt collection"
+msgstr ""
+
+msgctxt "#32070"
+msgid "Going to update %i show(s) missing watched status"
+msgstr ""
+
+msgctxt "#32071"
+msgid "Checking watched episodes on Trakt"
+msgstr ""
+
+msgctxt "#32072"
+msgid "%i show(s) had missing watched status"
+msgstr ""
+
+msgctxt "#32073"
+msgid "%i episodes are being updated"
+msgstr ""
+
+msgctxt "#32074"
+msgid "Checking watched episodes on Kodi"
+msgstr ""
+
+msgctxt "#32075"
+msgid "Episode Sync Complete"
+msgstr ""
+
+msgctxt "#32076"
+msgid "%i movie(s) will be removed from Trakt collection"
+msgstr ""
+
+msgctxt "#32077"
+msgid "Cleaning Trakt TV show collection"
+msgstr ""
+
+msgctxt "#32078"
+msgid "episodes are being removed"
+msgstr ""
+
+msgctxt "#32079"
+msgid "Loading movies from Kodi"
+msgstr ""
+
+msgctxt "#32080"
+msgid "Movies loaded from Kodi"
+msgstr ""
+
+msgctxt "#32081"
+msgid "Retrieving movie collection from Trakt"
+msgstr ""
+
+msgctxt "#32082"
+msgid "Retrieving watched movies from Trakt"
+msgstr ""
+
+msgctxt "#32083"
+msgid "Retrieved movie data from Trakt"
+msgstr ""
+
+msgctxt "#32084"
+msgid "Trakt movie collection is up to date, no movies to add"
+msgstr ""
+
+msgctxt "#32085"
+msgid "%i movie(s) were added to your Trakt collection"
+msgstr ""
+
+msgctxt "#32086"
+msgid "Trakt movie playcounts are up to date"
+msgstr ""
+
+msgctxt "#32087"
+msgid "Playcounts updated for %i movie(s) on Trakt"
+msgstr ""
+
+msgctxt "#32088"
+msgid "Kodi movie playcounts are up to date"
+msgstr ""
+
+msgctxt "#32089"
+msgid "Updating %i of %i movie playcount(s) in Kodi"
+msgstr ""
+
+msgctxt "#32090"
+msgid "Playcounts updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32091"
+msgid "Trakt movie collection is up to date, no movies removed"
+msgstr ""
+
+msgctxt "#32092"
+msgid "%i movie(s) were removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32093"
+msgid "Updating %i of %i movie playcount(s) on Trakt"
+msgstr ""
+
+msgctxt "#32094"
+msgid "Loading episode data from Kodi"
+msgstr ""
+
+msgctxt "#32095"
+msgid "Loading shows from Kodi"
+msgstr ""
+
+msgctxt "#32096"
+msgid "Shows loaded from Kodi"
+msgstr ""
+
+msgctxt "#32097"
+msgid "Parsing %i of %i episode data from Kodi"
+msgstr ""
+
+msgctxt "#32098"
+msgid "Loaded episode data from Kodi"
+msgstr ""
+
+msgctxt "#32099"
+msgid "Loading episode data from Trakt"
+msgstr ""
+
+msgctxt "#32100"
+msgid "Retrieving episode collection from Trakt"
+msgstr ""
+
+msgctxt "#32101"
+msgid "Retrieving watched episodes from Trakt"
+msgstr ""
+
+msgctxt "#32102"
+msgid "Parsing episode data %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32103"
+msgid "Retrieved episode data from Trakt"
+msgstr ""
+
+msgctxt "#32104"
+msgid "Trakt episode collection is up to date, no episodes to add"
+msgstr ""
+
+msgctxt "#32105"
+msgid "%i episode(s) were added to your Trakt collection"
+msgstr ""
+
+msgctxt "#32106"
+msgid "Trakt episode playcounts are up to date"
+msgstr ""
+
+msgctxt "#32107"
+msgid "Kodi episode playcounts are up to date"
+msgstr ""
+
+msgctxt "#32108"
+msgid "Updating %i of %i episode playcount(s) in Kodi"
+msgstr ""
+
+msgctxt "#32109"
+msgid "Playcounts updated for %i show(s) in Kodi"
+msgstr ""
+
+msgctxt "#32110"
+msgid "Trakt episode collection is clean, no episodes to remove"
+msgstr ""
+
+msgctxt "#32111"
+msgid "%i episode(s) are being removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32112"
+msgid "%i episode(s) were removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32113"
+msgid "Trakt - Marked as watched"
+msgstr ""
+
+msgctxt "#32114"
+msgid "Trakt - Failed marking as watched"
+msgstr ""
+
+msgctxt "#32115"
+msgid "%d episode(s) of '%s'"
+msgstr ""
+
+msgctxt "#32116"
+msgid "Enable debug mode"
+msgstr ""
+
+msgctxt "#32117"
+msgid "Sync movie playback progress to Kodi"
+msgstr ""
+
+msgctxt "#32118"
+msgid "Sync episode playback progress to Kodi"
+msgstr ""
+
+msgctxt "#32119"
+msgid "Retrieving episode playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32120"
+msgid "Parsing episode playback progress %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32121"
+msgid "Retrieved episode playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32122"
+msgid "Retrieving movie playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32123"
+msgid "Parsing movie playback progress %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32124"
+msgid "Retrieved movie playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32125"
+msgid "Kodi movie playback progress is up to date"
+msgstr ""
+
+msgctxt "#32126"
+msgid "%i movie(s) playback progress will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32127"
+msgid "Updating %i of %i movie(s) playback progress in Kodi"
+msgstr ""
+
+msgctxt "#32128"
+msgid "Playback progress updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32129"
+msgid "Kodi episode playback progress is up to date"
+msgstr ""
+
+msgctxt "#32130"
+msgid "Updating %i of %i episode(s) playback progress in Kodi"
+msgstr ""
+
+msgctxt "#32131"
+msgid "Playback progress updated for %i episode(s) in Kodi"
+msgstr ""
+
+msgctxt "#32132"
+msgid "Unrate this season"
+msgstr ""
+
+msgctxt "#32133"
+msgid "Manage Movie's Lists"
+msgstr ""
+
+msgctxt "#32134"
+msgid "Manage Show's Lists"
+msgstr ""
+
+msgctxt "#32135"
+msgid "Remove from Watchlist"
+msgstr ""
+
+msgctxt "#32136"
+msgid "Add to watchlist"
+msgstr ""
+
+msgctxt "#32137"
+msgid "Rate this movie"
+msgstr ""
+
+msgctxt "#32138"
+msgid "Rate this show"
+msgstr ""
+
+msgctxt "#32139"
+msgid "Rate this episode"
+msgstr ""
+
+msgctxt "#32140"
+msgid "Toggle watched"
+msgstr ""
+
+msgctxt "#32141"
+msgid "Manage all lists"
+msgstr ""
+
+msgctxt "#32142"
+msgid "Update all tags"
+msgstr ""
+
+msgctxt "#32143"
+msgid "Synchronize library"
+msgstr ""
+
+msgctxt "#32144"
+msgid "How do I authorize the trakt addon to access my trakt.tv account?"
+msgstr ""
+
+# empty strings from id 32145 to 32146
+msgctxt "#32147"
+msgid "Trakt.tv PIN Authorization Failed"
+msgstr ""
+
+# empty string with id 32148
+msgctxt "#32149"
+msgid "Rate this Season"
+msgstr ""
+
+msgctxt "#32150"
+msgid "You will be reminded in 24 hours"
+msgstr ""
+
+msgctxt "#32151"
+msgid "Use Addon Settings later if you change your mind"
+msgstr ""
+
+msgctxt "#32152"
+msgid "Trakt Authorization Complete"
+msgstr ""
+
+msgctxt "#32153"
+msgid "Trakt Account Authorization"
+msgstr ""
+
+msgctxt "#32154"
+msgid "Authorize"
+msgstr ""
+
+msgctxt "#32155"
+msgid "Remind Me Later"
+msgstr ""
+
+msgctxt "#32156"
+msgid "No Thanks"
+msgstr ""
+
+msgctxt "#32157"
+msgid "Account Authorization"
+msgstr ""
+
+# empty string with id 32158
+msgctxt "#32159"
+msgid "Visit {0} or scan the QR code."
+msgstr ""
+
+msgctxt "#32162"
+msgid "The trakt addon CAN NOT be used without authorizing it to access your trakt.tv account."
+msgstr ""
+
+msgctxt "#32163"
+msgid "User"
+msgstr ""
+
+msgctxt "#32164"
+msgid "Fallback to Title/Year matching if necessary"
+msgstr ""
+
+msgctxt "#32165"
+msgid "Trakt - Added to watchlist"
+msgstr ""
+
+msgctxt "#32166"
+msgid "Trakt - Failed adding to watchlist"
+msgstr ""
+
+msgctxt "#32167"
+msgid "Offset scrobble start by X minutes"
+msgstr ""
+
+msgctxt "#32168"
+msgid "Sync ratings"
+msgstr ""
+
+msgctxt "#32169"
+msgid "Kodi movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32170"
+msgid "%i movie(s) ratings will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32171"
+msgid "Updating %i of %i movie ratings in Kodi"
+msgstr ""
+
+msgctxt "#32172"
+msgid "Ratings updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32173"
+msgid "Kodi episode ratings are up to date"
+msgstr ""
+
+msgctxt "#32174"
+msgid "Updating %i of %i episode ratings in Kodi"
+msgstr ""
+
+msgctxt "#32175"
+msgid "Ratings updated for %i episode(s) in Kodi"
+msgstr ""
+
+msgctxt "#32176"
+msgid "Kodi show ratings are up to date"
+msgstr ""
+
+msgctxt "#32177"
+msgid "Updating %i of %i show ratings in Kodi"
+msgstr ""
+
+msgctxt "#32178"
+msgid "Ratings updated for %i show(s) in Kodi"
+msgstr ""
+
+msgctxt "#32179"
+msgid "Trakt movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32180"
+msgid "%i movie ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32181"
+msgid "Trakt show ratings are up to date"
+msgstr ""
+
+msgctxt "#32182"
+msgid "%i show ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32183"
+msgid "Attempt to scrobble MythTV PVR recordings"
+msgstr ""
+
+msgctxt "#32184"
+msgid "Attempt secondary show title search"
+msgstr ""
+
+msgctxt "#32185"
+msgid "Exclude Plugins"
+msgstr ""
+
+msgctxt "#32186"
+msgid "Allow script exclusions"
+msgstr ""

--- a/script.trakt/resources/language/resource.language.sq_AL/strings.po
+++ b/script.trakt/resources/language/resource.language.sq_AL/strings.po
@@ -10,28 +10,712 @@ msgstr ""
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Kodi Translation Team\n"
 "Language-Team: Albanian (http://www.transifex.com/projects/p/xbmc-addons/language/sq/)\n"
+"Language: sq\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: sq\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 msgctxt "#32000"
 msgid "General"
 msgstr "I përgjithsëm"
 
+# empty strings from id 32001 to 32002
+msgctxt "#32003"
+msgid "Startup Delay"
+msgstr ""
+
 msgctxt "#32004"
 msgid "Rating"
 msgstr "Vlerësimi"
+
+msgctxt "#32005"
+msgid "Rate Movie after watching"
+msgstr ""
+
+msgctxt "#32006"
+msgid "Rate TV show Episode after watching"
+msgstr ""
+
+msgctxt "#32008"
+msgid "Minimum percent watched to display rating dialog"
+msgstr ""
+
+msgctxt "#32009"
+msgid "Allow re-rating of media"
+msgstr ""
+
+msgctxt "#32010"
+msgid "Default rating"
+msgstr ""
+
+# Scrobbling Settings
+msgctxt "#32011"
+msgid "Scrobbling"
+msgstr ""
+
+msgctxt "#32012"
+msgid "Scrobble movies"
+msgstr ""
+
+msgctxt "#32013"
+msgid "Scrobble TV show episodes"
+msgstr ""
+
+msgctxt "#32014"
+msgid "Show notification on scrobble"
+msgstr ""
+
+msgctxt "#32015"
+msgid "Trakt - Scrobbled successfully"
+msgstr ""
+
+msgctxt "#32016"
+msgid "Exclusions"
+msgstr ""
+
+msgctxt "#32017"
+msgid "Exclude Live TV"
+msgstr ""
+
+msgctxt "#32018"
+msgid "Exclude HTTP sources"
+msgstr ""
+
+msgctxt "#32019"
+msgid "Exclude path"
+msgstr ""
+
+msgctxt "#32020"
+msgid "Folder's path (including subfolders)"
+msgstr ""
+
+# empty strings from id 32021 to 32022
+msgctxt "#32023"
+msgid "Can not connect to Trakt"
+msgstr ""
 
 msgctxt "#32024"
 msgid "Error"
 msgstr "Gabim"
 
+# empty string with id 32025
+msgctxt "#32026"
+msgid "What Did You Think?"
+msgstr ""
+
+msgctxt "#32027"
+msgid "Totally Ninja!"
+msgstr ""
+
+msgctxt "#32028"
+msgid "Weak Sauce :("
+msgstr ""
+
+msgctxt "#32029"
+msgid "Terrible"
+msgstr ""
+
+msgctxt "#32030"
+msgid "Bad"
+msgstr ""
+
+msgctxt "#32031"
+msgid "Poor"
+msgstr ""
+
+msgctxt "#32032"
+msgid "Meh"
+msgstr ""
+
 msgctxt "#32033"
 msgid "Fair"
 msgstr "Bukur"
 
+msgctxt "#32034"
+msgid "Good"
+msgstr ""
+
+msgctxt "#32035"
+msgid "Great"
+msgstr ""
+
+msgctxt "#32036"
+msgid "Superb"
+msgstr ""
+
+msgctxt "#32037"
+msgid "Unrate this movie"
+msgstr ""
+
+msgctxt "#32038"
+msgid "Unrate this show"
+msgstr ""
+
+msgctxt "#32039"
+msgid "Unrate this episode"
+msgstr ""
+
+msgctxt "#32040"
+msgid "Trakt - Rating submitted successfully"
+msgstr ""
+
+msgctxt "#32041"
+msgid "Trakt - Already rated"
+msgstr ""
+
+msgctxt "#32042"
+msgid "Trakt - Unrated successfully"
+msgstr ""
+
+msgctxt "#32043"
+msgid "Trakt - Already has the same rating"
+msgstr ""
+
+msgctxt "#32044"
+msgid "Trakt - Problem submitting rating"
+msgstr ""
+
+msgctxt "#32045"
+msgid "Synchronize"
+msgstr ""
+
 msgctxt "#32046"
 msgid "Movies"
 msgstr "Filma"
+
+msgctxt "#32047"
+msgid "Add new movies to Trakt collection"
+msgstr ""
+
+msgctxt "#32048"
+msgid "Add watched movies to Trakt history"
+msgstr ""
+
+msgctxt "#32049"
+msgid "Mark movies from Trakt history as watched in Kodi"
+msgstr ""
+
+msgctxt "#32050"
+msgid "TV Episodes"
+msgstr ""
+
+msgctxt "#32051"
+msgid "Add new TV episodes to Trakt collection"
+msgstr ""
+
+msgctxt "#32052"
+msgid "Add watched TV episodes to Trakt history"
+msgstr ""
+
+msgctxt "#32053"
+msgid "Mark TV episodes from Trakt history as watched in Kodi"
+msgstr ""
+
+msgctxt "#32054"
+msgid "Service"
+msgstr ""
+
+msgctxt "#32055"
+msgid "Sync collection on library update or cleaning"
+msgstr ""
+
+msgctxt "#32056"
+msgid "Show sync notifications"
+msgstr ""
+
+msgctxt "#32057"
+msgid "Remove deleted movies from Trakt collection"
+msgstr ""
+
+msgctxt "#32058"
+msgid "Remove deleted TV episodes from Trakt collection"
+msgstr ""
+
+# empty string with id 32059
+msgctxt "#32060"
+msgid "Hide notifications during playback"
+msgstr ""
+
+msgctxt "#32061"
+msgid "Sync started"
+msgstr ""
+
+msgctxt "#32062"
+msgid "Sync complete"
+msgstr ""
+
+msgctxt "#32063"
+msgid "%i movie(s) will be added to Trakt collection"
+msgstr ""
+
+msgctxt "#32064"
+msgid "%i movie playcount(s) will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32065"
+msgid "%i movie(s) playcount will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32066"
+msgid "Movie Sync Complete"
+msgstr ""
+
+msgctxt "#32067"
+msgid "Going to add %i show(s) to Trakt collection"
+msgstr ""
+
+msgctxt "#32068"
+msgid "Checking for episodes missing from Trakt collection"
+msgstr ""
+
+msgctxt "#32069"
+msgid "%i of %i show(s) have episodes added to Trakt collection"
+msgstr ""
+
+msgctxt "#32070"
+msgid "Going to update %i show(s) missing watched status"
+msgstr ""
+
+msgctxt "#32071"
+msgid "Checking watched episodes on Trakt"
+msgstr ""
+
+msgctxt "#32072"
+msgid "%i show(s) had missing watched status"
+msgstr ""
+
+msgctxt "#32073"
+msgid "%i episodes are being updated"
+msgstr ""
+
+msgctxt "#32074"
+msgid "Checking watched episodes on Kodi"
+msgstr ""
+
+msgctxt "#32075"
+msgid "Episode Sync Complete"
+msgstr ""
+
+msgctxt "#32076"
+msgid "%i movie(s) will be removed from Trakt collection"
+msgstr ""
+
+msgctxt "#32077"
+msgid "Cleaning Trakt TV show collection"
+msgstr ""
+
+msgctxt "#32078"
+msgid "episodes are being removed"
+msgstr ""
+
+msgctxt "#32079"
+msgid "Loading movies from Kodi"
+msgstr ""
+
+msgctxt "#32080"
+msgid "Movies loaded from Kodi"
+msgstr ""
+
+msgctxt "#32081"
+msgid "Retrieving movie collection from Trakt"
+msgstr ""
+
+msgctxt "#32082"
+msgid "Retrieving watched movies from Trakt"
+msgstr ""
+
+msgctxt "#32083"
+msgid "Retrieved movie data from Trakt"
+msgstr ""
+
+msgctxt "#32084"
+msgid "Trakt movie collection is up to date, no movies to add"
+msgstr ""
+
+msgctxt "#32085"
+msgid "%i movie(s) were added to your Trakt collection"
+msgstr ""
+
+msgctxt "#32086"
+msgid "Trakt movie playcounts are up to date"
+msgstr ""
+
+msgctxt "#32087"
+msgid "Playcounts updated for %i movie(s) on Trakt"
+msgstr ""
+
+msgctxt "#32088"
+msgid "Kodi movie playcounts are up to date"
+msgstr ""
+
+msgctxt "#32089"
+msgid "Updating %i of %i movie playcount(s) in Kodi"
+msgstr ""
+
+msgctxt "#32090"
+msgid "Playcounts updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32091"
+msgid "Trakt movie collection is up to date, no movies removed"
+msgstr ""
+
+msgctxt "#32092"
+msgid "%i movie(s) were removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32093"
+msgid "Updating %i of %i movie playcount(s) on Trakt"
+msgstr ""
+
+msgctxt "#32094"
+msgid "Loading episode data from Kodi"
+msgstr ""
+
+msgctxt "#32095"
+msgid "Loading shows from Kodi"
+msgstr ""
+
+msgctxt "#32096"
+msgid "Shows loaded from Kodi"
+msgstr ""
+
+msgctxt "#32097"
+msgid "Parsing %i of %i episode data from Kodi"
+msgstr ""
+
+msgctxt "#32098"
+msgid "Loaded episode data from Kodi"
+msgstr ""
+
+msgctxt "#32099"
+msgid "Loading episode data from Trakt"
+msgstr ""
+
+msgctxt "#32100"
+msgid "Retrieving episode collection from Trakt"
+msgstr ""
+
+msgctxt "#32101"
+msgid "Retrieving watched episodes from Trakt"
+msgstr ""
+
+msgctxt "#32102"
+msgid "Parsing episode data %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32103"
+msgid "Retrieved episode data from Trakt"
+msgstr ""
+
+msgctxt "#32104"
+msgid "Trakt episode collection is up to date, no episodes to add"
+msgstr ""
+
+msgctxt "#32105"
+msgid "%i episode(s) were added to your Trakt collection"
+msgstr ""
+
+msgctxt "#32106"
+msgid "Trakt episode playcounts are up to date"
+msgstr ""
+
+msgctxt "#32107"
+msgid "Kodi episode playcounts are up to date"
+msgstr ""
+
+msgctxt "#32108"
+msgid "Updating %i of %i episode playcount(s) in Kodi"
+msgstr ""
+
+msgctxt "#32109"
+msgid "Playcounts updated for %i show(s) in Kodi"
+msgstr ""
+
+msgctxt "#32110"
+msgid "Trakt episode collection is clean, no episodes to remove"
+msgstr ""
+
+msgctxt "#32111"
+msgid "%i episode(s) are being removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32112"
+msgid "%i episode(s) were removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32113"
+msgid "Trakt - Marked as watched"
+msgstr ""
+
+msgctxt "#32114"
+msgid "Trakt - Failed marking as watched"
+msgstr ""
+
+msgctxt "#32115"
+msgid "%d episode(s) of '%s'"
+msgstr ""
+
+msgctxt "#32116"
+msgid "Enable debug mode"
+msgstr ""
+
+msgctxt "#32117"
+msgid "Sync movie playback progress to Kodi"
+msgstr ""
+
+msgctxt "#32118"
+msgid "Sync episode playback progress to Kodi"
+msgstr ""
+
+msgctxt "#32119"
+msgid "Retrieving episode playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32120"
+msgid "Parsing episode playback progress %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32121"
+msgid "Retrieved episode playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32122"
+msgid "Retrieving movie playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32123"
+msgid "Parsing movie playback progress %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32124"
+msgid "Retrieved movie playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32125"
+msgid "Kodi movie playback progress is up to date"
+msgstr ""
+
+msgctxt "#32126"
+msgid "%i movie(s) playback progress will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32127"
+msgid "Updating %i of %i movie(s) playback progress in Kodi"
+msgstr ""
+
+msgctxt "#32128"
+msgid "Playback progress updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32129"
+msgid "Kodi episode playback progress is up to date"
+msgstr ""
+
+msgctxt "#32130"
+msgid "Updating %i of %i episode(s) playback progress in Kodi"
+msgstr ""
+
+msgctxt "#32131"
+msgid "Playback progress updated for %i episode(s) in Kodi"
+msgstr ""
+
+msgctxt "#32132"
+msgid "Unrate this season"
+msgstr ""
+
+msgctxt "#32133"
+msgid "Manage Movie's Lists"
+msgstr ""
+
+msgctxt "#32134"
+msgid "Manage Show's Lists"
+msgstr ""
+
+msgctxt "#32135"
+msgid "Remove from Watchlist"
+msgstr ""
+
+msgctxt "#32136"
+msgid "Add to watchlist"
+msgstr ""
+
+msgctxt "#32137"
+msgid "Rate this movie"
+msgstr ""
+
+msgctxt "#32138"
+msgid "Rate this show"
+msgstr ""
+
+msgctxt "#32139"
+msgid "Rate this episode"
+msgstr ""
+
+msgctxt "#32140"
+msgid "Toggle watched"
+msgstr ""
+
+msgctxt "#32141"
+msgid "Manage all lists"
+msgstr ""
+
+msgctxt "#32142"
+msgid "Update all tags"
+msgstr ""
+
+msgctxt "#32143"
+msgid "Synchronize library"
+msgstr ""
+
+msgctxt "#32144"
+msgid "How do I authorize the trakt addon to access my trakt.tv account?"
+msgstr ""
+
+# empty strings from id 32145 to 32146
+msgctxt "#32147"
+msgid "Trakt.tv PIN Authorization Failed"
+msgstr ""
+
+# empty string with id 32148
+msgctxt "#32149"
+msgid "Rate this Season"
+msgstr ""
+
+msgctxt "#32150"
+msgid "You will be reminded in 24 hours"
+msgstr ""
+
+msgctxt "#32151"
+msgid "Use Addon Settings later if you change your mind"
+msgstr ""
+
+msgctxt "#32152"
+msgid "Trakt Authorization Complete"
+msgstr ""
+
+msgctxt "#32153"
+msgid "Trakt Account Authorization"
+msgstr ""
+
+msgctxt "#32154"
+msgid "Authorize"
+msgstr ""
+
+msgctxt "#32155"
+msgid "Remind Me Later"
+msgstr ""
+
+msgctxt "#32156"
+msgid "No Thanks"
+msgstr ""
+
+msgctxt "#32157"
+msgid "Account Authorization"
+msgstr ""
+
+# empty string with id 32158
+msgctxt "#32159"
+msgid "Visit {0} or scan the QR code."
+msgstr ""
+
+msgctxt "#32162"
+msgid "The trakt addon CAN NOT be used without authorizing it to access your trakt.tv account."
+msgstr ""
+
+msgctxt "#32163"
+msgid "User"
+msgstr ""
+
+msgctxt "#32164"
+msgid "Fallback to Title/Year matching if necessary"
+msgstr ""
+
+msgctxt "#32165"
+msgid "Trakt - Added to watchlist"
+msgstr ""
+
+msgctxt "#32166"
+msgid "Trakt - Failed adding to watchlist"
+msgstr ""
+
+msgctxt "#32167"
+msgid "Offset scrobble start by X minutes"
+msgstr ""
+
+msgctxt "#32168"
+msgid "Sync ratings"
+msgstr ""
+
+msgctxt "#32169"
+msgid "Kodi movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32170"
+msgid "%i movie(s) ratings will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32171"
+msgid "Updating %i of %i movie ratings in Kodi"
+msgstr ""
+
+msgctxt "#32172"
+msgid "Ratings updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32173"
+msgid "Kodi episode ratings are up to date"
+msgstr ""
+
+msgctxt "#32174"
+msgid "Updating %i of %i episode ratings in Kodi"
+msgstr ""
+
+msgctxt "#32175"
+msgid "Ratings updated for %i episode(s) in Kodi"
+msgstr ""
+
+msgctxt "#32176"
+msgid "Kodi show ratings are up to date"
+msgstr ""
+
+msgctxt "#32177"
+msgid "Updating %i of %i show ratings in Kodi"
+msgstr ""
+
+msgctxt "#32178"
+msgid "Ratings updated for %i show(s) in Kodi"
+msgstr ""
+
+msgctxt "#32179"
+msgid "Trakt movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32180"
+msgid "%i movie ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32181"
+msgid "Trakt show ratings are up to date"
+msgstr ""
+
+msgctxt "#32182"
+msgid "%i show ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32183"
+msgid "Attempt to scrobble MythTV PVR recordings"
+msgstr ""
+
+msgctxt "#32184"
+msgid "Attempt secondary show title search"
+msgstr ""
+
+msgctxt "#32185"
+msgid "Exclude Plugins"
+msgstr ""
+
+msgctxt "#32186"
+msgid "Allow script exclusions"
+msgstr ""

--- a/script.trakt/resources/language/resource.language.sr_RS/strings.po
+++ b/script.trakt/resources/language/resource.language.sr_RS/strings.po
@@ -10,28 +10,712 @@ msgstr ""
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Kodi Translation Team\n"
 "Language-Team: Serbian (Cyrillic) (http://www.transifex.com/projects/p/xbmc-addons/language/sr_RS/)\n"
+"Language: sr_RS\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: sr_RS\n"
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 
 msgctxt "#32000"
 msgid "General"
 msgstr "Опште"
 
+# empty strings from id 32001 to 32002
+msgctxt "#32003"
+msgid "Startup Delay"
+msgstr ""
+
 msgctxt "#32004"
 msgid "Rating"
 msgstr "Оцена"
+
+msgctxt "#32005"
+msgid "Rate Movie after watching"
+msgstr ""
+
+msgctxt "#32006"
+msgid "Rate TV show Episode after watching"
+msgstr ""
+
+msgctxt "#32008"
+msgid "Minimum percent watched to display rating dialog"
+msgstr ""
+
+msgctxt "#32009"
+msgid "Allow re-rating of media"
+msgstr ""
+
+msgctxt "#32010"
+msgid "Default rating"
+msgstr ""
+
+# Scrobbling Settings
+msgctxt "#32011"
+msgid "Scrobbling"
+msgstr ""
+
+msgctxt "#32012"
+msgid "Scrobble movies"
+msgstr ""
+
+msgctxt "#32013"
+msgid "Scrobble TV show episodes"
+msgstr ""
+
+msgctxt "#32014"
+msgid "Show notification on scrobble"
+msgstr ""
+
+msgctxt "#32015"
+msgid "Trakt - Scrobbled successfully"
+msgstr ""
+
+msgctxt "#32016"
+msgid "Exclusions"
+msgstr ""
+
+msgctxt "#32017"
+msgid "Exclude Live TV"
+msgstr ""
+
+msgctxt "#32018"
+msgid "Exclude HTTP sources"
+msgstr ""
+
+msgctxt "#32019"
+msgid "Exclude path"
+msgstr ""
+
+msgctxt "#32020"
+msgid "Folder's path (including subfolders)"
+msgstr ""
+
+# empty strings from id 32021 to 32022
+msgctxt "#32023"
+msgid "Can not connect to Trakt"
+msgstr ""
 
 msgctxt "#32024"
 msgid "Error"
 msgstr "Грешка"
 
+# empty string with id 32025
+msgctxt "#32026"
+msgid "What Did You Think?"
+msgstr ""
+
+msgctxt "#32027"
+msgid "Totally Ninja!"
+msgstr ""
+
+msgctxt "#32028"
+msgid "Weak Sauce :("
+msgstr ""
+
+msgctxt "#32029"
+msgid "Terrible"
+msgstr ""
+
+msgctxt "#32030"
+msgid "Bad"
+msgstr ""
+
+msgctxt "#32031"
+msgid "Poor"
+msgstr ""
+
+msgctxt "#32032"
+msgid "Meh"
+msgstr ""
+
 msgctxt "#32033"
 msgid "Fair"
 msgstr "умерено"
 
+msgctxt "#32034"
+msgid "Good"
+msgstr ""
+
+msgctxt "#32035"
+msgid "Great"
+msgstr ""
+
+msgctxt "#32036"
+msgid "Superb"
+msgstr ""
+
+msgctxt "#32037"
+msgid "Unrate this movie"
+msgstr ""
+
+msgctxt "#32038"
+msgid "Unrate this show"
+msgstr ""
+
+msgctxt "#32039"
+msgid "Unrate this episode"
+msgstr ""
+
+msgctxt "#32040"
+msgid "Trakt - Rating submitted successfully"
+msgstr ""
+
+msgctxt "#32041"
+msgid "Trakt - Already rated"
+msgstr ""
+
+msgctxt "#32042"
+msgid "Trakt - Unrated successfully"
+msgstr ""
+
+msgctxt "#32043"
+msgid "Trakt - Already has the same rating"
+msgstr ""
+
+msgctxt "#32044"
+msgid "Trakt - Problem submitting rating"
+msgstr ""
+
+msgctxt "#32045"
+msgid "Synchronize"
+msgstr ""
+
 msgctxt "#32046"
 msgid "Movies"
 msgstr "Филмови"
+
+msgctxt "#32047"
+msgid "Add new movies to Trakt collection"
+msgstr ""
+
+msgctxt "#32048"
+msgid "Add watched movies to Trakt history"
+msgstr ""
+
+msgctxt "#32049"
+msgid "Mark movies from Trakt history as watched in Kodi"
+msgstr ""
+
+msgctxt "#32050"
+msgid "TV Episodes"
+msgstr ""
+
+msgctxt "#32051"
+msgid "Add new TV episodes to Trakt collection"
+msgstr ""
+
+msgctxt "#32052"
+msgid "Add watched TV episodes to Trakt history"
+msgstr ""
+
+msgctxt "#32053"
+msgid "Mark TV episodes from Trakt history as watched in Kodi"
+msgstr ""
+
+msgctxt "#32054"
+msgid "Service"
+msgstr ""
+
+msgctxt "#32055"
+msgid "Sync collection on library update or cleaning"
+msgstr ""
+
+msgctxt "#32056"
+msgid "Show sync notifications"
+msgstr ""
+
+msgctxt "#32057"
+msgid "Remove deleted movies from Trakt collection"
+msgstr ""
+
+msgctxt "#32058"
+msgid "Remove deleted TV episodes from Trakt collection"
+msgstr ""
+
+# empty string with id 32059
+msgctxt "#32060"
+msgid "Hide notifications during playback"
+msgstr ""
+
+msgctxt "#32061"
+msgid "Sync started"
+msgstr ""
+
+msgctxt "#32062"
+msgid "Sync complete"
+msgstr ""
+
+msgctxt "#32063"
+msgid "%i movie(s) will be added to Trakt collection"
+msgstr ""
+
+msgctxt "#32064"
+msgid "%i movie playcount(s) will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32065"
+msgid "%i movie(s) playcount will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32066"
+msgid "Movie Sync Complete"
+msgstr ""
+
+msgctxt "#32067"
+msgid "Going to add %i show(s) to Trakt collection"
+msgstr ""
+
+msgctxt "#32068"
+msgid "Checking for episodes missing from Trakt collection"
+msgstr ""
+
+msgctxt "#32069"
+msgid "%i of %i show(s) have episodes added to Trakt collection"
+msgstr ""
+
+msgctxt "#32070"
+msgid "Going to update %i show(s) missing watched status"
+msgstr ""
+
+msgctxt "#32071"
+msgid "Checking watched episodes on Trakt"
+msgstr ""
+
+msgctxt "#32072"
+msgid "%i show(s) had missing watched status"
+msgstr ""
+
+msgctxt "#32073"
+msgid "%i episodes are being updated"
+msgstr ""
+
+msgctxt "#32074"
+msgid "Checking watched episodes on Kodi"
+msgstr ""
+
+msgctxt "#32075"
+msgid "Episode Sync Complete"
+msgstr ""
+
+msgctxt "#32076"
+msgid "%i movie(s) will be removed from Trakt collection"
+msgstr ""
+
+msgctxt "#32077"
+msgid "Cleaning Trakt TV show collection"
+msgstr ""
+
+msgctxt "#32078"
+msgid "episodes are being removed"
+msgstr ""
+
+msgctxt "#32079"
+msgid "Loading movies from Kodi"
+msgstr ""
+
+msgctxt "#32080"
+msgid "Movies loaded from Kodi"
+msgstr ""
+
+msgctxt "#32081"
+msgid "Retrieving movie collection from Trakt"
+msgstr ""
+
+msgctxt "#32082"
+msgid "Retrieving watched movies from Trakt"
+msgstr ""
+
+msgctxt "#32083"
+msgid "Retrieved movie data from Trakt"
+msgstr ""
+
+msgctxt "#32084"
+msgid "Trakt movie collection is up to date, no movies to add"
+msgstr ""
+
+msgctxt "#32085"
+msgid "%i movie(s) were added to your Trakt collection"
+msgstr ""
+
+msgctxt "#32086"
+msgid "Trakt movie playcounts are up to date"
+msgstr ""
+
+msgctxt "#32087"
+msgid "Playcounts updated for %i movie(s) on Trakt"
+msgstr ""
+
+msgctxt "#32088"
+msgid "Kodi movie playcounts are up to date"
+msgstr ""
+
+msgctxt "#32089"
+msgid "Updating %i of %i movie playcount(s) in Kodi"
+msgstr ""
+
+msgctxt "#32090"
+msgid "Playcounts updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32091"
+msgid "Trakt movie collection is up to date, no movies removed"
+msgstr ""
+
+msgctxt "#32092"
+msgid "%i movie(s) were removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32093"
+msgid "Updating %i of %i movie playcount(s) on Trakt"
+msgstr ""
+
+msgctxt "#32094"
+msgid "Loading episode data from Kodi"
+msgstr ""
+
+msgctxt "#32095"
+msgid "Loading shows from Kodi"
+msgstr ""
+
+msgctxt "#32096"
+msgid "Shows loaded from Kodi"
+msgstr ""
+
+msgctxt "#32097"
+msgid "Parsing %i of %i episode data from Kodi"
+msgstr ""
+
+msgctxt "#32098"
+msgid "Loaded episode data from Kodi"
+msgstr ""
+
+msgctxt "#32099"
+msgid "Loading episode data from Trakt"
+msgstr ""
+
+msgctxt "#32100"
+msgid "Retrieving episode collection from Trakt"
+msgstr ""
+
+msgctxt "#32101"
+msgid "Retrieving watched episodes from Trakt"
+msgstr ""
+
+msgctxt "#32102"
+msgid "Parsing episode data %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32103"
+msgid "Retrieved episode data from Trakt"
+msgstr ""
+
+msgctxt "#32104"
+msgid "Trakt episode collection is up to date, no episodes to add"
+msgstr ""
+
+msgctxt "#32105"
+msgid "%i episode(s) were added to your Trakt collection"
+msgstr ""
+
+msgctxt "#32106"
+msgid "Trakt episode playcounts are up to date"
+msgstr ""
+
+msgctxt "#32107"
+msgid "Kodi episode playcounts are up to date"
+msgstr ""
+
+msgctxt "#32108"
+msgid "Updating %i of %i episode playcount(s) in Kodi"
+msgstr ""
+
+msgctxt "#32109"
+msgid "Playcounts updated for %i show(s) in Kodi"
+msgstr ""
+
+msgctxt "#32110"
+msgid "Trakt episode collection is clean, no episodes to remove"
+msgstr ""
+
+msgctxt "#32111"
+msgid "%i episode(s) are being removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32112"
+msgid "%i episode(s) were removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32113"
+msgid "Trakt - Marked as watched"
+msgstr ""
+
+msgctxt "#32114"
+msgid "Trakt - Failed marking as watched"
+msgstr ""
+
+msgctxt "#32115"
+msgid "%d episode(s) of '%s'"
+msgstr ""
+
+msgctxt "#32116"
+msgid "Enable debug mode"
+msgstr ""
+
+msgctxt "#32117"
+msgid "Sync movie playback progress to Kodi"
+msgstr ""
+
+msgctxt "#32118"
+msgid "Sync episode playback progress to Kodi"
+msgstr ""
+
+msgctxt "#32119"
+msgid "Retrieving episode playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32120"
+msgid "Parsing episode playback progress %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32121"
+msgid "Retrieved episode playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32122"
+msgid "Retrieving movie playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32123"
+msgid "Parsing movie playback progress %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32124"
+msgid "Retrieved movie playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32125"
+msgid "Kodi movie playback progress is up to date"
+msgstr ""
+
+msgctxt "#32126"
+msgid "%i movie(s) playback progress will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32127"
+msgid "Updating %i of %i movie(s) playback progress in Kodi"
+msgstr ""
+
+msgctxt "#32128"
+msgid "Playback progress updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32129"
+msgid "Kodi episode playback progress is up to date"
+msgstr ""
+
+msgctxt "#32130"
+msgid "Updating %i of %i episode(s) playback progress in Kodi"
+msgstr ""
+
+msgctxt "#32131"
+msgid "Playback progress updated for %i episode(s) in Kodi"
+msgstr ""
+
+msgctxt "#32132"
+msgid "Unrate this season"
+msgstr ""
+
+msgctxt "#32133"
+msgid "Manage Movie's Lists"
+msgstr ""
+
+msgctxt "#32134"
+msgid "Manage Show's Lists"
+msgstr ""
+
+msgctxt "#32135"
+msgid "Remove from Watchlist"
+msgstr ""
+
+msgctxt "#32136"
+msgid "Add to watchlist"
+msgstr ""
+
+msgctxt "#32137"
+msgid "Rate this movie"
+msgstr ""
+
+msgctxt "#32138"
+msgid "Rate this show"
+msgstr ""
+
+msgctxt "#32139"
+msgid "Rate this episode"
+msgstr ""
+
+msgctxt "#32140"
+msgid "Toggle watched"
+msgstr ""
+
+msgctxt "#32141"
+msgid "Manage all lists"
+msgstr ""
+
+msgctxt "#32142"
+msgid "Update all tags"
+msgstr ""
+
+msgctxt "#32143"
+msgid "Synchronize library"
+msgstr ""
+
+msgctxt "#32144"
+msgid "How do I authorize the trakt addon to access my trakt.tv account?"
+msgstr ""
+
+# empty strings from id 32145 to 32146
+msgctxt "#32147"
+msgid "Trakt.tv PIN Authorization Failed"
+msgstr ""
+
+# empty string with id 32148
+msgctxt "#32149"
+msgid "Rate this Season"
+msgstr ""
+
+msgctxt "#32150"
+msgid "You will be reminded in 24 hours"
+msgstr ""
+
+msgctxt "#32151"
+msgid "Use Addon Settings later if you change your mind"
+msgstr ""
+
+msgctxt "#32152"
+msgid "Trakt Authorization Complete"
+msgstr ""
+
+msgctxt "#32153"
+msgid "Trakt Account Authorization"
+msgstr ""
+
+msgctxt "#32154"
+msgid "Authorize"
+msgstr ""
+
+msgctxt "#32155"
+msgid "Remind Me Later"
+msgstr ""
+
+msgctxt "#32156"
+msgid "No Thanks"
+msgstr ""
+
+msgctxt "#32157"
+msgid "Account Authorization"
+msgstr ""
+
+# empty string with id 32158
+msgctxt "#32159"
+msgid "Visit {0} or scan the QR code."
+msgstr ""
+
+msgctxt "#32162"
+msgid "The trakt addon CAN NOT be used without authorizing it to access your trakt.tv account."
+msgstr ""
+
+msgctxt "#32163"
+msgid "User"
+msgstr ""
+
+msgctxt "#32164"
+msgid "Fallback to Title/Year matching if necessary"
+msgstr ""
+
+msgctxt "#32165"
+msgid "Trakt - Added to watchlist"
+msgstr ""
+
+msgctxt "#32166"
+msgid "Trakt - Failed adding to watchlist"
+msgstr ""
+
+msgctxt "#32167"
+msgid "Offset scrobble start by X minutes"
+msgstr ""
+
+msgctxt "#32168"
+msgid "Sync ratings"
+msgstr ""
+
+msgctxt "#32169"
+msgid "Kodi movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32170"
+msgid "%i movie(s) ratings will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32171"
+msgid "Updating %i of %i movie ratings in Kodi"
+msgstr ""
+
+msgctxt "#32172"
+msgid "Ratings updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32173"
+msgid "Kodi episode ratings are up to date"
+msgstr ""
+
+msgctxt "#32174"
+msgid "Updating %i of %i episode ratings in Kodi"
+msgstr ""
+
+msgctxt "#32175"
+msgid "Ratings updated for %i episode(s) in Kodi"
+msgstr ""
+
+msgctxt "#32176"
+msgid "Kodi show ratings are up to date"
+msgstr ""
+
+msgctxt "#32177"
+msgid "Updating %i of %i show ratings in Kodi"
+msgstr ""
+
+msgctxt "#32178"
+msgid "Ratings updated for %i show(s) in Kodi"
+msgstr ""
+
+msgctxt "#32179"
+msgid "Trakt movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32180"
+msgid "%i movie ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32181"
+msgid "Trakt show ratings are up to date"
+msgstr ""
+
+msgctxt "#32182"
+msgid "%i show ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32183"
+msgid "Attempt to scrobble MythTV PVR recordings"
+msgstr ""
+
+msgctxt "#32184"
+msgid "Attempt secondary show title search"
+msgstr ""
+
+msgctxt "#32185"
+msgid "Exclude Plugins"
+msgstr ""
+
+msgctxt "#32186"
+msgid "Allow script exclusions"
+msgstr ""

--- a/script.trakt/resources/language/resource.language.sr_RS@latin/strings.po
+++ b/script.trakt/resources/language/resource.language.sr_RS@latin/strings.po
@@ -10,28 +10,712 @@ msgstr ""
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Kodi Translation Team\n"
 "Language-Team: Serbian (http://www.transifex.com/projects/p/xbmc-addons/language/sr/)\n"
+"Language: sr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: sr\n"
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 
 msgctxt "#32000"
 msgid "General"
 msgstr "Opšte"
 
+# empty strings from id 32001 to 32002
+msgctxt "#32003"
+msgid "Startup Delay"
+msgstr ""
+
 msgctxt "#32004"
 msgid "Rating"
 msgstr "Ocena"
+
+msgctxt "#32005"
+msgid "Rate Movie after watching"
+msgstr ""
+
+msgctxt "#32006"
+msgid "Rate TV show Episode after watching"
+msgstr ""
+
+msgctxt "#32008"
+msgid "Minimum percent watched to display rating dialog"
+msgstr ""
+
+msgctxt "#32009"
+msgid "Allow re-rating of media"
+msgstr ""
+
+msgctxt "#32010"
+msgid "Default rating"
+msgstr ""
+
+# Scrobbling Settings
+msgctxt "#32011"
+msgid "Scrobbling"
+msgstr ""
+
+msgctxt "#32012"
+msgid "Scrobble movies"
+msgstr ""
+
+msgctxt "#32013"
+msgid "Scrobble TV show episodes"
+msgstr ""
+
+msgctxt "#32014"
+msgid "Show notification on scrobble"
+msgstr ""
+
+msgctxt "#32015"
+msgid "Trakt - Scrobbled successfully"
+msgstr ""
+
+msgctxt "#32016"
+msgid "Exclusions"
+msgstr ""
+
+msgctxt "#32017"
+msgid "Exclude Live TV"
+msgstr ""
+
+msgctxt "#32018"
+msgid "Exclude HTTP sources"
+msgstr ""
+
+msgctxt "#32019"
+msgid "Exclude path"
+msgstr ""
+
+msgctxt "#32020"
+msgid "Folder's path (including subfolders)"
+msgstr ""
+
+# empty strings from id 32021 to 32022
+msgctxt "#32023"
+msgid "Can not connect to Trakt"
+msgstr ""
 
 msgctxt "#32024"
 msgid "Error"
 msgstr "Greška"
 
+# empty string with id 32025
+msgctxt "#32026"
+msgid "What Did You Think?"
+msgstr ""
+
+msgctxt "#32027"
+msgid "Totally Ninja!"
+msgstr ""
+
+msgctxt "#32028"
+msgid "Weak Sauce :("
+msgstr ""
+
+msgctxt "#32029"
+msgid "Terrible"
+msgstr ""
+
+msgctxt "#32030"
+msgid "Bad"
+msgstr ""
+
+msgctxt "#32031"
+msgid "Poor"
+msgstr ""
+
+msgctxt "#32032"
+msgid "Meh"
+msgstr ""
+
 msgctxt "#32033"
 msgid "Fair"
 msgstr "umereno"
 
+msgctxt "#32034"
+msgid "Good"
+msgstr ""
+
+msgctxt "#32035"
+msgid "Great"
+msgstr ""
+
+msgctxt "#32036"
+msgid "Superb"
+msgstr ""
+
+msgctxt "#32037"
+msgid "Unrate this movie"
+msgstr ""
+
+msgctxt "#32038"
+msgid "Unrate this show"
+msgstr ""
+
+msgctxt "#32039"
+msgid "Unrate this episode"
+msgstr ""
+
+msgctxt "#32040"
+msgid "Trakt - Rating submitted successfully"
+msgstr ""
+
+msgctxt "#32041"
+msgid "Trakt - Already rated"
+msgstr ""
+
+msgctxt "#32042"
+msgid "Trakt - Unrated successfully"
+msgstr ""
+
+msgctxt "#32043"
+msgid "Trakt - Already has the same rating"
+msgstr ""
+
+msgctxt "#32044"
+msgid "Trakt - Problem submitting rating"
+msgstr ""
+
+msgctxt "#32045"
+msgid "Synchronize"
+msgstr ""
+
 msgctxt "#32046"
 msgid "Movies"
 msgstr "Filmovi"
+
+msgctxt "#32047"
+msgid "Add new movies to Trakt collection"
+msgstr ""
+
+msgctxt "#32048"
+msgid "Add watched movies to Trakt history"
+msgstr ""
+
+msgctxt "#32049"
+msgid "Mark movies from Trakt history as watched in Kodi"
+msgstr ""
+
+msgctxt "#32050"
+msgid "TV Episodes"
+msgstr ""
+
+msgctxt "#32051"
+msgid "Add new TV episodes to Trakt collection"
+msgstr ""
+
+msgctxt "#32052"
+msgid "Add watched TV episodes to Trakt history"
+msgstr ""
+
+msgctxt "#32053"
+msgid "Mark TV episodes from Trakt history as watched in Kodi"
+msgstr ""
+
+msgctxt "#32054"
+msgid "Service"
+msgstr ""
+
+msgctxt "#32055"
+msgid "Sync collection on library update or cleaning"
+msgstr ""
+
+msgctxt "#32056"
+msgid "Show sync notifications"
+msgstr ""
+
+msgctxt "#32057"
+msgid "Remove deleted movies from Trakt collection"
+msgstr ""
+
+msgctxt "#32058"
+msgid "Remove deleted TV episodes from Trakt collection"
+msgstr ""
+
+# empty string with id 32059
+msgctxt "#32060"
+msgid "Hide notifications during playback"
+msgstr ""
+
+msgctxt "#32061"
+msgid "Sync started"
+msgstr ""
+
+msgctxt "#32062"
+msgid "Sync complete"
+msgstr ""
+
+msgctxt "#32063"
+msgid "%i movie(s) will be added to Trakt collection"
+msgstr ""
+
+msgctxt "#32064"
+msgid "%i movie playcount(s) will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32065"
+msgid "%i movie(s) playcount will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32066"
+msgid "Movie Sync Complete"
+msgstr ""
+
+msgctxt "#32067"
+msgid "Going to add %i show(s) to Trakt collection"
+msgstr ""
+
+msgctxt "#32068"
+msgid "Checking for episodes missing from Trakt collection"
+msgstr ""
+
+msgctxt "#32069"
+msgid "%i of %i show(s) have episodes added to Trakt collection"
+msgstr ""
+
+msgctxt "#32070"
+msgid "Going to update %i show(s) missing watched status"
+msgstr ""
+
+msgctxt "#32071"
+msgid "Checking watched episodes on Trakt"
+msgstr ""
+
+msgctxt "#32072"
+msgid "%i show(s) had missing watched status"
+msgstr ""
+
+msgctxt "#32073"
+msgid "%i episodes are being updated"
+msgstr ""
+
+msgctxt "#32074"
+msgid "Checking watched episodes on Kodi"
+msgstr ""
+
+msgctxt "#32075"
+msgid "Episode Sync Complete"
+msgstr ""
+
+msgctxt "#32076"
+msgid "%i movie(s) will be removed from Trakt collection"
+msgstr ""
+
+msgctxt "#32077"
+msgid "Cleaning Trakt TV show collection"
+msgstr ""
+
+msgctxt "#32078"
+msgid "episodes are being removed"
+msgstr ""
+
+msgctxt "#32079"
+msgid "Loading movies from Kodi"
+msgstr ""
+
+msgctxt "#32080"
+msgid "Movies loaded from Kodi"
+msgstr ""
+
+msgctxt "#32081"
+msgid "Retrieving movie collection from Trakt"
+msgstr ""
+
+msgctxt "#32082"
+msgid "Retrieving watched movies from Trakt"
+msgstr ""
+
+msgctxt "#32083"
+msgid "Retrieved movie data from Trakt"
+msgstr ""
+
+msgctxt "#32084"
+msgid "Trakt movie collection is up to date, no movies to add"
+msgstr ""
+
+msgctxt "#32085"
+msgid "%i movie(s) were added to your Trakt collection"
+msgstr ""
+
+msgctxt "#32086"
+msgid "Trakt movie playcounts are up to date"
+msgstr ""
+
+msgctxt "#32087"
+msgid "Playcounts updated for %i movie(s) on Trakt"
+msgstr ""
+
+msgctxt "#32088"
+msgid "Kodi movie playcounts are up to date"
+msgstr ""
+
+msgctxt "#32089"
+msgid "Updating %i of %i movie playcount(s) in Kodi"
+msgstr ""
+
+msgctxt "#32090"
+msgid "Playcounts updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32091"
+msgid "Trakt movie collection is up to date, no movies removed"
+msgstr ""
+
+msgctxt "#32092"
+msgid "%i movie(s) were removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32093"
+msgid "Updating %i of %i movie playcount(s) on Trakt"
+msgstr ""
+
+msgctxt "#32094"
+msgid "Loading episode data from Kodi"
+msgstr ""
+
+msgctxt "#32095"
+msgid "Loading shows from Kodi"
+msgstr ""
+
+msgctxt "#32096"
+msgid "Shows loaded from Kodi"
+msgstr ""
+
+msgctxt "#32097"
+msgid "Parsing %i of %i episode data from Kodi"
+msgstr ""
+
+msgctxt "#32098"
+msgid "Loaded episode data from Kodi"
+msgstr ""
+
+msgctxt "#32099"
+msgid "Loading episode data from Trakt"
+msgstr ""
+
+msgctxt "#32100"
+msgid "Retrieving episode collection from Trakt"
+msgstr ""
+
+msgctxt "#32101"
+msgid "Retrieving watched episodes from Trakt"
+msgstr ""
+
+msgctxt "#32102"
+msgid "Parsing episode data %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32103"
+msgid "Retrieved episode data from Trakt"
+msgstr ""
+
+msgctxt "#32104"
+msgid "Trakt episode collection is up to date, no episodes to add"
+msgstr ""
+
+msgctxt "#32105"
+msgid "%i episode(s) were added to your Trakt collection"
+msgstr ""
+
+msgctxt "#32106"
+msgid "Trakt episode playcounts are up to date"
+msgstr ""
+
+msgctxt "#32107"
+msgid "Kodi episode playcounts are up to date"
+msgstr ""
+
+msgctxt "#32108"
+msgid "Updating %i of %i episode playcount(s) in Kodi"
+msgstr ""
+
+msgctxt "#32109"
+msgid "Playcounts updated for %i show(s) in Kodi"
+msgstr ""
+
+msgctxt "#32110"
+msgid "Trakt episode collection is clean, no episodes to remove"
+msgstr ""
+
+msgctxt "#32111"
+msgid "%i episode(s) are being removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32112"
+msgid "%i episode(s) were removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32113"
+msgid "Trakt - Marked as watched"
+msgstr ""
+
+msgctxt "#32114"
+msgid "Trakt - Failed marking as watched"
+msgstr ""
+
+msgctxt "#32115"
+msgid "%d episode(s) of '%s'"
+msgstr ""
+
+msgctxt "#32116"
+msgid "Enable debug mode"
+msgstr ""
+
+msgctxt "#32117"
+msgid "Sync movie playback progress to Kodi"
+msgstr ""
+
+msgctxt "#32118"
+msgid "Sync episode playback progress to Kodi"
+msgstr ""
+
+msgctxt "#32119"
+msgid "Retrieving episode playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32120"
+msgid "Parsing episode playback progress %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32121"
+msgid "Retrieved episode playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32122"
+msgid "Retrieving movie playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32123"
+msgid "Parsing movie playback progress %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32124"
+msgid "Retrieved movie playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32125"
+msgid "Kodi movie playback progress is up to date"
+msgstr ""
+
+msgctxt "#32126"
+msgid "%i movie(s) playback progress will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32127"
+msgid "Updating %i of %i movie(s) playback progress in Kodi"
+msgstr ""
+
+msgctxt "#32128"
+msgid "Playback progress updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32129"
+msgid "Kodi episode playback progress is up to date"
+msgstr ""
+
+msgctxt "#32130"
+msgid "Updating %i of %i episode(s) playback progress in Kodi"
+msgstr ""
+
+msgctxt "#32131"
+msgid "Playback progress updated for %i episode(s) in Kodi"
+msgstr ""
+
+msgctxt "#32132"
+msgid "Unrate this season"
+msgstr ""
+
+msgctxt "#32133"
+msgid "Manage Movie's Lists"
+msgstr ""
+
+msgctxt "#32134"
+msgid "Manage Show's Lists"
+msgstr ""
+
+msgctxt "#32135"
+msgid "Remove from Watchlist"
+msgstr ""
+
+msgctxt "#32136"
+msgid "Add to watchlist"
+msgstr ""
+
+msgctxt "#32137"
+msgid "Rate this movie"
+msgstr ""
+
+msgctxt "#32138"
+msgid "Rate this show"
+msgstr ""
+
+msgctxt "#32139"
+msgid "Rate this episode"
+msgstr ""
+
+msgctxt "#32140"
+msgid "Toggle watched"
+msgstr ""
+
+msgctxt "#32141"
+msgid "Manage all lists"
+msgstr ""
+
+msgctxt "#32142"
+msgid "Update all tags"
+msgstr ""
+
+msgctxt "#32143"
+msgid "Synchronize library"
+msgstr ""
+
+msgctxt "#32144"
+msgid "How do I authorize the trakt addon to access my trakt.tv account?"
+msgstr ""
+
+# empty strings from id 32145 to 32146
+msgctxt "#32147"
+msgid "Trakt.tv PIN Authorization Failed"
+msgstr ""
+
+# empty string with id 32148
+msgctxt "#32149"
+msgid "Rate this Season"
+msgstr ""
+
+msgctxt "#32150"
+msgid "You will be reminded in 24 hours"
+msgstr ""
+
+msgctxt "#32151"
+msgid "Use Addon Settings later if you change your mind"
+msgstr ""
+
+msgctxt "#32152"
+msgid "Trakt Authorization Complete"
+msgstr ""
+
+msgctxt "#32153"
+msgid "Trakt Account Authorization"
+msgstr ""
+
+msgctxt "#32154"
+msgid "Authorize"
+msgstr ""
+
+msgctxt "#32155"
+msgid "Remind Me Later"
+msgstr ""
+
+msgctxt "#32156"
+msgid "No Thanks"
+msgstr ""
+
+msgctxt "#32157"
+msgid "Account Authorization"
+msgstr ""
+
+# empty string with id 32158
+msgctxt "#32159"
+msgid "Visit {0} or scan the QR code."
+msgstr ""
+
+msgctxt "#32162"
+msgid "The trakt addon CAN NOT be used without authorizing it to access your trakt.tv account."
+msgstr ""
+
+msgctxt "#32163"
+msgid "User"
+msgstr ""
+
+msgctxt "#32164"
+msgid "Fallback to Title/Year matching if necessary"
+msgstr ""
+
+msgctxt "#32165"
+msgid "Trakt - Added to watchlist"
+msgstr ""
+
+msgctxt "#32166"
+msgid "Trakt - Failed adding to watchlist"
+msgstr ""
+
+msgctxt "#32167"
+msgid "Offset scrobble start by X minutes"
+msgstr ""
+
+msgctxt "#32168"
+msgid "Sync ratings"
+msgstr ""
+
+msgctxt "#32169"
+msgid "Kodi movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32170"
+msgid "%i movie(s) ratings will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32171"
+msgid "Updating %i of %i movie ratings in Kodi"
+msgstr ""
+
+msgctxt "#32172"
+msgid "Ratings updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32173"
+msgid "Kodi episode ratings are up to date"
+msgstr ""
+
+msgctxt "#32174"
+msgid "Updating %i of %i episode ratings in Kodi"
+msgstr ""
+
+msgctxt "#32175"
+msgid "Ratings updated for %i episode(s) in Kodi"
+msgstr ""
+
+msgctxt "#32176"
+msgid "Kodi show ratings are up to date"
+msgstr ""
+
+msgctxt "#32177"
+msgid "Updating %i of %i show ratings in Kodi"
+msgstr ""
+
+msgctxt "#32178"
+msgid "Ratings updated for %i show(s) in Kodi"
+msgstr ""
+
+msgctxt "#32179"
+msgid "Trakt movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32180"
+msgid "%i movie ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32181"
+msgid "Trakt show ratings are up to date"
+msgstr ""
+
+msgctxt "#32182"
+msgid "%i show ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32183"
+msgid "Attempt to scrobble MythTV PVR recordings"
+msgstr ""
+
+msgctxt "#32184"
+msgid "Attempt secondary show title search"
+msgstr ""
+
+msgctxt "#32185"
+msgid "Exclude Plugins"
+msgstr ""
+
+msgctxt "#32186"
+msgid "Allow script exclusions"
+msgstr ""

--- a/script.trakt/resources/language/resource.language.sv_SE/strings.po
+++ b/script.trakt/resources/language/resource.language.sv_SE/strings.po
@@ -7,14 +7,15 @@ msgstr ""
 "Project-Id-Version: XBMC Addons\n"
 "Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: Kodi Translation Team\n"
-"Language-Team: Swedish (http://www.transifex.com/projects/p/xbmc-addons/language/sv/)\n"
+"PO-Revision-Date: 2021-03-20 15:56+0000\n"
+"Last-Translator: Christian Gade <gade@kodi.tv>\n"
+"Language-Team: Swedish <https://kodi.weblate.cloud/projects/kodi-add-ons-scripts/script-trakt/sv_se/>\n"
+"Language: sv_SE\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: sv\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Generator: Weblate 4.5.1\n"
 
 msgctxt "#32000"
 msgid "General"
@@ -215,6 +216,10 @@ msgstr "Tjänst"
 msgctxt "#32055"
 msgid "Sync collection on library update or cleaning"
 msgstr "Synkronisera samlingar på trakt vid uppdatering eller städning av bibliotek"
+
+msgctxt "#32056"
+msgid "Show sync notifications"
+msgstr ""
 
 msgctxt "#32057"
 msgid "Remove deleted movies from Trakt collection"
@@ -486,7 +491,7 @@ msgstr "Hämtade uppspelningsförlopp för film från Trakt"
 
 msgctxt "#32125"
 msgid "Kodi movie playback progress is up to date"
-msgstr "Uppspelningsförlopp för film i Kodi är av senaste versionen."
+msgstr "Uppspelningsförlopp för film i Kodi är av senaste versionen"
 
 msgctxt "#32126"
 msgid "%i movie(s) playback progress will be updated in Kodi"
@@ -502,7 +507,7 @@ msgstr "Uppspelningsförlopp för %i film(er) uppdaterat i Kodi"
 
 msgctxt "#32129"
 msgid "Kodi episode playback progress is up to date"
-msgstr "Uppspelningsförlopp för avsnitt i Kodi är av senaste versionen."
+msgstr "Uppspelningsförlopp för avsnitt i Kodi är av senaste versionen"
 
 msgctxt "#32130"
 msgid "Updating %i of %i episode(s) playback progress in Kodi"
@@ -528,6 +533,185 @@ msgctxt "#32135"
 msgid "Remove from Watchlist"
 msgstr "Tag bort från Watchlist"
 
+msgctxt "#32136"
+msgid "Add to watchlist"
+msgstr ""
+
+msgctxt "#32137"
+msgid "Rate this movie"
+msgstr ""
+
+msgctxt "#32138"
+msgid "Rate this show"
+msgstr ""
+
+msgctxt "#32139"
+msgid "Rate this episode"
+msgstr ""
+
+msgctxt "#32140"
+msgid "Toggle watched"
+msgstr ""
+
+msgctxt "#32141"
+msgid "Manage all lists"
+msgstr ""
+
+msgctxt "#32142"
+msgid "Update all tags"
+msgstr ""
+
+msgctxt "#32143"
+msgid "Synchronize library"
+msgstr ""
+
+msgctxt "#32144"
+msgid "How do I authorize the trakt addon to access my trakt.tv account?"
+msgstr ""
+
+# empty strings from id 32145 to 32146
+msgctxt "#32147"
+msgid "Trakt.tv PIN Authorization Failed"
+msgstr ""
+
+# empty string with id 32148
+msgctxt "#32149"
+msgid "Rate this Season"
+msgstr ""
+
+msgctxt "#32150"
+msgid "You will be reminded in 24 hours"
+msgstr ""
+
+msgctxt "#32151"
+msgid "Use Addon Settings later if you change your mind"
+msgstr ""
+
+msgctxt "#32152"
+msgid "Trakt Authorization Complete"
+msgstr ""
+
+msgctxt "#32153"
+msgid "Trakt Account Authorization"
+msgstr ""
+
+msgctxt "#32154"
+msgid "Authorize"
+msgstr ""
+
+msgctxt "#32155"
+msgid "Remind Me Later"
+msgstr ""
+
+msgctxt "#32156"
+msgid "No Thanks"
+msgstr ""
+
+msgctxt "#32157"
+msgid "Account Authorization"
+msgstr ""
+
+# empty string with id 32158
+msgctxt "#32159"
+msgid "Visit {0} or scan the QR code."
+msgstr ""
+
+msgctxt "#32162"
+msgid "The trakt addon CAN NOT be used without authorizing it to access your trakt.tv account."
+msgstr ""
+
 msgctxt "#32163"
 msgid "User"
 msgstr "Användare"
+
+msgctxt "#32164"
+msgid "Fallback to Title/Year matching if necessary"
+msgstr ""
+
+msgctxt "#32165"
+msgid "Trakt - Added to watchlist"
+msgstr ""
+
+msgctxt "#32166"
+msgid "Trakt - Failed adding to watchlist"
+msgstr ""
+
+msgctxt "#32167"
+msgid "Offset scrobble start by X minutes"
+msgstr ""
+
+msgctxt "#32168"
+msgid "Sync ratings"
+msgstr ""
+
+msgctxt "#32169"
+msgid "Kodi movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32170"
+msgid "%i movie(s) ratings will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32171"
+msgid "Updating %i of %i movie ratings in Kodi"
+msgstr ""
+
+msgctxt "#32172"
+msgid "Ratings updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32173"
+msgid "Kodi episode ratings are up to date"
+msgstr ""
+
+msgctxt "#32174"
+msgid "Updating %i of %i episode ratings in Kodi"
+msgstr ""
+
+msgctxt "#32175"
+msgid "Ratings updated for %i episode(s) in Kodi"
+msgstr ""
+
+msgctxt "#32176"
+msgid "Kodi show ratings are up to date"
+msgstr ""
+
+msgctxt "#32177"
+msgid "Updating %i of %i show ratings in Kodi"
+msgstr ""
+
+msgctxt "#32178"
+msgid "Ratings updated for %i show(s) in Kodi"
+msgstr ""
+
+msgctxt "#32179"
+msgid "Trakt movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32180"
+msgid "%i movie ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32181"
+msgid "Trakt show ratings are up to date"
+msgstr ""
+
+msgctxt "#32182"
+msgid "%i show ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32183"
+msgid "Attempt to scrobble MythTV PVR recordings"
+msgstr ""
+
+msgctxt "#32184"
+msgid "Attempt secondary show title search"
+msgstr ""
+
+msgctxt "#32185"
+msgid "Exclude Plugins"
+msgstr ""
+
+msgctxt "#32186"
+msgid "Allow script exclusions"
+msgstr ""

--- a/script.trakt/resources/language/resource.language.szl/strings.po
+++ b/script.trakt/resources/language/resource.language.szl/strings.po
@@ -1,0 +1,723 @@
+# Kodi Media Center language file
+# Addon Name: Trakt
+# Addon id: script.trakt
+# Addon Provider: Trakt.tv, Razze
+msgid ""
+msgstr ""
+"Project-Id-Version: XBMC Addons\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
+"POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: szl\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 "
+"|| n%100>=20) ? 1 : 2;\n"
+
+# General Settings
+msgctxt "#32000"
+msgid "General"
+msgstr ""
+
+# empty strings from id 32001 to 32002
+msgctxt "#32003"
+msgid "Startup Delay"
+msgstr ""
+
+msgctxt "#32004"
+msgid "Rating"
+msgstr ""
+
+msgctxt "#32005"
+msgid "Rate Movie after watching"
+msgstr ""
+
+msgctxt "#32006"
+msgid "Rate TV show Episode after watching"
+msgstr ""
+
+msgctxt "#32008"
+msgid "Minimum percent watched to display rating dialog"
+msgstr ""
+
+msgctxt "#32009"
+msgid "Allow re-rating of media"
+msgstr ""
+
+msgctxt "#32010"
+msgid "Default rating"
+msgstr ""
+
+# Scrobbling Settings
+msgctxt "#32011"
+msgid "Scrobbling"
+msgstr ""
+
+msgctxt "#32012"
+msgid "Scrobble movies"
+msgstr ""
+
+msgctxt "#32013"
+msgid "Scrobble TV show episodes"
+msgstr ""
+
+msgctxt "#32014"
+msgid "Show notification on scrobble"
+msgstr ""
+
+msgctxt "#32015"
+msgid "Trakt - Scrobbled successfully"
+msgstr ""
+
+msgctxt "#32016"
+msgid "Exclusions"
+msgstr ""
+
+msgctxt "#32017"
+msgid "Exclude Live TV"
+msgstr ""
+
+msgctxt "#32018"
+msgid "Exclude HTTP sources"
+msgstr ""
+
+msgctxt "#32019"
+msgid "Exclude path"
+msgstr ""
+
+msgctxt "#32020"
+msgid "Folder's path (including subfolders)"
+msgstr ""
+
+# empty strings from id 32021 to 32022
+msgctxt "#32023"
+msgid "Can not connect to Trakt"
+msgstr ""
+
+msgctxt "#32024"
+msgid "Error"
+msgstr ""
+
+# empty string with id 32025
+msgctxt "#32026"
+msgid "What Did You Think?"
+msgstr ""
+
+msgctxt "#32027"
+msgid "Totally Ninja!"
+msgstr ""
+
+msgctxt "#32028"
+msgid "Weak Sauce :("
+msgstr ""
+
+msgctxt "#32029"
+msgid "Terrible"
+msgstr ""
+
+msgctxt "#32030"
+msgid "Bad"
+msgstr ""
+
+msgctxt "#32031"
+msgid "Poor"
+msgstr ""
+
+msgctxt "#32032"
+msgid "Meh"
+msgstr ""
+
+msgctxt "#32033"
+msgid "Fair"
+msgstr ""
+
+msgctxt "#32034"
+msgid "Good"
+msgstr ""
+
+msgctxt "#32035"
+msgid "Great"
+msgstr ""
+
+msgctxt "#32036"
+msgid "Superb"
+msgstr ""
+
+msgctxt "#32037"
+msgid "Unrate this movie"
+msgstr ""
+
+msgctxt "#32038"
+msgid "Unrate this show"
+msgstr ""
+
+msgctxt "#32039"
+msgid "Unrate this episode"
+msgstr ""
+
+msgctxt "#32040"
+msgid "Trakt - Rating submitted successfully"
+msgstr ""
+
+msgctxt "#32041"
+msgid "Trakt - Already rated"
+msgstr ""
+
+msgctxt "#32042"
+msgid "Trakt - Unrated successfully"
+msgstr ""
+
+msgctxt "#32043"
+msgid "Trakt - Already has the same rating"
+msgstr ""
+
+msgctxt "#32044"
+msgid "Trakt - Problem submitting rating"
+msgstr ""
+
+msgctxt "#32045"
+msgid "Synchronize"
+msgstr ""
+
+msgctxt "#32046"
+msgid "Movies"
+msgstr ""
+
+msgctxt "#32047"
+msgid "Add new movies to Trakt collection"
+msgstr ""
+
+msgctxt "#32048"
+msgid "Add watched movies to Trakt history"
+msgstr ""
+
+msgctxt "#32049"
+msgid "Mark movies from Trakt history as watched in Kodi"
+msgstr ""
+
+msgctxt "#32050"
+msgid "TV Episodes"
+msgstr ""
+
+msgctxt "#32051"
+msgid "Add new TV episodes to Trakt collection"
+msgstr ""
+
+msgctxt "#32052"
+msgid "Add watched TV episodes to Trakt history"
+msgstr ""
+
+msgctxt "#32053"
+msgid "Mark TV episodes from Trakt history as watched in Kodi"
+msgstr ""
+
+msgctxt "#32054"
+msgid "Service"
+msgstr ""
+
+msgctxt "#32055"
+msgid "Sync collection on library update or cleaning"
+msgstr ""
+
+msgctxt "#32056"
+msgid "Show sync notifications"
+msgstr ""
+
+msgctxt "#32057"
+msgid "Remove deleted movies from Trakt collection"
+msgstr ""
+
+msgctxt "#32058"
+msgid "Remove deleted TV episodes from Trakt collection"
+msgstr ""
+
+# empty string with id 32059
+msgctxt "#32060"
+msgid "Hide notifications during playback"
+msgstr ""
+
+msgctxt "#32061"
+msgid "Sync started"
+msgstr ""
+
+msgctxt "#32062"
+msgid "Sync complete"
+msgstr ""
+
+msgctxt "#32063"
+msgid "%i movie(s) will be added to Trakt collection"
+msgstr ""
+
+msgctxt "#32064"
+msgid "%i movie playcount(s) will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32065"
+msgid "%i movie(s) playcount will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32066"
+msgid "Movie Sync Complete"
+msgstr ""
+
+msgctxt "#32067"
+msgid "Going to add %i show(s) to Trakt collection"
+msgstr ""
+
+msgctxt "#32068"
+msgid "Checking for episodes missing from Trakt collection"
+msgstr ""
+
+msgctxt "#32069"
+msgid "%i of %i show(s) have episodes added to Trakt collection"
+msgstr ""
+
+msgctxt "#32070"
+msgid "Going to update %i show(s) missing watched status"
+msgstr ""
+
+msgctxt "#32071"
+msgid "Checking watched episodes on Trakt"
+msgstr ""
+
+msgctxt "#32072"
+msgid "%i show(s) had missing watched status"
+msgstr ""
+
+msgctxt "#32073"
+msgid "%i episodes are being updated"
+msgstr ""
+
+msgctxt "#32074"
+msgid "Checking watched episodes on Kodi"
+msgstr ""
+
+msgctxt "#32075"
+msgid "Episode Sync Complete"
+msgstr ""
+
+msgctxt "#32076"
+msgid "%i movie(s) will be removed from Trakt collection"
+msgstr ""
+
+msgctxt "#32077"
+msgid "Cleaning Trakt TV show collection"
+msgstr ""
+
+msgctxt "#32078"
+msgid "episodes are being removed"
+msgstr ""
+
+msgctxt "#32079"
+msgid "Loading movies from Kodi"
+msgstr ""
+
+msgctxt "#32080"
+msgid "Movies loaded from Kodi"
+msgstr ""
+
+msgctxt "#32081"
+msgid "Retrieving movie collection from Trakt"
+msgstr ""
+
+msgctxt "#32082"
+msgid "Retrieving watched movies from Trakt"
+msgstr ""
+
+msgctxt "#32083"
+msgid "Retrieved movie data from Trakt"
+msgstr ""
+
+msgctxt "#32084"
+msgid "Trakt movie collection is up to date, no movies to add"
+msgstr ""
+
+msgctxt "#32085"
+msgid "%i movie(s) were added to your Trakt collection"
+msgstr ""
+
+msgctxt "#32086"
+msgid "Trakt movie playcounts are up to date"
+msgstr ""
+
+msgctxt "#32087"
+msgid "Playcounts updated for %i movie(s) on Trakt"
+msgstr ""
+
+msgctxt "#32088"
+msgid "Kodi movie playcounts are up to date"
+msgstr ""
+
+msgctxt "#32089"
+msgid "Updating %i of %i movie playcount(s) in Kodi"
+msgstr ""
+
+msgctxt "#32090"
+msgid "Playcounts updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32091"
+msgid "Trakt movie collection is up to date, no movies removed"
+msgstr ""
+
+msgctxt "#32092"
+msgid "%i movie(s) were removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32093"
+msgid "Updating %i of %i movie playcount(s) on Trakt"
+msgstr ""
+
+msgctxt "#32094"
+msgid "Loading episode data from Kodi"
+msgstr ""
+
+msgctxt "#32095"
+msgid "Loading shows from Kodi"
+msgstr ""
+
+msgctxt "#32096"
+msgid "Shows loaded from Kodi"
+msgstr ""
+
+msgctxt "#32097"
+msgid "Parsing %i of %i episode data from Kodi"
+msgstr ""
+
+msgctxt "#32098"
+msgid "Loaded episode data from Kodi"
+msgstr ""
+
+msgctxt "#32099"
+msgid "Loading episode data from Trakt"
+msgstr ""
+
+msgctxt "#32100"
+msgid "Retrieving episode collection from Trakt"
+msgstr ""
+
+msgctxt "#32101"
+msgid "Retrieving watched episodes from Trakt"
+msgstr ""
+
+msgctxt "#32102"
+msgid "Parsing episode data %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32103"
+msgid "Retrieved episode data from Trakt"
+msgstr ""
+
+msgctxt "#32104"
+msgid "Trakt episode collection is up to date, no episodes to add"
+msgstr ""
+
+msgctxt "#32105"
+msgid "%i episode(s) were added to your Trakt collection"
+msgstr ""
+
+msgctxt "#32106"
+msgid "Trakt episode playcounts are up to date"
+msgstr ""
+
+msgctxt "#32107"
+msgid "Kodi episode playcounts are up to date"
+msgstr ""
+
+msgctxt "#32108"
+msgid "Updating %i of %i episode playcount(s) in Kodi"
+msgstr ""
+
+msgctxt "#32109"
+msgid "Playcounts updated for %i show(s) in Kodi"
+msgstr ""
+
+msgctxt "#32110"
+msgid "Trakt episode collection is clean, no episodes to remove"
+msgstr ""
+
+msgctxt "#32111"
+msgid "%i episode(s) are being removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32112"
+msgid "%i episode(s) were removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32113"
+msgid "Trakt - Marked as watched"
+msgstr ""
+
+msgctxt "#32114"
+msgid "Trakt - Failed marking as watched"
+msgstr ""
+
+msgctxt "#32115"
+msgid "%d episode(s) of '%s'"
+msgstr ""
+
+msgctxt "#32116"
+msgid "Enable debug mode"
+msgstr ""
+
+msgctxt "#32117"
+msgid "Sync movie playback progress to Kodi"
+msgstr ""
+
+msgctxt "#32118"
+msgid "Sync episode playback progress to Kodi"
+msgstr ""
+
+msgctxt "#32119"
+msgid "Retrieving episode playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32120"
+msgid "Parsing episode playback progress %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32121"
+msgid "Retrieved episode playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32122"
+msgid "Retrieving movie playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32123"
+msgid "Parsing movie playback progress %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32124"
+msgid "Retrieved movie playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32125"
+msgid "Kodi movie playback progress is up to date"
+msgstr ""
+
+msgctxt "#32126"
+msgid "%i movie(s) playback progress will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32127"
+msgid "Updating %i of %i movie(s) playback progress in Kodi"
+msgstr ""
+
+msgctxt "#32128"
+msgid "Playback progress updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32129"
+msgid "Kodi episode playback progress is up to date"
+msgstr ""
+
+msgctxt "#32130"
+msgid "Updating %i of %i episode(s) playback progress in Kodi"
+msgstr ""
+
+msgctxt "#32131"
+msgid "Playback progress updated for %i episode(s) in Kodi"
+msgstr ""
+
+msgctxt "#32132"
+msgid "Unrate this season"
+msgstr ""
+
+msgctxt "#32133"
+msgid "Manage Movie's Lists"
+msgstr ""
+
+msgctxt "#32134"
+msgid "Manage Show's Lists"
+msgstr ""
+
+msgctxt "#32135"
+msgid "Remove from Watchlist"
+msgstr ""
+
+msgctxt "#32136"
+msgid "Add to watchlist"
+msgstr ""
+
+msgctxt "#32137"
+msgid "Rate this movie"
+msgstr ""
+
+msgctxt "#32138"
+msgid "Rate this show"
+msgstr ""
+
+msgctxt "#32139"
+msgid "Rate this episode"
+msgstr ""
+
+msgctxt "#32140"
+msgid "Toggle watched"
+msgstr ""
+
+msgctxt "#32141"
+msgid "Manage all lists"
+msgstr ""
+
+msgctxt "#32142"
+msgid "Update all tags"
+msgstr ""
+
+msgctxt "#32143"
+msgid "Synchronize library"
+msgstr ""
+
+msgctxt "#32144"
+msgid "How do I authorize the trakt addon to access my trakt.tv account?"
+msgstr ""
+
+# empty strings from id 32145 to 32146
+msgctxt "#32147"
+msgid "Trakt.tv PIN Authorization Failed"
+msgstr ""
+
+# empty string with id 32148
+msgctxt "#32149"
+msgid "Rate this Season"
+msgstr ""
+
+msgctxt "#32150"
+msgid "You will be reminded in 24 hours"
+msgstr ""
+
+msgctxt "#32151"
+msgid "Use Addon Settings later if you change your mind"
+msgstr ""
+
+msgctxt "#32152"
+msgid "Trakt Authorization Complete"
+msgstr ""
+
+msgctxt "#32153"
+msgid "Trakt Account Authorization"
+msgstr ""
+
+msgctxt "#32154"
+msgid "Authorize"
+msgstr ""
+
+msgctxt "#32155"
+msgid "Remind Me Later"
+msgstr ""
+
+msgctxt "#32156"
+msgid "No Thanks"
+msgstr ""
+
+msgctxt "#32157"
+msgid "Account Authorization"
+msgstr ""
+
+# empty string with id 32158
+msgctxt "#32159"
+msgid "Visit {0} or scan the QR code."
+msgstr ""
+
+msgctxt "#32162"
+msgid "The trakt addon CAN NOT be used without authorizing it to access your trakt.tv account."
+msgstr ""
+
+msgctxt "#32163"
+msgid "User"
+msgstr ""
+
+msgctxt "#32164"
+msgid "Fallback to Title/Year matching if necessary"
+msgstr ""
+
+msgctxt "#32165"
+msgid "Trakt - Added to watchlist"
+msgstr ""
+
+msgctxt "#32166"
+msgid "Trakt - Failed adding to watchlist"
+msgstr ""
+
+msgctxt "#32167"
+msgid "Offset scrobble start by X minutes"
+msgstr ""
+
+msgctxt "#32168"
+msgid "Sync ratings"
+msgstr ""
+
+msgctxt "#32169"
+msgid "Kodi movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32170"
+msgid "%i movie(s) ratings will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32171"
+msgid "Updating %i of %i movie ratings in Kodi"
+msgstr ""
+
+msgctxt "#32172"
+msgid "Ratings updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32173"
+msgid "Kodi episode ratings are up to date"
+msgstr ""
+
+msgctxt "#32174"
+msgid "Updating %i of %i episode ratings in Kodi"
+msgstr ""
+
+msgctxt "#32175"
+msgid "Ratings updated for %i episode(s) in Kodi"
+msgstr ""
+
+msgctxt "#32176"
+msgid "Kodi show ratings are up to date"
+msgstr ""
+
+msgctxt "#32177"
+msgid "Updating %i of %i show ratings in Kodi"
+msgstr ""
+
+msgctxt "#32178"
+msgid "Ratings updated for %i show(s) in Kodi"
+msgstr ""
+
+msgctxt "#32179"
+msgid "Trakt movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32180"
+msgid "%i movie ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32181"
+msgid "Trakt show ratings are up to date"
+msgstr ""
+
+msgctxt "#32182"
+msgid "%i show ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32183"
+msgid "Attempt to scrobble MythTV PVR recordings"
+msgstr ""
+
+msgctxt "#32184"
+msgid "Attempt secondary show title search"
+msgstr ""
+
+msgctxt "#32185"
+msgid "Exclude Plugins"
+msgstr ""
+
+msgctxt "#32186"
+msgid "Allow script exclusions"
+msgstr ""

--- a/script.trakt/resources/language/resource.language.ta_IN/strings.po
+++ b/script.trakt/resources/language/resource.language.ta_IN/strings.po
@@ -10,32 +10,712 @@ msgstr ""
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Kodi Translation Team\n"
 "Language-Team: Tamil (India) (http://www.transifex.com/projects/p/xbmc-addons/language/ta_IN/)\n"
+"Language: ta_IN\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: ta_IN\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 msgctxt "#32000"
 msgid "General"
 msgstr "பொதுவானது"
 
+# empty strings from id 32001 to 32002
+msgctxt "#32003"
+msgid "Startup Delay"
+msgstr ""
+
 msgctxt "#32004"
 msgid "Rating"
 msgstr "மதிப்பீடு"
+
+msgctxt "#32005"
+msgid "Rate Movie after watching"
+msgstr ""
+
+msgctxt "#32006"
+msgid "Rate TV show Episode after watching"
+msgstr ""
+
+msgctxt "#32008"
+msgid "Minimum percent watched to display rating dialog"
+msgstr ""
+
+msgctxt "#32009"
+msgid "Allow re-rating of media"
+msgstr ""
+
+msgctxt "#32010"
+msgid "Default rating"
+msgstr ""
+
+# Scrobbling Settings
+msgctxt "#32011"
+msgid "Scrobbling"
+msgstr ""
+
+msgctxt "#32012"
+msgid "Scrobble movies"
+msgstr ""
+
+msgctxt "#32013"
+msgid "Scrobble TV show episodes"
+msgstr ""
+
+msgctxt "#32014"
+msgid "Show notification on scrobble"
+msgstr ""
+
+msgctxt "#32015"
+msgid "Trakt - Scrobbled successfully"
+msgstr ""
+
+msgctxt "#32016"
+msgid "Exclusions"
+msgstr ""
+
+msgctxt "#32017"
+msgid "Exclude Live TV"
+msgstr ""
+
+msgctxt "#32018"
+msgid "Exclude HTTP sources"
+msgstr ""
+
+msgctxt "#32019"
+msgid "Exclude path"
+msgstr ""
+
+msgctxt "#32020"
+msgid "Folder's path (including subfolders)"
+msgstr ""
+
+# empty strings from id 32021 to 32022
+msgctxt "#32023"
+msgid "Can not connect to Trakt"
+msgstr ""
 
 msgctxt "#32024"
 msgid "Error"
 msgstr "பிழை"
 
+# empty string with id 32025
+msgctxt "#32026"
+msgid "What Did You Think?"
+msgstr ""
+
+msgctxt "#32027"
+msgid "Totally Ninja!"
+msgstr ""
+
+msgctxt "#32028"
+msgid "Weak Sauce :("
+msgstr ""
+
+msgctxt "#32029"
+msgid "Terrible"
+msgstr ""
+
+msgctxt "#32030"
+msgid "Bad"
+msgstr ""
+
+msgctxt "#32031"
+msgid "Poor"
+msgstr ""
+
+msgctxt "#32032"
+msgid "Meh"
+msgstr ""
+
 msgctxt "#32033"
 msgid "Fair"
 msgstr "நடுவுநிலை"
+
+msgctxt "#32034"
+msgid "Good"
+msgstr ""
+
+msgctxt "#32035"
+msgid "Great"
+msgstr ""
+
+msgctxt "#32036"
+msgid "Superb"
+msgstr ""
+
+msgctxt "#32037"
+msgid "Unrate this movie"
+msgstr ""
+
+msgctxt "#32038"
+msgid "Unrate this show"
+msgstr ""
+
+msgctxt "#32039"
+msgid "Unrate this episode"
+msgstr ""
+
+msgctxt "#32040"
+msgid "Trakt - Rating submitted successfully"
+msgstr ""
+
+msgctxt "#32041"
+msgid "Trakt - Already rated"
+msgstr ""
+
+msgctxt "#32042"
+msgid "Trakt - Unrated successfully"
+msgstr ""
+
+msgctxt "#32043"
+msgid "Trakt - Already has the same rating"
+msgstr ""
+
+msgctxt "#32044"
+msgid "Trakt - Problem submitting rating"
+msgstr ""
+
+msgctxt "#32045"
+msgid "Synchronize"
+msgstr ""
 
 msgctxt "#32046"
 msgid "Movies"
 msgstr "திரைப்படங்கள்"
 
+msgctxt "#32047"
+msgid "Add new movies to Trakt collection"
+msgstr ""
+
+msgctxt "#32048"
+msgid "Add watched movies to Trakt history"
+msgstr ""
+
+msgctxt "#32049"
+msgid "Mark movies from Trakt history as watched in Kodi"
+msgstr ""
+
+msgctxt "#32050"
+msgid "TV Episodes"
+msgstr ""
+
+msgctxt "#32051"
+msgid "Add new TV episodes to Trakt collection"
+msgstr ""
+
+msgctxt "#32052"
+msgid "Add watched TV episodes to Trakt history"
+msgstr ""
+
+msgctxt "#32053"
+msgid "Mark TV episodes from Trakt history as watched in Kodi"
+msgstr ""
+
 msgctxt "#32054"
 msgid "Service"
 msgstr "சேவை"
+
+msgctxt "#32055"
+msgid "Sync collection on library update or cleaning"
+msgstr ""
+
+msgctxt "#32056"
+msgid "Show sync notifications"
+msgstr ""
+
+msgctxt "#32057"
+msgid "Remove deleted movies from Trakt collection"
+msgstr ""
+
+msgctxt "#32058"
+msgid "Remove deleted TV episodes from Trakt collection"
+msgstr ""
+
+# empty string with id 32059
+msgctxt "#32060"
+msgid "Hide notifications during playback"
+msgstr ""
+
+msgctxt "#32061"
+msgid "Sync started"
+msgstr ""
+
+msgctxt "#32062"
+msgid "Sync complete"
+msgstr ""
+
+msgctxt "#32063"
+msgid "%i movie(s) will be added to Trakt collection"
+msgstr ""
+
+msgctxt "#32064"
+msgid "%i movie playcount(s) will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32065"
+msgid "%i movie(s) playcount will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32066"
+msgid "Movie Sync Complete"
+msgstr ""
+
+msgctxt "#32067"
+msgid "Going to add %i show(s) to Trakt collection"
+msgstr ""
+
+msgctxt "#32068"
+msgid "Checking for episodes missing from Trakt collection"
+msgstr ""
+
+msgctxt "#32069"
+msgid "%i of %i show(s) have episodes added to Trakt collection"
+msgstr ""
+
+msgctxt "#32070"
+msgid "Going to update %i show(s) missing watched status"
+msgstr ""
+
+msgctxt "#32071"
+msgid "Checking watched episodes on Trakt"
+msgstr ""
+
+msgctxt "#32072"
+msgid "%i show(s) had missing watched status"
+msgstr ""
+
+msgctxt "#32073"
+msgid "%i episodes are being updated"
+msgstr ""
+
+msgctxt "#32074"
+msgid "Checking watched episodes on Kodi"
+msgstr ""
+
+msgctxt "#32075"
+msgid "Episode Sync Complete"
+msgstr ""
+
+msgctxt "#32076"
+msgid "%i movie(s) will be removed from Trakt collection"
+msgstr ""
+
+msgctxt "#32077"
+msgid "Cleaning Trakt TV show collection"
+msgstr ""
+
+msgctxt "#32078"
+msgid "episodes are being removed"
+msgstr ""
+
+msgctxt "#32079"
+msgid "Loading movies from Kodi"
+msgstr ""
+
+msgctxt "#32080"
+msgid "Movies loaded from Kodi"
+msgstr ""
+
+msgctxt "#32081"
+msgid "Retrieving movie collection from Trakt"
+msgstr ""
+
+msgctxt "#32082"
+msgid "Retrieving watched movies from Trakt"
+msgstr ""
+
+msgctxt "#32083"
+msgid "Retrieved movie data from Trakt"
+msgstr ""
+
+msgctxt "#32084"
+msgid "Trakt movie collection is up to date, no movies to add"
+msgstr ""
+
+msgctxt "#32085"
+msgid "%i movie(s) were added to your Trakt collection"
+msgstr ""
+
+msgctxt "#32086"
+msgid "Trakt movie playcounts are up to date"
+msgstr ""
+
+msgctxt "#32087"
+msgid "Playcounts updated for %i movie(s) on Trakt"
+msgstr ""
+
+msgctxt "#32088"
+msgid "Kodi movie playcounts are up to date"
+msgstr ""
+
+msgctxt "#32089"
+msgid "Updating %i of %i movie playcount(s) in Kodi"
+msgstr ""
+
+msgctxt "#32090"
+msgid "Playcounts updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32091"
+msgid "Trakt movie collection is up to date, no movies removed"
+msgstr ""
+
+msgctxt "#32092"
+msgid "%i movie(s) were removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32093"
+msgid "Updating %i of %i movie playcount(s) on Trakt"
+msgstr ""
+
+msgctxt "#32094"
+msgid "Loading episode data from Kodi"
+msgstr ""
+
+msgctxt "#32095"
+msgid "Loading shows from Kodi"
+msgstr ""
+
+msgctxt "#32096"
+msgid "Shows loaded from Kodi"
+msgstr ""
+
+msgctxt "#32097"
+msgid "Parsing %i of %i episode data from Kodi"
+msgstr ""
+
+msgctxt "#32098"
+msgid "Loaded episode data from Kodi"
+msgstr ""
+
+msgctxt "#32099"
+msgid "Loading episode data from Trakt"
+msgstr ""
+
+msgctxt "#32100"
+msgid "Retrieving episode collection from Trakt"
+msgstr ""
+
+msgctxt "#32101"
+msgid "Retrieving watched episodes from Trakt"
+msgstr ""
+
+msgctxt "#32102"
+msgid "Parsing episode data %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32103"
+msgid "Retrieved episode data from Trakt"
+msgstr ""
+
+msgctxt "#32104"
+msgid "Trakt episode collection is up to date, no episodes to add"
+msgstr ""
+
+msgctxt "#32105"
+msgid "%i episode(s) were added to your Trakt collection"
+msgstr ""
+
+msgctxt "#32106"
+msgid "Trakt episode playcounts are up to date"
+msgstr ""
+
+msgctxt "#32107"
+msgid "Kodi episode playcounts are up to date"
+msgstr ""
+
+msgctxt "#32108"
+msgid "Updating %i of %i episode playcount(s) in Kodi"
+msgstr ""
+
+msgctxt "#32109"
+msgid "Playcounts updated for %i show(s) in Kodi"
+msgstr ""
+
+msgctxt "#32110"
+msgid "Trakt episode collection is clean, no episodes to remove"
+msgstr ""
+
+msgctxt "#32111"
+msgid "%i episode(s) are being removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32112"
+msgid "%i episode(s) were removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32113"
+msgid "Trakt - Marked as watched"
+msgstr ""
+
+msgctxt "#32114"
+msgid "Trakt - Failed marking as watched"
+msgstr ""
+
+msgctxt "#32115"
+msgid "%d episode(s) of '%s'"
+msgstr ""
+
+msgctxt "#32116"
+msgid "Enable debug mode"
+msgstr ""
+
+msgctxt "#32117"
+msgid "Sync movie playback progress to Kodi"
+msgstr ""
+
+msgctxt "#32118"
+msgid "Sync episode playback progress to Kodi"
+msgstr ""
+
+msgctxt "#32119"
+msgid "Retrieving episode playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32120"
+msgid "Parsing episode playback progress %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32121"
+msgid "Retrieved episode playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32122"
+msgid "Retrieving movie playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32123"
+msgid "Parsing movie playback progress %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32124"
+msgid "Retrieved movie playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32125"
+msgid "Kodi movie playback progress is up to date"
+msgstr ""
+
+msgctxt "#32126"
+msgid "%i movie(s) playback progress will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32127"
+msgid "Updating %i of %i movie(s) playback progress in Kodi"
+msgstr ""
+
+msgctxt "#32128"
+msgid "Playback progress updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32129"
+msgid "Kodi episode playback progress is up to date"
+msgstr ""
+
+msgctxt "#32130"
+msgid "Updating %i of %i episode(s) playback progress in Kodi"
+msgstr ""
+
+msgctxt "#32131"
+msgid "Playback progress updated for %i episode(s) in Kodi"
+msgstr ""
+
+msgctxt "#32132"
+msgid "Unrate this season"
+msgstr ""
+
+msgctxt "#32133"
+msgid "Manage Movie's Lists"
+msgstr ""
+
+msgctxt "#32134"
+msgid "Manage Show's Lists"
+msgstr ""
+
+msgctxt "#32135"
+msgid "Remove from Watchlist"
+msgstr ""
+
+msgctxt "#32136"
+msgid "Add to watchlist"
+msgstr ""
+
+msgctxt "#32137"
+msgid "Rate this movie"
+msgstr ""
+
+msgctxt "#32138"
+msgid "Rate this show"
+msgstr ""
+
+msgctxt "#32139"
+msgid "Rate this episode"
+msgstr ""
+
+msgctxt "#32140"
+msgid "Toggle watched"
+msgstr ""
+
+msgctxt "#32141"
+msgid "Manage all lists"
+msgstr ""
+
+msgctxt "#32142"
+msgid "Update all tags"
+msgstr ""
+
+msgctxt "#32143"
+msgid "Synchronize library"
+msgstr ""
+
+msgctxt "#32144"
+msgid "How do I authorize the trakt addon to access my trakt.tv account?"
+msgstr ""
+
+# empty strings from id 32145 to 32146
+msgctxt "#32147"
+msgid "Trakt.tv PIN Authorization Failed"
+msgstr ""
+
+# empty string with id 32148
+msgctxt "#32149"
+msgid "Rate this Season"
+msgstr ""
+
+msgctxt "#32150"
+msgid "You will be reminded in 24 hours"
+msgstr ""
+
+msgctxt "#32151"
+msgid "Use Addon Settings later if you change your mind"
+msgstr ""
+
+msgctxt "#32152"
+msgid "Trakt Authorization Complete"
+msgstr ""
+
+msgctxt "#32153"
+msgid "Trakt Account Authorization"
+msgstr ""
+
+msgctxt "#32154"
+msgid "Authorize"
+msgstr ""
+
+msgctxt "#32155"
+msgid "Remind Me Later"
+msgstr ""
+
+msgctxt "#32156"
+msgid "No Thanks"
+msgstr ""
+
+msgctxt "#32157"
+msgid "Account Authorization"
+msgstr ""
+
+# empty string with id 32158
+msgctxt "#32159"
+msgid "Visit {0} or scan the QR code."
+msgstr ""
+
+msgctxt "#32162"
+msgid "The trakt addon CAN NOT be used without authorizing it to access your trakt.tv account."
+msgstr ""
+
+msgctxt "#32163"
+msgid "User"
+msgstr ""
+
+msgctxt "#32164"
+msgid "Fallback to Title/Year matching if necessary"
+msgstr ""
+
+msgctxt "#32165"
+msgid "Trakt - Added to watchlist"
+msgstr ""
+
+msgctxt "#32166"
+msgid "Trakt - Failed adding to watchlist"
+msgstr ""
+
+msgctxt "#32167"
+msgid "Offset scrobble start by X minutes"
+msgstr ""
+
+msgctxt "#32168"
+msgid "Sync ratings"
+msgstr ""
+
+msgctxt "#32169"
+msgid "Kodi movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32170"
+msgid "%i movie(s) ratings will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32171"
+msgid "Updating %i of %i movie ratings in Kodi"
+msgstr ""
+
+msgctxt "#32172"
+msgid "Ratings updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32173"
+msgid "Kodi episode ratings are up to date"
+msgstr ""
+
+msgctxt "#32174"
+msgid "Updating %i of %i episode ratings in Kodi"
+msgstr ""
+
+msgctxt "#32175"
+msgid "Ratings updated for %i episode(s) in Kodi"
+msgstr ""
+
+msgctxt "#32176"
+msgid "Kodi show ratings are up to date"
+msgstr ""
+
+msgctxt "#32177"
+msgid "Updating %i of %i show ratings in Kodi"
+msgstr ""
+
+msgctxt "#32178"
+msgid "Ratings updated for %i show(s) in Kodi"
+msgstr ""
+
+msgctxt "#32179"
+msgid "Trakt movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32180"
+msgid "%i movie ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32181"
+msgid "Trakt show ratings are up to date"
+msgstr ""
+
+msgctxt "#32182"
+msgid "%i show ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32183"
+msgid "Attempt to scrobble MythTV PVR recordings"
+msgstr ""
+
+msgctxt "#32184"
+msgid "Attempt secondary show title search"
+msgstr ""
+
+msgctxt "#32185"
+msgid "Exclude Plugins"
+msgstr ""
+
+msgctxt "#32186"
+msgid "Allow script exclusions"
+msgstr ""

--- a/script.trakt/resources/language/resource.language.te_in/strings.po
+++ b/script.trakt/resources/language/resource.language.te_in/strings.po
@@ -1,0 +1,722 @@
+# Kodi Media Center language file
+# Addon Name: Trakt
+# Addon id: script.trakt
+# Addon Provider: Trakt.tv, Razze
+msgid ""
+msgstr ""
+"Project-Id-Version: XBMC Addons\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
+"POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: te_in\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+
+# General Settings
+msgctxt "#32000"
+msgid "General"
+msgstr ""
+
+# empty strings from id 32001 to 32002
+msgctxt "#32003"
+msgid "Startup Delay"
+msgstr ""
+
+msgctxt "#32004"
+msgid "Rating"
+msgstr ""
+
+msgctxt "#32005"
+msgid "Rate Movie after watching"
+msgstr ""
+
+msgctxt "#32006"
+msgid "Rate TV show Episode after watching"
+msgstr ""
+
+msgctxt "#32008"
+msgid "Minimum percent watched to display rating dialog"
+msgstr ""
+
+msgctxt "#32009"
+msgid "Allow re-rating of media"
+msgstr ""
+
+msgctxt "#32010"
+msgid "Default rating"
+msgstr ""
+
+# Scrobbling Settings
+msgctxt "#32011"
+msgid "Scrobbling"
+msgstr ""
+
+msgctxt "#32012"
+msgid "Scrobble movies"
+msgstr ""
+
+msgctxt "#32013"
+msgid "Scrobble TV show episodes"
+msgstr ""
+
+msgctxt "#32014"
+msgid "Show notification on scrobble"
+msgstr ""
+
+msgctxt "#32015"
+msgid "Trakt - Scrobbled successfully"
+msgstr ""
+
+msgctxt "#32016"
+msgid "Exclusions"
+msgstr ""
+
+msgctxt "#32017"
+msgid "Exclude Live TV"
+msgstr ""
+
+msgctxt "#32018"
+msgid "Exclude HTTP sources"
+msgstr ""
+
+msgctxt "#32019"
+msgid "Exclude path"
+msgstr ""
+
+msgctxt "#32020"
+msgid "Folder's path (including subfolders)"
+msgstr ""
+
+# empty strings from id 32021 to 32022
+msgctxt "#32023"
+msgid "Can not connect to Trakt"
+msgstr ""
+
+msgctxt "#32024"
+msgid "Error"
+msgstr ""
+
+# empty string with id 32025
+msgctxt "#32026"
+msgid "What Did You Think?"
+msgstr ""
+
+msgctxt "#32027"
+msgid "Totally Ninja!"
+msgstr ""
+
+msgctxt "#32028"
+msgid "Weak Sauce :("
+msgstr ""
+
+msgctxt "#32029"
+msgid "Terrible"
+msgstr ""
+
+msgctxt "#32030"
+msgid "Bad"
+msgstr ""
+
+msgctxt "#32031"
+msgid "Poor"
+msgstr ""
+
+msgctxt "#32032"
+msgid "Meh"
+msgstr ""
+
+msgctxt "#32033"
+msgid "Fair"
+msgstr ""
+
+msgctxt "#32034"
+msgid "Good"
+msgstr ""
+
+msgctxt "#32035"
+msgid "Great"
+msgstr ""
+
+msgctxt "#32036"
+msgid "Superb"
+msgstr ""
+
+msgctxt "#32037"
+msgid "Unrate this movie"
+msgstr ""
+
+msgctxt "#32038"
+msgid "Unrate this show"
+msgstr ""
+
+msgctxt "#32039"
+msgid "Unrate this episode"
+msgstr ""
+
+msgctxt "#32040"
+msgid "Trakt - Rating submitted successfully"
+msgstr ""
+
+msgctxt "#32041"
+msgid "Trakt - Already rated"
+msgstr ""
+
+msgctxt "#32042"
+msgid "Trakt - Unrated successfully"
+msgstr ""
+
+msgctxt "#32043"
+msgid "Trakt - Already has the same rating"
+msgstr ""
+
+msgctxt "#32044"
+msgid "Trakt - Problem submitting rating"
+msgstr ""
+
+msgctxt "#32045"
+msgid "Synchronize"
+msgstr ""
+
+msgctxt "#32046"
+msgid "Movies"
+msgstr ""
+
+msgctxt "#32047"
+msgid "Add new movies to Trakt collection"
+msgstr ""
+
+msgctxt "#32048"
+msgid "Add watched movies to Trakt history"
+msgstr ""
+
+msgctxt "#32049"
+msgid "Mark movies from Trakt history as watched in Kodi"
+msgstr ""
+
+msgctxt "#32050"
+msgid "TV Episodes"
+msgstr ""
+
+msgctxt "#32051"
+msgid "Add new TV episodes to Trakt collection"
+msgstr ""
+
+msgctxt "#32052"
+msgid "Add watched TV episodes to Trakt history"
+msgstr ""
+
+msgctxt "#32053"
+msgid "Mark TV episodes from Trakt history as watched in Kodi"
+msgstr ""
+
+msgctxt "#32054"
+msgid "Service"
+msgstr ""
+
+msgctxt "#32055"
+msgid "Sync collection on library update or cleaning"
+msgstr ""
+
+msgctxt "#32056"
+msgid "Show sync notifications"
+msgstr ""
+
+msgctxt "#32057"
+msgid "Remove deleted movies from Trakt collection"
+msgstr ""
+
+msgctxt "#32058"
+msgid "Remove deleted TV episodes from Trakt collection"
+msgstr ""
+
+# empty string with id 32059
+msgctxt "#32060"
+msgid "Hide notifications during playback"
+msgstr ""
+
+msgctxt "#32061"
+msgid "Sync started"
+msgstr ""
+
+msgctxt "#32062"
+msgid "Sync complete"
+msgstr ""
+
+msgctxt "#32063"
+msgid "%i movie(s) will be added to Trakt collection"
+msgstr ""
+
+msgctxt "#32064"
+msgid "%i movie playcount(s) will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32065"
+msgid "%i movie(s) playcount will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32066"
+msgid "Movie Sync Complete"
+msgstr ""
+
+msgctxt "#32067"
+msgid "Going to add %i show(s) to Trakt collection"
+msgstr ""
+
+msgctxt "#32068"
+msgid "Checking for episodes missing from Trakt collection"
+msgstr ""
+
+msgctxt "#32069"
+msgid "%i of %i show(s) have episodes added to Trakt collection"
+msgstr ""
+
+msgctxt "#32070"
+msgid "Going to update %i show(s) missing watched status"
+msgstr ""
+
+msgctxt "#32071"
+msgid "Checking watched episodes on Trakt"
+msgstr ""
+
+msgctxt "#32072"
+msgid "%i show(s) had missing watched status"
+msgstr ""
+
+msgctxt "#32073"
+msgid "%i episodes are being updated"
+msgstr ""
+
+msgctxt "#32074"
+msgid "Checking watched episodes on Kodi"
+msgstr ""
+
+msgctxt "#32075"
+msgid "Episode Sync Complete"
+msgstr ""
+
+msgctxt "#32076"
+msgid "%i movie(s) will be removed from Trakt collection"
+msgstr ""
+
+msgctxt "#32077"
+msgid "Cleaning Trakt TV show collection"
+msgstr ""
+
+msgctxt "#32078"
+msgid "episodes are being removed"
+msgstr ""
+
+msgctxt "#32079"
+msgid "Loading movies from Kodi"
+msgstr ""
+
+msgctxt "#32080"
+msgid "Movies loaded from Kodi"
+msgstr ""
+
+msgctxt "#32081"
+msgid "Retrieving movie collection from Trakt"
+msgstr ""
+
+msgctxt "#32082"
+msgid "Retrieving watched movies from Trakt"
+msgstr ""
+
+msgctxt "#32083"
+msgid "Retrieved movie data from Trakt"
+msgstr ""
+
+msgctxt "#32084"
+msgid "Trakt movie collection is up to date, no movies to add"
+msgstr ""
+
+msgctxt "#32085"
+msgid "%i movie(s) were added to your Trakt collection"
+msgstr ""
+
+msgctxt "#32086"
+msgid "Trakt movie playcounts are up to date"
+msgstr ""
+
+msgctxt "#32087"
+msgid "Playcounts updated for %i movie(s) on Trakt"
+msgstr ""
+
+msgctxt "#32088"
+msgid "Kodi movie playcounts are up to date"
+msgstr ""
+
+msgctxt "#32089"
+msgid "Updating %i of %i movie playcount(s) in Kodi"
+msgstr ""
+
+msgctxt "#32090"
+msgid "Playcounts updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32091"
+msgid "Trakt movie collection is up to date, no movies removed"
+msgstr ""
+
+msgctxt "#32092"
+msgid "%i movie(s) were removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32093"
+msgid "Updating %i of %i movie playcount(s) on Trakt"
+msgstr ""
+
+msgctxt "#32094"
+msgid "Loading episode data from Kodi"
+msgstr ""
+
+msgctxt "#32095"
+msgid "Loading shows from Kodi"
+msgstr ""
+
+msgctxt "#32096"
+msgid "Shows loaded from Kodi"
+msgstr ""
+
+msgctxt "#32097"
+msgid "Parsing %i of %i episode data from Kodi"
+msgstr ""
+
+msgctxt "#32098"
+msgid "Loaded episode data from Kodi"
+msgstr ""
+
+msgctxt "#32099"
+msgid "Loading episode data from Trakt"
+msgstr ""
+
+msgctxt "#32100"
+msgid "Retrieving episode collection from Trakt"
+msgstr ""
+
+msgctxt "#32101"
+msgid "Retrieving watched episodes from Trakt"
+msgstr ""
+
+msgctxt "#32102"
+msgid "Parsing episode data %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32103"
+msgid "Retrieved episode data from Trakt"
+msgstr ""
+
+msgctxt "#32104"
+msgid "Trakt episode collection is up to date, no episodes to add"
+msgstr ""
+
+msgctxt "#32105"
+msgid "%i episode(s) were added to your Trakt collection"
+msgstr ""
+
+msgctxt "#32106"
+msgid "Trakt episode playcounts are up to date"
+msgstr ""
+
+msgctxt "#32107"
+msgid "Kodi episode playcounts are up to date"
+msgstr ""
+
+msgctxt "#32108"
+msgid "Updating %i of %i episode playcount(s) in Kodi"
+msgstr ""
+
+msgctxt "#32109"
+msgid "Playcounts updated for %i show(s) in Kodi"
+msgstr ""
+
+msgctxt "#32110"
+msgid "Trakt episode collection is clean, no episodes to remove"
+msgstr ""
+
+msgctxt "#32111"
+msgid "%i episode(s) are being removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32112"
+msgid "%i episode(s) were removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32113"
+msgid "Trakt - Marked as watched"
+msgstr ""
+
+msgctxt "#32114"
+msgid "Trakt - Failed marking as watched"
+msgstr ""
+
+msgctxt "#32115"
+msgid "%d episode(s) of '%s'"
+msgstr ""
+
+msgctxt "#32116"
+msgid "Enable debug mode"
+msgstr ""
+
+msgctxt "#32117"
+msgid "Sync movie playback progress to Kodi"
+msgstr ""
+
+msgctxt "#32118"
+msgid "Sync episode playback progress to Kodi"
+msgstr ""
+
+msgctxt "#32119"
+msgid "Retrieving episode playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32120"
+msgid "Parsing episode playback progress %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32121"
+msgid "Retrieved episode playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32122"
+msgid "Retrieving movie playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32123"
+msgid "Parsing movie playback progress %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32124"
+msgid "Retrieved movie playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32125"
+msgid "Kodi movie playback progress is up to date"
+msgstr ""
+
+msgctxt "#32126"
+msgid "%i movie(s) playback progress will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32127"
+msgid "Updating %i of %i movie(s) playback progress in Kodi"
+msgstr ""
+
+msgctxt "#32128"
+msgid "Playback progress updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32129"
+msgid "Kodi episode playback progress is up to date"
+msgstr ""
+
+msgctxt "#32130"
+msgid "Updating %i of %i episode(s) playback progress in Kodi"
+msgstr ""
+
+msgctxt "#32131"
+msgid "Playback progress updated for %i episode(s) in Kodi"
+msgstr ""
+
+msgctxt "#32132"
+msgid "Unrate this season"
+msgstr ""
+
+msgctxt "#32133"
+msgid "Manage Movie's Lists"
+msgstr ""
+
+msgctxt "#32134"
+msgid "Manage Show's Lists"
+msgstr ""
+
+msgctxt "#32135"
+msgid "Remove from Watchlist"
+msgstr ""
+
+msgctxt "#32136"
+msgid "Add to watchlist"
+msgstr ""
+
+msgctxt "#32137"
+msgid "Rate this movie"
+msgstr ""
+
+msgctxt "#32138"
+msgid "Rate this show"
+msgstr ""
+
+msgctxt "#32139"
+msgid "Rate this episode"
+msgstr ""
+
+msgctxt "#32140"
+msgid "Toggle watched"
+msgstr ""
+
+msgctxt "#32141"
+msgid "Manage all lists"
+msgstr ""
+
+msgctxt "#32142"
+msgid "Update all tags"
+msgstr ""
+
+msgctxt "#32143"
+msgid "Synchronize library"
+msgstr ""
+
+msgctxt "#32144"
+msgid "How do I authorize the trakt addon to access my trakt.tv account?"
+msgstr ""
+
+# empty strings from id 32145 to 32146
+msgctxt "#32147"
+msgid "Trakt.tv PIN Authorization Failed"
+msgstr ""
+
+# empty string with id 32148
+msgctxt "#32149"
+msgid "Rate this Season"
+msgstr ""
+
+msgctxt "#32150"
+msgid "You will be reminded in 24 hours"
+msgstr ""
+
+msgctxt "#32151"
+msgid "Use Addon Settings later if you change your mind"
+msgstr ""
+
+msgctxt "#32152"
+msgid "Trakt Authorization Complete"
+msgstr ""
+
+msgctxt "#32153"
+msgid "Trakt Account Authorization"
+msgstr ""
+
+msgctxt "#32154"
+msgid "Authorize"
+msgstr ""
+
+msgctxt "#32155"
+msgid "Remind Me Later"
+msgstr ""
+
+msgctxt "#32156"
+msgid "No Thanks"
+msgstr ""
+
+msgctxt "#32157"
+msgid "Account Authorization"
+msgstr ""
+
+# empty string with id 32158
+msgctxt "#32159"
+msgid "Visit {0} or scan the QR code."
+msgstr ""
+
+msgctxt "#32162"
+msgid "The trakt addon CAN NOT be used without authorizing it to access your trakt.tv account."
+msgstr ""
+
+msgctxt "#32163"
+msgid "User"
+msgstr ""
+
+msgctxt "#32164"
+msgid "Fallback to Title/Year matching if necessary"
+msgstr ""
+
+msgctxt "#32165"
+msgid "Trakt - Added to watchlist"
+msgstr ""
+
+msgctxt "#32166"
+msgid "Trakt - Failed adding to watchlist"
+msgstr ""
+
+msgctxt "#32167"
+msgid "Offset scrobble start by X minutes"
+msgstr ""
+
+msgctxt "#32168"
+msgid "Sync ratings"
+msgstr ""
+
+msgctxt "#32169"
+msgid "Kodi movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32170"
+msgid "%i movie(s) ratings will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32171"
+msgid "Updating %i of %i movie ratings in Kodi"
+msgstr ""
+
+msgctxt "#32172"
+msgid "Ratings updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32173"
+msgid "Kodi episode ratings are up to date"
+msgstr ""
+
+msgctxt "#32174"
+msgid "Updating %i of %i episode ratings in Kodi"
+msgstr ""
+
+msgctxt "#32175"
+msgid "Ratings updated for %i episode(s) in Kodi"
+msgstr ""
+
+msgctxt "#32176"
+msgid "Kodi show ratings are up to date"
+msgstr ""
+
+msgctxt "#32177"
+msgid "Updating %i of %i show ratings in Kodi"
+msgstr ""
+
+msgctxt "#32178"
+msgid "Ratings updated for %i show(s) in Kodi"
+msgstr ""
+
+msgctxt "#32179"
+msgid "Trakt movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32180"
+msgid "%i movie ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32181"
+msgid "Trakt show ratings are up to date"
+msgstr ""
+
+msgctxt "#32182"
+msgid "%i show ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32183"
+msgid "Attempt to scrobble MythTV PVR recordings"
+msgstr ""
+
+msgctxt "#32184"
+msgid "Attempt secondary show title search"
+msgstr ""
+
+msgctxt "#32185"
+msgid "Exclude Plugins"
+msgstr ""
+
+msgctxt "#32186"
+msgid "Allow script exclusions"
+msgstr ""

--- a/script.trakt/resources/language/resource.language.tg_tj/strings.po
+++ b/script.trakt/resources/language/resource.language.tg_tj/strings.po
@@ -1,0 +1,722 @@
+# Kodi Media Center language file
+# Addon Name: Trakt
+# Addon id: script.trakt
+# Addon Provider: Trakt.tv, Razze
+msgid ""
+msgstr ""
+"Project-Id-Version: XBMC Addons\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
+"POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: tg_tj\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+# General Settings
+msgctxt "#32000"
+msgid "General"
+msgstr ""
+
+# empty strings from id 32001 to 32002
+msgctxt "#32003"
+msgid "Startup Delay"
+msgstr ""
+
+msgctxt "#32004"
+msgid "Rating"
+msgstr ""
+
+msgctxt "#32005"
+msgid "Rate Movie after watching"
+msgstr ""
+
+msgctxt "#32006"
+msgid "Rate TV show Episode after watching"
+msgstr ""
+
+msgctxt "#32008"
+msgid "Minimum percent watched to display rating dialog"
+msgstr ""
+
+msgctxt "#32009"
+msgid "Allow re-rating of media"
+msgstr ""
+
+msgctxt "#32010"
+msgid "Default rating"
+msgstr ""
+
+# Scrobbling Settings
+msgctxt "#32011"
+msgid "Scrobbling"
+msgstr ""
+
+msgctxt "#32012"
+msgid "Scrobble movies"
+msgstr ""
+
+msgctxt "#32013"
+msgid "Scrobble TV show episodes"
+msgstr ""
+
+msgctxt "#32014"
+msgid "Show notification on scrobble"
+msgstr ""
+
+msgctxt "#32015"
+msgid "Trakt - Scrobbled successfully"
+msgstr ""
+
+msgctxt "#32016"
+msgid "Exclusions"
+msgstr ""
+
+msgctxt "#32017"
+msgid "Exclude Live TV"
+msgstr ""
+
+msgctxt "#32018"
+msgid "Exclude HTTP sources"
+msgstr ""
+
+msgctxt "#32019"
+msgid "Exclude path"
+msgstr ""
+
+msgctxt "#32020"
+msgid "Folder's path (including subfolders)"
+msgstr ""
+
+# empty strings from id 32021 to 32022
+msgctxt "#32023"
+msgid "Can not connect to Trakt"
+msgstr ""
+
+msgctxt "#32024"
+msgid "Error"
+msgstr ""
+
+# empty string with id 32025
+msgctxt "#32026"
+msgid "What Did You Think?"
+msgstr ""
+
+msgctxt "#32027"
+msgid "Totally Ninja!"
+msgstr ""
+
+msgctxt "#32028"
+msgid "Weak Sauce :("
+msgstr ""
+
+msgctxt "#32029"
+msgid "Terrible"
+msgstr ""
+
+msgctxt "#32030"
+msgid "Bad"
+msgstr ""
+
+msgctxt "#32031"
+msgid "Poor"
+msgstr ""
+
+msgctxt "#32032"
+msgid "Meh"
+msgstr ""
+
+msgctxt "#32033"
+msgid "Fair"
+msgstr ""
+
+msgctxt "#32034"
+msgid "Good"
+msgstr ""
+
+msgctxt "#32035"
+msgid "Great"
+msgstr ""
+
+msgctxt "#32036"
+msgid "Superb"
+msgstr ""
+
+msgctxt "#32037"
+msgid "Unrate this movie"
+msgstr ""
+
+msgctxt "#32038"
+msgid "Unrate this show"
+msgstr ""
+
+msgctxt "#32039"
+msgid "Unrate this episode"
+msgstr ""
+
+msgctxt "#32040"
+msgid "Trakt - Rating submitted successfully"
+msgstr ""
+
+msgctxt "#32041"
+msgid "Trakt - Already rated"
+msgstr ""
+
+msgctxt "#32042"
+msgid "Trakt - Unrated successfully"
+msgstr ""
+
+msgctxt "#32043"
+msgid "Trakt - Already has the same rating"
+msgstr ""
+
+msgctxt "#32044"
+msgid "Trakt - Problem submitting rating"
+msgstr ""
+
+msgctxt "#32045"
+msgid "Synchronize"
+msgstr ""
+
+msgctxt "#32046"
+msgid "Movies"
+msgstr ""
+
+msgctxt "#32047"
+msgid "Add new movies to Trakt collection"
+msgstr ""
+
+msgctxt "#32048"
+msgid "Add watched movies to Trakt history"
+msgstr ""
+
+msgctxt "#32049"
+msgid "Mark movies from Trakt history as watched in Kodi"
+msgstr ""
+
+msgctxt "#32050"
+msgid "TV Episodes"
+msgstr ""
+
+msgctxt "#32051"
+msgid "Add new TV episodes to Trakt collection"
+msgstr ""
+
+msgctxt "#32052"
+msgid "Add watched TV episodes to Trakt history"
+msgstr ""
+
+msgctxt "#32053"
+msgid "Mark TV episodes from Trakt history as watched in Kodi"
+msgstr ""
+
+msgctxt "#32054"
+msgid "Service"
+msgstr ""
+
+msgctxt "#32055"
+msgid "Sync collection on library update or cleaning"
+msgstr ""
+
+msgctxt "#32056"
+msgid "Show sync notifications"
+msgstr ""
+
+msgctxt "#32057"
+msgid "Remove deleted movies from Trakt collection"
+msgstr ""
+
+msgctxt "#32058"
+msgid "Remove deleted TV episodes from Trakt collection"
+msgstr ""
+
+# empty string with id 32059
+msgctxt "#32060"
+msgid "Hide notifications during playback"
+msgstr ""
+
+msgctxt "#32061"
+msgid "Sync started"
+msgstr ""
+
+msgctxt "#32062"
+msgid "Sync complete"
+msgstr ""
+
+msgctxt "#32063"
+msgid "%i movie(s) will be added to Trakt collection"
+msgstr ""
+
+msgctxt "#32064"
+msgid "%i movie playcount(s) will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32065"
+msgid "%i movie(s) playcount will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32066"
+msgid "Movie Sync Complete"
+msgstr ""
+
+msgctxt "#32067"
+msgid "Going to add %i show(s) to Trakt collection"
+msgstr ""
+
+msgctxt "#32068"
+msgid "Checking for episodes missing from Trakt collection"
+msgstr ""
+
+msgctxt "#32069"
+msgid "%i of %i show(s) have episodes added to Trakt collection"
+msgstr ""
+
+msgctxt "#32070"
+msgid "Going to update %i show(s) missing watched status"
+msgstr ""
+
+msgctxt "#32071"
+msgid "Checking watched episodes on Trakt"
+msgstr ""
+
+msgctxt "#32072"
+msgid "%i show(s) had missing watched status"
+msgstr ""
+
+msgctxt "#32073"
+msgid "%i episodes are being updated"
+msgstr ""
+
+msgctxt "#32074"
+msgid "Checking watched episodes on Kodi"
+msgstr ""
+
+msgctxt "#32075"
+msgid "Episode Sync Complete"
+msgstr ""
+
+msgctxt "#32076"
+msgid "%i movie(s) will be removed from Trakt collection"
+msgstr ""
+
+msgctxt "#32077"
+msgid "Cleaning Trakt TV show collection"
+msgstr ""
+
+msgctxt "#32078"
+msgid "episodes are being removed"
+msgstr ""
+
+msgctxt "#32079"
+msgid "Loading movies from Kodi"
+msgstr ""
+
+msgctxt "#32080"
+msgid "Movies loaded from Kodi"
+msgstr ""
+
+msgctxt "#32081"
+msgid "Retrieving movie collection from Trakt"
+msgstr ""
+
+msgctxt "#32082"
+msgid "Retrieving watched movies from Trakt"
+msgstr ""
+
+msgctxt "#32083"
+msgid "Retrieved movie data from Trakt"
+msgstr ""
+
+msgctxt "#32084"
+msgid "Trakt movie collection is up to date, no movies to add"
+msgstr ""
+
+msgctxt "#32085"
+msgid "%i movie(s) were added to your Trakt collection"
+msgstr ""
+
+msgctxt "#32086"
+msgid "Trakt movie playcounts are up to date"
+msgstr ""
+
+msgctxt "#32087"
+msgid "Playcounts updated for %i movie(s) on Trakt"
+msgstr ""
+
+msgctxt "#32088"
+msgid "Kodi movie playcounts are up to date"
+msgstr ""
+
+msgctxt "#32089"
+msgid "Updating %i of %i movie playcount(s) in Kodi"
+msgstr ""
+
+msgctxt "#32090"
+msgid "Playcounts updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32091"
+msgid "Trakt movie collection is up to date, no movies removed"
+msgstr ""
+
+msgctxt "#32092"
+msgid "%i movie(s) were removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32093"
+msgid "Updating %i of %i movie playcount(s) on Trakt"
+msgstr ""
+
+msgctxt "#32094"
+msgid "Loading episode data from Kodi"
+msgstr ""
+
+msgctxt "#32095"
+msgid "Loading shows from Kodi"
+msgstr ""
+
+msgctxt "#32096"
+msgid "Shows loaded from Kodi"
+msgstr ""
+
+msgctxt "#32097"
+msgid "Parsing %i of %i episode data from Kodi"
+msgstr ""
+
+msgctxt "#32098"
+msgid "Loaded episode data from Kodi"
+msgstr ""
+
+msgctxt "#32099"
+msgid "Loading episode data from Trakt"
+msgstr ""
+
+msgctxt "#32100"
+msgid "Retrieving episode collection from Trakt"
+msgstr ""
+
+msgctxt "#32101"
+msgid "Retrieving watched episodes from Trakt"
+msgstr ""
+
+msgctxt "#32102"
+msgid "Parsing episode data %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32103"
+msgid "Retrieved episode data from Trakt"
+msgstr ""
+
+msgctxt "#32104"
+msgid "Trakt episode collection is up to date, no episodes to add"
+msgstr ""
+
+msgctxt "#32105"
+msgid "%i episode(s) were added to your Trakt collection"
+msgstr ""
+
+msgctxt "#32106"
+msgid "Trakt episode playcounts are up to date"
+msgstr ""
+
+msgctxt "#32107"
+msgid "Kodi episode playcounts are up to date"
+msgstr ""
+
+msgctxt "#32108"
+msgid "Updating %i of %i episode playcount(s) in Kodi"
+msgstr ""
+
+msgctxt "#32109"
+msgid "Playcounts updated for %i show(s) in Kodi"
+msgstr ""
+
+msgctxt "#32110"
+msgid "Trakt episode collection is clean, no episodes to remove"
+msgstr ""
+
+msgctxt "#32111"
+msgid "%i episode(s) are being removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32112"
+msgid "%i episode(s) were removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32113"
+msgid "Trakt - Marked as watched"
+msgstr ""
+
+msgctxt "#32114"
+msgid "Trakt - Failed marking as watched"
+msgstr ""
+
+msgctxt "#32115"
+msgid "%d episode(s) of '%s'"
+msgstr ""
+
+msgctxt "#32116"
+msgid "Enable debug mode"
+msgstr ""
+
+msgctxt "#32117"
+msgid "Sync movie playback progress to Kodi"
+msgstr ""
+
+msgctxt "#32118"
+msgid "Sync episode playback progress to Kodi"
+msgstr ""
+
+msgctxt "#32119"
+msgid "Retrieving episode playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32120"
+msgid "Parsing episode playback progress %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32121"
+msgid "Retrieved episode playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32122"
+msgid "Retrieving movie playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32123"
+msgid "Parsing movie playback progress %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32124"
+msgid "Retrieved movie playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32125"
+msgid "Kodi movie playback progress is up to date"
+msgstr ""
+
+msgctxt "#32126"
+msgid "%i movie(s) playback progress will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32127"
+msgid "Updating %i of %i movie(s) playback progress in Kodi"
+msgstr ""
+
+msgctxt "#32128"
+msgid "Playback progress updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32129"
+msgid "Kodi episode playback progress is up to date"
+msgstr ""
+
+msgctxt "#32130"
+msgid "Updating %i of %i episode(s) playback progress in Kodi"
+msgstr ""
+
+msgctxt "#32131"
+msgid "Playback progress updated for %i episode(s) in Kodi"
+msgstr ""
+
+msgctxt "#32132"
+msgid "Unrate this season"
+msgstr ""
+
+msgctxt "#32133"
+msgid "Manage Movie's Lists"
+msgstr ""
+
+msgctxt "#32134"
+msgid "Manage Show's Lists"
+msgstr ""
+
+msgctxt "#32135"
+msgid "Remove from Watchlist"
+msgstr ""
+
+msgctxt "#32136"
+msgid "Add to watchlist"
+msgstr ""
+
+msgctxt "#32137"
+msgid "Rate this movie"
+msgstr ""
+
+msgctxt "#32138"
+msgid "Rate this show"
+msgstr ""
+
+msgctxt "#32139"
+msgid "Rate this episode"
+msgstr ""
+
+msgctxt "#32140"
+msgid "Toggle watched"
+msgstr ""
+
+msgctxt "#32141"
+msgid "Manage all lists"
+msgstr ""
+
+msgctxt "#32142"
+msgid "Update all tags"
+msgstr ""
+
+msgctxt "#32143"
+msgid "Synchronize library"
+msgstr ""
+
+msgctxt "#32144"
+msgid "How do I authorize the trakt addon to access my trakt.tv account?"
+msgstr ""
+
+# empty strings from id 32145 to 32146
+msgctxt "#32147"
+msgid "Trakt.tv PIN Authorization Failed"
+msgstr ""
+
+# empty string with id 32148
+msgctxt "#32149"
+msgid "Rate this Season"
+msgstr ""
+
+msgctxt "#32150"
+msgid "You will be reminded in 24 hours"
+msgstr ""
+
+msgctxt "#32151"
+msgid "Use Addon Settings later if you change your mind"
+msgstr ""
+
+msgctxt "#32152"
+msgid "Trakt Authorization Complete"
+msgstr ""
+
+msgctxt "#32153"
+msgid "Trakt Account Authorization"
+msgstr ""
+
+msgctxt "#32154"
+msgid "Authorize"
+msgstr ""
+
+msgctxt "#32155"
+msgid "Remind Me Later"
+msgstr ""
+
+msgctxt "#32156"
+msgid "No Thanks"
+msgstr ""
+
+msgctxt "#32157"
+msgid "Account Authorization"
+msgstr ""
+
+# empty string with id 32158
+msgctxt "#32159"
+msgid "Visit {0} or scan the QR code."
+msgstr ""
+
+msgctxt "#32162"
+msgid "The trakt addon CAN NOT be used without authorizing it to access your trakt.tv account."
+msgstr ""
+
+msgctxt "#32163"
+msgid "User"
+msgstr ""
+
+msgctxt "#32164"
+msgid "Fallback to Title/Year matching if necessary"
+msgstr ""
+
+msgctxt "#32165"
+msgid "Trakt - Added to watchlist"
+msgstr ""
+
+msgctxt "#32166"
+msgid "Trakt - Failed adding to watchlist"
+msgstr ""
+
+msgctxt "#32167"
+msgid "Offset scrobble start by X minutes"
+msgstr ""
+
+msgctxt "#32168"
+msgid "Sync ratings"
+msgstr ""
+
+msgctxt "#32169"
+msgid "Kodi movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32170"
+msgid "%i movie(s) ratings will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32171"
+msgid "Updating %i of %i movie ratings in Kodi"
+msgstr ""
+
+msgctxt "#32172"
+msgid "Ratings updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32173"
+msgid "Kodi episode ratings are up to date"
+msgstr ""
+
+msgctxt "#32174"
+msgid "Updating %i of %i episode ratings in Kodi"
+msgstr ""
+
+msgctxt "#32175"
+msgid "Ratings updated for %i episode(s) in Kodi"
+msgstr ""
+
+msgctxt "#32176"
+msgid "Kodi show ratings are up to date"
+msgstr ""
+
+msgctxt "#32177"
+msgid "Updating %i of %i show ratings in Kodi"
+msgstr ""
+
+msgctxt "#32178"
+msgid "Ratings updated for %i show(s) in Kodi"
+msgstr ""
+
+msgctxt "#32179"
+msgid "Trakt movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32180"
+msgid "%i movie ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32181"
+msgid "Trakt show ratings are up to date"
+msgstr ""
+
+msgctxt "#32182"
+msgid "%i show ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32183"
+msgid "Attempt to scrobble MythTV PVR recordings"
+msgstr ""
+
+msgctxt "#32184"
+msgid "Attempt secondary show title search"
+msgstr ""
+
+msgctxt "#32185"
+msgid "Exclude Plugins"
+msgstr ""
+
+msgctxt "#32186"
+msgid "Allow script exclusions"
+msgstr ""

--- a/script.trakt/resources/language/resource.language.th_TH/strings.po
+++ b/script.trakt/resources/language/resource.language.th_TH/strings.po
@@ -10,36 +10,712 @@ msgstr ""
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Kodi Translation Team\n"
 "Language-Team: Thai (http://www.transifex.com/projects/p/xbmc-addons/language/th/)\n"
+"Language: th\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: th\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 msgctxt "#32000"
 msgid "General"
 msgstr "ทั่วไป"
 
+# empty strings from id 32001 to 32002
+msgctxt "#32003"
+msgid "Startup Delay"
+msgstr ""
+
 msgctxt "#32004"
 msgid "Rating"
 msgstr "เรตติ้ง"
+
+msgctxt "#32005"
+msgid "Rate Movie after watching"
+msgstr ""
+
+msgctxt "#32006"
+msgid "Rate TV show Episode after watching"
+msgstr ""
+
+msgctxt "#32008"
+msgid "Minimum percent watched to display rating dialog"
+msgstr ""
+
+msgctxt "#32009"
+msgid "Allow re-rating of media"
+msgstr ""
+
+msgctxt "#32010"
+msgid "Default rating"
+msgstr ""
+
+# Scrobbling Settings
+msgctxt "#32011"
+msgid "Scrobbling"
+msgstr ""
+
+msgctxt "#32012"
+msgid "Scrobble movies"
+msgstr ""
+
+msgctxt "#32013"
+msgid "Scrobble TV show episodes"
+msgstr ""
+
+msgctxt "#32014"
+msgid "Show notification on scrobble"
+msgstr ""
+
+msgctxt "#32015"
+msgid "Trakt - Scrobbled successfully"
+msgstr ""
+
+msgctxt "#32016"
+msgid "Exclusions"
+msgstr ""
+
+msgctxt "#32017"
+msgid "Exclude Live TV"
+msgstr ""
+
+msgctxt "#32018"
+msgid "Exclude HTTP sources"
+msgstr ""
+
+msgctxt "#32019"
+msgid "Exclude path"
+msgstr ""
+
+msgctxt "#32020"
+msgid "Folder's path (including subfolders)"
+msgstr ""
+
+# empty strings from id 32021 to 32022
+msgctxt "#32023"
+msgid "Can not connect to Trakt"
+msgstr ""
 
 msgctxt "#32024"
 msgid "Error"
 msgstr "ผิดพลาด"
 
+# empty string with id 32025
+msgctxt "#32026"
+msgid "What Did You Think?"
+msgstr ""
+
+msgctxt "#32027"
+msgid "Totally Ninja!"
+msgstr ""
+
+msgctxt "#32028"
+msgid "Weak Sauce :("
+msgstr ""
+
+msgctxt "#32029"
+msgid "Terrible"
+msgstr ""
+
+msgctxt "#32030"
+msgid "Bad"
+msgstr ""
+
+msgctxt "#32031"
+msgid "Poor"
+msgstr ""
+
+msgctxt "#32032"
+msgid "Meh"
+msgstr ""
+
 msgctxt "#32033"
 msgid "Fair"
 msgstr "ปกติ"
+
+msgctxt "#32034"
+msgid "Good"
+msgstr ""
+
+msgctxt "#32035"
+msgid "Great"
+msgstr ""
+
+msgctxt "#32036"
+msgid "Superb"
+msgstr ""
+
+msgctxt "#32037"
+msgid "Unrate this movie"
+msgstr ""
+
+msgctxt "#32038"
+msgid "Unrate this show"
+msgstr ""
+
+msgctxt "#32039"
+msgid "Unrate this episode"
+msgstr ""
+
+msgctxt "#32040"
+msgid "Trakt - Rating submitted successfully"
+msgstr ""
+
+msgctxt "#32041"
+msgid "Trakt - Already rated"
+msgstr ""
+
+msgctxt "#32042"
+msgid "Trakt - Unrated successfully"
+msgstr ""
+
+msgctxt "#32043"
+msgid "Trakt - Already has the same rating"
+msgstr ""
+
+msgctxt "#32044"
+msgid "Trakt - Problem submitting rating"
+msgstr ""
+
+msgctxt "#32045"
+msgid "Synchronize"
+msgstr ""
 
 msgctxt "#32046"
 msgid "Movies"
 msgstr "ภาพยนตร์"
 
+msgctxt "#32047"
+msgid "Add new movies to Trakt collection"
+msgstr ""
+
+msgctxt "#32048"
+msgid "Add watched movies to Trakt history"
+msgstr ""
+
+msgctxt "#32049"
+msgid "Mark movies from Trakt history as watched in Kodi"
+msgstr ""
+
+msgctxt "#32050"
+msgid "TV Episodes"
+msgstr ""
+
+msgctxt "#32051"
+msgid "Add new TV episodes to Trakt collection"
+msgstr ""
+
+msgctxt "#32052"
+msgid "Add watched TV episodes to Trakt history"
+msgstr ""
+
+msgctxt "#32053"
+msgid "Mark TV episodes from Trakt history as watched in Kodi"
+msgstr ""
+
 msgctxt "#32054"
 msgid "Service"
 msgstr "บริการ"
 
+msgctxt "#32055"
+msgid "Sync collection on library update or cleaning"
+msgstr ""
+
+msgctxt "#32056"
+msgid "Show sync notifications"
+msgstr ""
+
+msgctxt "#32057"
+msgid "Remove deleted movies from Trakt collection"
+msgstr ""
+
+msgctxt "#32058"
+msgid "Remove deleted TV episodes from Trakt collection"
+msgstr ""
+
+# empty string with id 32059
+msgctxt "#32060"
+msgid "Hide notifications during playback"
+msgstr ""
+
+msgctxt "#32061"
+msgid "Sync started"
+msgstr ""
+
+msgctxt "#32062"
+msgid "Sync complete"
+msgstr ""
+
+msgctxt "#32063"
+msgid "%i movie(s) will be added to Trakt collection"
+msgstr ""
+
+msgctxt "#32064"
+msgid "%i movie playcount(s) will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32065"
+msgid "%i movie(s) playcount will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32066"
+msgid "Movie Sync Complete"
+msgstr ""
+
+msgctxt "#32067"
+msgid "Going to add %i show(s) to Trakt collection"
+msgstr ""
+
+msgctxt "#32068"
+msgid "Checking for episodes missing from Trakt collection"
+msgstr ""
+
+msgctxt "#32069"
+msgid "%i of %i show(s) have episodes added to Trakt collection"
+msgstr ""
+
+msgctxt "#32070"
+msgid "Going to update %i show(s) missing watched status"
+msgstr ""
+
+msgctxt "#32071"
+msgid "Checking watched episodes on Trakt"
+msgstr ""
+
+msgctxt "#32072"
+msgid "%i show(s) had missing watched status"
+msgstr ""
+
+msgctxt "#32073"
+msgid "%i episodes are being updated"
+msgstr ""
+
+msgctxt "#32074"
+msgid "Checking watched episodes on Kodi"
+msgstr ""
+
+msgctxt "#32075"
+msgid "Episode Sync Complete"
+msgstr ""
+
+msgctxt "#32076"
+msgid "%i movie(s) will be removed from Trakt collection"
+msgstr ""
+
+msgctxt "#32077"
+msgid "Cleaning Trakt TV show collection"
+msgstr ""
+
+msgctxt "#32078"
+msgid "episodes are being removed"
+msgstr ""
+
+msgctxt "#32079"
+msgid "Loading movies from Kodi"
+msgstr ""
+
+msgctxt "#32080"
+msgid "Movies loaded from Kodi"
+msgstr ""
+
+msgctxt "#32081"
+msgid "Retrieving movie collection from Trakt"
+msgstr ""
+
+msgctxt "#32082"
+msgid "Retrieving watched movies from Trakt"
+msgstr ""
+
+msgctxt "#32083"
+msgid "Retrieved movie data from Trakt"
+msgstr ""
+
+msgctxt "#32084"
+msgid "Trakt movie collection is up to date, no movies to add"
+msgstr ""
+
+msgctxt "#32085"
+msgid "%i movie(s) were added to your Trakt collection"
+msgstr ""
+
+msgctxt "#32086"
+msgid "Trakt movie playcounts are up to date"
+msgstr ""
+
+msgctxt "#32087"
+msgid "Playcounts updated for %i movie(s) on Trakt"
+msgstr ""
+
+msgctxt "#32088"
+msgid "Kodi movie playcounts are up to date"
+msgstr ""
+
+msgctxt "#32089"
+msgid "Updating %i of %i movie playcount(s) in Kodi"
+msgstr ""
+
+msgctxt "#32090"
+msgid "Playcounts updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32091"
+msgid "Trakt movie collection is up to date, no movies removed"
+msgstr ""
+
+msgctxt "#32092"
+msgid "%i movie(s) were removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32093"
+msgid "Updating %i of %i movie playcount(s) on Trakt"
+msgstr ""
+
+msgctxt "#32094"
+msgid "Loading episode data from Kodi"
+msgstr ""
+
+msgctxt "#32095"
+msgid "Loading shows from Kodi"
+msgstr ""
+
+msgctxt "#32096"
+msgid "Shows loaded from Kodi"
+msgstr ""
+
+msgctxt "#32097"
+msgid "Parsing %i of %i episode data from Kodi"
+msgstr ""
+
+msgctxt "#32098"
+msgid "Loaded episode data from Kodi"
+msgstr ""
+
+msgctxt "#32099"
+msgid "Loading episode data from Trakt"
+msgstr ""
+
+msgctxt "#32100"
+msgid "Retrieving episode collection from Trakt"
+msgstr ""
+
+msgctxt "#32101"
+msgid "Retrieving watched episodes from Trakt"
+msgstr ""
+
+msgctxt "#32102"
+msgid "Parsing episode data %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32103"
+msgid "Retrieved episode data from Trakt"
+msgstr ""
+
+msgctxt "#32104"
+msgid "Trakt episode collection is up to date, no episodes to add"
+msgstr ""
+
+msgctxt "#32105"
+msgid "%i episode(s) were added to your Trakt collection"
+msgstr ""
+
+msgctxt "#32106"
+msgid "Trakt episode playcounts are up to date"
+msgstr ""
+
+msgctxt "#32107"
+msgid "Kodi episode playcounts are up to date"
+msgstr ""
+
+msgctxt "#32108"
+msgid "Updating %i of %i episode playcount(s) in Kodi"
+msgstr ""
+
+msgctxt "#32109"
+msgid "Playcounts updated for %i show(s) in Kodi"
+msgstr ""
+
+msgctxt "#32110"
+msgid "Trakt episode collection is clean, no episodes to remove"
+msgstr ""
+
+msgctxt "#32111"
+msgid "%i episode(s) are being removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32112"
+msgid "%i episode(s) were removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32113"
+msgid "Trakt - Marked as watched"
+msgstr ""
+
+msgctxt "#32114"
+msgid "Trakt - Failed marking as watched"
+msgstr ""
+
+msgctxt "#32115"
+msgid "%d episode(s) of '%s'"
+msgstr ""
+
+msgctxt "#32116"
+msgid "Enable debug mode"
+msgstr ""
+
+msgctxt "#32117"
+msgid "Sync movie playback progress to Kodi"
+msgstr ""
+
+msgctxt "#32118"
+msgid "Sync episode playback progress to Kodi"
+msgstr ""
+
+msgctxt "#32119"
+msgid "Retrieving episode playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32120"
+msgid "Parsing episode playback progress %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32121"
+msgid "Retrieved episode playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32122"
+msgid "Retrieving movie playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32123"
+msgid "Parsing movie playback progress %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32124"
+msgid "Retrieved movie playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32125"
+msgid "Kodi movie playback progress is up to date"
+msgstr ""
+
+msgctxt "#32126"
+msgid "%i movie(s) playback progress will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32127"
+msgid "Updating %i of %i movie(s) playback progress in Kodi"
+msgstr ""
+
+msgctxt "#32128"
+msgid "Playback progress updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32129"
+msgid "Kodi episode playback progress is up to date"
+msgstr ""
+
+msgctxt "#32130"
+msgid "Updating %i of %i episode(s) playback progress in Kodi"
+msgstr ""
+
+msgctxt "#32131"
+msgid "Playback progress updated for %i episode(s) in Kodi"
+msgstr ""
+
+msgctxt "#32132"
+msgid "Unrate this season"
+msgstr ""
+
+msgctxt "#32133"
+msgid "Manage Movie's Lists"
+msgstr ""
+
+msgctxt "#32134"
+msgid "Manage Show's Lists"
+msgstr ""
+
+msgctxt "#32135"
+msgid "Remove from Watchlist"
+msgstr ""
+
+msgctxt "#32136"
+msgid "Add to watchlist"
+msgstr ""
+
+msgctxt "#32137"
+msgid "Rate this movie"
+msgstr ""
+
+msgctxt "#32138"
+msgid "Rate this show"
+msgstr ""
+
+msgctxt "#32139"
+msgid "Rate this episode"
+msgstr ""
+
+msgctxt "#32140"
+msgid "Toggle watched"
+msgstr ""
+
+msgctxt "#32141"
+msgid "Manage all lists"
+msgstr ""
+
+msgctxt "#32142"
+msgid "Update all tags"
+msgstr ""
+
+msgctxt "#32143"
+msgid "Synchronize library"
+msgstr ""
+
+msgctxt "#32144"
+msgid "How do I authorize the trakt addon to access my trakt.tv account?"
+msgstr ""
+
+# empty strings from id 32145 to 32146
+msgctxt "#32147"
+msgid "Trakt.tv PIN Authorization Failed"
+msgstr ""
+
+# empty string with id 32148
+msgctxt "#32149"
+msgid "Rate this Season"
+msgstr ""
+
+msgctxt "#32150"
+msgid "You will be reminded in 24 hours"
+msgstr ""
+
+msgctxt "#32151"
+msgid "Use Addon Settings later if you change your mind"
+msgstr ""
+
+msgctxt "#32152"
+msgid "Trakt Authorization Complete"
+msgstr ""
+
+msgctxt "#32153"
+msgid "Trakt Account Authorization"
+msgstr ""
+
+msgctxt "#32154"
+msgid "Authorize"
+msgstr ""
+
+msgctxt "#32155"
+msgid "Remind Me Later"
+msgstr ""
+
+msgctxt "#32156"
+msgid "No Thanks"
+msgstr ""
+
+msgctxt "#32157"
+msgid "Account Authorization"
+msgstr ""
+
+# empty string with id 32158
+msgctxt "#32159"
+msgid "Visit {0} or scan the QR code."
+msgstr ""
+
+msgctxt "#32162"
+msgid "The trakt addon CAN NOT be used without authorizing it to access your trakt.tv account."
+msgstr ""
+
 msgctxt "#32163"
 msgid "User"
 msgstr "ผู้ใช้"
+
+msgctxt "#32164"
+msgid "Fallback to Title/Year matching if necessary"
+msgstr ""
+
+msgctxt "#32165"
+msgid "Trakt - Added to watchlist"
+msgstr ""
+
+msgctxt "#32166"
+msgid "Trakt - Failed adding to watchlist"
+msgstr ""
+
+msgctxt "#32167"
+msgid "Offset scrobble start by X minutes"
+msgstr ""
+
+msgctxt "#32168"
+msgid "Sync ratings"
+msgstr ""
+
+msgctxt "#32169"
+msgid "Kodi movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32170"
+msgid "%i movie(s) ratings will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32171"
+msgid "Updating %i of %i movie ratings in Kodi"
+msgstr ""
+
+msgctxt "#32172"
+msgid "Ratings updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32173"
+msgid "Kodi episode ratings are up to date"
+msgstr ""
+
+msgctxt "#32174"
+msgid "Updating %i of %i episode ratings in Kodi"
+msgstr ""
+
+msgctxt "#32175"
+msgid "Ratings updated for %i episode(s) in Kodi"
+msgstr ""
+
+msgctxt "#32176"
+msgid "Kodi show ratings are up to date"
+msgstr ""
+
+msgctxt "#32177"
+msgid "Updating %i of %i show ratings in Kodi"
+msgstr ""
+
+msgctxt "#32178"
+msgid "Ratings updated for %i show(s) in Kodi"
+msgstr ""
+
+msgctxt "#32179"
+msgid "Trakt movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32180"
+msgid "%i movie ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32181"
+msgid "Trakt show ratings are up to date"
+msgstr ""
+
+msgctxt "#32182"
+msgid "%i show ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32183"
+msgid "Attempt to scrobble MythTV PVR recordings"
+msgstr ""
+
+msgctxt "#32184"
+msgid "Attempt secondary show title search"
+msgstr ""
+
+msgctxt "#32185"
+msgid "Exclude Plugins"
+msgstr ""
+
+msgctxt "#32186"
+msgid "Allow script exclusions"
+msgstr ""

--- a/script.trakt/resources/language/resource.language.tr_TR/strings.po
+++ b/script.trakt/resources/language/resource.language.tr_TR/strings.po
@@ -10,10 +10,10 @@ msgstr ""
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Kodi Translation Team\n"
 "Language-Team: Turkish (http://www.transifex.com/projects/p/xbmc-addons/language/tr/)\n"
+"Language: tr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: tr\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 msgctxt "#32000"
@@ -36,13 +36,63 @@ msgctxt "#32006"
 msgid "Rate TV show Episode after watching"
 msgstr "Televizyon yayını izledikten sonra derecelendir"
 
+msgctxt "#32008"
+msgid "Minimum percent watched to display rating dialog"
+msgstr ""
+
+msgctxt "#32009"
+msgid "Allow re-rating of media"
+msgstr ""
+
 msgctxt "#32010"
 msgid "Default rating"
 msgstr "Varsayılan derecelendirme"
 
+# Scrobbling Settings
+msgctxt "#32011"
+msgid "Scrobbling"
+msgstr ""
+
+msgctxt "#32012"
+msgid "Scrobble movies"
+msgstr ""
+
+msgctxt "#32013"
+msgid "Scrobble TV show episodes"
+msgstr ""
+
+msgctxt "#32014"
+msgid "Show notification on scrobble"
+msgstr ""
+
+msgctxt "#32015"
+msgid "Trakt - Scrobbled successfully"
+msgstr ""
+
 msgctxt "#32016"
 msgid "Exclusions"
 msgstr "İstisnalar"
+
+msgctxt "#32017"
+msgid "Exclude Live TV"
+msgstr ""
+
+msgctxt "#32018"
+msgid "Exclude HTTP sources"
+msgstr ""
+
+msgctxt "#32019"
+msgid "Exclude path"
+msgstr ""
+
+msgctxt "#32020"
+msgid "Folder's path (including subfolders)"
+msgstr ""
+
+# empty strings from id 32021 to 32022
+msgctxt "#32023"
+msgid "Can not connect to Trakt"
+msgstr ""
 
 msgctxt "#32024"
 msgid "Error"
@@ -52,14 +102,618 @@ msgctxt "#32026"
 msgid "What Did You Think?"
 msgstr "Ne Düşünüyorsun?"
 
+msgctxt "#32027"
+msgid "Totally Ninja!"
+msgstr ""
+
+msgctxt "#32028"
+msgid "Weak Sauce :("
+msgstr ""
+
+msgctxt "#32029"
+msgid "Terrible"
+msgstr ""
+
+msgctxt "#32030"
+msgid "Bad"
+msgstr ""
+
+msgctxt "#32031"
+msgid "Poor"
+msgstr ""
+
+msgctxt "#32032"
+msgid "Meh"
+msgstr ""
+
 msgctxt "#32033"
 msgid "Fair"
 msgstr "Güzel"
+
+msgctxt "#32034"
+msgid "Good"
+msgstr ""
+
+msgctxt "#32035"
+msgid "Great"
+msgstr ""
+
+msgctxt "#32036"
+msgid "Superb"
+msgstr ""
+
+msgctxt "#32037"
+msgid "Unrate this movie"
+msgstr ""
+
+msgctxt "#32038"
+msgid "Unrate this show"
+msgstr ""
+
+msgctxt "#32039"
+msgid "Unrate this episode"
+msgstr ""
+
+msgctxt "#32040"
+msgid "Trakt - Rating submitted successfully"
+msgstr ""
+
+msgctxt "#32041"
+msgid "Trakt - Already rated"
+msgstr ""
+
+msgctxt "#32042"
+msgid "Trakt - Unrated successfully"
+msgstr ""
+
+msgctxt "#32043"
+msgid "Trakt - Already has the same rating"
+msgstr ""
+
+msgctxt "#32044"
+msgid "Trakt - Problem submitting rating"
+msgstr ""
+
+msgctxt "#32045"
+msgid "Synchronize"
+msgstr ""
 
 msgctxt "#32046"
 msgid "Movies"
 msgstr "Filmler"
 
+msgctxt "#32047"
+msgid "Add new movies to Trakt collection"
+msgstr ""
+
+msgctxt "#32048"
+msgid "Add watched movies to Trakt history"
+msgstr ""
+
+msgctxt "#32049"
+msgid "Mark movies from Trakt history as watched in Kodi"
+msgstr ""
+
+msgctxt "#32050"
+msgid "TV Episodes"
+msgstr ""
+
+msgctxt "#32051"
+msgid "Add new TV episodes to Trakt collection"
+msgstr ""
+
+msgctxt "#32052"
+msgid "Add watched TV episodes to Trakt history"
+msgstr ""
+
+msgctxt "#32053"
+msgid "Mark TV episodes from Trakt history as watched in Kodi"
+msgstr ""
+
 msgctxt "#32054"
 msgid "Service"
 msgstr "Hizmet"
+
+msgctxt "#32055"
+msgid "Sync collection on library update or cleaning"
+msgstr ""
+
+msgctxt "#32056"
+msgid "Show sync notifications"
+msgstr ""
+
+msgctxt "#32057"
+msgid "Remove deleted movies from Trakt collection"
+msgstr ""
+
+msgctxt "#32058"
+msgid "Remove deleted TV episodes from Trakt collection"
+msgstr ""
+
+# empty string with id 32059
+msgctxt "#32060"
+msgid "Hide notifications during playback"
+msgstr ""
+
+msgctxt "#32061"
+msgid "Sync started"
+msgstr ""
+
+msgctxt "#32062"
+msgid "Sync complete"
+msgstr ""
+
+msgctxt "#32063"
+msgid "%i movie(s) will be added to Trakt collection"
+msgstr ""
+
+msgctxt "#32064"
+msgid "%i movie playcount(s) will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32065"
+msgid "%i movie(s) playcount will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32066"
+msgid "Movie Sync Complete"
+msgstr ""
+
+msgctxt "#32067"
+msgid "Going to add %i show(s) to Trakt collection"
+msgstr ""
+
+msgctxt "#32068"
+msgid "Checking for episodes missing from Trakt collection"
+msgstr ""
+
+msgctxt "#32069"
+msgid "%i of %i show(s) have episodes added to Trakt collection"
+msgstr ""
+
+msgctxt "#32070"
+msgid "Going to update %i show(s) missing watched status"
+msgstr ""
+
+msgctxt "#32071"
+msgid "Checking watched episodes on Trakt"
+msgstr ""
+
+msgctxt "#32072"
+msgid "%i show(s) had missing watched status"
+msgstr ""
+
+msgctxt "#32073"
+msgid "%i episodes are being updated"
+msgstr ""
+
+msgctxt "#32074"
+msgid "Checking watched episodes on Kodi"
+msgstr ""
+
+msgctxt "#32075"
+msgid "Episode Sync Complete"
+msgstr ""
+
+msgctxt "#32076"
+msgid "%i movie(s) will be removed from Trakt collection"
+msgstr ""
+
+msgctxt "#32077"
+msgid "Cleaning Trakt TV show collection"
+msgstr ""
+
+msgctxt "#32078"
+msgid "episodes are being removed"
+msgstr ""
+
+msgctxt "#32079"
+msgid "Loading movies from Kodi"
+msgstr ""
+
+msgctxt "#32080"
+msgid "Movies loaded from Kodi"
+msgstr ""
+
+msgctxt "#32081"
+msgid "Retrieving movie collection from Trakt"
+msgstr ""
+
+msgctxt "#32082"
+msgid "Retrieving watched movies from Trakt"
+msgstr ""
+
+msgctxt "#32083"
+msgid "Retrieved movie data from Trakt"
+msgstr ""
+
+msgctxt "#32084"
+msgid "Trakt movie collection is up to date, no movies to add"
+msgstr ""
+
+msgctxt "#32085"
+msgid "%i movie(s) were added to your Trakt collection"
+msgstr ""
+
+msgctxt "#32086"
+msgid "Trakt movie playcounts are up to date"
+msgstr ""
+
+msgctxt "#32087"
+msgid "Playcounts updated for %i movie(s) on Trakt"
+msgstr ""
+
+msgctxt "#32088"
+msgid "Kodi movie playcounts are up to date"
+msgstr ""
+
+msgctxt "#32089"
+msgid "Updating %i of %i movie playcount(s) in Kodi"
+msgstr ""
+
+msgctxt "#32090"
+msgid "Playcounts updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32091"
+msgid "Trakt movie collection is up to date, no movies removed"
+msgstr ""
+
+msgctxt "#32092"
+msgid "%i movie(s) were removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32093"
+msgid "Updating %i of %i movie playcount(s) on Trakt"
+msgstr ""
+
+msgctxt "#32094"
+msgid "Loading episode data from Kodi"
+msgstr ""
+
+msgctxt "#32095"
+msgid "Loading shows from Kodi"
+msgstr ""
+
+msgctxt "#32096"
+msgid "Shows loaded from Kodi"
+msgstr ""
+
+msgctxt "#32097"
+msgid "Parsing %i of %i episode data from Kodi"
+msgstr ""
+
+msgctxt "#32098"
+msgid "Loaded episode data from Kodi"
+msgstr ""
+
+msgctxt "#32099"
+msgid "Loading episode data from Trakt"
+msgstr ""
+
+msgctxt "#32100"
+msgid "Retrieving episode collection from Trakt"
+msgstr ""
+
+msgctxt "#32101"
+msgid "Retrieving watched episodes from Trakt"
+msgstr ""
+
+msgctxt "#32102"
+msgid "Parsing episode data %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32103"
+msgid "Retrieved episode data from Trakt"
+msgstr ""
+
+msgctxt "#32104"
+msgid "Trakt episode collection is up to date, no episodes to add"
+msgstr ""
+
+msgctxt "#32105"
+msgid "%i episode(s) were added to your Trakt collection"
+msgstr ""
+
+msgctxt "#32106"
+msgid "Trakt episode playcounts are up to date"
+msgstr ""
+
+msgctxt "#32107"
+msgid "Kodi episode playcounts are up to date"
+msgstr ""
+
+msgctxt "#32108"
+msgid "Updating %i of %i episode playcount(s) in Kodi"
+msgstr ""
+
+msgctxt "#32109"
+msgid "Playcounts updated for %i show(s) in Kodi"
+msgstr ""
+
+msgctxt "#32110"
+msgid "Trakt episode collection is clean, no episodes to remove"
+msgstr ""
+
+msgctxt "#32111"
+msgid "%i episode(s) are being removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32112"
+msgid "%i episode(s) were removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32113"
+msgid "Trakt - Marked as watched"
+msgstr ""
+
+msgctxt "#32114"
+msgid "Trakt - Failed marking as watched"
+msgstr ""
+
+msgctxt "#32115"
+msgid "%d episode(s) of '%s'"
+msgstr ""
+
+msgctxt "#32116"
+msgid "Enable debug mode"
+msgstr ""
+
+msgctxt "#32117"
+msgid "Sync movie playback progress to Kodi"
+msgstr ""
+
+msgctxt "#32118"
+msgid "Sync episode playback progress to Kodi"
+msgstr ""
+
+msgctxt "#32119"
+msgid "Retrieving episode playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32120"
+msgid "Parsing episode playback progress %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32121"
+msgid "Retrieved episode playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32122"
+msgid "Retrieving movie playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32123"
+msgid "Parsing movie playback progress %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32124"
+msgid "Retrieved movie playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32125"
+msgid "Kodi movie playback progress is up to date"
+msgstr ""
+
+msgctxt "#32126"
+msgid "%i movie(s) playback progress will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32127"
+msgid "Updating %i of %i movie(s) playback progress in Kodi"
+msgstr ""
+
+msgctxt "#32128"
+msgid "Playback progress updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32129"
+msgid "Kodi episode playback progress is up to date"
+msgstr ""
+
+msgctxt "#32130"
+msgid "Updating %i of %i episode(s) playback progress in Kodi"
+msgstr ""
+
+msgctxt "#32131"
+msgid "Playback progress updated for %i episode(s) in Kodi"
+msgstr ""
+
+msgctxt "#32132"
+msgid "Unrate this season"
+msgstr ""
+
+msgctxt "#32133"
+msgid "Manage Movie's Lists"
+msgstr ""
+
+msgctxt "#32134"
+msgid "Manage Show's Lists"
+msgstr ""
+
+msgctxt "#32135"
+msgid "Remove from Watchlist"
+msgstr ""
+
+msgctxt "#32136"
+msgid "Add to watchlist"
+msgstr ""
+
+msgctxt "#32137"
+msgid "Rate this movie"
+msgstr ""
+
+msgctxt "#32138"
+msgid "Rate this show"
+msgstr ""
+
+msgctxt "#32139"
+msgid "Rate this episode"
+msgstr ""
+
+msgctxt "#32140"
+msgid "Toggle watched"
+msgstr ""
+
+msgctxt "#32141"
+msgid "Manage all lists"
+msgstr ""
+
+msgctxt "#32142"
+msgid "Update all tags"
+msgstr ""
+
+msgctxt "#32143"
+msgid "Synchronize library"
+msgstr ""
+
+msgctxt "#32144"
+msgid "How do I authorize the trakt addon to access my trakt.tv account?"
+msgstr ""
+
+# empty strings from id 32145 to 32146
+msgctxt "#32147"
+msgid "Trakt.tv PIN Authorization Failed"
+msgstr ""
+
+# empty string with id 32148
+msgctxt "#32149"
+msgid "Rate this Season"
+msgstr ""
+
+msgctxt "#32150"
+msgid "You will be reminded in 24 hours"
+msgstr ""
+
+msgctxt "#32151"
+msgid "Use Addon Settings later if you change your mind"
+msgstr ""
+
+msgctxt "#32152"
+msgid "Trakt Authorization Complete"
+msgstr ""
+
+msgctxt "#32153"
+msgid "Trakt Account Authorization"
+msgstr ""
+
+msgctxt "#32154"
+msgid "Authorize"
+msgstr ""
+
+msgctxt "#32155"
+msgid "Remind Me Later"
+msgstr ""
+
+msgctxt "#32156"
+msgid "No Thanks"
+msgstr ""
+
+msgctxt "#32157"
+msgid "Account Authorization"
+msgstr ""
+
+# empty string with id 32158
+msgctxt "#32159"
+msgid "Visit {0} or scan the QR code."
+msgstr ""
+
+msgctxt "#32162"
+msgid "The trakt addon CAN NOT be used without authorizing it to access your trakt.tv account."
+msgstr ""
+
+msgctxt "#32163"
+msgid "User"
+msgstr ""
+
+msgctxt "#32164"
+msgid "Fallback to Title/Year matching if necessary"
+msgstr ""
+
+msgctxt "#32165"
+msgid "Trakt - Added to watchlist"
+msgstr ""
+
+msgctxt "#32166"
+msgid "Trakt - Failed adding to watchlist"
+msgstr ""
+
+msgctxt "#32167"
+msgid "Offset scrobble start by X minutes"
+msgstr ""
+
+msgctxt "#32168"
+msgid "Sync ratings"
+msgstr ""
+
+msgctxt "#32169"
+msgid "Kodi movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32170"
+msgid "%i movie(s) ratings will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32171"
+msgid "Updating %i of %i movie ratings in Kodi"
+msgstr ""
+
+msgctxt "#32172"
+msgid "Ratings updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32173"
+msgid "Kodi episode ratings are up to date"
+msgstr ""
+
+msgctxt "#32174"
+msgid "Updating %i of %i episode ratings in Kodi"
+msgstr ""
+
+msgctxt "#32175"
+msgid "Ratings updated for %i episode(s) in Kodi"
+msgstr ""
+
+msgctxt "#32176"
+msgid "Kodi show ratings are up to date"
+msgstr ""
+
+msgctxt "#32177"
+msgid "Updating %i of %i show ratings in Kodi"
+msgstr ""
+
+msgctxt "#32178"
+msgid "Ratings updated for %i show(s) in Kodi"
+msgstr ""
+
+msgctxt "#32179"
+msgid "Trakt movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32180"
+msgid "%i movie ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32181"
+msgid "Trakt show ratings are up to date"
+msgstr ""
+
+msgctxt "#32182"
+msgid "%i show ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32183"
+msgid "Attempt to scrobble MythTV PVR recordings"
+msgstr ""
+
+msgctxt "#32184"
+msgid "Attempt secondary show title search"
+msgstr ""
+
+msgctxt "#32185"
+msgid "Exclude Plugins"
+msgstr ""
+
+msgctxt "#32186"
+msgid "Allow script exclusions"
+msgstr ""

--- a/script.trakt/resources/language/resource.language.uk_UA/strings.po
+++ b/script.trakt/resources/language/resource.language.uk_UA/strings.po
@@ -10,32 +10,712 @@ msgstr ""
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Kodi Translation Team\n"
 "Language-Team: Ukrainian (http://www.transifex.com/projects/p/xbmc-addons/language/uk/)\n"
+"Language: uk\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: uk\n"
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 
 msgctxt "#32000"
 msgid "General"
 msgstr "Загальні"
 
+# empty strings from id 32001 to 32002
+msgctxt "#32003"
+msgid "Startup Delay"
+msgstr ""
+
 msgctxt "#32004"
 msgid "Rating"
 msgstr "Рейтинг"
+
+msgctxt "#32005"
+msgid "Rate Movie after watching"
+msgstr ""
+
+msgctxt "#32006"
+msgid "Rate TV show Episode after watching"
+msgstr ""
+
+msgctxt "#32008"
+msgid "Minimum percent watched to display rating dialog"
+msgstr ""
+
+msgctxt "#32009"
+msgid "Allow re-rating of media"
+msgstr ""
+
+msgctxt "#32010"
+msgid "Default rating"
+msgstr ""
+
+# Scrobbling Settings
+msgctxt "#32011"
+msgid "Scrobbling"
+msgstr ""
+
+msgctxt "#32012"
+msgid "Scrobble movies"
+msgstr ""
+
+msgctxt "#32013"
+msgid "Scrobble TV show episodes"
+msgstr ""
+
+msgctxt "#32014"
+msgid "Show notification on scrobble"
+msgstr ""
+
+msgctxt "#32015"
+msgid "Trakt - Scrobbled successfully"
+msgstr ""
+
+msgctxt "#32016"
+msgid "Exclusions"
+msgstr ""
+
+msgctxt "#32017"
+msgid "Exclude Live TV"
+msgstr ""
+
+msgctxt "#32018"
+msgid "Exclude HTTP sources"
+msgstr ""
+
+msgctxt "#32019"
+msgid "Exclude path"
+msgstr ""
+
+msgctxt "#32020"
+msgid "Folder's path (including subfolders)"
+msgstr ""
+
+# empty strings from id 32021 to 32022
+msgctxt "#32023"
+msgid "Can not connect to Trakt"
+msgstr ""
 
 msgctxt "#32024"
 msgid "Error"
 msgstr "Помилка"
 
+# empty string with id 32025
+msgctxt "#32026"
+msgid "What Did You Think?"
+msgstr ""
+
+msgctxt "#32027"
+msgid "Totally Ninja!"
+msgstr ""
+
+msgctxt "#32028"
+msgid "Weak Sauce :("
+msgstr ""
+
+msgctxt "#32029"
+msgid "Terrible"
+msgstr ""
+
+msgctxt "#32030"
+msgid "Bad"
+msgstr ""
+
+msgctxt "#32031"
+msgid "Poor"
+msgstr ""
+
+msgctxt "#32032"
+msgid "Meh"
+msgstr ""
+
 msgctxt "#32033"
 msgid "Fair"
 msgstr "безхмарно"
+
+msgctxt "#32034"
+msgid "Good"
+msgstr ""
+
+msgctxt "#32035"
+msgid "Great"
+msgstr ""
+
+msgctxt "#32036"
+msgid "Superb"
+msgstr ""
+
+msgctxt "#32037"
+msgid "Unrate this movie"
+msgstr ""
+
+msgctxt "#32038"
+msgid "Unrate this show"
+msgstr ""
+
+msgctxt "#32039"
+msgid "Unrate this episode"
+msgstr ""
+
+msgctxt "#32040"
+msgid "Trakt - Rating submitted successfully"
+msgstr ""
+
+msgctxt "#32041"
+msgid "Trakt - Already rated"
+msgstr ""
+
+msgctxt "#32042"
+msgid "Trakt - Unrated successfully"
+msgstr ""
+
+msgctxt "#32043"
+msgid "Trakt - Already has the same rating"
+msgstr ""
+
+msgctxt "#32044"
+msgid "Trakt - Problem submitting rating"
+msgstr ""
+
+msgctxt "#32045"
+msgid "Synchronize"
+msgstr ""
 
 msgctxt "#32046"
 msgid "Movies"
 msgstr "Фільми"
 
+msgctxt "#32047"
+msgid "Add new movies to Trakt collection"
+msgstr ""
+
+msgctxt "#32048"
+msgid "Add watched movies to Trakt history"
+msgstr ""
+
+msgctxt "#32049"
+msgid "Mark movies from Trakt history as watched in Kodi"
+msgstr ""
+
+msgctxt "#32050"
+msgid "TV Episodes"
+msgstr ""
+
+msgctxt "#32051"
+msgid "Add new TV episodes to Trakt collection"
+msgstr ""
+
+msgctxt "#32052"
+msgid "Add watched TV episodes to Trakt history"
+msgstr ""
+
+msgctxt "#32053"
+msgid "Mark TV episodes from Trakt history as watched in Kodi"
+msgstr ""
+
 msgctxt "#32054"
 msgid "Service"
 msgstr "Служба"
+
+msgctxt "#32055"
+msgid "Sync collection on library update or cleaning"
+msgstr ""
+
+msgctxt "#32056"
+msgid "Show sync notifications"
+msgstr ""
+
+msgctxt "#32057"
+msgid "Remove deleted movies from Trakt collection"
+msgstr ""
+
+msgctxt "#32058"
+msgid "Remove deleted TV episodes from Trakt collection"
+msgstr ""
+
+# empty string with id 32059
+msgctxt "#32060"
+msgid "Hide notifications during playback"
+msgstr ""
+
+msgctxt "#32061"
+msgid "Sync started"
+msgstr ""
+
+msgctxt "#32062"
+msgid "Sync complete"
+msgstr ""
+
+msgctxt "#32063"
+msgid "%i movie(s) will be added to Trakt collection"
+msgstr ""
+
+msgctxt "#32064"
+msgid "%i movie playcount(s) will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32065"
+msgid "%i movie(s) playcount will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32066"
+msgid "Movie Sync Complete"
+msgstr ""
+
+msgctxt "#32067"
+msgid "Going to add %i show(s) to Trakt collection"
+msgstr ""
+
+msgctxt "#32068"
+msgid "Checking for episodes missing from Trakt collection"
+msgstr ""
+
+msgctxt "#32069"
+msgid "%i of %i show(s) have episodes added to Trakt collection"
+msgstr ""
+
+msgctxt "#32070"
+msgid "Going to update %i show(s) missing watched status"
+msgstr ""
+
+msgctxt "#32071"
+msgid "Checking watched episodes on Trakt"
+msgstr ""
+
+msgctxt "#32072"
+msgid "%i show(s) had missing watched status"
+msgstr ""
+
+msgctxt "#32073"
+msgid "%i episodes are being updated"
+msgstr ""
+
+msgctxt "#32074"
+msgid "Checking watched episodes on Kodi"
+msgstr ""
+
+msgctxt "#32075"
+msgid "Episode Sync Complete"
+msgstr ""
+
+msgctxt "#32076"
+msgid "%i movie(s) will be removed from Trakt collection"
+msgstr ""
+
+msgctxt "#32077"
+msgid "Cleaning Trakt TV show collection"
+msgstr ""
+
+msgctxt "#32078"
+msgid "episodes are being removed"
+msgstr ""
+
+msgctxt "#32079"
+msgid "Loading movies from Kodi"
+msgstr ""
+
+msgctxt "#32080"
+msgid "Movies loaded from Kodi"
+msgstr ""
+
+msgctxt "#32081"
+msgid "Retrieving movie collection from Trakt"
+msgstr ""
+
+msgctxt "#32082"
+msgid "Retrieving watched movies from Trakt"
+msgstr ""
+
+msgctxt "#32083"
+msgid "Retrieved movie data from Trakt"
+msgstr ""
+
+msgctxt "#32084"
+msgid "Trakt movie collection is up to date, no movies to add"
+msgstr ""
+
+msgctxt "#32085"
+msgid "%i movie(s) were added to your Trakt collection"
+msgstr ""
+
+msgctxt "#32086"
+msgid "Trakt movie playcounts are up to date"
+msgstr ""
+
+msgctxt "#32087"
+msgid "Playcounts updated for %i movie(s) on Trakt"
+msgstr ""
+
+msgctxt "#32088"
+msgid "Kodi movie playcounts are up to date"
+msgstr ""
+
+msgctxt "#32089"
+msgid "Updating %i of %i movie playcount(s) in Kodi"
+msgstr ""
+
+msgctxt "#32090"
+msgid "Playcounts updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32091"
+msgid "Trakt movie collection is up to date, no movies removed"
+msgstr ""
+
+msgctxt "#32092"
+msgid "%i movie(s) were removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32093"
+msgid "Updating %i of %i movie playcount(s) on Trakt"
+msgstr ""
+
+msgctxt "#32094"
+msgid "Loading episode data from Kodi"
+msgstr ""
+
+msgctxt "#32095"
+msgid "Loading shows from Kodi"
+msgstr ""
+
+msgctxt "#32096"
+msgid "Shows loaded from Kodi"
+msgstr ""
+
+msgctxt "#32097"
+msgid "Parsing %i of %i episode data from Kodi"
+msgstr ""
+
+msgctxt "#32098"
+msgid "Loaded episode data from Kodi"
+msgstr ""
+
+msgctxt "#32099"
+msgid "Loading episode data from Trakt"
+msgstr ""
+
+msgctxt "#32100"
+msgid "Retrieving episode collection from Trakt"
+msgstr ""
+
+msgctxt "#32101"
+msgid "Retrieving watched episodes from Trakt"
+msgstr ""
+
+msgctxt "#32102"
+msgid "Parsing episode data %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32103"
+msgid "Retrieved episode data from Trakt"
+msgstr ""
+
+msgctxt "#32104"
+msgid "Trakt episode collection is up to date, no episodes to add"
+msgstr ""
+
+msgctxt "#32105"
+msgid "%i episode(s) were added to your Trakt collection"
+msgstr ""
+
+msgctxt "#32106"
+msgid "Trakt episode playcounts are up to date"
+msgstr ""
+
+msgctxt "#32107"
+msgid "Kodi episode playcounts are up to date"
+msgstr ""
+
+msgctxt "#32108"
+msgid "Updating %i of %i episode playcount(s) in Kodi"
+msgstr ""
+
+msgctxt "#32109"
+msgid "Playcounts updated for %i show(s) in Kodi"
+msgstr ""
+
+msgctxt "#32110"
+msgid "Trakt episode collection is clean, no episodes to remove"
+msgstr ""
+
+msgctxt "#32111"
+msgid "%i episode(s) are being removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32112"
+msgid "%i episode(s) were removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32113"
+msgid "Trakt - Marked as watched"
+msgstr ""
+
+msgctxt "#32114"
+msgid "Trakt - Failed marking as watched"
+msgstr ""
+
+msgctxt "#32115"
+msgid "%d episode(s) of '%s'"
+msgstr ""
+
+msgctxt "#32116"
+msgid "Enable debug mode"
+msgstr ""
+
+msgctxt "#32117"
+msgid "Sync movie playback progress to Kodi"
+msgstr ""
+
+msgctxt "#32118"
+msgid "Sync episode playback progress to Kodi"
+msgstr ""
+
+msgctxt "#32119"
+msgid "Retrieving episode playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32120"
+msgid "Parsing episode playback progress %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32121"
+msgid "Retrieved episode playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32122"
+msgid "Retrieving movie playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32123"
+msgid "Parsing movie playback progress %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32124"
+msgid "Retrieved movie playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32125"
+msgid "Kodi movie playback progress is up to date"
+msgstr ""
+
+msgctxt "#32126"
+msgid "%i movie(s) playback progress will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32127"
+msgid "Updating %i of %i movie(s) playback progress in Kodi"
+msgstr ""
+
+msgctxt "#32128"
+msgid "Playback progress updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32129"
+msgid "Kodi episode playback progress is up to date"
+msgstr ""
+
+msgctxt "#32130"
+msgid "Updating %i of %i episode(s) playback progress in Kodi"
+msgstr ""
+
+msgctxt "#32131"
+msgid "Playback progress updated for %i episode(s) in Kodi"
+msgstr ""
+
+msgctxt "#32132"
+msgid "Unrate this season"
+msgstr ""
+
+msgctxt "#32133"
+msgid "Manage Movie's Lists"
+msgstr ""
+
+msgctxt "#32134"
+msgid "Manage Show's Lists"
+msgstr ""
+
+msgctxt "#32135"
+msgid "Remove from Watchlist"
+msgstr ""
+
+msgctxt "#32136"
+msgid "Add to watchlist"
+msgstr ""
+
+msgctxt "#32137"
+msgid "Rate this movie"
+msgstr ""
+
+msgctxt "#32138"
+msgid "Rate this show"
+msgstr ""
+
+msgctxt "#32139"
+msgid "Rate this episode"
+msgstr ""
+
+msgctxt "#32140"
+msgid "Toggle watched"
+msgstr ""
+
+msgctxt "#32141"
+msgid "Manage all lists"
+msgstr ""
+
+msgctxt "#32142"
+msgid "Update all tags"
+msgstr ""
+
+msgctxt "#32143"
+msgid "Synchronize library"
+msgstr ""
+
+msgctxt "#32144"
+msgid "How do I authorize the trakt addon to access my trakt.tv account?"
+msgstr ""
+
+# empty strings from id 32145 to 32146
+msgctxt "#32147"
+msgid "Trakt.tv PIN Authorization Failed"
+msgstr ""
+
+# empty string with id 32148
+msgctxt "#32149"
+msgid "Rate this Season"
+msgstr ""
+
+msgctxt "#32150"
+msgid "You will be reminded in 24 hours"
+msgstr ""
+
+msgctxt "#32151"
+msgid "Use Addon Settings later if you change your mind"
+msgstr ""
+
+msgctxt "#32152"
+msgid "Trakt Authorization Complete"
+msgstr ""
+
+msgctxt "#32153"
+msgid "Trakt Account Authorization"
+msgstr ""
+
+msgctxt "#32154"
+msgid "Authorize"
+msgstr ""
+
+msgctxt "#32155"
+msgid "Remind Me Later"
+msgstr ""
+
+msgctxt "#32156"
+msgid "No Thanks"
+msgstr ""
+
+msgctxt "#32157"
+msgid "Account Authorization"
+msgstr ""
+
+# empty string with id 32158
+msgctxt "#32159"
+msgid "Visit {0} or scan the QR code."
+msgstr ""
+
+msgctxt "#32162"
+msgid "The trakt addon CAN NOT be used without authorizing it to access your trakt.tv account."
+msgstr ""
+
+msgctxt "#32163"
+msgid "User"
+msgstr ""
+
+msgctxt "#32164"
+msgid "Fallback to Title/Year matching if necessary"
+msgstr ""
+
+msgctxt "#32165"
+msgid "Trakt - Added to watchlist"
+msgstr ""
+
+msgctxt "#32166"
+msgid "Trakt - Failed adding to watchlist"
+msgstr ""
+
+msgctxt "#32167"
+msgid "Offset scrobble start by X minutes"
+msgstr ""
+
+msgctxt "#32168"
+msgid "Sync ratings"
+msgstr ""
+
+msgctxt "#32169"
+msgid "Kodi movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32170"
+msgid "%i movie(s) ratings will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32171"
+msgid "Updating %i of %i movie ratings in Kodi"
+msgstr ""
+
+msgctxt "#32172"
+msgid "Ratings updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32173"
+msgid "Kodi episode ratings are up to date"
+msgstr ""
+
+msgctxt "#32174"
+msgid "Updating %i of %i episode ratings in Kodi"
+msgstr ""
+
+msgctxt "#32175"
+msgid "Ratings updated for %i episode(s) in Kodi"
+msgstr ""
+
+msgctxt "#32176"
+msgid "Kodi show ratings are up to date"
+msgstr ""
+
+msgctxt "#32177"
+msgid "Updating %i of %i show ratings in Kodi"
+msgstr ""
+
+msgctxt "#32178"
+msgid "Ratings updated for %i show(s) in Kodi"
+msgstr ""
+
+msgctxt "#32179"
+msgid "Trakt movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32180"
+msgid "%i movie ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32181"
+msgid "Trakt show ratings are up to date"
+msgstr ""
+
+msgctxt "#32182"
+msgid "%i show ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32183"
+msgid "Attempt to scrobble MythTV PVR recordings"
+msgstr ""
+
+msgctxt "#32184"
+msgid "Attempt secondary show title search"
+msgstr ""
+
+msgctxt "#32185"
+msgid "Exclude Plugins"
+msgstr ""
+
+msgctxt "#32186"
+msgid "Allow script exclusions"
+msgstr ""

--- a/script.trakt/resources/language/resource.language.uz_UZ/strings.po
+++ b/script.trakt/resources/language/resource.language.uz_UZ/strings.po
@@ -10,24 +10,712 @@ msgstr ""
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Kodi Translation Team\n"
 "Language-Team: Uzbek (http://www.transifex.com/projects/p/xbmc-addons/language/uz/)\n"
+"Language: uz\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: uz\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 msgctxt "#32000"
 msgid "General"
 msgstr "Umumiy"
 
+# empty strings from id 32001 to 32002
+msgctxt "#32003"
+msgid "Startup Delay"
+msgstr ""
+
 msgctxt "#32004"
 msgid "Rating"
 msgstr "Reyting"
+
+msgctxt "#32005"
+msgid "Rate Movie after watching"
+msgstr ""
+
+msgctxt "#32006"
+msgid "Rate TV show Episode after watching"
+msgstr ""
+
+msgctxt "#32008"
+msgid "Minimum percent watched to display rating dialog"
+msgstr ""
+
+msgctxt "#32009"
+msgid "Allow re-rating of media"
+msgstr ""
+
+msgctxt "#32010"
+msgid "Default rating"
+msgstr ""
+
+# Scrobbling Settings
+msgctxt "#32011"
+msgid "Scrobbling"
+msgstr ""
+
+msgctxt "#32012"
+msgid "Scrobble movies"
+msgstr ""
+
+msgctxt "#32013"
+msgid "Scrobble TV show episodes"
+msgstr ""
+
+msgctxt "#32014"
+msgid "Show notification on scrobble"
+msgstr ""
+
+msgctxt "#32015"
+msgid "Trakt - Scrobbled successfully"
+msgstr ""
+
+msgctxt "#32016"
+msgid "Exclusions"
+msgstr ""
+
+msgctxt "#32017"
+msgid "Exclude Live TV"
+msgstr ""
+
+msgctxt "#32018"
+msgid "Exclude HTTP sources"
+msgstr ""
+
+msgctxt "#32019"
+msgid "Exclude path"
+msgstr ""
+
+msgctxt "#32020"
+msgid "Folder's path (including subfolders)"
+msgstr ""
+
+# empty strings from id 32021 to 32022
+msgctxt "#32023"
+msgid "Can not connect to Trakt"
+msgstr ""
 
 msgctxt "#32024"
 msgid "Error"
 msgstr "Xato"
 
+# empty string with id 32025
+msgctxt "#32026"
+msgid "What Did You Think?"
+msgstr ""
+
+msgctxt "#32027"
+msgid "Totally Ninja!"
+msgstr ""
+
+msgctxt "#32028"
+msgid "Weak Sauce :("
+msgstr ""
+
+msgctxt "#32029"
+msgid "Terrible"
+msgstr ""
+
+msgctxt "#32030"
+msgid "Bad"
+msgstr ""
+
+msgctxt "#32031"
+msgid "Poor"
+msgstr ""
+
+msgctxt "#32032"
+msgid "Meh"
+msgstr ""
+
+msgctxt "#32033"
+msgid "Fair"
+msgstr ""
+
+msgctxt "#32034"
+msgid "Good"
+msgstr ""
+
+msgctxt "#32035"
+msgid "Great"
+msgstr ""
+
+msgctxt "#32036"
+msgid "Superb"
+msgstr ""
+
+msgctxt "#32037"
+msgid "Unrate this movie"
+msgstr ""
+
+msgctxt "#32038"
+msgid "Unrate this show"
+msgstr ""
+
+msgctxt "#32039"
+msgid "Unrate this episode"
+msgstr ""
+
+msgctxt "#32040"
+msgid "Trakt - Rating submitted successfully"
+msgstr ""
+
+msgctxt "#32041"
+msgid "Trakt - Already rated"
+msgstr ""
+
+msgctxt "#32042"
+msgid "Trakt - Unrated successfully"
+msgstr ""
+
+msgctxt "#32043"
+msgid "Trakt - Already has the same rating"
+msgstr ""
+
+msgctxt "#32044"
+msgid "Trakt - Problem submitting rating"
+msgstr ""
+
+msgctxt "#32045"
+msgid "Synchronize"
+msgstr ""
+
 msgctxt "#32046"
 msgid "Movies"
 msgstr "Filmlar"
+
+msgctxt "#32047"
+msgid "Add new movies to Trakt collection"
+msgstr ""
+
+msgctxt "#32048"
+msgid "Add watched movies to Trakt history"
+msgstr ""
+
+msgctxt "#32049"
+msgid "Mark movies from Trakt history as watched in Kodi"
+msgstr ""
+
+msgctxt "#32050"
+msgid "TV Episodes"
+msgstr ""
+
+msgctxt "#32051"
+msgid "Add new TV episodes to Trakt collection"
+msgstr ""
+
+msgctxt "#32052"
+msgid "Add watched TV episodes to Trakt history"
+msgstr ""
+
+msgctxt "#32053"
+msgid "Mark TV episodes from Trakt history as watched in Kodi"
+msgstr ""
+
+msgctxt "#32054"
+msgid "Service"
+msgstr ""
+
+msgctxt "#32055"
+msgid "Sync collection on library update or cleaning"
+msgstr ""
+
+msgctxt "#32056"
+msgid "Show sync notifications"
+msgstr ""
+
+msgctxt "#32057"
+msgid "Remove deleted movies from Trakt collection"
+msgstr ""
+
+msgctxt "#32058"
+msgid "Remove deleted TV episodes from Trakt collection"
+msgstr ""
+
+# empty string with id 32059
+msgctxt "#32060"
+msgid "Hide notifications during playback"
+msgstr ""
+
+msgctxt "#32061"
+msgid "Sync started"
+msgstr ""
+
+msgctxt "#32062"
+msgid "Sync complete"
+msgstr ""
+
+msgctxt "#32063"
+msgid "%i movie(s) will be added to Trakt collection"
+msgstr ""
+
+msgctxt "#32064"
+msgid "%i movie playcount(s) will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32065"
+msgid "%i movie(s) playcount will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32066"
+msgid "Movie Sync Complete"
+msgstr ""
+
+msgctxt "#32067"
+msgid "Going to add %i show(s) to Trakt collection"
+msgstr ""
+
+msgctxt "#32068"
+msgid "Checking for episodes missing from Trakt collection"
+msgstr ""
+
+msgctxt "#32069"
+msgid "%i of %i show(s) have episodes added to Trakt collection"
+msgstr ""
+
+msgctxt "#32070"
+msgid "Going to update %i show(s) missing watched status"
+msgstr ""
+
+msgctxt "#32071"
+msgid "Checking watched episodes on Trakt"
+msgstr ""
+
+msgctxt "#32072"
+msgid "%i show(s) had missing watched status"
+msgstr ""
+
+msgctxt "#32073"
+msgid "%i episodes are being updated"
+msgstr ""
+
+msgctxt "#32074"
+msgid "Checking watched episodes on Kodi"
+msgstr ""
+
+msgctxt "#32075"
+msgid "Episode Sync Complete"
+msgstr ""
+
+msgctxt "#32076"
+msgid "%i movie(s) will be removed from Trakt collection"
+msgstr ""
+
+msgctxt "#32077"
+msgid "Cleaning Trakt TV show collection"
+msgstr ""
+
+msgctxt "#32078"
+msgid "episodes are being removed"
+msgstr ""
+
+msgctxt "#32079"
+msgid "Loading movies from Kodi"
+msgstr ""
+
+msgctxt "#32080"
+msgid "Movies loaded from Kodi"
+msgstr ""
+
+msgctxt "#32081"
+msgid "Retrieving movie collection from Trakt"
+msgstr ""
+
+msgctxt "#32082"
+msgid "Retrieving watched movies from Trakt"
+msgstr ""
+
+msgctxt "#32083"
+msgid "Retrieved movie data from Trakt"
+msgstr ""
+
+msgctxt "#32084"
+msgid "Trakt movie collection is up to date, no movies to add"
+msgstr ""
+
+msgctxt "#32085"
+msgid "%i movie(s) were added to your Trakt collection"
+msgstr ""
+
+msgctxt "#32086"
+msgid "Trakt movie playcounts are up to date"
+msgstr ""
+
+msgctxt "#32087"
+msgid "Playcounts updated for %i movie(s) on Trakt"
+msgstr ""
+
+msgctxt "#32088"
+msgid "Kodi movie playcounts are up to date"
+msgstr ""
+
+msgctxt "#32089"
+msgid "Updating %i of %i movie playcount(s) in Kodi"
+msgstr ""
+
+msgctxt "#32090"
+msgid "Playcounts updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32091"
+msgid "Trakt movie collection is up to date, no movies removed"
+msgstr ""
+
+msgctxt "#32092"
+msgid "%i movie(s) were removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32093"
+msgid "Updating %i of %i movie playcount(s) on Trakt"
+msgstr ""
+
+msgctxt "#32094"
+msgid "Loading episode data from Kodi"
+msgstr ""
+
+msgctxt "#32095"
+msgid "Loading shows from Kodi"
+msgstr ""
+
+msgctxt "#32096"
+msgid "Shows loaded from Kodi"
+msgstr ""
+
+msgctxt "#32097"
+msgid "Parsing %i of %i episode data from Kodi"
+msgstr ""
+
+msgctxt "#32098"
+msgid "Loaded episode data from Kodi"
+msgstr ""
+
+msgctxt "#32099"
+msgid "Loading episode data from Trakt"
+msgstr ""
+
+msgctxt "#32100"
+msgid "Retrieving episode collection from Trakt"
+msgstr ""
+
+msgctxt "#32101"
+msgid "Retrieving watched episodes from Trakt"
+msgstr ""
+
+msgctxt "#32102"
+msgid "Parsing episode data %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32103"
+msgid "Retrieved episode data from Trakt"
+msgstr ""
+
+msgctxt "#32104"
+msgid "Trakt episode collection is up to date, no episodes to add"
+msgstr ""
+
+msgctxt "#32105"
+msgid "%i episode(s) were added to your Trakt collection"
+msgstr ""
+
+msgctxt "#32106"
+msgid "Trakt episode playcounts are up to date"
+msgstr ""
+
+msgctxt "#32107"
+msgid "Kodi episode playcounts are up to date"
+msgstr ""
+
+msgctxt "#32108"
+msgid "Updating %i of %i episode playcount(s) in Kodi"
+msgstr ""
+
+msgctxt "#32109"
+msgid "Playcounts updated for %i show(s) in Kodi"
+msgstr ""
+
+msgctxt "#32110"
+msgid "Trakt episode collection is clean, no episodes to remove"
+msgstr ""
+
+msgctxt "#32111"
+msgid "%i episode(s) are being removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32112"
+msgid "%i episode(s) were removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32113"
+msgid "Trakt - Marked as watched"
+msgstr ""
+
+msgctxt "#32114"
+msgid "Trakt - Failed marking as watched"
+msgstr ""
+
+msgctxt "#32115"
+msgid "%d episode(s) of '%s'"
+msgstr ""
+
+msgctxt "#32116"
+msgid "Enable debug mode"
+msgstr ""
+
+msgctxt "#32117"
+msgid "Sync movie playback progress to Kodi"
+msgstr ""
+
+msgctxt "#32118"
+msgid "Sync episode playback progress to Kodi"
+msgstr ""
+
+msgctxt "#32119"
+msgid "Retrieving episode playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32120"
+msgid "Parsing episode playback progress %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32121"
+msgid "Retrieved episode playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32122"
+msgid "Retrieving movie playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32123"
+msgid "Parsing movie playback progress %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32124"
+msgid "Retrieved movie playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32125"
+msgid "Kodi movie playback progress is up to date"
+msgstr ""
+
+msgctxt "#32126"
+msgid "%i movie(s) playback progress will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32127"
+msgid "Updating %i of %i movie(s) playback progress in Kodi"
+msgstr ""
+
+msgctxt "#32128"
+msgid "Playback progress updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32129"
+msgid "Kodi episode playback progress is up to date"
+msgstr ""
+
+msgctxt "#32130"
+msgid "Updating %i of %i episode(s) playback progress in Kodi"
+msgstr ""
+
+msgctxt "#32131"
+msgid "Playback progress updated for %i episode(s) in Kodi"
+msgstr ""
+
+msgctxt "#32132"
+msgid "Unrate this season"
+msgstr ""
+
+msgctxt "#32133"
+msgid "Manage Movie's Lists"
+msgstr ""
+
+msgctxt "#32134"
+msgid "Manage Show's Lists"
+msgstr ""
+
+msgctxt "#32135"
+msgid "Remove from Watchlist"
+msgstr ""
+
+msgctxt "#32136"
+msgid "Add to watchlist"
+msgstr ""
+
+msgctxt "#32137"
+msgid "Rate this movie"
+msgstr ""
+
+msgctxt "#32138"
+msgid "Rate this show"
+msgstr ""
+
+msgctxt "#32139"
+msgid "Rate this episode"
+msgstr ""
+
+msgctxt "#32140"
+msgid "Toggle watched"
+msgstr ""
+
+msgctxt "#32141"
+msgid "Manage all lists"
+msgstr ""
+
+msgctxt "#32142"
+msgid "Update all tags"
+msgstr ""
+
+msgctxt "#32143"
+msgid "Synchronize library"
+msgstr ""
+
+msgctxt "#32144"
+msgid "How do I authorize the trakt addon to access my trakt.tv account?"
+msgstr ""
+
+# empty strings from id 32145 to 32146
+msgctxt "#32147"
+msgid "Trakt.tv PIN Authorization Failed"
+msgstr ""
+
+# empty string with id 32148
+msgctxt "#32149"
+msgid "Rate this Season"
+msgstr ""
+
+msgctxt "#32150"
+msgid "You will be reminded in 24 hours"
+msgstr ""
+
+msgctxt "#32151"
+msgid "Use Addon Settings later if you change your mind"
+msgstr ""
+
+msgctxt "#32152"
+msgid "Trakt Authorization Complete"
+msgstr ""
+
+msgctxt "#32153"
+msgid "Trakt Account Authorization"
+msgstr ""
+
+msgctxt "#32154"
+msgid "Authorize"
+msgstr ""
+
+msgctxt "#32155"
+msgid "Remind Me Later"
+msgstr ""
+
+msgctxt "#32156"
+msgid "No Thanks"
+msgstr ""
+
+msgctxt "#32157"
+msgid "Account Authorization"
+msgstr ""
+
+# empty string with id 32158
+msgctxt "#32159"
+msgid "Visit {0} or scan the QR code."
+msgstr ""
+
+msgctxt "#32162"
+msgid "The trakt addon CAN NOT be used without authorizing it to access your trakt.tv account."
+msgstr ""
+
+msgctxt "#32163"
+msgid "User"
+msgstr ""
+
+msgctxt "#32164"
+msgid "Fallback to Title/Year matching if necessary"
+msgstr ""
+
+msgctxt "#32165"
+msgid "Trakt - Added to watchlist"
+msgstr ""
+
+msgctxt "#32166"
+msgid "Trakt - Failed adding to watchlist"
+msgstr ""
+
+msgctxt "#32167"
+msgid "Offset scrobble start by X minutes"
+msgstr ""
+
+msgctxt "#32168"
+msgid "Sync ratings"
+msgstr ""
+
+msgctxt "#32169"
+msgid "Kodi movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32170"
+msgid "%i movie(s) ratings will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32171"
+msgid "Updating %i of %i movie ratings in Kodi"
+msgstr ""
+
+msgctxt "#32172"
+msgid "Ratings updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32173"
+msgid "Kodi episode ratings are up to date"
+msgstr ""
+
+msgctxt "#32174"
+msgid "Updating %i of %i episode ratings in Kodi"
+msgstr ""
+
+msgctxt "#32175"
+msgid "Ratings updated for %i episode(s) in Kodi"
+msgstr ""
+
+msgctxt "#32176"
+msgid "Kodi show ratings are up to date"
+msgstr ""
+
+msgctxt "#32177"
+msgid "Updating %i of %i show ratings in Kodi"
+msgstr ""
+
+msgctxt "#32178"
+msgid "Ratings updated for %i show(s) in Kodi"
+msgstr ""
+
+msgctxt "#32179"
+msgid "Trakt movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32180"
+msgid "%i movie ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32181"
+msgid "Trakt show ratings are up to date"
+msgstr ""
+
+msgctxt "#32182"
+msgid "%i show ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32183"
+msgid "Attempt to scrobble MythTV PVR recordings"
+msgstr ""
+
+msgctxt "#32184"
+msgid "Attempt secondary show title search"
+msgstr ""
+
+msgctxt "#32185"
+msgid "Exclude Plugins"
+msgstr ""
+
+msgctxt "#32186"
+msgid "Allow script exclusions"
+msgstr ""

--- a/script.trakt/resources/language/resource.language.vi_VN/strings.po
+++ b/script.trakt/resources/language/resource.language.vi_VN/strings.po
@@ -10,32 +10,712 @@ msgstr ""
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Kodi Translation Team\n"
 "Language-Team: Vietnamese (http://www.transifex.com/projects/p/xbmc-addons/language/vi/)\n"
+"Language: vi\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: vi\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 msgctxt "#32000"
 msgid "General"
 msgstr "Chung"
 
+# empty strings from id 32001 to 32002
+msgctxt "#32003"
+msgid "Startup Delay"
+msgstr ""
+
 msgctxt "#32004"
 msgid "Rating"
 msgstr "Chấm điểm"
+
+msgctxt "#32005"
+msgid "Rate Movie after watching"
+msgstr ""
+
+msgctxt "#32006"
+msgid "Rate TV show Episode after watching"
+msgstr ""
+
+msgctxt "#32008"
+msgid "Minimum percent watched to display rating dialog"
+msgstr ""
+
+msgctxt "#32009"
+msgid "Allow re-rating of media"
+msgstr ""
+
+msgctxt "#32010"
+msgid "Default rating"
+msgstr ""
+
+# Scrobbling Settings
+msgctxt "#32011"
+msgid "Scrobbling"
+msgstr ""
+
+msgctxt "#32012"
+msgid "Scrobble movies"
+msgstr ""
+
+msgctxt "#32013"
+msgid "Scrobble TV show episodes"
+msgstr ""
+
+msgctxt "#32014"
+msgid "Show notification on scrobble"
+msgstr ""
+
+msgctxt "#32015"
+msgid "Trakt - Scrobbled successfully"
+msgstr ""
+
+msgctxt "#32016"
+msgid "Exclusions"
+msgstr ""
+
+msgctxt "#32017"
+msgid "Exclude Live TV"
+msgstr ""
+
+msgctxt "#32018"
+msgid "Exclude HTTP sources"
+msgstr ""
+
+msgctxt "#32019"
+msgid "Exclude path"
+msgstr ""
+
+msgctxt "#32020"
+msgid "Folder's path (including subfolders)"
+msgstr ""
+
+# empty strings from id 32021 to 32022
+msgctxt "#32023"
+msgid "Can not connect to Trakt"
+msgstr ""
 
 msgctxt "#32024"
 msgid "Error"
 msgstr "Lỗi"
 
+# empty string with id 32025
+msgctxt "#32026"
+msgid "What Did You Think?"
+msgstr ""
+
+msgctxt "#32027"
+msgid "Totally Ninja!"
+msgstr ""
+
+msgctxt "#32028"
+msgid "Weak Sauce :("
+msgstr ""
+
+msgctxt "#32029"
+msgid "Terrible"
+msgstr ""
+
+msgctxt "#32030"
+msgid "Bad"
+msgstr ""
+
+msgctxt "#32031"
+msgid "Poor"
+msgstr ""
+
+msgctxt "#32032"
+msgid "Meh"
+msgstr ""
+
 msgctxt "#32033"
 msgid "Fair"
 msgstr "Vừa"
+
+msgctxt "#32034"
+msgid "Good"
+msgstr ""
+
+msgctxt "#32035"
+msgid "Great"
+msgstr ""
+
+msgctxt "#32036"
+msgid "Superb"
+msgstr ""
+
+msgctxt "#32037"
+msgid "Unrate this movie"
+msgstr ""
+
+msgctxt "#32038"
+msgid "Unrate this show"
+msgstr ""
+
+msgctxt "#32039"
+msgid "Unrate this episode"
+msgstr ""
+
+msgctxt "#32040"
+msgid "Trakt - Rating submitted successfully"
+msgstr ""
+
+msgctxt "#32041"
+msgid "Trakt - Already rated"
+msgstr ""
+
+msgctxt "#32042"
+msgid "Trakt - Unrated successfully"
+msgstr ""
+
+msgctxt "#32043"
+msgid "Trakt - Already has the same rating"
+msgstr ""
+
+msgctxt "#32044"
+msgid "Trakt - Problem submitting rating"
+msgstr ""
+
+msgctxt "#32045"
+msgid "Synchronize"
+msgstr ""
 
 msgctxt "#32046"
 msgid "Movies"
 msgstr "Phim"
 
+msgctxt "#32047"
+msgid "Add new movies to Trakt collection"
+msgstr ""
+
+msgctxt "#32048"
+msgid "Add watched movies to Trakt history"
+msgstr ""
+
+msgctxt "#32049"
+msgid "Mark movies from Trakt history as watched in Kodi"
+msgstr ""
+
+msgctxt "#32050"
+msgid "TV Episodes"
+msgstr ""
+
+msgctxt "#32051"
+msgid "Add new TV episodes to Trakt collection"
+msgstr ""
+
+msgctxt "#32052"
+msgid "Add watched TV episodes to Trakt history"
+msgstr ""
+
+msgctxt "#32053"
+msgid "Mark TV episodes from Trakt history as watched in Kodi"
+msgstr ""
+
 msgctxt "#32054"
 msgid "Service"
 msgstr "Dịch Vụ"
+
+msgctxt "#32055"
+msgid "Sync collection on library update or cleaning"
+msgstr ""
+
+msgctxt "#32056"
+msgid "Show sync notifications"
+msgstr ""
+
+msgctxt "#32057"
+msgid "Remove deleted movies from Trakt collection"
+msgstr ""
+
+msgctxt "#32058"
+msgid "Remove deleted TV episodes from Trakt collection"
+msgstr ""
+
+# empty string with id 32059
+msgctxt "#32060"
+msgid "Hide notifications during playback"
+msgstr ""
+
+msgctxt "#32061"
+msgid "Sync started"
+msgstr ""
+
+msgctxt "#32062"
+msgid "Sync complete"
+msgstr ""
+
+msgctxt "#32063"
+msgid "%i movie(s) will be added to Trakt collection"
+msgstr ""
+
+msgctxt "#32064"
+msgid "%i movie playcount(s) will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32065"
+msgid "%i movie(s) playcount will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32066"
+msgid "Movie Sync Complete"
+msgstr ""
+
+msgctxt "#32067"
+msgid "Going to add %i show(s) to Trakt collection"
+msgstr ""
+
+msgctxt "#32068"
+msgid "Checking for episodes missing from Trakt collection"
+msgstr ""
+
+msgctxt "#32069"
+msgid "%i of %i show(s) have episodes added to Trakt collection"
+msgstr ""
+
+msgctxt "#32070"
+msgid "Going to update %i show(s) missing watched status"
+msgstr ""
+
+msgctxt "#32071"
+msgid "Checking watched episodes on Trakt"
+msgstr ""
+
+msgctxt "#32072"
+msgid "%i show(s) had missing watched status"
+msgstr ""
+
+msgctxt "#32073"
+msgid "%i episodes are being updated"
+msgstr ""
+
+msgctxt "#32074"
+msgid "Checking watched episodes on Kodi"
+msgstr ""
+
+msgctxt "#32075"
+msgid "Episode Sync Complete"
+msgstr ""
+
+msgctxt "#32076"
+msgid "%i movie(s) will be removed from Trakt collection"
+msgstr ""
+
+msgctxt "#32077"
+msgid "Cleaning Trakt TV show collection"
+msgstr ""
+
+msgctxt "#32078"
+msgid "episodes are being removed"
+msgstr ""
+
+msgctxt "#32079"
+msgid "Loading movies from Kodi"
+msgstr ""
+
+msgctxt "#32080"
+msgid "Movies loaded from Kodi"
+msgstr ""
+
+msgctxt "#32081"
+msgid "Retrieving movie collection from Trakt"
+msgstr ""
+
+msgctxt "#32082"
+msgid "Retrieving watched movies from Trakt"
+msgstr ""
+
+msgctxt "#32083"
+msgid "Retrieved movie data from Trakt"
+msgstr ""
+
+msgctxt "#32084"
+msgid "Trakt movie collection is up to date, no movies to add"
+msgstr ""
+
+msgctxt "#32085"
+msgid "%i movie(s) were added to your Trakt collection"
+msgstr ""
+
+msgctxt "#32086"
+msgid "Trakt movie playcounts are up to date"
+msgstr ""
+
+msgctxt "#32087"
+msgid "Playcounts updated for %i movie(s) on Trakt"
+msgstr ""
+
+msgctxt "#32088"
+msgid "Kodi movie playcounts are up to date"
+msgstr ""
+
+msgctxt "#32089"
+msgid "Updating %i of %i movie playcount(s) in Kodi"
+msgstr ""
+
+msgctxt "#32090"
+msgid "Playcounts updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32091"
+msgid "Trakt movie collection is up to date, no movies removed"
+msgstr ""
+
+msgctxt "#32092"
+msgid "%i movie(s) were removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32093"
+msgid "Updating %i of %i movie playcount(s) on Trakt"
+msgstr ""
+
+msgctxt "#32094"
+msgid "Loading episode data from Kodi"
+msgstr ""
+
+msgctxt "#32095"
+msgid "Loading shows from Kodi"
+msgstr ""
+
+msgctxt "#32096"
+msgid "Shows loaded from Kodi"
+msgstr ""
+
+msgctxt "#32097"
+msgid "Parsing %i of %i episode data from Kodi"
+msgstr ""
+
+msgctxt "#32098"
+msgid "Loaded episode data from Kodi"
+msgstr ""
+
+msgctxt "#32099"
+msgid "Loading episode data from Trakt"
+msgstr ""
+
+msgctxt "#32100"
+msgid "Retrieving episode collection from Trakt"
+msgstr ""
+
+msgctxt "#32101"
+msgid "Retrieving watched episodes from Trakt"
+msgstr ""
+
+msgctxt "#32102"
+msgid "Parsing episode data %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32103"
+msgid "Retrieved episode data from Trakt"
+msgstr ""
+
+msgctxt "#32104"
+msgid "Trakt episode collection is up to date, no episodes to add"
+msgstr ""
+
+msgctxt "#32105"
+msgid "%i episode(s) were added to your Trakt collection"
+msgstr ""
+
+msgctxt "#32106"
+msgid "Trakt episode playcounts are up to date"
+msgstr ""
+
+msgctxt "#32107"
+msgid "Kodi episode playcounts are up to date"
+msgstr ""
+
+msgctxt "#32108"
+msgid "Updating %i of %i episode playcount(s) in Kodi"
+msgstr ""
+
+msgctxt "#32109"
+msgid "Playcounts updated for %i show(s) in Kodi"
+msgstr ""
+
+msgctxt "#32110"
+msgid "Trakt episode collection is clean, no episodes to remove"
+msgstr ""
+
+msgctxt "#32111"
+msgid "%i episode(s) are being removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32112"
+msgid "%i episode(s) were removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32113"
+msgid "Trakt - Marked as watched"
+msgstr ""
+
+msgctxt "#32114"
+msgid "Trakt - Failed marking as watched"
+msgstr ""
+
+msgctxt "#32115"
+msgid "%d episode(s) of '%s'"
+msgstr ""
+
+msgctxt "#32116"
+msgid "Enable debug mode"
+msgstr ""
+
+msgctxt "#32117"
+msgid "Sync movie playback progress to Kodi"
+msgstr ""
+
+msgctxt "#32118"
+msgid "Sync episode playback progress to Kodi"
+msgstr ""
+
+msgctxt "#32119"
+msgid "Retrieving episode playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32120"
+msgid "Parsing episode playback progress %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32121"
+msgid "Retrieved episode playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32122"
+msgid "Retrieving movie playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32123"
+msgid "Parsing movie playback progress %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32124"
+msgid "Retrieved movie playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32125"
+msgid "Kodi movie playback progress is up to date"
+msgstr ""
+
+msgctxt "#32126"
+msgid "%i movie(s) playback progress will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32127"
+msgid "Updating %i of %i movie(s) playback progress in Kodi"
+msgstr ""
+
+msgctxt "#32128"
+msgid "Playback progress updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32129"
+msgid "Kodi episode playback progress is up to date"
+msgstr ""
+
+msgctxt "#32130"
+msgid "Updating %i of %i episode(s) playback progress in Kodi"
+msgstr ""
+
+msgctxt "#32131"
+msgid "Playback progress updated for %i episode(s) in Kodi"
+msgstr ""
+
+msgctxt "#32132"
+msgid "Unrate this season"
+msgstr ""
+
+msgctxt "#32133"
+msgid "Manage Movie's Lists"
+msgstr ""
+
+msgctxt "#32134"
+msgid "Manage Show's Lists"
+msgstr ""
+
+msgctxt "#32135"
+msgid "Remove from Watchlist"
+msgstr ""
+
+msgctxt "#32136"
+msgid "Add to watchlist"
+msgstr ""
+
+msgctxt "#32137"
+msgid "Rate this movie"
+msgstr ""
+
+msgctxt "#32138"
+msgid "Rate this show"
+msgstr ""
+
+msgctxt "#32139"
+msgid "Rate this episode"
+msgstr ""
+
+msgctxt "#32140"
+msgid "Toggle watched"
+msgstr ""
+
+msgctxt "#32141"
+msgid "Manage all lists"
+msgstr ""
+
+msgctxt "#32142"
+msgid "Update all tags"
+msgstr ""
+
+msgctxt "#32143"
+msgid "Synchronize library"
+msgstr ""
+
+msgctxt "#32144"
+msgid "How do I authorize the trakt addon to access my trakt.tv account?"
+msgstr ""
+
+# empty strings from id 32145 to 32146
+msgctxt "#32147"
+msgid "Trakt.tv PIN Authorization Failed"
+msgstr ""
+
+# empty string with id 32148
+msgctxt "#32149"
+msgid "Rate this Season"
+msgstr ""
+
+msgctxt "#32150"
+msgid "You will be reminded in 24 hours"
+msgstr ""
+
+msgctxt "#32151"
+msgid "Use Addon Settings later if you change your mind"
+msgstr ""
+
+msgctxt "#32152"
+msgid "Trakt Authorization Complete"
+msgstr ""
+
+msgctxt "#32153"
+msgid "Trakt Account Authorization"
+msgstr ""
+
+msgctxt "#32154"
+msgid "Authorize"
+msgstr ""
+
+msgctxt "#32155"
+msgid "Remind Me Later"
+msgstr ""
+
+msgctxt "#32156"
+msgid "No Thanks"
+msgstr ""
+
+msgctxt "#32157"
+msgid "Account Authorization"
+msgstr ""
+
+# empty string with id 32158
+msgctxt "#32159"
+msgid "Visit {0} or scan the QR code."
+msgstr ""
+
+msgctxt "#32162"
+msgid "The trakt addon CAN NOT be used without authorizing it to access your trakt.tv account."
+msgstr ""
+
+msgctxt "#32163"
+msgid "User"
+msgstr ""
+
+msgctxt "#32164"
+msgid "Fallback to Title/Year matching if necessary"
+msgstr ""
+
+msgctxt "#32165"
+msgid "Trakt - Added to watchlist"
+msgstr ""
+
+msgctxt "#32166"
+msgid "Trakt - Failed adding to watchlist"
+msgstr ""
+
+msgctxt "#32167"
+msgid "Offset scrobble start by X minutes"
+msgstr ""
+
+msgctxt "#32168"
+msgid "Sync ratings"
+msgstr ""
+
+msgctxt "#32169"
+msgid "Kodi movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32170"
+msgid "%i movie(s) ratings will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32171"
+msgid "Updating %i of %i movie ratings in Kodi"
+msgstr ""
+
+msgctxt "#32172"
+msgid "Ratings updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32173"
+msgid "Kodi episode ratings are up to date"
+msgstr ""
+
+msgctxt "#32174"
+msgid "Updating %i of %i episode ratings in Kodi"
+msgstr ""
+
+msgctxt "#32175"
+msgid "Ratings updated for %i episode(s) in Kodi"
+msgstr ""
+
+msgctxt "#32176"
+msgid "Kodi show ratings are up to date"
+msgstr ""
+
+msgctxt "#32177"
+msgid "Updating %i of %i show ratings in Kodi"
+msgstr ""
+
+msgctxt "#32178"
+msgid "Ratings updated for %i show(s) in Kodi"
+msgstr ""
+
+msgctxt "#32179"
+msgid "Trakt movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32180"
+msgid "%i movie ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32181"
+msgid "Trakt show ratings are up to date"
+msgstr ""
+
+msgctxt "#32182"
+msgid "%i show ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32183"
+msgid "Attempt to scrobble MythTV PVR recordings"
+msgstr ""
+
+msgctxt "#32184"
+msgid "Attempt secondary show title search"
+msgstr ""
+
+msgctxt "#32185"
+msgid "Exclude Plugins"
+msgstr ""
+
+msgctxt "#32186"
+msgid "Allow script exclusions"
+msgstr ""

--- a/script.trakt/resources/language/resource.language.zh_CN/strings.po
+++ b/script.trakt/resources/language/resource.language.zh_CN/strings.po
@@ -10,15 +10,20 @@ msgstr ""
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Kodi Translation Team\n"
 "Language-Team: Chinese (Simple) (http://www.transifex.com/projects/p/xbmc-addons/language/zh/)\n"
+"Language: zh\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: zh\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 msgctxt "#32000"
 msgid "General"
 msgstr "常规"
+
+# empty strings from id 32001 to 32002
+msgctxt "#32003"
+msgid "Startup Delay"
+msgstr ""
 
 msgctxt "#32004"
 msgid "Rating"
@@ -28,13 +33,148 @@ msgctxt "#32005"
 msgid "Rate Movie after watching"
 msgstr "观看电影后评分"
 
+msgctxt "#32006"
+msgid "Rate TV show Episode after watching"
+msgstr ""
+
+msgctxt "#32008"
+msgid "Minimum percent watched to display rating dialog"
+msgstr ""
+
+msgctxt "#32009"
+msgid "Allow re-rating of media"
+msgstr ""
+
+msgctxt "#32010"
+msgid "Default rating"
+msgstr ""
+
+# Scrobbling Settings
+msgctxt "#32011"
+msgid "Scrobbling"
+msgstr ""
+
+msgctxt "#32012"
+msgid "Scrobble movies"
+msgstr ""
+
+msgctxt "#32013"
+msgid "Scrobble TV show episodes"
+msgstr ""
+
+msgctxt "#32014"
+msgid "Show notification on scrobble"
+msgstr ""
+
+msgctxt "#32015"
+msgid "Trakt - Scrobbled successfully"
+msgstr ""
+
+msgctxt "#32016"
+msgid "Exclusions"
+msgstr ""
+
+msgctxt "#32017"
+msgid "Exclude Live TV"
+msgstr ""
+
+msgctxt "#32018"
+msgid "Exclude HTTP sources"
+msgstr ""
+
+msgctxt "#32019"
+msgid "Exclude path"
+msgstr ""
+
+msgctxt "#32020"
+msgid "Folder's path (including subfolders)"
+msgstr ""
+
+# empty strings from id 32021 to 32022
+msgctxt "#32023"
+msgid "Can not connect to Trakt"
+msgstr ""
+
 msgctxt "#32024"
 msgid "Error"
 msgstr "错误"
 
+# empty string with id 32025
+msgctxt "#32026"
+msgid "What Did You Think?"
+msgstr ""
+
+msgctxt "#32027"
+msgid "Totally Ninja!"
+msgstr ""
+
+msgctxt "#32028"
+msgid "Weak Sauce :("
+msgstr ""
+
+msgctxt "#32029"
+msgid "Terrible"
+msgstr ""
+
+msgctxt "#32030"
+msgid "Bad"
+msgstr ""
+
+msgctxt "#32031"
+msgid "Poor"
+msgstr ""
+
+msgctxt "#32032"
+msgid "Meh"
+msgstr ""
+
 msgctxt "#32033"
 msgid "Fair"
 msgstr "晴"
+
+msgctxt "#32034"
+msgid "Good"
+msgstr ""
+
+msgctxt "#32035"
+msgid "Great"
+msgstr ""
+
+msgctxt "#32036"
+msgid "Superb"
+msgstr ""
+
+msgctxt "#32037"
+msgid "Unrate this movie"
+msgstr ""
+
+msgctxt "#32038"
+msgid "Unrate this show"
+msgstr ""
+
+msgctxt "#32039"
+msgid "Unrate this episode"
+msgstr ""
+
+msgctxt "#32040"
+msgid "Trakt - Rating submitted successfully"
+msgstr ""
+
+msgctxt "#32041"
+msgid "Trakt - Already rated"
+msgstr ""
+
+msgctxt "#32042"
+msgid "Trakt - Unrated successfully"
+msgstr ""
+
+msgctxt "#32043"
+msgid "Trakt - Already has the same rating"
+msgstr ""
+
+msgctxt "#32044"
+msgid "Trakt - Problem submitting rating"
+msgstr ""
 
 msgctxt "#32045"
 msgid "Synchronize"
@@ -44,10 +184,538 @@ msgctxt "#32046"
 msgid "Movies"
 msgstr "电影"
 
+msgctxt "#32047"
+msgid "Add new movies to Trakt collection"
+msgstr ""
+
+msgctxt "#32048"
+msgid "Add watched movies to Trakt history"
+msgstr ""
+
+msgctxt "#32049"
+msgid "Mark movies from Trakt history as watched in Kodi"
+msgstr ""
+
+msgctxt "#32050"
+msgid "TV Episodes"
+msgstr ""
+
+msgctxt "#32051"
+msgid "Add new TV episodes to Trakt collection"
+msgstr ""
+
+msgctxt "#32052"
+msgid "Add watched TV episodes to Trakt history"
+msgstr ""
+
+msgctxt "#32053"
+msgid "Mark TV episodes from Trakt history as watched in Kodi"
+msgstr ""
+
 msgctxt "#32054"
 msgid "Service"
 msgstr "服务"
 
+msgctxt "#32055"
+msgid "Sync collection on library update or cleaning"
+msgstr ""
+
+msgctxt "#32056"
+msgid "Show sync notifications"
+msgstr ""
+
+msgctxt "#32057"
+msgid "Remove deleted movies from Trakt collection"
+msgstr ""
+
+msgctxt "#32058"
+msgid "Remove deleted TV episodes from Trakt collection"
+msgstr ""
+
+# empty string with id 32059
+msgctxt "#32060"
+msgid "Hide notifications during playback"
+msgstr ""
+
+msgctxt "#32061"
+msgid "Sync started"
+msgstr ""
+
+msgctxt "#32062"
+msgid "Sync complete"
+msgstr ""
+
+msgctxt "#32063"
+msgid "%i movie(s) will be added to Trakt collection"
+msgstr ""
+
+msgctxt "#32064"
+msgid "%i movie playcount(s) will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32065"
+msgid "%i movie(s) playcount will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32066"
+msgid "Movie Sync Complete"
+msgstr ""
+
+msgctxt "#32067"
+msgid "Going to add %i show(s) to Trakt collection"
+msgstr ""
+
+msgctxt "#32068"
+msgid "Checking for episodes missing from Trakt collection"
+msgstr ""
+
+msgctxt "#32069"
+msgid "%i of %i show(s) have episodes added to Trakt collection"
+msgstr ""
+
+msgctxt "#32070"
+msgid "Going to update %i show(s) missing watched status"
+msgstr ""
+
+msgctxt "#32071"
+msgid "Checking watched episodes on Trakt"
+msgstr ""
+
+msgctxt "#32072"
+msgid "%i show(s) had missing watched status"
+msgstr ""
+
+msgctxt "#32073"
+msgid "%i episodes are being updated"
+msgstr ""
+
+msgctxt "#32074"
+msgid "Checking watched episodes on Kodi"
+msgstr ""
+
+msgctxt "#32075"
+msgid "Episode Sync Complete"
+msgstr ""
+
+msgctxt "#32076"
+msgid "%i movie(s) will be removed from Trakt collection"
+msgstr ""
+
+msgctxt "#32077"
+msgid "Cleaning Trakt TV show collection"
+msgstr ""
+
+msgctxt "#32078"
+msgid "episodes are being removed"
+msgstr ""
+
+msgctxt "#32079"
+msgid "Loading movies from Kodi"
+msgstr ""
+
+msgctxt "#32080"
+msgid "Movies loaded from Kodi"
+msgstr ""
+
+msgctxt "#32081"
+msgid "Retrieving movie collection from Trakt"
+msgstr ""
+
+msgctxt "#32082"
+msgid "Retrieving watched movies from Trakt"
+msgstr ""
+
+msgctxt "#32083"
+msgid "Retrieved movie data from Trakt"
+msgstr ""
+
+msgctxt "#32084"
+msgid "Trakt movie collection is up to date, no movies to add"
+msgstr ""
+
+msgctxt "#32085"
+msgid "%i movie(s) were added to your Trakt collection"
+msgstr ""
+
+msgctxt "#32086"
+msgid "Trakt movie playcounts are up to date"
+msgstr ""
+
+msgctxt "#32087"
+msgid "Playcounts updated for %i movie(s) on Trakt"
+msgstr ""
+
+msgctxt "#32088"
+msgid "Kodi movie playcounts are up to date"
+msgstr ""
+
+msgctxt "#32089"
+msgid "Updating %i of %i movie playcount(s) in Kodi"
+msgstr ""
+
+msgctxt "#32090"
+msgid "Playcounts updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32091"
+msgid "Trakt movie collection is up to date, no movies removed"
+msgstr ""
+
+msgctxt "#32092"
+msgid "%i movie(s) were removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32093"
+msgid "Updating %i of %i movie playcount(s) on Trakt"
+msgstr ""
+
+msgctxt "#32094"
+msgid "Loading episode data from Kodi"
+msgstr ""
+
+msgctxt "#32095"
+msgid "Loading shows from Kodi"
+msgstr ""
+
+msgctxt "#32096"
+msgid "Shows loaded from Kodi"
+msgstr ""
+
+msgctxt "#32097"
+msgid "Parsing %i of %i episode data from Kodi"
+msgstr ""
+
+msgctxt "#32098"
+msgid "Loaded episode data from Kodi"
+msgstr ""
+
+msgctxt "#32099"
+msgid "Loading episode data from Trakt"
+msgstr ""
+
+msgctxt "#32100"
+msgid "Retrieving episode collection from Trakt"
+msgstr ""
+
+msgctxt "#32101"
+msgid "Retrieving watched episodes from Trakt"
+msgstr ""
+
+msgctxt "#32102"
+msgid "Parsing episode data %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32103"
+msgid "Retrieved episode data from Trakt"
+msgstr ""
+
+msgctxt "#32104"
+msgid "Trakt episode collection is up to date, no episodes to add"
+msgstr ""
+
+msgctxt "#32105"
+msgid "%i episode(s) were added to your Trakt collection"
+msgstr ""
+
+msgctxt "#32106"
+msgid "Trakt episode playcounts are up to date"
+msgstr ""
+
+msgctxt "#32107"
+msgid "Kodi episode playcounts are up to date"
+msgstr ""
+
+msgctxt "#32108"
+msgid "Updating %i of %i episode playcount(s) in Kodi"
+msgstr ""
+
+msgctxt "#32109"
+msgid "Playcounts updated for %i show(s) in Kodi"
+msgstr ""
+
+msgctxt "#32110"
+msgid "Trakt episode collection is clean, no episodes to remove"
+msgstr ""
+
+msgctxt "#32111"
+msgid "%i episode(s) are being removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32112"
+msgid "%i episode(s) were removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32113"
+msgid "Trakt - Marked as watched"
+msgstr ""
+
+msgctxt "#32114"
+msgid "Trakt - Failed marking as watched"
+msgstr ""
+
+msgctxt "#32115"
+msgid "%d episode(s) of '%s'"
+msgstr ""
+
+msgctxt "#32116"
+msgid "Enable debug mode"
+msgstr ""
+
+msgctxt "#32117"
+msgid "Sync movie playback progress to Kodi"
+msgstr ""
+
+msgctxt "#32118"
+msgid "Sync episode playback progress to Kodi"
+msgstr ""
+
+msgctxt "#32119"
+msgid "Retrieving episode playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32120"
+msgid "Parsing episode playback progress %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32121"
+msgid "Retrieved episode playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32122"
+msgid "Retrieving movie playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32123"
+msgid "Parsing movie playback progress %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32124"
+msgid "Retrieved movie playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32125"
+msgid "Kodi movie playback progress is up to date"
+msgstr ""
+
+msgctxt "#32126"
+msgid "%i movie(s) playback progress will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32127"
+msgid "Updating %i of %i movie(s) playback progress in Kodi"
+msgstr ""
+
+msgctxt "#32128"
+msgid "Playback progress updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32129"
+msgid "Kodi episode playback progress is up to date"
+msgstr ""
+
+msgctxt "#32130"
+msgid "Updating %i of %i episode(s) playback progress in Kodi"
+msgstr ""
+
+msgctxt "#32131"
+msgid "Playback progress updated for %i episode(s) in Kodi"
+msgstr ""
+
+msgctxt "#32132"
+msgid "Unrate this season"
+msgstr ""
+
+msgctxt "#32133"
+msgid "Manage Movie's Lists"
+msgstr ""
+
+msgctxt "#32134"
+msgid "Manage Show's Lists"
+msgstr ""
+
+msgctxt "#32135"
+msgid "Remove from Watchlist"
+msgstr ""
+
+msgctxt "#32136"
+msgid "Add to watchlist"
+msgstr ""
+
+msgctxt "#32137"
+msgid "Rate this movie"
+msgstr ""
+
+msgctxt "#32138"
+msgid "Rate this show"
+msgstr ""
+
+msgctxt "#32139"
+msgid "Rate this episode"
+msgstr ""
+
+msgctxt "#32140"
+msgid "Toggle watched"
+msgstr ""
+
+msgctxt "#32141"
+msgid "Manage all lists"
+msgstr ""
+
+msgctxt "#32142"
+msgid "Update all tags"
+msgstr ""
+
+msgctxt "#32143"
+msgid "Synchronize library"
+msgstr ""
+
+msgctxt "#32144"
+msgid "How do I authorize the trakt addon to access my trakt.tv account?"
+msgstr ""
+
+# empty strings from id 32145 to 32146
+msgctxt "#32147"
+msgid "Trakt.tv PIN Authorization Failed"
+msgstr ""
+
+# empty string with id 32148
+msgctxt "#32149"
+msgid "Rate this Season"
+msgstr ""
+
+msgctxt "#32150"
+msgid "You will be reminded in 24 hours"
+msgstr ""
+
+msgctxt "#32151"
+msgid "Use Addon Settings later if you change your mind"
+msgstr ""
+
+msgctxt "#32152"
+msgid "Trakt Authorization Complete"
+msgstr ""
+
+msgctxt "#32153"
+msgid "Trakt Account Authorization"
+msgstr ""
+
+msgctxt "#32154"
+msgid "Authorize"
+msgstr ""
+
+msgctxt "#32155"
+msgid "Remind Me Later"
+msgstr ""
+
+msgctxt "#32156"
+msgid "No Thanks"
+msgstr ""
+
+msgctxt "#32157"
+msgid "Account Authorization"
+msgstr ""
+
+# empty string with id 32158
+msgctxt "#32159"
+msgid "Visit {0} or scan the QR code."
+msgstr ""
+
+msgctxt "#32162"
+msgid "The trakt addon CAN NOT be used without authorizing it to access your trakt.tv account."
+msgstr ""
+
 msgctxt "#32163"
 msgid "User"
 msgstr "用户"
+
+msgctxt "#32164"
+msgid "Fallback to Title/Year matching if necessary"
+msgstr ""
+
+msgctxt "#32165"
+msgid "Trakt - Added to watchlist"
+msgstr ""
+
+msgctxt "#32166"
+msgid "Trakt - Failed adding to watchlist"
+msgstr ""
+
+msgctxt "#32167"
+msgid "Offset scrobble start by X minutes"
+msgstr ""
+
+msgctxt "#32168"
+msgid "Sync ratings"
+msgstr ""
+
+msgctxt "#32169"
+msgid "Kodi movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32170"
+msgid "%i movie(s) ratings will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32171"
+msgid "Updating %i of %i movie ratings in Kodi"
+msgstr ""
+
+msgctxt "#32172"
+msgid "Ratings updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32173"
+msgid "Kodi episode ratings are up to date"
+msgstr ""
+
+msgctxt "#32174"
+msgid "Updating %i of %i episode ratings in Kodi"
+msgstr ""
+
+msgctxt "#32175"
+msgid "Ratings updated for %i episode(s) in Kodi"
+msgstr ""
+
+msgctxt "#32176"
+msgid "Kodi show ratings are up to date"
+msgstr ""
+
+msgctxt "#32177"
+msgid "Updating %i of %i show ratings in Kodi"
+msgstr ""
+
+msgctxt "#32178"
+msgid "Ratings updated for %i show(s) in Kodi"
+msgstr ""
+
+msgctxt "#32179"
+msgid "Trakt movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32180"
+msgid "%i movie ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32181"
+msgid "Trakt show ratings are up to date"
+msgstr ""
+
+msgctxt "#32182"
+msgid "%i show ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32183"
+msgid "Attempt to scrobble MythTV PVR recordings"
+msgstr ""
+
+msgctxt "#32184"
+msgid "Attempt secondary show title search"
+msgstr ""
+
+msgctxt "#32185"
+msgid "Exclude Plugins"
+msgstr ""
+
+msgctxt "#32186"
+msgid "Allow script exclusions"
+msgstr ""

--- a/script.trakt/resources/language/resource.language.zh_TW/strings.po
+++ b/script.trakt/resources/language/resource.language.zh_TW/strings.po
@@ -10,36 +10,712 @@ msgstr ""
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Kodi Translation Team\n"
 "Language-Team: Chinese (Traditional) (http://www.transifex.com/projects/p/xbmc-addons/language/zh_TW/)\n"
+"Language: zh_TW\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: zh_TW\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 msgctxt "#32000"
 msgid "General"
 msgstr "一般設定"
 
+# empty strings from id 32001 to 32002
+msgctxt "#32003"
+msgid "Startup Delay"
+msgstr ""
+
 msgctxt "#32004"
 msgid "Rating"
 msgstr "評分"
+
+msgctxt "#32005"
+msgid "Rate Movie after watching"
+msgstr ""
+
+msgctxt "#32006"
+msgid "Rate TV show Episode after watching"
+msgstr ""
+
+msgctxt "#32008"
+msgid "Minimum percent watched to display rating dialog"
+msgstr ""
+
+msgctxt "#32009"
+msgid "Allow re-rating of media"
+msgstr ""
+
+msgctxt "#32010"
+msgid "Default rating"
+msgstr ""
+
+# Scrobbling Settings
+msgctxt "#32011"
+msgid "Scrobbling"
+msgstr ""
+
+msgctxt "#32012"
+msgid "Scrobble movies"
+msgstr ""
+
+msgctxt "#32013"
+msgid "Scrobble TV show episodes"
+msgstr ""
+
+msgctxt "#32014"
+msgid "Show notification on scrobble"
+msgstr ""
+
+msgctxt "#32015"
+msgid "Trakt - Scrobbled successfully"
+msgstr ""
+
+msgctxt "#32016"
+msgid "Exclusions"
+msgstr ""
+
+msgctxt "#32017"
+msgid "Exclude Live TV"
+msgstr ""
+
+msgctxt "#32018"
+msgid "Exclude HTTP sources"
+msgstr ""
+
+msgctxt "#32019"
+msgid "Exclude path"
+msgstr ""
+
+msgctxt "#32020"
+msgid "Folder's path (including subfolders)"
+msgstr ""
+
+# empty strings from id 32021 to 32022
+msgctxt "#32023"
+msgid "Can not connect to Trakt"
+msgstr ""
 
 msgctxt "#32024"
 msgid "Error"
 msgstr "錯誤"
 
+# empty string with id 32025
+msgctxt "#32026"
+msgid "What Did You Think?"
+msgstr ""
+
+msgctxt "#32027"
+msgid "Totally Ninja!"
+msgstr ""
+
+msgctxt "#32028"
+msgid "Weak Sauce :("
+msgstr ""
+
+msgctxt "#32029"
+msgid "Terrible"
+msgstr ""
+
+msgctxt "#32030"
+msgid "Bad"
+msgstr ""
+
+msgctxt "#32031"
+msgid "Poor"
+msgstr ""
+
+msgctxt "#32032"
+msgid "Meh"
+msgstr ""
+
 msgctxt "#32033"
 msgid "Fair"
 msgstr "轉晴"
+
+msgctxt "#32034"
+msgid "Good"
+msgstr ""
+
+msgctxt "#32035"
+msgid "Great"
+msgstr ""
+
+msgctxt "#32036"
+msgid "Superb"
+msgstr ""
+
+msgctxt "#32037"
+msgid "Unrate this movie"
+msgstr ""
+
+msgctxt "#32038"
+msgid "Unrate this show"
+msgstr ""
+
+msgctxt "#32039"
+msgid "Unrate this episode"
+msgstr ""
+
+msgctxt "#32040"
+msgid "Trakt - Rating submitted successfully"
+msgstr ""
+
+msgctxt "#32041"
+msgid "Trakt - Already rated"
+msgstr ""
+
+msgctxt "#32042"
+msgid "Trakt - Unrated successfully"
+msgstr ""
+
+msgctxt "#32043"
+msgid "Trakt - Already has the same rating"
+msgstr ""
+
+msgctxt "#32044"
+msgid "Trakt - Problem submitting rating"
+msgstr ""
+
+msgctxt "#32045"
+msgid "Synchronize"
+msgstr ""
 
 msgctxt "#32046"
 msgid "Movies"
 msgstr "影片"
 
+msgctxt "#32047"
+msgid "Add new movies to Trakt collection"
+msgstr ""
+
+msgctxt "#32048"
+msgid "Add watched movies to Trakt history"
+msgstr ""
+
+msgctxt "#32049"
+msgid "Mark movies from Trakt history as watched in Kodi"
+msgstr ""
+
+msgctxt "#32050"
+msgid "TV Episodes"
+msgstr ""
+
+msgctxt "#32051"
+msgid "Add new TV episodes to Trakt collection"
+msgstr ""
+
+msgctxt "#32052"
+msgid "Add watched TV episodes to Trakt history"
+msgstr ""
+
+msgctxt "#32053"
+msgid "Mark TV episodes from Trakt history as watched in Kodi"
+msgstr ""
+
 msgctxt "#32054"
 msgid "Service"
 msgstr "服務"
 
+msgctxt "#32055"
+msgid "Sync collection on library update or cleaning"
+msgstr ""
+
+msgctxt "#32056"
+msgid "Show sync notifications"
+msgstr ""
+
+msgctxt "#32057"
+msgid "Remove deleted movies from Trakt collection"
+msgstr ""
+
+msgctxt "#32058"
+msgid "Remove deleted TV episodes from Trakt collection"
+msgstr ""
+
+# empty string with id 32059
+msgctxt "#32060"
+msgid "Hide notifications during playback"
+msgstr ""
+
+msgctxt "#32061"
+msgid "Sync started"
+msgstr ""
+
+msgctxt "#32062"
+msgid "Sync complete"
+msgstr ""
+
+msgctxt "#32063"
+msgid "%i movie(s) will be added to Trakt collection"
+msgstr ""
+
+msgctxt "#32064"
+msgid "%i movie playcount(s) will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32065"
+msgid "%i movie(s) playcount will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32066"
+msgid "Movie Sync Complete"
+msgstr ""
+
+msgctxt "#32067"
+msgid "Going to add %i show(s) to Trakt collection"
+msgstr ""
+
+msgctxt "#32068"
+msgid "Checking for episodes missing from Trakt collection"
+msgstr ""
+
+msgctxt "#32069"
+msgid "%i of %i show(s) have episodes added to Trakt collection"
+msgstr ""
+
+msgctxt "#32070"
+msgid "Going to update %i show(s) missing watched status"
+msgstr ""
+
+msgctxt "#32071"
+msgid "Checking watched episodes on Trakt"
+msgstr ""
+
+msgctxt "#32072"
+msgid "%i show(s) had missing watched status"
+msgstr ""
+
+msgctxt "#32073"
+msgid "%i episodes are being updated"
+msgstr ""
+
+msgctxt "#32074"
+msgid "Checking watched episodes on Kodi"
+msgstr ""
+
+msgctxt "#32075"
+msgid "Episode Sync Complete"
+msgstr ""
+
+msgctxt "#32076"
+msgid "%i movie(s) will be removed from Trakt collection"
+msgstr ""
+
+msgctxt "#32077"
+msgid "Cleaning Trakt TV show collection"
+msgstr ""
+
+msgctxt "#32078"
+msgid "episodes are being removed"
+msgstr ""
+
+msgctxt "#32079"
+msgid "Loading movies from Kodi"
+msgstr ""
+
+msgctxt "#32080"
+msgid "Movies loaded from Kodi"
+msgstr ""
+
+msgctxt "#32081"
+msgid "Retrieving movie collection from Trakt"
+msgstr ""
+
+msgctxt "#32082"
+msgid "Retrieving watched movies from Trakt"
+msgstr ""
+
+msgctxt "#32083"
+msgid "Retrieved movie data from Trakt"
+msgstr ""
+
+msgctxt "#32084"
+msgid "Trakt movie collection is up to date, no movies to add"
+msgstr ""
+
+msgctxt "#32085"
+msgid "%i movie(s) were added to your Trakt collection"
+msgstr ""
+
+msgctxt "#32086"
+msgid "Trakt movie playcounts are up to date"
+msgstr ""
+
+msgctxt "#32087"
+msgid "Playcounts updated for %i movie(s) on Trakt"
+msgstr ""
+
+msgctxt "#32088"
+msgid "Kodi movie playcounts are up to date"
+msgstr ""
+
+msgctxt "#32089"
+msgid "Updating %i of %i movie playcount(s) in Kodi"
+msgstr ""
+
+msgctxt "#32090"
+msgid "Playcounts updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32091"
+msgid "Trakt movie collection is up to date, no movies removed"
+msgstr ""
+
+msgctxt "#32092"
+msgid "%i movie(s) were removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32093"
+msgid "Updating %i of %i movie playcount(s) on Trakt"
+msgstr ""
+
+msgctxt "#32094"
+msgid "Loading episode data from Kodi"
+msgstr ""
+
+msgctxt "#32095"
+msgid "Loading shows from Kodi"
+msgstr ""
+
+msgctxt "#32096"
+msgid "Shows loaded from Kodi"
+msgstr ""
+
+msgctxt "#32097"
+msgid "Parsing %i of %i episode data from Kodi"
+msgstr ""
+
+msgctxt "#32098"
+msgid "Loaded episode data from Kodi"
+msgstr ""
+
+msgctxt "#32099"
+msgid "Loading episode data from Trakt"
+msgstr ""
+
+msgctxt "#32100"
+msgid "Retrieving episode collection from Trakt"
+msgstr ""
+
+msgctxt "#32101"
+msgid "Retrieving watched episodes from Trakt"
+msgstr ""
+
+msgctxt "#32102"
+msgid "Parsing episode data %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32103"
+msgid "Retrieved episode data from Trakt"
+msgstr ""
+
+msgctxt "#32104"
+msgid "Trakt episode collection is up to date, no episodes to add"
+msgstr ""
+
+msgctxt "#32105"
+msgid "%i episode(s) were added to your Trakt collection"
+msgstr ""
+
+msgctxt "#32106"
+msgid "Trakt episode playcounts are up to date"
+msgstr ""
+
+msgctxt "#32107"
+msgid "Kodi episode playcounts are up to date"
+msgstr ""
+
+msgctxt "#32108"
+msgid "Updating %i of %i episode playcount(s) in Kodi"
+msgstr ""
+
+msgctxt "#32109"
+msgid "Playcounts updated for %i show(s) in Kodi"
+msgstr ""
+
+msgctxt "#32110"
+msgid "Trakt episode collection is clean, no episodes to remove"
+msgstr ""
+
+msgctxt "#32111"
+msgid "%i episode(s) are being removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32112"
+msgid "%i episode(s) were removed from your Trakt collection"
+msgstr ""
+
+msgctxt "#32113"
+msgid "Trakt - Marked as watched"
+msgstr ""
+
+msgctxt "#32114"
+msgid "Trakt - Failed marking as watched"
+msgstr ""
+
+msgctxt "#32115"
+msgid "%d episode(s) of '%s'"
+msgstr ""
+
+msgctxt "#32116"
+msgid "Enable debug mode"
+msgstr ""
+
+msgctxt "#32117"
+msgid "Sync movie playback progress to Kodi"
+msgstr ""
+
+msgctxt "#32118"
+msgid "Sync episode playback progress to Kodi"
+msgstr ""
+
+msgctxt "#32119"
+msgid "Retrieving episode playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32120"
+msgid "Parsing episode playback progress %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32121"
+msgid "Retrieved episode playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32122"
+msgid "Retrieving movie playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32123"
+msgid "Parsing movie playback progress %i of %i from Trakt"
+msgstr ""
+
+msgctxt "#32124"
+msgid "Retrieved movie playback progress from Trakt"
+msgstr ""
+
+msgctxt "#32125"
+msgid "Kodi movie playback progress is up to date"
+msgstr ""
+
+msgctxt "#32126"
+msgid "%i movie(s) playback progress will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32127"
+msgid "Updating %i of %i movie(s) playback progress in Kodi"
+msgstr ""
+
+msgctxt "#32128"
+msgid "Playback progress updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32129"
+msgid "Kodi episode playback progress is up to date"
+msgstr ""
+
+msgctxt "#32130"
+msgid "Updating %i of %i episode(s) playback progress in Kodi"
+msgstr ""
+
+msgctxt "#32131"
+msgid "Playback progress updated for %i episode(s) in Kodi"
+msgstr ""
+
+msgctxt "#32132"
+msgid "Unrate this season"
+msgstr ""
+
+msgctxt "#32133"
+msgid "Manage Movie's Lists"
+msgstr ""
+
+msgctxt "#32134"
+msgid "Manage Show's Lists"
+msgstr ""
+
+msgctxt "#32135"
+msgid "Remove from Watchlist"
+msgstr ""
+
+msgctxt "#32136"
+msgid "Add to watchlist"
+msgstr ""
+
+msgctxt "#32137"
+msgid "Rate this movie"
+msgstr ""
+
+msgctxt "#32138"
+msgid "Rate this show"
+msgstr ""
+
+msgctxt "#32139"
+msgid "Rate this episode"
+msgstr ""
+
+msgctxt "#32140"
+msgid "Toggle watched"
+msgstr ""
+
+msgctxt "#32141"
+msgid "Manage all lists"
+msgstr ""
+
+msgctxt "#32142"
+msgid "Update all tags"
+msgstr ""
+
+msgctxt "#32143"
+msgid "Synchronize library"
+msgstr ""
+
+msgctxt "#32144"
+msgid "How do I authorize the trakt addon to access my trakt.tv account?"
+msgstr ""
+
+# empty strings from id 32145 to 32146
+msgctxt "#32147"
+msgid "Trakt.tv PIN Authorization Failed"
+msgstr ""
+
+# empty string with id 32148
+msgctxt "#32149"
+msgid "Rate this Season"
+msgstr ""
+
+msgctxt "#32150"
+msgid "You will be reminded in 24 hours"
+msgstr ""
+
+msgctxt "#32151"
+msgid "Use Addon Settings later if you change your mind"
+msgstr ""
+
+msgctxt "#32152"
+msgid "Trakt Authorization Complete"
+msgstr ""
+
+msgctxt "#32153"
+msgid "Trakt Account Authorization"
+msgstr ""
+
+msgctxt "#32154"
+msgid "Authorize"
+msgstr ""
+
+msgctxt "#32155"
+msgid "Remind Me Later"
+msgstr ""
+
+msgctxt "#32156"
+msgid "No Thanks"
+msgstr ""
+
+msgctxt "#32157"
+msgid "Account Authorization"
+msgstr ""
+
+# empty string with id 32158
+msgctxt "#32159"
+msgid "Visit {0} or scan the QR code."
+msgstr ""
+
+msgctxt "#32162"
+msgid "The trakt addon CAN NOT be used without authorizing it to access your trakt.tv account."
+msgstr ""
+
 msgctxt "#32163"
 msgid "User"
 msgstr "用戶"
+
+msgctxt "#32164"
+msgid "Fallback to Title/Year matching if necessary"
+msgstr ""
+
+msgctxt "#32165"
+msgid "Trakt - Added to watchlist"
+msgstr ""
+
+msgctxt "#32166"
+msgid "Trakt - Failed adding to watchlist"
+msgstr ""
+
+msgctxt "#32167"
+msgid "Offset scrobble start by X minutes"
+msgstr ""
+
+msgctxt "#32168"
+msgid "Sync ratings"
+msgstr ""
+
+msgctxt "#32169"
+msgid "Kodi movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32170"
+msgid "%i movie(s) ratings will be updated in Kodi"
+msgstr ""
+
+msgctxt "#32171"
+msgid "Updating %i of %i movie ratings in Kodi"
+msgstr ""
+
+msgctxt "#32172"
+msgid "Ratings updated for %i movie(s) in Kodi"
+msgstr ""
+
+msgctxt "#32173"
+msgid "Kodi episode ratings are up to date"
+msgstr ""
+
+msgctxt "#32174"
+msgid "Updating %i of %i episode ratings in Kodi"
+msgstr ""
+
+msgctxt "#32175"
+msgid "Ratings updated for %i episode(s) in Kodi"
+msgstr ""
+
+msgctxt "#32176"
+msgid "Kodi show ratings are up to date"
+msgstr ""
+
+msgctxt "#32177"
+msgid "Updating %i of %i show ratings in Kodi"
+msgstr ""
+
+msgctxt "#32178"
+msgid "Ratings updated for %i show(s) in Kodi"
+msgstr ""
+
+msgctxt "#32179"
+msgid "Trakt movie ratings are up to date"
+msgstr ""
+
+msgctxt "#32180"
+msgid "%i movie ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32181"
+msgid "Trakt show ratings are up to date"
+msgstr ""
+
+msgctxt "#32182"
+msgid "%i show ratings will be updated on Trakt"
+msgstr ""
+
+msgctxt "#32183"
+msgid "Attempt to scrobble MythTV PVR recordings"
+msgstr ""
+
+msgctxt "#32184"
+msgid "Attempt secondary show title search"
+msgstr ""
+
+msgctxt "#32185"
+msgid "Exclude Plugins"
+msgstr ""
+
+msgctxt "#32186"
+msgid "Allow script exclusions"
+msgstr ""

--- a/script.trakt/resources/lib/syncEpisodes.py
+++ b/script.trakt/resources/lib/syncEpisodes.py
@@ -113,6 +113,10 @@ class SyncEpisodes:
             y = ((i / x) * 8) + 2
             self.sync.UpdateProgress(
                 int(y), line2=kodiUtilities.getString(32097) % (i, x))
+            
+            if 'ids' not in show_col1:
+                logger.debug("[Episodes Sync] Tvshow %s has no imdbnumber or uniqueid" % show_col1['tvshowid'])
+                continue
 
             show = {'title': show_col1['title'], 'ids': show_col1['ids'], 'year': show_col1['year'], 'rating': show_col1['rating'],
                     'tvshowid': show_col1['tvshowid'], 'seasons': []}


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: Trakt
  - Add-on ID: script.trakt
  - Version number: 3.4.2
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/trakt/script.trakt
  
Automatically scrobble all TV episodes and movies you are watching to Trakt.tv! Keep a comprehensive history of everything you've watched and be part of a global community of TV and movie enthusiasts. Sign up for a free account at http://trakt.tv and get a ton of features:

- Automatically scrobble what you're watching
- Mobile apps for iPhone, iPad, Android, and Windows Phone
- Share what you're watching (in real time) and rating to facebook and twitter
- Personalized calendar so you never miss a TV show
- Follow your friends and people you're interesed in
- Use watchlists so you don't forget to what to watch
- Track your media collections and impress your friends
- Create custom lists around any topics you choose
- Easily track your TV show progress across all seasons and episodes
- Track your progress against industry lists such as the IMDb Top 250
- Discover new shows and movies based on your viewing habits
- Widgets for your forum signature

What can this addon do?

- Automatically scrobble all TV episodes and movies you are watching
- Sync your TV episode and movie collections to Trakt (triggered after a library update)
- Auto clean your Trakt collection so that it matches up with Kodi
- Keep watched statuses synced between Kodi and Trakt
- Rate movies and episode after watching them

Special thanks to all who contributed to this plugin! Check the commit history and changelog to see these talented developers.

### Description of changes:

- Handle cases of missing ids for tvshows
- Update translations

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
