### PR TITLE
[script.common.plugin.cache] v2.6.1.2

### DIFF
--- a/script.common.plugin.cache/addon.xml
+++ b/script.common.plugin.cache/addon.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='yes'?>
-<addon id="script.common.plugin.cache" name="Common plugin cache" provider-name="anxdpanic, TheCollective" version="2.6.1.1">
+<addon id="script.common.plugin.cache" name="Common plugin cache" provider-name="anxdpanic, TheCollective" version="2.6.1.2">
     <requires>
         <import addon="xbmc.python" version="3.0.0"/>
     </requires>
@@ -7,8 +7,7 @@
     <extension point="xbmc.python.module" library="resources/lib/storage_server/"/>
     <extension point="xbmc.addon.metadata">
         <news>
-[fix] shutdown taking longer than 5 seconds
-[fix] ignore encoding issues for socket data
+[fix] make compatible with Kodi Nexus
         </news>
         <assets>
             <icon>icon.png</icon>

--- a/script.common.plugin.cache/resources/lib/storage_server/StorageServer.py
+++ b/script.common.plugin.cache/resources/lib/storage_server/StorageServer.py
@@ -81,7 +81,7 @@ class StorageServer:
         self.version = to_unicode(self.settings.getAddonInfo('version'))
         self.plugin = u"StorageClient-" + self.version
 
-        self.path = to_unicode(self.xbmc.translatePath('special://temp/'))
+        self.path = to_unicode(self.xbmcvfs.translatePath('special://temp/'))
         if not self.xbmcvfs.exists(self.path):
             self._log(u"Making path structure: " + self.path)
             self.xbmcvfs.mkdir(self.path)
@@ -157,7 +157,7 @@ class StorageServer:
 
             if self._usePosixSockets():
                 self._log("POSIX")
-                self.socket = os.path.join(to_unicode(self.xbmc.translatePath('special://temp/')),
+                self.socket = os.path.join(to_unicode(self.xbmcvfs.translatePath('special://temp/')),
                                            'commoncache.socket')
                 if self.xbmcvfs.exists(self.socket) and check_stale:
                     self._log("Deleting stale socket file : " + self.socket)


### PR DESCRIPTION
### Description
<!--- Provide a short summary of submitted add-on in case it's a new addition. -->
<!--- If it's plugin update only highlight biggest changes if needed. -->
<!--- Make sure you follow the checklist below before finalising your pull-request. -->
replaced xbmc.translatePath with xbmcvfs.translatePath to make the script usable in Kodi Nexus. This change works in Matrix too and removes the xbmc.translatePath deprecated messages from the log
### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [X] Each add-on submission should be a single commit with using the following style: [script.foo.bar] 1.0.0

Additional information :
- Submitting your add-on to this specific branch makes it available to any Kodi version equal or higher than the branch name with the applicable Kodi dependencies limits.
- [add-on development](http://kodi.wiki/view/Add-on_development) wiki page.
- Kodi [pydocs](http://kodi.wiki/view/PyDocs) provide information about the Python API
- [PEP8](https://www.python.org/dev/peps/pep-0008/) codingstyle which is considered best practise but not mandatory.
- This add-on repository has automated code guideline check which could help you improve your coding. You can find the results of these check at [Codacy](https://www.codacy.com/app/Kodi/repo-scripts/dashboard). You can create your own account as well to continuously monitor your python coding before submitting to repo.
- Development questions can be asked in the [add-on development](http://forum.kodi.tv/forumdisplay.php?fid=26) section on the Kodi forum.
