### PR TITLE
[weather.ozweather@matrix] 2.0.1

### DIFF
--- a/weather.ozweather/addon.xml
+++ b/weather.ozweather/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="weather.ozweather" name="Oz Weather" version="2.0.0" provider-name="Bossanova808">
+<addon id="weather.ozweather" name="Oz Weather" version="2.0.1" provider-name="Bossanova808">
 	<requires>
 		<import addon="xbmc.python" version="3.0.0"/>
     	<import addon="script.module.requests" version="2.22.0+matrix.1"/>
@@ -22,9 +22,12 @@
        		<icon>icon.png</icon>
        		<fanart>fanart.jpg</fanart>
 		</assets>
-		<news>V2.0.0
+		<news>v2.01
+			- Tweaks to cope with some BOM weather stations that return incomplete data
+			v2.0.0
 			- N.B. If you have run a version before 2.0, please re-configure the addon to set-up your new BOM locations
 			- Rewrite to use BOM API directly, leave Weatherzone in as a fallback option. if BOM not configured or available
+			- Auto-locate closest radar
 			- Add mechanism to manually purge radar backgrounds via addon settings
 			- Remove periodic refresh of backgrounds in favour of the above
 			- Update settings.xml to new Kodi format

--- a/weather.ozweather/changelog.txt
+++ b/weather.ozweather/changelog.txt
@@ -1,4 +1,8 @@
-V2.0.0
+v2.0.1
+- Deal better with observation stations that don't provide data
+- Set some custom skin labels to improve custom skin file behaviours
+
+v2.0.0
 - N.B. If you have run a version before 2.0, please re-configure the addon to set-up your BOM locations!
 - Rewrite to use BOM API directly, leave Weatherzone in as a fallback option if BOM not configured or available
 - Add mechanism to manually purge radar backgrounds via addon settings

--- a/weather.ozweather/resources/lib/common.py
+++ b/weather.ozweather/resources/lib/common.py
@@ -3,7 +3,7 @@
 Handy utility functions for Kodi Addons
 By bossanova808
 Free in all senses....
-VERSION 0.2.1 2021-06-06
+VERSION 0.2.3 2021-06-21
 (For Kodi Matrix & later)
 """
 import sys
@@ -62,10 +62,6 @@ if not xbmc.getUserAgent():
         if exception_instance:
             print(f'EXCPT: {traceback.format_exc(exception_instance)}')
 
-    def log_info(message, exception_instance=None):
-        log(f'INFO : {message}')
-        if exception_instance:
-            print(f'EXCPT: {traceback.format_exc(exception_instance)}')
 
 else:
 
@@ -75,7 +71,7 @@ else:
 
         :param message: required, the message to log
         :param exception_instance: optional, an instance of some Exception
-        :param level: optional, the Kodi log level to use, default LOGDEBUG
+        :param level: optional, the Kodi log level to use, default LOGDEBUG but can override with level=xbmc.LOGINFO
         """
 
         message = f'### {ADDON_NAME} {ADDON_VERSION} - {message}'
@@ -86,16 +82,6 @@ else:
         else:
             xbmc.log(message_with_exception, level)
 
-
-    def log_info(message, exception_instance=None):
-        """
-        Log a message at the LOGINFO level, i.e. even if Kodi debugging is not turned on. Use very sparingly.
-
-        :param message: required, the message to log
-        :param exception_instance: optional, an instance of some Exception
-        """
-        log(message, exception_instance, level=xbmc.LOGINFO)
-
     def set_property(window, name, value=""):
         """
         Set a property on a window.
@@ -105,6 +91,9 @@ else:
         :param name: Required.  Name of the property.
         :param value: Optional (defaults to "").  Set the property to this value.  An empty string clears the property.
         """
+        if value is None:
+            window.clearProperty(name)
+
         value = str(value)
         if value:
             log(f'Setting window property {name} to value {value}')
@@ -190,10 +179,10 @@ def footprints(startup=True):
     :param startup: optional, default True.  If true, log the startup of an addon, otherwise log the exit.
     """
     if startup:
-        log_info(f'Starting...')
-        log_info(f'Kodi Version: {KODI_VERSION}')
-        log_info(f'Addon arguments: {ADDON_ARGUMENTS}')
+        log(f'Starting...', level=xbmc.LOGINFO)
+        log(f'Kodi Version: {KODI_VERSION}', level=xbmc.LOGINFO)
+        log(f'Addon arguments: {ADDON_ARGUMENTS}', level=xbmc.LOGINFO)
     else:
-        log_info(f'Exiting...')
+        log(f'Exiting...', level=xbmc.LOGINFO)
 
 

--- a/weather.ozweather/resources/lib/forecast.py
+++ b/weather.ozweather/resources/lib/forecast.py
@@ -40,7 +40,10 @@ def clear_properties():
         set_property(WEATHER_WINDOW, 'Current.Condition')
         set_property(WEATHER_WINDOW, 'Current.ConditionLong')
         set_property(WEATHER_WINDOW, 'Current.Temperature')
+        set_property(WEATHER_WINDOW, 'Current.Ozw_Temperature')
         set_property(WEATHER_WINDOW, 'Current.Wind')
+        set_property(WEATHER_WINDOW, 'Current.WindSpeed')
+        set_property(WEATHER_WINDOW, 'Current.Ozw_WindSpeed')
         set_property(WEATHER_WINDOW, 'Current.WindDirection')
         set_property(WEATHER_WINDOW, 'Current.WindDegree')
         set_property(WEATHER_WINDOW, 'Current.WindGust')
@@ -49,7 +52,9 @@ def clear_properties():
         set_property(WEATHER_WINDOW, 'Current.FireDangerText')
         set_property(WEATHER_WINDOW, 'Current.Visibility')
         set_property(WEATHER_WINDOW, 'Current.Humidity')
+        set_property(WEATHER_WINDOW, 'Current.Ozw_Humidity')
         set_property(WEATHER_WINDOW, 'Current.FeelsLike')
+        set_property(WEATHER_WINDOW, 'Current.Ozw_FeelsLike')
         set_property(WEATHER_WINDOW, 'Current.DewPoint')
         set_property(WEATHER_WINDOW, 'Current.UVIndex')
         set_property(WEATHER_WINDOW, 'Current.OutlookIcon')
@@ -179,7 +184,7 @@ def forecast(geohash, url_path, radar_code):
 
     # At this point, we should have _something_ - if not, log the issue and we're done...
     if not weather_data:
-        log_info("Unable to get weather_data from BOM or from Weatherzone - internet connection issue or addon not configured?")
+        log("Unable to get weather_data from BOM OR from Weatherzone - internet connection issue or addon not configured?", level=xbmc.LOGINFO)
         return
 
     # We have weather_data - set all the properties on Kodi's weather window...
@@ -195,8 +200,9 @@ def forecast(geohash, url_path, radar_code):
 
     # And announce everything is fetched..
     set_property(WEATHER_WINDOW, "Weather.IsFetched", "true")
+    set_property(WEATHER_WINDOW, "Daily.IsFetched", "true")
+    set_property(WEATHER_WINDOW, "Today.IsFetched", "true")
     set_property(WEATHER_WINDOW, 'Forecast.Updated', time.strftime("%d/%m/%Y %H:%M"))
-    set_property(WEATHER_WINDOW, 'Today.IsFetched', "true")
 
 
 def get_weather():

--- a/weather.ozweather/resources/lib/weatherzone/weatherzone_forecast.py
+++ b/weather.ozweather/resources/lib/weatherzone/weatherzone_forecast.py
@@ -139,12 +139,18 @@ def getWeatherData(url_path):
             div_current_details_lhs = soup.find("div", class_="details_lhs")
             lhs = div_current_details_lhs.find_all("td", class_="hilite")
 
+            # Labels we set to emulate the BOM data...
+            weather_data["Current.NowLabel"] = "Predicted Min"
+            weather_data["Current.LaterLabel"] = "Predicted Max"
+
             # LHS
             try:
                 weather_data["Current.Temperature"] = str(int(round(float(lhs[0].text[:-2]))))
+                weather_data["Current.OzW_Temperature"] = str(int(round(float(lhs[0].text[:-2]))))
             except Exception as inst:
                 log(str(inst))
                 weather_data["Current.Temperature"] = "?"
+                weather_data["Current.OzW_Temperature"] = "?"
             try:
                 weather_data["Current.DewPoint"] = str(int(round(float(lhs[1].text[:-2]))))
             except Exception as inst:
@@ -152,14 +158,18 @@ def getWeatherData(url_path):
                 weather_data["Current.DewPoint"] = "?"
             try:
                 weather_data["Current.FeelsLike"] = str(int(round(float(lhs[2].text[:-2]))))
+                weather_data["Current.Ozw_FeelsLike"] = str(int(round(float(lhs[2].text[:-2]))))
             except Exception as inst:
                 log(str(inst))
                 weather_data["Current.FeelsLike"] = "?"
+                weather_data["Current.Ozw_FeelsLike"] = "N/A"
             try:
                 weather_data["Current.Humidity"] = str(int(round(float(lhs[3].text[:-1]))))
+                weather_data["Current.Ozw_Humidity"] = str(int(round(float(lhs[3].text[:-1]))))
             except Exception as inst:
                 log(str(inst))
                 weather_data["Current.Humidity"] = "?"
+                weather_data["Current.OzW_Humidity"] = "N/A"
             try:
                 weather_data["Current.WindDirection"] = str(lhs[4].text.split(" ")[0])
                 weather_data["Current.WindDegree"] = weather_data["Current.WindDirection"]
@@ -329,6 +339,8 @@ def getWeatherData(url_path):
                         try:
                             value = '%s' % td.text[:-2]
                             set_keys(weather_data, i, ["HighTemp", "HighTemperature"], value)
+                            if i == 0:
+                                set_key(weather_data, i, "NowValue", value)
                         except Exception as inst:
                             log(str(inst))
                             log("Exception in HighTemp,HighTemperature")
@@ -341,6 +353,8 @@ def getWeatherData(url_path):
                         try:
                             value = '%s' % td.text[:-2]
                             set_keys(weather_data, i, ["LowTemp", "LowTemperature"], value)
+                            if i == 0:
+                                set_key(weather_data, i, "LaterValue", value)
                         except Exception as inst:
                             log(str(inst))
                             log("Exception in LowTemp,LowTemperature")
@@ -368,11 +382,13 @@ def getWeatherData(url_path):
                             value = '%s' % td.text
                             set_key(weather_data, i, "Precipitation", value)
                             set_key(weather_data, i, "RainChanceAmount", value)
+                            set_key(weather_data, i, "RainAmount", value)
                         except Exception as inst:
                             log(str(inst))
                             log("Exception in Precipitation,RainChanceAmount")
                             set_key(weather_data, i, "Precipitation", "?")
                             set_key(weather_data, i, "RainChanceAmount", "?")
+                            set_key(weather_data, i, "RainAmount", "?")
                 # UV
                 if index == 6:
 
@@ -424,6 +440,7 @@ def getWeatherData(url_path):
             for i in range(0, len(wind_speeds9am)):
                 # set_key(i, "WindSpeed", "9am - " + wind_speeds9am[i] + ", 3pm - " + wind_speeds3pm[i])
                 set_key(weather_data, i, "WindSpeed", wind_speeds3pm[i])
+                set_key(weather_data, i, "OzW_WindSpeed", wind_speeds3pm[i])
                 # set_key(i, "WindDirection", "9am - " + wind_directions9am[i] + ", 3pm - " + windDirections3pm[i])
                 set_key(weather_data, i, "WindDirection", wind_directions3pm[i])
 


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: Oz Weather
  - Add-on ID: weather.ozweather
  - Version number: 2.0.1
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/bossanova808/weather.ozweather
  
Weather forecasting and radar images for Australia using Bureau of Meteorology data.  For full features (animated radars & ABC weather videos) - make sure you install the replacement skin files - see information at the addon wiki (https://kodi.wiki/index.php?title=Add-on:Oz_Weather).

### Description of changes:

v2.01
			- Tweaks to cope with some BOM weather stations that return incomplete data
			v2.0.0
			- N.B. If you have run a version before 2.0, please re-configure the addon to set-up your new BOM locations
			- Rewrite to use BOM API directly, leave Weatherzone in as a fallback option. if BOM not configured or available
			- Auto-locate closest radar
			- Add mechanism to manually purge radar backgrounds via addon settings
			- Remove periodic refresh of backgrounds in favour of the above
			- Update settings.xml to new Kodi format
			- Modernise code throughout
    	

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
