### PR TITLE
[service.watchedlist] 1.3.3

### DIFF
--- a/service.watchedlist/addon.xml
+++ b/service.watchedlist/addon.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="service.watchedlist"
     name="WatchedList"
-    version="1.3.2"
+    version="1.3.3"
     provider-name="schapplm">
     <requires>
         <import addon="xbmc.python" version="3.0.0"/>

--- a/service.watchedlist/changelog.txt
+++ b/service.watchedlist/changelog.txt
@@ -1,3 +1,6 @@
+version 1.3.3 (01.08.2021)
+* Fix for new python interface in Kodi v20
+
 version 1.3 (24.04.2020)
 * Updated to work with Python 3
 

--- a/service.watchedlist/lib/watchedlist/utils.py
+++ b/service.watchedlist/lib/watchedlist/utils.py
@@ -21,7 +21,7 @@ def data_dir():
     """"get user data directory of this addon.
     according to http://wiki.xbmc.org/index.php?title=Add-on_Rules#Requirements_for_scripts_and_plugins
     """
-    _datapath = xbmc.translatePath(_Addon.getAddonInfo('profile'))
+    _datapath = xbmcvfs.translatePath(_Addon.getAddonInfo('profile'))
     if not xbmcvfs.exists(_datapath):
         xbmcvfs.mkdir(_datapath)
     return _datapath

--- a/service.watchedlist/lib/watchedlist/watchedlist.py
+++ b/service.watchedlist/lib/watchedlist/watchedlist.py
@@ -409,7 +409,7 @@ class WatchedList:
                 # load the db path
                 if utils.getSetting("extdb") == 'false':
                     # use the default file
-                    self.dbdirectory = xbmc.translatePath(utils.data_dir())
+                    self.dbdirectory = xbmcvfs.translatePath(utils.data_dir())
                     buggalo.addExtraData('dbdirectory', self.dbdirectory)
                     self.dbpath = os.path.join(self.dbdirectory, "watchedlist.db")
                 else:
@@ -417,7 +417,7 @@ class WatchedList:
 
                     while not self.monitor.abortRequested():
                         # use a user specified file, for example to synchronize multiple clients
-                        self.dbdirectory = xbmc.translatePath(utils.getSetting("dbpath"))
+                        self.dbdirectory = xbmcvfs.translatePath(utils.getSetting("dbpath"))
                         self.dbfileaccess = utils.fileaccessmode(self.dbdirectory)
                         self.dbpath = os.path.join(self.dbdirectory, utils.getSetting("dbfilename"))
 
@@ -446,7 +446,7 @@ class WatchedList:
                     buggalo.addExtraData('dbdirectory_copy', self.dbdirectory_copy)
                     buggalo.addExtraData('dbpath_copy', self.dbpath_copy)
                     # work in copy directory in the Kodi profile folder
-                    self.dbdirectory = os.path.join(xbmc.translatePath(utils.data_dir()), 'dbcopy' + os.sep)
+                    self.dbdirectory = os.path.join(xbmcvfs.translatePath(utils.data_dir()), 'dbcopy' + os.sep)
                     if not xbmcvfs.exists(self.dbdirectory):  # directory has to end with '/' (os.sep)
                         xbmcvfs.mkdir(self.dbdirectory)
                         utils.log(u'created directory %s' % str(self.dbdirectory))


### PR DESCRIPTION
Fix for [changed interface of xbmc.translatePath()](https://forum.kodi.tv/showthread.php?tid=344263&pid=2975581#pid2975581).
This fix is not necessary in Kodi 19, but is needed for Kodi 20.
No change of functionality.