### PR TITLE
[script.module.websocket] 0.58.0+matrix.2

### DIFF
--- a/script.module.websocket/addon.xml
+++ b/script.module.websocket/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.module.websocket" name="websocket library" version="0.58.0+matrix.1" provider-name="liris">
+<addon id="script.module.websocket" name="websocket library" version="0.58.0+matrix.2" provider-name="liris">
   <requires>
     <import addon="xbmc.python" version="3.0.0" />
     <import addon="script.module.six" version="1.14.0+matrix.2" />

--- a/script.module.websocket/lib/websocket/_abnf.py
+++ b/script.module.websocket/lib/websocket/_abnf.py
@@ -34,7 +34,7 @@ from threading import Lock
 
 try:
     if six.PY3:
-        import numpy
+        numpy = None
     else:
         numpy = None
 except ImportError:


### PR DESCRIPTION
### Description
- disable use of numpy with Python3 (corrects an issue with Kodi crashing on certain platforms)

This is a non-upstream patch particularly for Kodi, so I'll have to reapply it whenever there is a module update, at least until we confirm that numpy is not causing Kodi crashes on certain platforms.

<!--- Provide a short summary of submitted add-on in case it's a new addition. -->
<!--- If it's plugin update only highlight biggest changes if needed. -->
<!--- Make sure you follow the checklist below before finalising your pull-request. -->
### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [script.foo.bar] 1.0.0