### PR TITLE
[service.libraryautoupdate] 1.2.3

### DIFF
--- a/service.libraryautoupdate/addon.xml
+++ b/service.libraryautoupdate/addon.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="service.libraryautoupdate"
-    name="Library Auto Update" version="1.2.2" provider-name="robweber">
+    name="Library Auto Update" version="1.2.3" provider-name="robweber">
   <requires>
     <import addon="xbmc.python" version="3.0.0"/>
     <import addon="script.module.dateutil" version="2.7.3" />
@@ -78,8 +78,7 @@
 	<assets>
 		<icon>resources/media/icon.png</icon>
 	</assets>
-	<news>Version 1.2.2
-- updated settings.xml to new format, added support for levels
-- xbmcgui.Dialog and xbmcvfs.translatePath fixes</news>
+	<news>Version 1.2.3
+- fix for hourly timer settings not working </news>
   </extension>
 </addon>

--- a/service.libraryautoupdate/resources/lib/service.py
+++ b/service.libraryautoupdate/resources/lib/service.py
@@ -18,15 +18,6 @@ class AutoUpdater:
 
     monitor = None
 
-    # setup the timer amounts
-    timer_amounts = {}
-    timer_amounts['0'] = 1
-    timer_amounts['1'] = 2
-    timer_amounts['2'] = 4
-    timer_amounts['3'] = 6
-    timer_amounts['4'] = 12
-    timer_amounts['5'] = 24
-
     def __init__(self):
         utils.check_data_dir()  # in case this directory does not exist yet
         self.monitor = UpdateMonitor(update_settings=self.createSchedules, after_scan=self.databaseUpdated)
@@ -214,7 +205,7 @@ class AutoUpdater:
             # copy the expression
             result = utils.getSetting(settingName + "_cron_expression")
         else:
-            result = '0 */' + str(self.timer_amounts[utils.getSetting(settingName + "_timer")]) + ' * * *'
+            result = '0 */' + str(utils.getSetting(settingName + "_timer")) + ' * * *'
 
         return result
 


### PR DESCRIPTION
### Description
Since update to new settings format the hourly time selection drop down was not working properly, added fix. 
### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [script.foo.bar] 1.0.0

Additional information :
- Submitting your add-on to this specific branch makes it available to any Kodi version equal or higher than the branch name with the applicable Kodi dependencies limits.
- [add-on development](http://kodi.wiki/view/Add-on_development) wiki page.
- Kodi [pydocs](http://kodi.wiki/view/PyDocs) provide information about the Python API
- [PEP8](https://www.python.org/dev/peps/pep-0008/) codingstyle which is considered best practise but not mandatory.
- This add-on repository has automated code guideline check which could help you improve your coding. You can find the results of these check at [Codacy](https://www.codacy.com/app/Kodi/repo-scripts/dashboard). You can create your own account as well to continuously monitor your python coding before submitting to repo.
- Development questions can be asked in the [add-on development](http://forum.kodi.tv/forumdisplay.php?fid=26) section on the Kodi forum.
