### PR TITLE
[script.module.inputstreamhelper@krypton] 0.5.7

### DIFF
--- a/script.module.inputstreamhelper/README.md
+++ b/script.module.inputstreamhelper/README.md
@@ -91,6 +91,9 @@ Please report any issues or bug reports on the [GitHub Issues](https://github.co
 This module is licensed under the **The MIT License**. Please see the [LICENSE.txt](LICENSE.txt) file for details.
 
 ## Releases
+### v0.5.7 (2021-07-02)
+- Further improve Widevine CDM installation on ARM hardware (@horstle)
+
 ### v0.5.6 (2021-06-24)
 - Improve Widevine CDM installation on ARM hardware (@mediaminister)
 - Postpone Widevine CDM updates when user rejects (@horstle)

--- a/script.module.inputstreamhelper/addon.xml
+++ b/script.module.inputstreamhelper/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.module.inputstreamhelper" name="InputStream Helper" version="0.5.6" provider-name="emilsvennesson, dagwieers, mediaminister, horstle">
+<addon id="script.module.inputstreamhelper" name="InputStream Helper" version="0.5.7" provider-name="emilsvennesson, dagwieers, mediaminister, horstle">
   <requires>
     <!--py3 compliant-->
     <import addon="xbmc.python" version="2.25.0"/>
@@ -23,7 +23,10 @@
     <description lang="fr_FR">Un simple module Kodi qui simplifie la vie des développeurs de modules complémentaires en s’appuyant sur des modules complémentaires basés sur InputStream et sur la lecture de DRM.</description>
     <description lang="es_ES">Un módulo Kodi simple que hace la vida más fácil para los desarrolladores de complementos que dependen de complementos basados en InputStream y reproducción de DRM.</description>
     <news>
-### v0.5.6 (2021-06-24)
+v0.5.7 (2021-07-02)
+- Further improve Widevine CDM installation on ARM hardware
+
+v0.5.6 (2021-06-24)
 - Improve Widevine CDM installation on ARM hardware
 - Postpone Widevine CDM updates when user rejects
 

--- a/script.module.inputstreamhelper/lib/inputstreamhelper/widevine/arm.py
+++ b/script.module.inputstreamhelper/lib/inputstreamhelper/widevine/arm.py
@@ -139,13 +139,22 @@ def supports_widevine_arm64tls():
 
     # LibreELEC 9.2.7: Check if TCMalloc library is preloaded or linked
     libtcmalloc = 'libtcmalloc'
-    process_maps = open('/proc/self/maps', 'r').read()
+    with open('/proc/self/maps', 'r') as maps:
+        process_maps = maps.read()
     is_tcmalloc_preloaded = bool(libtcmalloc in process_maps)
 
     # Experimental: detect TLS 64-byte alignment support, searching for 'arm64tls' string in ldd version
     cmd = ['ldd', '--version']
     ldd_version = run_cmd(cmd).get('output').split('\n')[0].split(' ')[-1]
     has_tls64bytes_support = bool('arm64tls' in ldd_version)
+
+    # Experimental: detect TLS 64-byte alignment support, checking environment variable
+    if not has_tls64bytes_support:
+        try:
+            libc_patchlevel = int(os.environ['LIBC_WIDEVINE_PATCHLEVEL'])
+            has_tls64bytes_support = libc_patchlevel >= 1
+        except KeyError:
+            has_tls64bytes_support = False
 
     return is_tcmalloc_preloaded or has_tls64bytes_support
 


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: InputStream Helper
  - Add-on ID: script.module.inputstreamhelper
  - Version number: 0.5.7
  - Kodi/repository version: krypton

- **Code location**
  - URL: https://github.com/emilsvennesson/script.module.inputstreamhelper
  
A simple Kodi module that makes life easier for add-on developers relying on InputStream based add-ons and DRM playback.

### Description of changes:


v0.5.7 (2021-07-02)
- Further improve Widevine CDM installation on ARM hardware

v0.5.6 (2021-06-24)
- Improve Widevine CDM installation on ARM hardware
- Postpone Widevine CDM updates when user rejects

v0.5.5 (2021-06-02)
- Improve Widevine CDM installation on ARM hardware

v0.5.4 (2021-05-27)
- Fix Widevine CDM installation on ARM hardware

v0.5.3 (2021-05-10)
- Temporary fix for Widevine CDM installation on ARM hardware
- Fix Widevine CDM installation on 32-bit Linux

v0.5.2 (2020-12-13)
- Update Chrome OS ARM hardware id's

v0.5.1 (2020-10-02)
- Fix incorrect ARM HWIDs: PHASER and PHASER360
- Added Hebrew translations
- Updated Dutch, Japanese and Korean translations

v0.5.0 (2020-06-25)
- Extract Widevine CDM directly from Chrome OS, minimizing disk space usage and eliminating the need for root access
- Improve progress dialog while extracting Widevine CDM on ARM devices
- Support resuming interrupted downloads on unreliable internet connections
- Reshape InputStream Helper information dialog
- Updated Dutch, English, French, German, Greek, Hungarian, Romanian, Russian, Spanish and Swedish translations
    

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
