### PR TITLE
[script.module.inputstreamhelper@matrix] 0.5.6+matrix.1

### DIFF
--- a/script.module.inputstreamhelper/README.md
+++ b/script.module.inputstreamhelper/README.md
@@ -91,6 +91,10 @@ Please report any issues or bug reports on the [GitHub Issues](https://github.co
 This module is licensed under the **The MIT License**. Please see the [LICENSE.txt](LICENSE.txt) file for details.
 
 ## Releases
+### v0.5.6 (2021-06-24)
+- Improve Widevine CDM installation on ARM hardware (@mediaminister)
+- Postpone Widevine CDM updates when user rejects (@horstle)
+
 ### v0.5.5 (2021-06-02)
 - Improve Widevine CDM installation on ARM hardware (@mediaminister)
 

--- a/script.module.inputstreamhelper/addon.xml
+++ b/script.module.inputstreamhelper/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.module.inputstreamhelper" name="InputStream Helper" version="0.5.5+matrix.1" provider-name="emilsvennesson, dagwieers, mediaminister, horstle">
+<addon id="script.module.inputstreamhelper" name="InputStream Helper" version="0.5.6+matrix.1" provider-name="emilsvennesson, dagwieers, mediaminister, horstle">
   <requires>
     <!--py3 compliant-->
     <import addon="xbmc.python" version="3.0.0"/>
@@ -23,6 +23,10 @@
     <description lang="fr_FR">Un simple module Kodi qui simplifie la vie des développeurs de modules complémentaires en s’appuyant sur des modules complémentaires basés sur InputStream et sur la lecture de DRM.</description>
     <description lang="es_ES">Un módulo Kodi simple que hace la vida más fácil para los desarrolladores de complementos que dependen de complementos basados en InputStream y reproducción de DRM.</description>
     <news>
+### v0.5.6 (2021-06-24)
+- Improve Widevine CDM installation on ARM hardware
+- Postpone Widevine CDM updates when user rejects
+
 v0.5.5 (2021-06-02)
 - Improve Widevine CDM installation on ARM hardware
 

--- a/script.module.inputstreamhelper/lib/inputstreamhelper/__init__.py
+++ b/script.module.inputstreamhelper/lib/inputstreamhelper/__init__.py
@@ -263,6 +263,11 @@ class Helper:
         """Prompts user to upgrade Widevine CDM when a newer version is available."""
         from time import localtime, strftime, time
 
+        update_declined_at = get_setting_float('update_declined_at', 0.0)
+        if update_declined_at + 3600 * 24 * 2 >= time():
+            log(2, 'User had declined an update on {date}', date=strftime('%Y-%m-%d %H:%M', localtime(update_declined_at)))
+            return
+
         last_check = get_setting_float('last_check', 0.0)
         if last_check and not self._first_run():
             if last_check + 3600 * 24 * get_setting_int('update_frequency', 14) >= time():
@@ -294,6 +299,7 @@ class Helper:
             if yesno_dialog(localize(30040), localize(30033), nolabel=localize(30028), yeslabel=localize(30034)):
                 self.install_widevine()
             else:
+                set_setting('update_declined_at', time())
                 log(3, 'User declined to update {component}.', component=component)
         else:
             set_setting('last_check', time())

--- a/script.module.inputstreamhelper/lib/inputstreamhelper/config.py
+++ b/script.module.inputstreamhelper/lib/inputstreamhelper/config.py
@@ -69,6 +69,7 @@ WIDEVINE_MINIMUM_KODI_VERSION = {
 
 HARDCODED_CHROMEOS_IMAGE = {
     'hwid': 'FIEVEL',
+    'hwidmatch': '^FIEVEL .*',
     'url': 'https://dl.google.com/dl/edgedl/chromeos/recovery/chromeos_13505.73.0_veyron-fievel_recovery_stable-channel_fievel-mp.bin.zip',
     'sha1': '9904e3141a2537f28469c7653c62200c1b03b057',
     'version': '13505.73.0',

--- a/script.module.inputstreamhelper/lib/inputstreamhelper/widevine/widevine.py
+++ b/script.module.inputstreamhelper/lib/inputstreamhelper/widevine/widevine.py
@@ -160,14 +160,18 @@ def latest_widevine_version(eula=False):
         versions = http_get(url)
         return versions.split()[-1]
 
-    from .arm import chromeos_config, select_best_chromeos_image
-    devices = chromeos_config()
-    arm_device = select_best_chromeos_image(devices)
+    from .arm import chromeos_config, hardcoded_chromeos_image, select_best_chromeos_image, supports_widevine_arm64tls
+    # Return hardcoded Chrome OS version for systems not supporting newer Widevine CDM's
+    if not supports_widevine_arm64tls():
+        arm_device = hardcoded_chromeos_image()
+    else:
+        devices = chromeos_config()
+        arm_device = select_best_chromeos_image(devices)
     if arm_device is None:
         log(4, 'We could not find an ARM device in the Chrome OS recovery.json')
         ok_dialog(localize(30004), localize(30005))
         return ''
-    return arm_device['version']
+    return arm_device.get('version')
 
 
 def latest_available_widevine_from_repo():

--- a/script.module.inputstreamhelper/resources/language/resource.language.en_gb/strings.po
+++ b/script.module.inputstreamhelper/resources/language/resource.language.en_gb/strings.po
@@ -278,7 +278,7 @@ msgid "{os} probably doesn't support the newest Widevine CDM. Would you try to i
 msgstr ""
 
 msgctxt "#30068"
-msgid "You're going to install an older Widevine CDM. Please note that Google will remove support for older Widevine CDM's on May 31, 2021."
+msgid "You're going to install an older Widevine CDM. Please note that Google will remove support for older Widevine CDM's at some point."
 msgstr ""
 
 

--- a/script.module.inputstreamhelper/resources/settings.xml
+++ b/script.module.inputstreamhelper/resources/settings.xml
@@ -3,6 +3,7 @@
     <category label="30900"> <!-- Expert -->
         <setting id="last_modified" default="0.0" visible="false"/>
         <setting id="last_check" default="0.0" visible="false"/>
+        <setting id="update_declined_at" default="0.0" visible="false"/>
         <setting id="version" default="" visible="false"/>
         <setting label="30901" help="30902" type="action" action="RunScript(script.module.inputstreamhelper, info)"/>
         <setting type="sep"/>


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: InputStream Helper
  - Add-on ID: script.module.inputstreamhelper
  - Version number: 0.5.6+matrix.1
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/emilsvennesson/script.module.inputstreamhelper
  
A simple Kodi module that makes life easier for add-on developers relying on InputStream based add-ons and DRM playback.

### Description of changes:


### v0.5.6 (2021-06-24)
- Improve Widevine CDM installation on ARM hardware
- Postpone Widevine CDM updates when user rejects

v0.5.5 (2021-06-02)
- Improve Widevine CDM installation on ARM hardware

v0.5.4 (2021-05-27)
- Fix Widevine CDM installation on ARM hardware

v0.5.3 (2021-05-10)
- Temporary fix for Widevine CDM installation on ARM hardware
- Fix Widevine CDM installation on 32-bit Linux

v0.5.2 (2020-12-13)
- Update Chrome OS ARM hardware id's

v0.5.1 (2020-10-02)
- Fix incorrect ARM HWIDs: PHASER and PHASER360
- Added Hebrew translations
- Updated Dutch, Japanese and Korean translations

v0.5.0 (2020-06-25)
- Extract Widevine CDM directly from Chrome OS, minimizing disk space usage and eliminating the need for root access
- Improve progress dialog while extracting Widevine CDM on ARM devices
- Support resuming interrupted downloads on unreliable internet connections
- Reshape InputStream Helper information dialog
- Updated Dutch, English, French, German, Greek, Hungarian, Romanian, Russian, Spanish and Swedish translations
    

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
