### PR TITLE
[script.service.next-episode@matrix] 1.2.4+matrix.1

### DIFF
--- a/script.service.next-episode/addon.xml
+++ b/script.service.next-episode/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon id="script.service.next-episode"
    name="Next Episode (next-episode.net)"
-   version="1.2.3+matrix.1"
+   version="1.2.4+matrix.1"
    provider-name="next-episode.net">
   <requires>
     <import addon="xbmc.python" version="3.0.0" />
@@ -29,7 +29,7 @@
     <assets>
       <icon>icon.png</icon>
     </assets>
-    <news>1.2.3:
-- Fix broken service.</news>
+    <news>1.2.4:
+- Fixed compatibility with Kodi 20 "Nexus".</news>
   </extension>
 </addon>

--- a/script.service.next-episode/libs/addon.py
+++ b/script.service.next-episode/libs/addon.py
@@ -3,14 +3,22 @@
 # License: GPL v. 3 <http://www.gnu.org/licenses/gpl-3.0.en.html>
 
 from __future__ import unicode_literals
+
 import os
+
 from kodi_six.xbmc import getInfoLabel
 from kodi_six.xbmcaddon import Addon
 
-__all__ = ['ADDON', 'ADDON_ID', 'ADDON_VERSION', 'ICON']
+try:
+    from kodi_six.xbmcvfs import translatePath
+except (ImportError, AttributeError):
+    from kodi_six.xbmc import translatePath
+
+__all__ = ['ADDON', 'ADDON_ID', 'ADDON_VERSION', 'ADDON_PATH', 'ICON']
 
 ADDON = Addon()
 ADDON_ID = ADDON.getAddonInfo('id')
 ADDON_VERSION = ADDON.getAddonInfo('version')
-ICON = os.path.join(ADDON.getAddonInfo('path'), 'icon.png')
+ADDON_PATH = translatePath(ADDON.getAddonInfo('path'))
+ICON = os.path.join(ADDON_PATH, 'icon.png')
 KODI_VERSION = getInfoLabel('System.BuildVersion')[:2]

--- a/script.service.next-episode/libs/exception_logger.py
+++ b/script.service.next-episode/libs/exception_logger.py
@@ -1,0 +1,155 @@
+# coding: utf-8
+# (c) Roman Miroshnychenko <roman1972@gmail.com> 2020
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""Exception logger with extended diagnostic info"""
+
+import inspect
+import sys
+from contextlib import contextmanager
+from platform import uname
+from pprint import pformat
+
+import six
+from kodi_six import xbmc
+
+from .logger import log_error
+
+try:
+    from typing import Text, Dict, Callable, Generator  # pylint: disable=unused-import
+except ImportError:
+    pass
+
+
+def _format_vars(variables):
+    # type: (dict) -> Text
+    """
+    Format variables dictionary
+
+    :param variables: variables dict
+    :return: formatted string with sorted ``var = val`` pairs
+    """
+    var_list = [(var, val) for var, val in six.iteritems(variables)
+                if not (var.startswith('__') or var.endswith('__'))]
+    var_list.sort(key=lambda i: i[0])
+    lines = []
+    for var, val in var_list:
+        lines.append('{} = {}'.format(var, pformat(val)))
+    return '\n'.join(lines)
+
+
+def _format_code_context(frame_info):
+    # type: (tuple) -> Text
+    context = ''
+    if frame_info[4] is not None:
+        for i, line in enumerate(frame_info[4], frame_info[2] - frame_info[5]):
+            if i == frame_info[2]:
+                context += '{}:>{}'.format(six.text_type(i).rjust(5), line)
+            else:
+                context += '{}: {}'.format(six.text_type(i).rjust(5), line)
+    return context
+
+
+FRAME_INFO_TEMPLATE = """File:
+{file_path}:{lineno}
+----------------------------------------------------------------------------------------------------
+Code context:
+{code_context}
+----------------------------------------------------------------------------------------------------
+Local variables:
+{local_vars}
+====================================================================================================
+"""
+
+
+def _format_frame_info(frame_info):
+    # type: (tuple) -> Text
+    return FRAME_INFO_TEMPLATE.format(
+        file_path=frame_info[1],
+        lineno=frame_info[2],
+        code_context=_format_code_context(frame_info),
+        local_vars=_format_vars(frame_info[0].f_locals)
+    )
+
+
+EXCEPTION_TEMPLATE = """
+*********************************** Unhandled exception detected ***********************************
+####################################################################################################
+                                           Diagnostic info
+----------------------------------------------------------------------------------------------------
+Exception type  : {exc_type}
+Exception value : {exc}
+System info     : {system_info}
+Python version  : {python_version}
+Kodi version    : {kodi_version}
+sys.argv        : {sys_argv}
+----------------------------------------------------------------------------------------------------
+sys.path:
+{sys_path}
+####################################################################################################
+                                            Stack Trace
+====================================================================================================
+{stack_trace}
+************************************* End of diagnostic info ***************************************
+"""
+
+
+@contextmanager
+def log_exception(logger_func=log_error):
+    # type: (Callable[[Text], None]) -> Generator[None, None, None]
+    """
+    Diagnostic helper context manager
+
+    It controls execution within its context and writes extended
+    diagnostic info to the Kodi log if an unhandled exception
+    happens within the context. The info includes the following items:
+
+    - System info
+    - Python version
+    - Kodi version
+    - Module path.
+    - Stack trace including:
+        * File path and line number where the exception happened
+        * Code fragment where the exception has happened.
+        * Local variables at the moment of the exception.
+
+    After logging the diagnostic info the exception is re-raised.
+
+    Example::
+
+        with debug_exception():
+            # Some risky code
+            raise RuntimeError('Fatal error!')
+
+    :param logger_func: logger function that accepts a single argument
+        that is a log message.
+    """
+    try:
+        yield
+    except Exception as exc:
+        stack_trace = ''
+        for frame_info in inspect.trace(5):
+            stack_trace += _format_frame_info(frame_info)
+        message = EXCEPTION_TEMPLATE.format(
+            exc_type=exc.__class__.__name__,
+            exc=exc,
+            system_info=uname(),
+            python_version=sys.version.replace('\n', ' '),
+            kodi_version=xbmc.getInfoLabel('System.BuildVersion'),
+            sys_argv=pformat(sys.argv),
+            sys_path=pformat(sys.path),
+            stack_trace=stack_trace
+        )
+        logger_func(message)
+        raise exc

--- a/script.service.next-episode/main.py
+++ b/script.service.next-episode/main.py
@@ -6,6 +6,7 @@
 from __future__ import unicode_literals
 import sys
 import pyxbmct
+from libs.exception_logger import log_exception
 from libs.gui import NextEpDialog, ui_string
 from libs.utils import sync_library, login
 
@@ -39,11 +40,12 @@ class MainDialog(NextEpDialog):
 
 
 if __name__ == '__main__':
-    if 'sync_library' in sys.argv:
-        sync_library()
-    elif 'login' in sys.argv:
-        login()
-    else:
-        main_dialog = MainDialog(520, 160, 2, 1, 'next-episode.net')
-        main_dialog.doModal()
-        del main_dialog
+    with log_exception():
+        if 'sync_library' in sys.argv:
+            sync_library()
+        elif 'login' in sys.argv:
+            login()
+        else:
+            main_dialog = MainDialog(520, 160, 2, 1, 'next-episode.net')
+            main_dialog.doModal()
+            del main_dialog

--- a/script.service.next-episode/service.py
+++ b/script.service.next-episode/service.py
@@ -4,11 +4,14 @@
 # License: GPL v. 3 <http://www.gnu.org/licenses/gpl-3.0.en.html>
 
 from __future__ import unicode_literals
+
+from libs.exception_logger import log_exception
 from libs.logger import log_info
 from libs.monitoring import UpdateMonitor, initial_prompt
 
-initial_prompt()
-update_monitor = UpdateMonitor()
-log_info('Service started')
-update_monitor.waitForAbort()
-log_info('Service stopped')
+with log_exception():
+    initial_prompt()
+    update_monitor = UpdateMonitor()
+    log_info('Service started')
+    update_monitor.waitForAbort()
+    log_info('Service stopped')


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: Next Episode (next-episode.net)
  - Add-on ID: script.service.next-episode
  - Version number: 1.2.4+matrix.1
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/santah/next-episode-kodi
  
The next-episode.net service for Kodi allows to add your movies and TV episodes from media library to your inventory on next-episode.net. The service also monitors video playback and updates 'watched' status of your movies and episodes on next-episode.net.[CR][B]Note:[/B] The addon works only with Kodi medialibrary!

### Description of changes:

1.2.4:
- Fixed compatibility with Kodi 20 "Nexus".

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
