### PR TITLE
[service.subtitles.rvm.addic7ed@matrix] 3.1.7+matrix.1

### DIFF
--- a/service.subtitles.rvm.addic7ed/addic7ed/utils.py
+++ b/service.subtitles.rvm.addic7ed/addic7ed/utils.py
@@ -5,6 +5,7 @@
 # License: GPL v.3 https://www.gnu.org/copyleft/gpl.html
 
 from __future__ import absolute_import, unicode_literals
+import json
 import re
 from collections import namedtuple
 from kodi_six import xbmc
@@ -57,20 +58,22 @@ class logger(object):
 
 def get_now_played():
     """
-    Get info about the currently played file via Kodi InfoLabels.
-    Alternatively this can be done via JSON-RPC
-    but looks like it does not return correct file path if file path
-    is actually an url and it there was a redirect.
+    Get info about the currently played file via JSON-RPC
 
     :return: currently played item's data
     :rtype: dict
     """
-    item = {
-        'season': xbmc.getInfoLabel('VideoPlayer.Season'),
-        'episode': xbmc.getInfoLabel('VideoPlayer.Episode'),
-        'showtitle': xbmc.getInfoLabel('VideoPlayer.TVShowTitle'),
-        'file': xbmc.Player().getPlayingFile(),
-    }
+    request = json.dumps({
+        'jsonrpc': '2.0',
+        'method': 'Player.GetItem',
+        'params': {
+            'playerid': 1,
+            'properties': ['showtitle', 'season', 'episode']
+         },
+        'id': '1'
+    })
+    item = json.loads(xbmc.executeJSONRPC(request))['result']['item']
+    item['file'] = xbmc.Player().getPlayingFile()  # It provides more correct result
     return item
 
 

--- a/service.subtitles.rvm.addic7ed/addon.xml
+++ b/service.subtitles.rvm.addic7ed/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon id="service.subtitles.rvm.addic7ed"
   name="Addic7ed.com"
-  version="3.1.6+matrix.1"
+  version="3.1.7+matrix.1"
   provider-name="Roman V.M.">
 <requires>
   <import addon="xbmc.python" version="3.0.0"/>
@@ -32,12 +32,11 @@
     <icon>icon.png</icon>
     <fanart>fanart.jpg</fanart>
   </assets>
-  <news>3.1.6:
+  <news>3.1.7
+- Fixed crashes when playing non-medialibrary items.
+3.1.6:
 - Fixed compatibility with Kodi 20 "Nexus".
-- Various internal changes.
-
-3.1.5:
-- Fixed a crash when downloading subs for the first time after installing the addon.</news>
+- Various internal changes.</news>
   <reuselanguageinvoker>false</reuselanguageinvoker>
 </extension>
 </addon>


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: Addic7ed.com
  - Add-on ID: service.subtitles.rvm.addic7ed
  - Version number: 3.1.7+matrix.1
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/romanvm/service.addic7ed
  
Subtitles service for Addic7ed.com. It supports only TV shows.

### Description of changes:

3.1.7
- Fixed crashes when playing non-medialibrary items.
3.1.6:
- Fixed compatibility with Kodi 20 "Nexus".
- Various internal changes.

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
