### PR TITLE
[script.xbmc.lcdproc] 3.90.2

### DIFF
--- a/script.xbmc.lcdproc/addon.xml
+++ b/script.xbmc.lcdproc/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.xbmc.lcdproc" name="XBMC LCDproc" version="3.90.1" provider-name="Team Kodi: Memphiz, Daniel 'herrnst' Scheller">
+<addon id="script.xbmc.lcdproc" name="XBMC LCDproc" version="3.90.2" provider-name="Team Kodi: Memphiz, Daniel 'herrnst' Scheller">
   <requires>
     <import addon="xbmc.python" version="3.0.0"/>
   </requires>
@@ -24,9 +24,8 @@
     <assets>
       <icon>resources/icon.png</icon>
     </assets>
-    <news>3.90.1
-- replace LOGNOTICE with LOGINFO, remove LOGSEVERE
-- use translatePath from xbmcvfs instead of xbmc
+    <news>3.90.2
+- fix compatibility with Python 3.9+
 </news>
   </extension>
 </addon>

--- a/script.xbmc.lcdproc/changelog.txt
+++ b/script.xbmc.lcdproc/changelog.txt
@@ -1,3 +1,5 @@
+3.90.2
+- fix compatibility with Python 3.9
 3.90.1
 - replace LOGNOTICE with LOGINFO, remove LOGSEVERE
 - use translatePath from xbmcvfs instead of xbmc

--- a/script.xbmc.lcdproc/resources/lib/lcdbase.py
+++ b/script.xbmc.lcdproc/resources/lib/lcdbase.py
@@ -247,7 +247,7 @@ class LcdBase():
       log(LOGERROR, "Parsing of %s failed" % (xmlFile))
       return False
 
-    for element in doc.getiterator():
+    for element in doc.iter():
       #PARSE LCD infos
       if element.tag == "lcd":
         # load our settings


### PR DESCRIPTION
### Description

Fixes compatibility with Python 3.9+

The lcd.xml parser still used the getiterator method, which seems to be deprecated since Python 2.7, but was finally dropped in 3.9.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [X] Each add-on submission should be a single commit with using the following style: [script.foo.bar] 1.0.0
