### PR TITLE
[script.logviewer@matrix] 2.1.5+matrix.1

### DIFF
--- a/script.logviewer/addon.xml
+++ b/script.logviewer/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<addon id="script.logviewer" name="Log Viewer for Kodi" provider-name="i96751414" version="2.1.4+matrix.1">
+<addon id="script.logviewer" name="Log Viewer for Kodi" provider-name="i96751414" version="2.1.5+matrix.1">
     <requires>
         <import addon="xbmc.python" version="3.0.0"/>
     </requires>
@@ -19,7 +19,7 @@
         <description lang="pt_PT">Ferramenta para verificar e ler facilmente o log do Kodi.</description>
         <platform>all</platform>
         <news>
-            - Updated to support Matrix log format
+            - Move xbmc.translatePath to xbmcvfs.translatePath (removed in v20)
         </news>
         <assets>
             <icon>icon.png</icon>

--- a/script.logviewer/resources/lib/logviewer.py
+++ b/script.logviewer/resources/lib/logviewer.py
@@ -7,6 +7,7 @@ import time
 
 import xbmc
 import xbmcgui
+import xbmcvfs
 
 from resources.lib.dialog import ACTION_PARENT_DIR, KEY_NAV_BACK, ACTION_PREVIOUS_MENU
 from resources.lib.logreader import LogReader
@@ -38,13 +39,13 @@ def log_location(old=False):
         elif xbmc.getCondVisibility("system.platform.ios"):
             log_path = "/var/mobile/Library/Preferences"
         elif xbmc.getCondVisibility("system.platform.windows"):
-            log_path = xbmc.translatePath("special://home")
+            log_path = xbmcvfs.translatePath("special://home")
         elif xbmc.getCondVisibility("system.platform.linux"):
-            log_path = xbmc.translatePath("special://home/temp")
+            log_path = xbmcvfs.translatePath("special://home/temp")
         else:
-            log_path = xbmc.translatePath("special://logpath")
+            log_path = xbmcvfs.translatePath("special://logpath")
     else:
-        log_path = xbmc.translatePath("special://logpath")
+        log_path = xbmcvfs.translatePath("special://logpath")
 
     try:
         app_name = get_application_name().lower()


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: Log Viewer for Kodi
  - Add-on ID: script.logviewer
  - Version number: 2.1.5+matrix.1
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/i96751414/script.logviewer
  
Tools to easily check and analyse Kodi log file.

### Description of changes:


            - Move xbmc.translatePath to xbmcvfs.translatePath (removed in v20)
        

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
