### PR TITLE
[script.module.inputstreamhelper@matrix] 0.5.3+matrix.1

### DIFF
--- a/script.module.inputstreamhelper/README.md
+++ b/script.module.inputstreamhelper/README.md
@@ -60,6 +60,7 @@ def run(addon_url):
     else:
         xbmcplugin.setContent(int(sys.argv[1]), 'videos')
         list_item = xbmcgui.ListItem(label='InputStream Helper Demo')
+        list_item.setInfo('video', {})
         list_item.setProperty('IsPlayable', 'true')
         url = addon_url + '/play'
         xbmcplugin.addDirectoryItem(int(sys.argv[1]), url, list_item)
@@ -90,6 +91,10 @@ Please report any issues or bug reports on the [GitHub Issues](https://github.co
 This module is licensed under the **The MIT License**. Please see the [LICENSE.txt](LICENSE.txt) file for details.
 
 ## Releases
+### v0.5.3 (2021-05-10)
+- Temporary fix for Widevine CDM installation on ARM hardware (@mediaminister)
+- Fix Widevine CDM installation on 32-bit Linux (@mediaminister)
+
 ### v0.5.2 (2020-12-13)
 - Update Chrome OS ARM hardware id's (@mediaminister)
 

--- a/script.module.inputstreamhelper/addon.xml
+++ b/script.module.inputstreamhelper/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.module.inputstreamhelper" name="InputStream Helper" version="0.5.2+matrix.1" provider-name="emilsvennesson, dagwieers, mediaminister, horstle">
+<addon id="script.module.inputstreamhelper" name="InputStream Helper" version="0.5.3+matrix.1" provider-name="emilsvennesson, dagwieers, mediaminister, horstle">
   <requires>
     <!--py3 compliant-->
     <import addon="xbmc.python" version="3.0.0"/>
@@ -23,6 +23,10 @@
     <description lang="fr_FR">Un simple module Kodi qui simplifie la vie des développeurs de modules complémentaires en s’appuyant sur des modules complémentaires basés sur InputStream et sur la lecture de DRM.</description>
     <description lang="es_ES">Un módulo Kodi simple que hace la vida más fácil para los desarrolladores de complementos que dependen de complementos basados en InputStream y reproducción de DRM.</description>
     <news>
+v0.5.3 (2021-05-10)
+- Temporary fix for Widevine CDM installation on ARM hardware
+- Fix Widevine CDM installation on 32-bit Linux
+
 v0.5.2 (2020-12-13)
 - Update Chrome OS ARM hardware id's
 

--- a/script.module.inputstreamhelper/lib/inputstreamhelper/__init__.py
+++ b/script.module.inputstreamhelper/lib/inputstreamhelper/__init__.py
@@ -11,8 +11,8 @@ from .kodiutils import (addon_version, delete, exists, get_proxies, get_setting,
                         set_setting, set_setting_bool, textviewer, translate_path, yesno_dialog)
 from .utils import arch, http_download, remove_tree, run_cmd, store, system_os, temp_path, unzip
 from .widevine.arm import install_widevine_arm, unmount
-from .widevine.widevine import (backup_path, has_widevinecdm, ia_cdm_path, install_cdm_from_backup, latest_widevine_version,
-                                load_widevine_config, missing_widevine_libs, widevine_config_path, widevine_eula, widevinecdm_path)
+from .widevine.widevine import (backup_path, has_widevinecdm, ia_cdm_path, install_cdm_from_backup, latest_available_widevine_from_repo,
+                                latest_widevine_version, load_widevine_config, missing_widevine_libs, widevine_config_path, widevine_eula, widevinecdm_path)
 from .unicodes import compat_path
 
 # NOTE: Work around issue caused by platform still using os.popen()
@@ -171,14 +171,11 @@ class Helper:
     @staticmethod
     def _install_widevine_x86(bpath):
         """Install Widevine CDM on x86 based architectures."""
-        cdm_version = latest_widevine_version()
+        cdm = latest_available_widevine_from_repo()
+        cdm_version = cdm.get('version')
 
         if not store('download_path'):
-            cdm_os = config.WIDEVINE_OS_MAP[system_os()]
-            cdm_arch = config.WIDEVINE_ARCH_MAP_X86[arch()]
-            url = config.WIDEVINE_DOWNLOAD_URL.format(version=cdm_version, os=cdm_os, arch=cdm_arch)
-
-            downloaded = http_download(url)
+            downloaded = http_download(cdm.get('url'))
         else:
             downloaded = True
 
@@ -279,13 +276,13 @@ class Helper:
         elif 'x86' in arch():
             component = 'Widevine CDM'
             current_version = wv_config['version']
+            latest_version = latest_available_widevine_from_repo().get('version')
         else:
             component = 'Chrome OS'
             current_version = wv_config['version']
-
-        latest_version = latest_widevine_version()
+            latest_version = latest_widevine_version()
         if not latest_version:
-            log(3, 'Updating widevine failed. Could not determine latest version.')
+            log(3, 'Updating Widevine CDM failed. Could not determine latest version.')
             return
 
         log(0, 'Latest {component} version is {version}', component=component, version=latest_version)

--- a/script.module.inputstreamhelper/lib/inputstreamhelper/config.py
+++ b/script.module.inputstreamhelper/lib/inputstreamhelper/config.py
@@ -82,21 +82,31 @@ CHROMEOS_RECOVERY_URL = 'https://dl.google.com/dl/edgedl/chromeos/recovery/recov
 # To keep the Chrome OS ARM hardware ID list up to date, the following resources can be used:
 # https://www.chromium.org/chromium-os/developer-information-for-chrome-os-devices
 # https://cros-updates-serving.appspot.com/
-# Last updated: 2020-10-05
+# Last updated: 2021-05-10
+# Temporary fix for https://github.com/emilsvennesson/script.module.inputstreamhelper/issues/437
+# Widevine on ARM hardware will probably fail again on June 1st 2021 when Chrome OS 91 will be released: https://chromiumdash.appspot.com/schedule
 CHROMEOS_RECOVERY_ARM_HWIDS = [
-    'BOB',
-    'DRUWL',
-    'DUMO',
-    'ELM',
-    'FIEVEL',
-    'HANA',
-    'JUNIPER-HVPU',
-    'KEVIN',
-    'KODAMA',
-    'KRANE-ZDKS',
-    'MICKEY',
+    # 'BOB',
+    # 'BURNET',
+    # 'DAMU',
+    # 'DRUWL',
+    # 'DUMO',
+    # 'ELM',
+    # 'ESCHE',
+    # 'FIEVEL',
+    # 'HANA',
+    # 'JUNIPER-HVPU',
+    # 'KAKADU-WFIQ',
+    # 'KAPPA',
+    # 'KENZO-IGRW',
+    # 'KEVIN',
+    # 'KODAMA',
+    # 'KRANE-ZDKS',
+    # 'LAZOR',
+    # 'POMPOM',
     'SCARLET',
-    'TIGER',
+    # 'TIGER',
+    # 'WILLOW-TFIY',
 ]
 
 CHROMEOS_BLOCK_SIZE = 512

--- a/script.module.inputstreamhelper/lib/inputstreamhelper/utils.py
+++ b/script.module.inputstreamhelper/lib/inputstreamhelper/utils.py
@@ -73,6 +73,17 @@ def http_get(url):
     return content.decode()
 
 
+def http_head(url):
+    """Perform an HTTP HEAD request and return status code"""
+    req = Request(url)
+    req.get_method = lambda: 'HEAD'
+    try:
+        resp = urlopen(req)
+        return resp.getcode()
+    except HTTPError as exc:
+        return exc.getcode()
+
+
 def http_download(url, message=None, checksum=None, hash_alg='sha1', dl_size=None, background=False):  # pylint: disable=too-many-statements
     """Makes HTTP request and displays a progress dialog on download."""
     if checksum:
@@ -170,19 +181,19 @@ def unzip(source, destination, file_to_unzip=None, result=[]):  # pylint: disabl
         mkdirs(destination)
 
     from zipfile import ZipFile
-    zip_obj = ZipFile(compat_path(source))
-    for filename in zip_obj.namelist():
-        if file_to_unzip and filename != file_to_unzip:
-            continue
+    with ZipFile(compat_path(source)) as zip_obj:
+        for filename in zip_obj.namelist():
+            if file_to_unzip and filename != file_to_unzip:
+                continue
 
-        # Detect and remove (dangling) symlinks before extraction
-        fullname = os.path.join(destination, filename)
-        if os.path.islink(compat_path(fullname)):
-            log(3, 'Remove (dangling) symlink at {symlink}', symlink=fullname)
-            delete(fullname)
+            # Detect and remove (dangling) symlinks before extraction
+            fullname = os.path.join(destination, filename)
+            if os.path.islink(compat_path(fullname)):
+                log(3, 'Remove (dangling) symlink at {symlink}', symlink=fullname)
+                delete(fullname)
 
-        zip_obj.extract(filename, compat_path(destination))
-        result.append(True)  # Pass by reference for Thread
+            zip_obj.extract(filename, compat_path(destination))
+            result.append(True)  # Pass by reference for Thread
 
     return bool(result)
 

--- a/script.module.inputstreamhelper/lib/inputstreamhelper/widevine/arm_chromeos.py
+++ b/script.module.inputstreamhelper/lib/inputstreamhelper/widevine/arm_chromeos.py
@@ -319,8 +319,8 @@ class ChromeOSImage:
     def get_bstream(imgpath):
         """Get a bytestream of the image"""
         if imgpath.endswith('.zip'):
-            bstream = ZipFile(compat_path(imgpath), 'r').open(os.path.basename(imgpath).strip('.zip'), 'r')
+            bstream = ZipFile(compat_path(imgpath), 'r').open(os.path.basename(imgpath).strip('.zip'), 'r')  # pylint: disable=consider-using-with
         else:
-            bstream = open(compat_path(imgpath), 'rb')
+            bstream = open(compat_path(imgpath), 'rb')  # pylint: disable=consider-using-with
 
         return [bstream, 0]


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: InputStream Helper
  - Add-on ID: script.module.inputstreamhelper
  - Version number: 0.5.3+matrix.1
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/emilsvennesson/script.module.inputstreamhelper
  
A simple Kodi module that makes life easier for add-on developers relying on InputStream based add-ons and DRM playback.

### Description of changes:


v0.5.3 (2021-05-10)
- Temporary fix for Widevine CDM installation on ARM hardware
- Fix Widevine CDM installation on 32-bit Linux

v0.5.2 (2020-12-13)
- Update Chrome OS ARM hardware id's

v0.5.1 (2020-10-02)
- Fix incorrect ARM HWIDs: PHASER and PHASER360
- Added Hebrew translations
- Updated Dutch, Japanese and Korean translations

v0.5.0 (2020-06-25)
- Extract Widevine CDM directly from Chrome OS, minimizing disk space usage and eliminating the need for root access
- Improve progress dialog while extracting Widevine CDM on ARM devices
- Support resuming interrupted downloads on unreliable internet connections
- Reshape InputStream Helper information dialog
- Updated Dutch, English, French, German, Greek, Hungarian, Romanian, Russian, Spanish and Swedish translations
    

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
