### PR TITLE
[script.common.plugin.cache@matrix] 2.6.3+matrix.1

### DIFF
--- a/script.common.plugin.cache/addon.xml
+++ b/script.common.plugin.cache/addon.xml
@@ -1,21 +1,21 @@
-<?xml version='1.0' encoding='UTF-8' standalone='yes'?>
-<addon id="script.common.plugin.cache" name="Common plugin cache" provider-name="anxdpanic, TheCollective" version="2.6.1.1">
-    <requires>
-        <import addon="xbmc.python" version="3.0.0"/>
-    </requires>
-    <extension point="xbmc.service" library="resources/lib/entry_point.py"/>
-    <extension point="xbmc.python.module" library="resources/lib/storage_server/"/>
-    <extension point="xbmc.addon.metadata">
-        <news>
-[fix] shutdown taking longer than 5 seconds
-[fix] ignore encoding issues for socket data
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<addon id="script.common.plugin.cache" name="Common plugin cache" provider-name="anxdpanic, TheCollective" version="2.6.3+matrix.1">
+  <requires>
+    <import addon="xbmc.python" version="3.0.0"/>
+  </requires>
+  <extension point="xbmc.service" library="resources/lib/entry_point.py"/>
+  <extension point="xbmc.python.module" library="resources/lib/storage_server/"/>
+  <extension point="xbmc.addon.metadata">
+    <news>
+[fix] use xbmcvfs.translatePath when available, xbmc.translatePath deprecated(Matrix) and removed(Nexus) |contrib: Gujal00|
         </news>
-        <assets>
-            <icon>icon.png</icon>
-        </assets>
-        <platform>all</platform>
-        <summary lang="en_GB">A common caching API for Kodi add-ons.</summary>
-        <license>GPL-3.0-only</license>
-        <source>https://github.com/anxdpanic/script.common.plugin.cache</source>
-    </extension>
+    <assets>
+      <icon>icon.png</icon>
+    </assets>
+    <platform>all</platform>
+    <license>GPL-3.0-only</license>
+    <source>https://github.com/anxdpanic/script.common.plugin.cache</source>
+    <summary lang="en_GB">A common caching API for Kodi add-ons.</summary>
+    <description lang="en_GB">A common caching API for Kodi add-ons.</description>
+  </extension>
 </addon>

--- a/script.common.plugin.cache/resources/language/resource.language.en_gb/strings.po
+++ b/script.common.plugin.cache/resources/language/resource.language.en_gb/strings.po
@@ -17,6 +17,14 @@ msgstr ""
 "Language: en\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
 
+msgctxt "Addon Summary"
+msgid "A common caching API for Kodi add-ons."
+msgstr ""
+
+msgctxt "Addon Description"
+msgid "A common caching API for Kodi add-ons."
+msgstr ""
+
 msgctxt "#32001"
 msgid "General"
 msgstr ""

--- a/script.common.plugin.cache/resources/lib/storage_server/StorageServer.py
+++ b/script.common.plugin.cache/resources/lib/storage_server/StorageServer.py
@@ -68,6 +68,11 @@ class StorageServer:
             import xbmcgui
             self.xbmcgui = xbmcgui
 
+        if hasattr(self.xbmcvfs, "translatePath"):
+            self.translate_path = self.xbmcvfs.translatePath
+        else:
+            self.translate_path = self.xbmc.translatePath
+
         self.instance = instance
         self._sock = None
         self.die = False
@@ -81,7 +86,7 @@ class StorageServer:
         self.version = to_unicode(self.settings.getAddonInfo('version'))
         self.plugin = u"StorageClient-" + self.version
 
-        self.path = to_unicode(self.xbmc.translatePath('special://temp/'))
+        self.path = to_unicode(self.translate_path('special://temp/'))
         if not self.xbmcvfs.exists(self.path):
             self._log(u"Making path structure: " + self.path)
             self.xbmcvfs.mkdir(self.path)
@@ -157,7 +162,7 @@ class StorageServer:
 
             if self._usePosixSockets():
                 self._log("POSIX")
-                self.socket = os.path.join(to_unicode(self.xbmc.translatePath('special://temp/')),
+                self.socket = os.path.join(to_unicode(self.translate_path('special://temp/')),
                                            'commoncache.socket')
                 if self.xbmcvfs.exists(self.socket) and check_stale:
                     self._log("Deleting stale socket file : " + self.socket)


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: Common plugin cache
  - Add-on ID: script.common.plugin.cache
  - Version number: 2.6.3+matrix.1
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/anxdpanic/script.common.plugin.cache
  
A common caching API for Kodi add-ons.

### Description of changes:


[fix] use xbmcvfs.translatePath when available, xbmc.translatePath deprecated(Matrix) and removed(Nexus) |contrib: Gujal00|
        

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
