### PR TITLE
[script.module.inputstreamhelper@matrix] 0.5.5+matrix.1

### DIFF
--- a/script.module.inputstreamhelper/README.md
+++ b/script.module.inputstreamhelper/README.md
@@ -91,6 +91,9 @@ Please report any issues or bug reports on the [GitHub Issues](https://github.co
 This module is licensed under the **The MIT License**. Please see the [LICENSE.txt](LICENSE.txt) file for details.
 
 ## Releases
+### v0.5.5 (2021-06-02)
+- Improve Widevine CDM installation on ARM hardware (@mediaminister)
+
 ### v0.5.4 (2021-05-27)
 - Fix Widevine CDM installation on ARM hardware (@mediaminister)
 

--- a/script.module.inputstreamhelper/addon.xml
+++ b/script.module.inputstreamhelper/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.module.inputstreamhelper" name="InputStream Helper" version="0.5.4+matrix.1" provider-name="emilsvennesson, dagwieers, mediaminister, horstle">
+<addon id="script.module.inputstreamhelper" name="InputStream Helper" version="0.5.5+matrix.1" provider-name="emilsvennesson, dagwieers, mediaminister, horstle">
   <requires>
     <!--py3 compliant-->
     <import addon="xbmc.python" version="3.0.0"/>
@@ -23,6 +23,9 @@
     <description lang="fr_FR">Un simple module Kodi qui simplifie la vie des développeurs de modules complémentaires en s’appuyant sur des modules complémentaires basés sur InputStream et sur la lecture de DRM.</description>
     <description lang="es_ES">Un módulo Kodi simple que hace la vida más fácil para los desarrolladores de complementos que dependen de complementos basados en InputStream y reproducción de DRM.</description>
     <news>
+v0.5.5 (2021-06-02)
+- Improve Widevine CDM installation on ARM hardware
+
 v0.5.4 (2021-05-27)
 - Fix Widevine CDM installation on ARM hardware
 

--- a/script.module.inputstreamhelper/lib/inputstreamhelper/kodiutils.py
+++ b/script.module.inputstreamhelper/lib/inputstreamhelper/kodiutils.py
@@ -69,10 +69,10 @@ def kodi_os():
     """Returns Kodi OS name as string"""
     # It takes a while to get this info
     count = 0
-    while ' (kernel: ' not in xbmc.getInfoLabel('System.OSVersionInfo') and count < 10:
+    while ' (kernel: ' not in to_unicode(xbmc.getInfoLabel('System.OSVersionInfo')) and count < 10:
         count += 1
         xbmc.sleep(100)
-    return xbmc.getInfoLabel('System.OSVersionInfo').split(' (kernel: ')[0]
+    return to_unicode(xbmc.getInfoLabel('System.OSVersionInfo')).split(' (kernel: ')[0]
 
 
 def translate_path(path):

--- a/script.module.inputstreamhelper/lib/inputstreamhelper/widevine/arm.py
+++ b/script.module.inputstreamhelper/lib/inputstreamhelper/widevine/arm.py
@@ -137,10 +137,13 @@ def install_widevine_arm(backup_path):
     # Google will remove support for older Widevine CDM's on May 31, 2021
     # More info at https://github.com/xbmc/inputstream.adaptive/issues/678 and https://www.widevine.com/news
 
-    # Experimental: Check for TCMalloc support
-    tcmalloc_path = '/usr/lib/libtcmalloc_minimal.so'
+    # Experimental: Check if TCMalloc library is preloaded or linked
+    libtcmalloc = 'libtcmalloc'
+    process_maps = open('/proc/self/maps', 'r').read()
+    is_tcmalloc_preloaded = bool(libtcmalloc in process_maps)
+
     arm_device = None
-    if not exists(tcmalloc_path):
+    if not is_tcmalloc_preloaded:
         # Propose user to install older version
         if yesno_dialog(localize(30066), localize(30067, os=kodi_os())):  # Your operating system probably doesn't support the newest Widevine CDM. Try older one?
             # Install hardcoded ChromeOS image


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: InputStream Helper
  - Add-on ID: script.module.inputstreamhelper
  - Version number: 0.5.5+matrix.1
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/emilsvennesson/script.module.inputstreamhelper
  
A simple Kodi module that makes life easier for add-on developers relying on InputStream based add-ons and DRM playback.

### Description of changes:


v0.5.5 (2021-06-02)
- Improve Widevine CDM installation on ARM hardware

v0.5.4 (2021-05-27)
- Fix Widevine CDM installation on ARM hardware

v0.5.3 (2021-05-10)
- Temporary fix for Widevine CDM installation on ARM hardware
- Fix Widevine CDM installation on 32-bit Linux

v0.5.2 (2020-12-13)
- Update Chrome OS ARM hardware id's

v0.5.1 (2020-10-02)
- Fix incorrect ARM HWIDs: PHASER and PHASER360
- Added Hebrew translations
- Updated Dutch, Japanese and Korean translations

v0.5.0 (2020-06-25)
- Extract Widevine CDM directly from Chrome OS, minimizing disk space usage and eliminating the need for root access
- Improve progress dialog while extracting Widevine CDM on ARM devices
- Support resuming interrupted downloads on unreliable internet connections
- Reshape InputStream Helper information dialog
- Updated Dutch, English, French, German, Greek, Hungarian, Romanian, Russian, Spanish and Swedish translations
    

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
