### PR TITLE
[script.xbmc.unpausejumpback@matrix] 3.0.2

### DIFF
--- a/script.xbmc.unpausejumpback/README.md
+++ b/script.xbmc.unpausejumpback/README.md
@@ -3,6 +3,8 @@ Kodi Unpause Jumpback
 
 `script.xbmc.unpausejumpback`
 
+[!["Buy Me A Coffee"](https://www.buymeacoffee.com/assets/img/custom_images/orange_img.png)](https://www.buymeacoffee.com/bossanova808) 
+
 Simple Kodi Service to jump back a configurable number of seconds after pause, or rewind/fast-forward events.
 
 By default the actual jump back happens on **resumption** of playback.  

--- a/script.xbmc.unpausejumpback/addon.xml
+++ b/script.xbmc.unpausejumpback/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.xbmc.unpausejumpback" name="Unpause Jumpback" version="3.0.1" provider-name="bossanova808,Memphiz,Lucleonhart,schumi2004,dkadioglu">
+<addon id="script.xbmc.unpausejumpback" name="Unpause Jumpback" version="3.0.2" provider-name="bossanova808,Memphiz,Lucleonhart,schumi2004,dkadioglu">
   <requires>
     <import addon="xbmc.python" version="3.0.0"/>
   </requires>
@@ -22,10 +22,13 @@
     <license>GPL-3.0-only</license>
     <website>https://github.com/bossanova808/script.xbmc.unpausejumpback/</website>
     <source>https://github.com/bossanova808/script.xbmc.unpausejumpback/</source>
-    <forum>http://forum.xbmc.org/showthread.php?tid=134837</forum>
+    <forum>https://forum.kodi.tv/showthread.php?tid=355778</forum>
     <email>bossonav808@gmail.com</email>
-    <news>v3.0.1
+    <news>v3.0.2
+        [fix] "XBMC is not playing any media file" errors
+        v3.0.1
         [fix] minor bugfix for http/s sources (plugins)
+        [fix] Update for changes to Kodi Matrix logging functions
         v3.0.0
         [new] Update for Kodi Matrix / Python 3, make unpause on resume vs. pause a choice, bugfixes and tidy up.
     </news>

--- a/script.xbmc.unpausejumpback/changelog.txt
+++ b/script.xbmc.unpausejumpback/changelog.txt
@@ -1,3 +1,6 @@
+3.0.2
+- fix "Kodi is not playing any media file" when skipping beyond end of file
+
 3.0.1
 - Minor bugfix with http/s sources (plugins)
 

--- a/script.xbmc.unpausejumpback/resources/lib/common.py
+++ b/script.xbmc.unpausejumpback/resources/lib/common.py
@@ -1,17 +1,18 @@
 # -*- coding: utf-8 -*-
-
-# Handy utility functions for Kodi Addons
-# By bossanova808
-# Free in all senses....
-# VERSION 0.1.4 2020-10-18
-# (For Kodi Matrix & later)
+"""
+Handy utility functions for Kodi Addons
+By bossanova808
+Free in all senses....
+VERSION 0.2.1 2021-06-06
+(For Kodi Matrix & later)
+"""
+import sys
+import traceback
 
 import xbmc
 import xbmcvfs
 import xbmcgui
 import xbmcaddon
-import sys
-import traceback
 
 ADDON = xbmcaddon.Addon()
 ADDON_NAME = ADDON.getAddonInfo('name')
@@ -19,42 +20,167 @@ ADDON_ID = ADDON.getAddonInfo('id')
 ADDON_ICON = ADDON.getAddonInfo('icon')
 ADDON_AUTHOR = ADDON.getAddonInfo('author')
 ADDON_VERSION = ADDON.getAddonInfo('version')
-ADDON_ARGUMENTS = str(sys.argv)
+ADDON_ARGUMENTS = f'{sys.argv}'
 CWD = ADDON.getAddonInfo('path')
 LANGUAGE = ADDON.getLocalizedString
 PROFILE = xbmcvfs.translatePath(ADDON.getAddonInfo('profile'))
 KODI_VERSION = xbmc.getInfoLabel('System.BuildVersion')
-USER_AGENT = "Mozilla/5.0 (Windows; U; Windows NT 5.1; fr; rv:1.9.0.1) Gecko/2008070208 Firefox/3.6"
+USER_AGENT = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Safari/537.36"
+HOME_WINDOW = xbmcgui.Window(10000)
 WEATHER_WINDOW = xbmcgui.Window(12600)
 
 
-def log(message, exception_instance=None, level=xbmc.LOGDEBUG):
-    """
-    Log a message to the Kodi debug log, if debug logging is turned on.
+"""
+Determine if we are unit testing outside of Kodi, or actually running within Kodi
+Because we're using Kodi stubs https://romanvm.github.io/Kodistubs/ we can't rely on 'import xbmc' failing
+So we use this hack - Kodi will return a user agent string, but Kodistrubs just returns and empty string.
+If we are unit testing, change logs -> print
 
-    :param message: required, the message to log
-    :param exception_instance: optional, an instance of some Exception
-    :param level: optional, the Kodi log level to use, default LOGDEBUG
-    """
+In other files, minimal code to make this work is:
 
-    message = f'### {ADDON_NAME} {ADDON_VERSION} - {message}'
-    message_with_exception = message + f' ### Exception: {traceback.format_exc(exception_instance)}'
+# Small hack to allow for unit testing - see common.py for explanation
+if not xbmc.getUserAgent():
+    sys.path.insert(0, '../../..') # modify this depending on actual level - assumes resources/lib/something/file.py
 
-    if exception_instance is None:
-        xbmc.log(message, level)
-    else:
-        xbmc.log(message_with_exception, level)
+from resources.lib.store import Store
+from resources.lib.common import *
+..etc
+
+"""
+
+unit_testing = False
+if not xbmc.getUserAgent():
+
+    xbmc = None
+    unit_testing = True
+    KODI_VERSION = 'N/A'
+
+    print("\nNo user agent, must be unit testing.\n")
+
+    def log(message, exception_instance=None, level=None):
+        print(f'DEBUG: {message}')
+        if exception_instance:
+            print(f'EXCPT: {traceback.format_exc(exception_instance)}')
+
+    def log_info(message, exception_instance=None):
+        log(f'INFO : {message}')
+        if exception_instance:
+            print(f'EXCPT: {traceback.format_exc(exception_instance)}')
+
+else:
+
+    def log(message, exception_instance=None, level=xbmc.LOGDEBUG):
+        """
+        Log a message to the Kodi debug log, if debug logging is turned on.
+
+        :param message: required, the message to log
+        :param exception_instance: optional, an instance of some Exception
+        :param level: optional, the Kodi log level to use, default LOGDEBUG
+        """
+
+        message = f'### {ADDON_NAME} {ADDON_VERSION} - {message}'
+        message_with_exception = message + f' ### Exception: {traceback.format_exc(exception_instance)}'
+
+        if exception_instance is None:
+            xbmc.log(message, level)
+        else:
+            xbmc.log(message_with_exception, level)
 
 
-def log_info(message, exception_instance=None):
-    """
-    Log a message at the LOGINFO level, i.e. even if Kodi debugging is not turned on. Use sparingly.
+    def log_info(message, exception_instance=None):
+        """
+        Log a message at the LOGINFO level, i.e. even if Kodi debugging is not turned on. Use very sparingly.
 
-    :param message: required, the message to log
-    :param exception_instance: optional, an instance of some Exception
-    """
+        :param message: required, the message to log
+        :param exception_instance: optional, an instance of some Exception
+        """
+        log(message, exception_instance, level=xbmc.LOGINFO)
 
-    log(message, exception_instance, level=xbmc.LOGINFO)
+    def set_property(window, name, value=""):
+        """
+        Set a property on a window.
+        To clear a property, provide an empty string
+
+        :param window: Required.  The Kodi window on which to set the property.
+        :param name: Required.  Name of the property.
+        :param value: Optional (defaults to "").  Set the property to this value.  An empty string clears the property.
+        """
+        value = str(value)
+        if value:
+            log(f'Setting window property {name} to value {value}')
+            window.setProperty(name, value)
+        else:
+            log(f'Clearing window property {name}')
+            window.clearProperty(name)
+
+    def get_property(window, name):
+        """
+        Return the value of a window property
+        @param window:
+        @param name:
+        @return:
+        """
+        return window.getProperty(name)
+
+
+    def get_property_as_bool(window, name):
+        """
+        Return the value of a window property as a boolean
+        @param window:
+        @param name:
+        @return:
+        """
+        return window.getProperty(name).lower() == "true"
+
+
+    def send_kodi_json(human_description, json_string):
+        """
+        Send a JSON command to Kodi, logging the human description, command, and result returned.
+
+        :param human_description: Required. A human sensible description of what the command is aiming to do/retrieve.
+        :param json_string: Required. The json command to send.
+        """
+        log(f'KODI JSON RPC command: {human_description} [{json_string}]')
+        result = xbmc.executeJSONRPC(json_string)
+        log(f'KODI JSON RPC result: {result}')
+        return result
+
+
+    def get_setting(setting):
+        """
+        Helper function to get string type from settings
+
+        @param setting:
+        @return: setting value
+        """
+        return ADDON.getSetting(setting).strip()
+
+
+    def get_setting_as_bool(setting):
+        """
+        Helper function to get bool type from settings
+
+        @param setting:
+        @return: setting value as boolen
+        """
+        return get_setting(setting).lower() == "true"
+
+
+    def notify(message, notification_type=xbmcgui.NOTIFICATION_ERROR, duration=5000):
+        """
+        Send a notification to the user via the Kodi GUI
+
+        @param message: the message to send
+        @param notification_type: xbmcgui.NOTIFICATION_ERROR (default), xbmcgui.NOTIFICATION_WARNING, or xbmcgui.NOTIFICATION_INFO
+        @param duration: time to display notification in milliseconds, default 5000
+        @return: None
+        """
+        dialog = xbmcgui.Dialog()
+
+        dialog.notification(ADDON_NAME,
+                            message,
+                            notification_type,
+                            duration)
 
 
 def footprints(startup=True):
@@ -71,47 +197,3 @@ def footprints(startup=True):
         log_info(f'Exiting...')
 
 
-def set_property(window, name, value=""):
-    """
-    Set a property on a window.
-    To clear a property, provide an empty string
-
-    :param window: Required.  The Kodi window on which to set the property.
-    :param name: Required.  Name of the property.
-    :param value: Optional (defaults to "").  Set the property to this value.  An empty string clears the property.
-    """
-    window.setProperty(name, value)
-    # if value and value != False and value != 'na.png':
-    #     log(f'Set window property: [{name}] - value: [{value}]')
-
-
-def send_kodi_json(human_description, json_string):
-    """
-    Send a JSON command to Kodi, logging the human description, command, and result returned.
-
-    :param human_description: Required. A human sensible description of what the command is aiming to do/retrieve.
-    :param json_string: Required. The json command to send.
-    """
-    log(f'KODI JSON RPC command: {human_description} [{json_string}]')
-    result = xbmc.executeJSONRPC(json_string)
-    log(f'KODI JSON RPC result: {str(result)}')
-
-
-def get_setting(setting):
-    """
-    Helper function to get string type from settings
-
-    @param setting:
-    @return: setting value
-    """
-    return ADDON.getSetting(setting).strip()
-
-
-def get_setting_as_bool(setting):
-    """
-    Helper function to get bool type from settings
-
-    @param setting:
-    @return: setting value as boolen
-    """
-    return get_setting(setting).lower() == "true"

--- a/script.xbmc.unpausejumpback/resources/lib/unpause_jumpback.py
+++ b/script.xbmc.unpausejumpback/resources/lib/unpause_jumpback.py
@@ -194,7 +194,13 @@ class MyPlayer(xbmc.Player):
 
         # If the addon is set to do a jump back when playback is started from a resume point...
         if self.jump_back_on_playback_started:
-            current_time = self.getTime()
+            try:
+                current_time = self.getTime()
+            except RuntimeError as exc:
+                log('No file is playing, stopping UnpauseJumpBack')
+                xbmc.executebuiltin('CancelAlarm(JumpbackPaused, true)')
+                pass
+
             log(f'onAVStarted at {current_time}')
 
             # check for exclusion
@@ -216,7 +222,13 @@ class MyPlayer(xbmc.Player):
             direction = 1
             abs_last_speed = abs(self.last_playback_speed)
             # default value, just in case
-            resume_time = self.getTime()
+            try:
+                resume_time = self.getTime()
+            except RuntimeError as exc:
+                log('No file is playing, stopping UnpauseJumpBack')
+                xbmc.executebuiltin('CancelAlarm(JumpbackPaused, true)')
+                pass
+                
             if self.last_playback_speed < 0:
                 log('Resuming. Was rewound with speed X%d.' % (abs(self.last_playback_speed)))
             if self.last_playback_speed > 1:


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: Unpause Jumpback
  - Add-on ID: script.xbmc.unpausejumpback
  - Version number: 3.0.2
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/bossanova808/script.xbmc.unpausejumpback/
  

        This addon will jump back a number of seconds whenever a video is un-paused - to make sure you don't miss anything.
        You can set the amount of seconds to jump back, and the minimum duration of the pause before the addon will trigger a jump back.
        It also allows to jump back or forward after rewind or fast-forward of a specified amount of seconds to compensate for over-shooting.
        (Originally created by Memphiz, up-keep taken over by bossanova808 in 2020 for Kodi Matrix and beyond).
    

### Description of changes:

v3.0.2
        [fix] "Kodi is not playing any media file" errors

Basically if a user skips past the end of the file, trap the error and cancel the unpause alarm.
    

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
