### PR TITLE
[script.module.inputstreamhelper@matrix] 0.5.4+matrix.1

### DIFF
--- a/script.module.inputstreamhelper/README.md
+++ b/script.module.inputstreamhelper/README.md
@@ -91,6 +91,9 @@ Please report any issues or bug reports on the [GitHub Issues](https://github.co
 This module is licensed under the **The MIT License**. Please see the [LICENSE.txt](LICENSE.txt) file for details.
 
 ## Releases
+### v0.5.4 (2021-05-27)
+- Fix Widevine CDM installation on ARM hardware (@mediaminister)
+
 ### v0.5.3 (2021-05-10)
 - Temporary fix for Widevine CDM installation on ARM hardware (@mediaminister)
 - Fix Widevine CDM installation on 32-bit Linux (@mediaminister)

--- a/script.module.inputstreamhelper/addon.xml
+++ b/script.module.inputstreamhelper/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.module.inputstreamhelper" name="InputStream Helper" version="0.5.3+matrix.1" provider-name="emilsvennesson, dagwieers, mediaminister, horstle">
+<addon id="script.module.inputstreamhelper" name="InputStream Helper" version="0.5.4+matrix.1" provider-name="emilsvennesson, dagwieers, mediaminister, horstle">
   <requires>
     <!--py3 compliant-->
     <import addon="xbmc.python" version="3.0.0"/>
@@ -23,6 +23,9 @@
     <description lang="fr_FR">Un simple module Kodi qui simplifie la vie des développeurs de modules complémentaires en s’appuyant sur des modules complémentaires basés sur InputStream et sur la lecture de DRM.</description>
     <description lang="es_ES">Un módulo Kodi simple que hace la vida más fácil para los desarrolladores de complementos que dependen de complementos basados en InputStream y reproducción de DRM.</description>
     <news>
+v0.5.4 (2021-05-27)
+- Fix Widevine CDM installation on ARM hardware
+
 v0.5.3 (2021-05-10)
 - Temporary fix for Widevine CDM installation on ARM hardware
 - Fix Widevine CDM installation on 32-bit Linux

--- a/script.module.inputstreamhelper/lib/inputstreamhelper/config.py
+++ b/script.module.inputstreamhelper/lib/inputstreamhelper/config.py
@@ -67,6 +67,14 @@ WIDEVINE_MINIMUM_KODI_VERSION = {
     'Darwin': '18.0'
 }
 
+HARDCODED_CHROMEOS_IMAGE = {
+    'hwid': 'FIEVEL',
+    'url': 'https://dl.google.com/dl/edgedl/chromeos/recovery/chromeos_13505.73.0_veyron-fievel_recovery_stable-channel_fievel-mp.bin.zip',
+    'sha1': '9904e3141a2537f28469c7653c62200c1b03b057',
+    'version': '13505.73.0',
+    'zipfilesize': '1032442523'
+}
+
 WIDEVINE_VERSIONS_URL = 'https://dl.google.com/widevine-cdm/versions.txt'
 
 WIDEVINE_DOWNLOAD_URL = 'https://dl.google.com/widevine-cdm/{version}-{os}-{arch}.zip'
@@ -82,31 +90,29 @@ CHROMEOS_RECOVERY_URL = 'https://dl.google.com/dl/edgedl/chromeos/recovery/recov
 # To keep the Chrome OS ARM hardware ID list up to date, the following resources can be used:
 # https://www.chromium.org/chromium-os/developer-information-for-chrome-os-devices
 # https://cros-updates-serving.appspot.com/
-# Last updated: 2021-05-10
-# Temporary fix for https://github.com/emilsvennesson/script.module.inputstreamhelper/issues/437
-# Widevine on ARM hardware will probably fail again on June 1st 2021 when Chrome OS 91 will be released: https://chromiumdash.appspot.com/schedule
+# Last updated: 2021-05-05
 CHROMEOS_RECOVERY_ARM_HWIDS = [
-    # 'BOB',
-    # 'BURNET',
-    # 'DAMU',
-    # 'DRUWL',
-    # 'DUMO',
-    # 'ELM',
-    # 'ESCHE',
-    # 'FIEVEL',
-    # 'HANA',
-    # 'JUNIPER-HVPU',
-    # 'KAKADU-WFIQ',
-    # 'KAPPA',
-    # 'KENZO-IGRW',
-    # 'KEVIN',
-    # 'KODAMA',
-    # 'KRANE-ZDKS',
-    # 'LAZOR',
-    # 'POMPOM',
+    'BOB',
+    'BURNET',
+    'DAMU',
+    'DRUWL',
+    'DUMO',
+    'ELM',
+    'ESCHE',
+    'FIEVEL',
+    'HANA',
+    'JUNIPER-HVPU',
+    'KAKADU-WFIQ',
+    'KAPPA',
+    'KENZO-IGRW',
+    'KEVIN',
+    'KODAMA',
+    'KRANE-ZDKS',
+    'LAZOR',
+    'POMPOM',
     'SCARLET',
-    # 'TIGER',
-    # 'WILLOW-TFIY',
+    'TIGER',
+    'WILLOW-TFIY',
 ]
 
 CHROMEOS_BLOCK_SIZE = 512

--- a/script.module.inputstreamhelper/lib/inputstreamhelper/kodiutils.py
+++ b/script.module.inputstreamhelper/lib/inputstreamhelper/kodiutils.py
@@ -65,6 +65,16 @@ def kodi_version_major():
     return int(kodi_version().split('.')[0])
 
 
+def kodi_os():
+    """Returns Kodi OS name as string"""
+    # It takes a while to get this info
+    count = 0
+    while ' (kernel: ' not in xbmc.getInfoLabel('System.OSVersionInfo') and count < 10:
+        count += 1
+        xbmc.sleep(100)
+    return xbmc.getInfoLabel('System.OSVersionInfo').split(' (kernel: ')[0]
+
+
 def translate_path(path):
     """Translate special xbmc paths"""
     return to_unicode(translatePath(from_unicode(path)))

--- a/script.module.inputstreamhelper/resources/language/resource.language.en_gb/strings.po
+++ b/script.module.inputstreamhelper/resources/language/resource.language.en_gb/strings.po
@@ -269,6 +269,19 @@ msgctxt "#30065"
 msgid "Shall we try again?"
 msgstr ""
 
+msgctxt "#30066"
+msgid "Warning"
+msgstr ""
+
+msgctxt "#30067"
+msgid "{os} probably doesn't support the newest Widevine CDM. Would you try to install an older Widevine CDM instead?"
+msgstr ""
+
+msgctxt "#30068"
+msgid "You're going to install an older Widevine CDM. Please note that Google will remove support for older Widevine CDM's on May 31, 2021."
+msgstr ""
+
+
 
 ### INFORMATION DIALOG
 msgctxt "#30800"


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: InputStream Helper
  - Add-on ID: script.module.inputstreamhelper
  - Version number: 0.5.4+matrix.1
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/emilsvennesson/script.module.inputstreamhelper
  
A simple Kodi module that makes life easier for add-on developers relying on InputStream based add-ons and DRM playback.

### Description of changes:


v0.5.4 (2021-05-27)
- Fix Widevine CDM installation on ARM hardware

v0.5.3 (2021-05-10)
- Temporary fix for Widevine CDM installation on ARM hardware
- Fix Widevine CDM installation on 32-bit Linux

v0.5.2 (2020-12-13)
- Update Chrome OS ARM hardware id's

v0.5.1 (2020-10-02)
- Fix incorrect ARM HWIDs: PHASER and PHASER360
- Added Hebrew translations
- Updated Dutch, Japanese and Korean translations

v0.5.0 (2020-06-25)
- Extract Widevine CDM directly from Chrome OS, minimizing disk space usage and eliminating the need for root access
- Improve progress dialog while extracting Widevine CDM on ARM devices
- Support resuming interrupted downloads on unreliable internet connections
- Reshape InputStream Helper information dialog
- Updated Dutch, English, French, German, Greek, Hungarian, Romanian, Russian, Spanish and Swedish translations
    

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
