### PR TITLE
[service.subtitles.rvm.addic7ed@krypton] 3.1.6

### DIFF
--- a/service.subtitles.rvm.addic7ed/addic7ed/actions.py
+++ b/service.subtitles.rvm.addic7ed/addic7ed/actions.py
@@ -161,7 +161,8 @@ def extract_episode_data():
     :raises ParseError: if cannot determine episode data
     """
     now_played = get_now_played()
-    filename = os.path.basename(urlparse.unquote(now_played['file']))
+    parsed = urlparse.urlparse(now_played['file'])
+    filename = os.path.basename(parsed.path)
     if addon.getSetting('use_filename') == 'true' or not now_played['showtitle']:
         # Try to get showname/season/episode data from
         # the filename if 'use_filename' setting is true

--- a/service.subtitles.rvm.addic7ed/addic7ed/addon.py
+++ b/service.subtitles.rvm.addic7ed/addic7ed/addon.py
@@ -1,15 +1,22 @@
 # coding: utf-8
 
 from __future__ import unicode_literals
+
 import os
-from kodi_six import xbmc, xbmcaddon
+
+from kodi_six import xbmcaddon
+
+try:
+    from kodi_six.xbmcvfs import translatePath
+except (ImportError, AttributeError):
+    from kodi_six.xbmc import translatePath
 
 __all__ = ['ADDON_ID', 'addon', 'path', 'profile', 'icon', 'get_ui_string']
 
 ADDON_ID = 'service.subtitles.rvm.addic7ed'
 addon = xbmcaddon.Addon(ADDON_ID)
-path = xbmc.translatePath(addon.getAddonInfo('path'))
-profile = xbmc.translatePath(addon.getAddonInfo('profile'))
+path = translatePath(addon.getAddonInfo('path'))
+profile = translatePath(addon.getAddonInfo('profile'))
 icon = os.path.join(path, 'icon.png')
 
 

--- a/service.subtitles.rvm.addic7ed/addic7ed/utils.py
+++ b/service.subtitles.rvm.addic7ed/addic7ed/utils.py
@@ -5,7 +5,6 @@
 # License: GPL v.3 https://www.gnu.org/copyleft/gpl.html
 
 from __future__ import absolute_import, unicode_literals
-import json
 import re
 from collections import namedtuple
 from kodi_six import xbmc
@@ -58,22 +57,21 @@ class logger(object):
 
 def get_now_played():
     """
-    Get info about the currently played file via JSON-RPC.
-    Alternatively this can be done via Kodi InfoLabels.
+    Get info about the currently played file via Kodi InfoLabels.
+    Alternatively this can be done via JSON-RPC
+    but looks like it does not return correct file path if file path
+    is actually an url and it there was a redirect.
 
     :return: currently played item's data
     :rtype: dict
     """
-    request = json.dumps(
-        {'jsonrpc': '2.0',
-         'method': 'Player.GetItem',
-         'params': {
-             'playerid': 1,
-             'properties': ['file', 'showtitle', 'season', 'episode']
-         },
-         'id': '1'}
-    )
-    return json.loads(xbmc.executeJSONRPC(request))['result']['item']
+    item = {
+        'season': xbmc.getInfoLabel('VideoPlayer.Season'),
+        'episode': xbmc.getInfoLabel('VideoPlayer.Episode'),
+        'showtitle': xbmc.getInfoLabel('VideoPlayer.TVShowTitle'),
+        'file': xbmc.Player().getPlayingFile(),
+    }
+    return item
 
 
 def normalize_showname(showname):

--- a/service.subtitles.rvm.addic7ed/addic7ed/webclient.py
+++ b/service.subtitles.rvm.addic7ed/addic7ed/webclient.py
@@ -40,7 +40,7 @@ class Session(object):
         logger.debug('Opening URL: {0}'.format(url))
         self._session.headers['Referer'] = referer
         try:
-            response = self._session.get(url, params=params)
+            response = self._session.get(url, params=params, verify=False)
         except requests.RequestException:
             logger.error('Unable to connect to Addic7ed.com!')
             raise Add7ConnectionError

--- a/service.subtitles.rvm.addic7ed/addon.xml
+++ b/service.subtitles.rvm.addic7ed/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon id="service.subtitles.rvm.addic7ed"
   name="Addic7ed.com"
-  version="3.1.5"
+  version="3.1.6"
   provider-name="Roman V.M.">
 <requires>
   <import addon="xbmc.python" version="2.25.0"/>
@@ -32,11 +32,12 @@
     <icon>icon.png</icon>
     <fanart>fanart.jpg</fanart>
   </assets>
-  <news>v.3.1.5:
-- Fixed a crash when downloading subs for the first time after installing the addon.
+  <news>3.1.6:
+- Fixed compatibility with Kodi 20 "Nexus".
+- Various internal changes.
 
-v.3.1.4:
-- Fix cleaning a temp download directory.</news>
+3.1.5:
+- Fixed a crash when downloading subs for the first time after installing the addon.</news>
   <reuselanguageinvoker>false</reuselanguageinvoker>
 </extension>
 </addon>


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: Addic7ed.com
  - Add-on ID: service.subtitles.rvm.addic7ed
  - Version number: 3.1.6
  - Kodi/repository version: krypton

- **Code location**
  - URL: https://github.com/romanvm/service.addic7ed
  
Subtitles service for Addic7ed.com. It supports only TV shows.

### Description of changes:

3.1.6:
- Fixed compatibility with Kodi 20 "Nexus".
- Various internal changes.

3.1.5:
- Fixed a crash when downloading subs for the first time after installing the addon.

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
