### PR TITLE
[script.tvmaze.scrobbler@leia] 1.2.0

### DIFF
--- a/script.tvmaze.scrobbler/addon.xml
+++ b/script.tvmaze.scrobbler/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon id="script.tvmaze.scrobbler"
    name="TVmaze Scrobbler/Tracker"
-   version="1.1.1"
+   version="1.2.0"
    provider-name="Roman V.M.">
   <requires>
     <import addon="xbmc.python" version="2.26.0" />
@@ -38,11 +38,10 @@ What this addon does:
       <icon>resources/images/icon.png</icon>
       <fanart>resources/images/background.jpg</fanart>
     </assets>
-    <news>1.1.1:
-- Fixed special episodes handling.
+    <news>1.2.0:
+- Added a setting to enable/disable episodes sync on medialibrary update (disabled by default).
 
-1.1.0:
-- Added periodic pulling of episode watched statuses from TVmaze.
-- Improved error logging.</news>
+1.1.1:
+- Fixed special episodes handling.</news>
   </extension>
 </addon>

--- a/script.tvmaze.scrobbler/libs/kodi_monitor.py
+++ b/script.tvmaze.scrobbler/libs/kodi_monitor.py
@@ -24,7 +24,7 @@ import xbmc
 
 from .pulled_episodes_db import PulledEpisodesDb
 from . import scrobbling_service as scrobbler
-from .kodi_service import logger
+from .kodi_service import logger, ADDON
 
 try:
     from typing import Text  # pylint: disable=unused-import
@@ -53,6 +53,6 @@ class KodiMonitor(xbmc.Monitor):  # pylint: disable=missing-docstring
 
     def onScanFinished(self, library):
         # type: (Text) -> None
-        if library == 'video':
+        if library == 'video' and ADDON.getSettingBool('sync_on_update'):
             scrobbler.sync_recent_episodes(show_warning=False)
             logger.debug('Recent episodes updated')

--- a/script.tvmaze.scrobbler/resources/language/resource.language.en_gb/strings.po
+++ b/script.tvmaze.scrobbler/resources/language/resource.language.en_gb/strings.po
@@ -146,3 +146,7 @@ msgstr ""
 msgctxt "#32034"
 msgid "Pull during playback"
 msgstr ""
+
+msgctxt "#32035"
+msgid "Sync episodes on medialibrary update"
+msgstr ""

--- a/script.tvmaze.scrobbler/resources/settings.xml
+++ b/script.tvmaze.scrobbler/resources/settings.xml
@@ -1,14 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <settings>
-    <setting label="32024" type="bool" id="pull_from_tvmaze" default="true" />
-    <setting label="32023" type="bool" id="show_notifications" default="true" />
-    <setting label="32032" type="bool" id="periodic_pull" default="false" />
-    <setting label="32033" type="labelenum" id="pull_interval_hours" values="1|3|6|12|24"
-             enable="eq(-1,true)" />
-    <setting label="32034" type="bool" id="pull_during_playback" default="false"
-             enable="eq(-2,true)" />
-    <!-- Hidden settings -->
-    <setting label="" type="text" id="username" default="" visible="false"/>
-    <setting label="" type="text" id="apikey" default="" visible="false"/>
-    <setting label="" type="text" id="time_last_pulled" default="" visible="false"/>
+    <category label="32000">
+        <setting label="32024" type="bool" id="pull_from_tvmaze" default="true" />
+        <setting label="32023" type="bool" id="show_notifications" default="true" />
+        <setting label="32035" type="bool" id="sync_on_update" default="false" />
+        <setting label="32032" type="bool" id="periodic_pull" default="false" />
+        <setting label="32033" type="labelenum" id="pull_interval_hours" values="1|3|6|12|24"
+                 enable="eq(-1,true)" />
+        <setting label="32034" type="bool" id="pull_during_playback" default="false"
+                 enable="eq(-2,true)" />
+        <!-- Hidden settings -->
+        <setting label="" type="text" id="username" default="" visible="false"/>
+        <setting label="" type="text" id="apikey" default="" visible="false"/>
+        <setting label="" type="text" id="time_last_pulled" default="" visible="false"/>
+    </category>
 </settings>


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: TVmaze Scrobbler/Tracker
  - Add-on ID: script.tvmaze.scrobbler
  - Version number: 1.2.0
  - Kodi/repository version: leia

- **Code location**
  - URL: https://github.com/romanvm/kodi.tvmaze.scrobbler
  
Automatically track all TV episodes you are watching to TVmaze. A must have if you want to sync your watch history between various applications.
Sign up for a free account at https://tvmaze.com for more features.

This Kodi TV episode Tracker uses the TVmaze.com user API's scrobbler endpoints(https://static.tvmaze.com/apidoc/)

What this addon does:
- Performs an initial sync between Kodi and TVmaze for the episodes you've watched.
- If you add an episode to the Kodi library it marks it as "acquired" on TVmaze.
- If you watch an episode in Kodi it marks it as "watched" in TVmaze.
- If you mark an episode as watched in TVmaze it marks it as watched in Kodi.

### Description of changes:

1.2.0:
- Added a setting to enable/disable episodes sync on medialibrary update (disabled by default).

1.1.1:
- Fixed special episodes handling.

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
