### PR TITLE
[script.tvmaze.scrobbler@leia] 1.2.1

### DIFF
--- a/script.tvmaze.scrobbler/addon.xml
+++ b/script.tvmaze.scrobbler/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon id="script.tvmaze.scrobbler"
    name="TVmaze Scrobbler/Tracker"
-   version="1.2.0"
+   version="1.2.1"
    provider-name="Roman V.M.">
   <requires>
     <import addon="xbmc.python" version="2.26.0" />
@@ -38,10 +38,7 @@ What this addon does:
       <icon>resources/images/icon.png</icon>
       <fanart>resources/images/background.jpg</fanart>
     </assets>
-    <news>1.2.0:
-- Added a setting to enable/disable episodes sync on medialibrary update (disabled by default).
-
-1.1.1:
-- Fixed special episodes handling.</news>
+    <news>1.2.1:
+- Fixed compatibility with Kodi 20 "Nexus".</news>
   </extension>
 </addon>

--- a/script.tvmaze.scrobbler/libs/kodi_service.py
+++ b/script.tvmaze.scrobbler/libs/kodi_service.py
@@ -28,6 +28,11 @@ from kodi_six.xbmcaddon import Addon
 from six.moves import cPickle as pickle
 
 try:
+    from kodi_six.xbmcvfs import translatePath
+except (ImportError, AttributeError):
+    from kodi_six.xbmc import translatePath
+
+try:
     from typing import Text, Dict, Callable, Generator  # pylint: disable=unused-import
 except ImportError:
     pass
@@ -37,9 +42,9 @@ ADDON = Addon()
 ADDON_ID = ADDON.getAddonInfo('id')
 ADDON_NAME = ADDON.getAddonInfo('name')
 ADDON_VERSION = ADDON.getAddonInfo('version')
-ADDON_PROFILE_DIR = xbmc.translatePath(ADDON.getAddonInfo('profile'))
-ADDON_DIR = xbmc.translatePath(ADDON.getAddonInfo('path'))
-ADDON_ICON = xbmc.translatePath(ADDON.getAddonInfo('icon'))
+ADDON_PROFILE_DIR = translatePath(ADDON.getAddonInfo('profile'))
+ADDON_DIR = translatePath(ADDON.getAddonInfo('path'))
+ADDON_ICON = translatePath(ADDON.getAddonInfo('icon'))
 
 if not os.path.exists(ADDON_PROFILE_DIR):
     os.mkdir(ADDON_PROFILE_DIR)


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: TVmaze Scrobbler/Tracker
  - Add-on ID: script.tvmaze.scrobbler
  - Version number: 1.2.1
  - Kodi/repository version: leia

- **Code location**
  - URL: https://github.com/romanvm/kodi.tvmaze.scrobbler
  
Automatically track all TV episodes you are watching to TVmaze. A must have if you want to sync your watch history between various applications.
Sign up for a free account at https://tvmaze.com for more features.

This Kodi TV episode Tracker uses the TVmaze.com user API's scrobbler endpoints(https://static.tvmaze.com/apidoc/)

What this addon does:
- Performs an initial sync between Kodi and TVmaze for the episodes you've watched.
- If you add an episode to the Kodi library it marks it as "acquired" on TVmaze.
- If you watch an episode in Kodi it marks it as "watched" in TVmaze.
- If you mark an episode as watched in TVmaze it marks it as watched in Kodi.

### Description of changes:

1.2.1:
- Fixed compatibility with Kodi 20 "Nexus".

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
