### PR TITLE
[script.service.next-episode@krypton] 1.2.5

### DIFF
--- a/script.service.next-episode/addon.xml
+++ b/script.service.next-episode/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon id="script.service.next-episode"
    name="Next Episode (next-episode.net)"
-   version="1.2.4"
+   version="1.2.5"
    provider-name="next-episode.net">
   <requires>
     <import addon="xbmc.python" version="2.25.0" />
@@ -29,7 +29,10 @@
     <assets>
       <icon>icon.png</icon>
     </assets>
-    <news>1.2.4:
+    <news>1.2.5:
+- Fixed crashes when movies do not have IMDB ID.
+
+1.2.4:
 - Fixed compatibility with Kodi 20 "Nexus".</news>
   </extension>
 </addon>

--- a/script.service.next-episode/libs/medialibrary.py
+++ b/script.service.next-episode/libs/medialibrary.py
@@ -119,12 +119,11 @@ def get_tvdb_id(tvshowid):
         params['properties'].append('uniqueid')
     result = send_json_rpc('VideoLibrary.GetTVShowDetails',
                            params)['tvshowdetails']
+    tvdbid = None
     if 'uniqueid' in result and result['uniqueid'].get('tvdb'):
         tvdbid = result['uniqueid']['tvdb']
     elif result.get('imdbnumber'):
         tvdbid = result['imdbnumber']
-    else:
-        raise NoDataError('Missing TVDB ID: {0}'.format(result))
     return tvdbid
 
 

--- a/script.service.next-episode/libs/nextepisode.py
+++ b/script.service.next-episode/libs/nextepisode.py
@@ -140,12 +140,14 @@ def prepare_movies_list(raw_movies):
     """
     listing = []
     for movie in raw_movies:
+        imdb_id = None
         if 'tt' in movie['imdbnumber']:
             imdb_id = movie['imdbnumber']
-        else:
+        elif 'uniqueid' in movie and movie['uniqueid'].get('imdb'):
             imdb_id = movie['uniqueid']['imdb']
-        watched = '1' if movie['playcount'] else '0'
-        listing.append({'imdb_id': imdb_id, 'watched': watched})
+        if imdb_id is not None:
+            watched = '1' if movie['playcount'] else '0'
+            listing.append({'imdb_id': imdb_id, 'watched': watched})
     return listing
 
 
@@ -161,15 +163,19 @@ def prepare_episodes_list(raw_episodes):
     listing = []
     thetvdb_id_map = {}
     for episode in raw_episodes:
-        season_num = str(episode['season'])
-        episode_num = str(episode['episode'])
-        watched = '1' if episode['playcount'] else '0'
         if episode['tvshowid'] not in thetvdb_id_map:
-            thetvdb_id_map[episode['tvshowid']] = get_tvdb_id(episode['tvshowid'])
-        listing.append(
-            {'thetvdb_id': thetvdb_id_map[episode['tvshowid']],
-             'season': season_num,
-             'episode': episode_num,
-             'watched': watched}
-        )
+            tvdb_id = get_tvdb_id(episode['tvshowid'])
+            thetvdb_id_map[episode['tvshowid']] = tvdb_id
+        else:
+            tvdb_id = thetvdb_id_map[episode['tvshowid']]
+        if tvdb_id is not None:
+            season_num = str(episode['season'])
+            episode_num = str(episode['episode'])
+            watched = '1' if episode['playcount'] else '0'
+            listing.append(
+                {'thetvdb_id': tvdb_id,
+                 'season': season_num,
+                 'episode': episode_num,
+                 'watched': watched}
+            )
     return listing

--- a/script.service.next-episode/libs/utils.py
+++ b/script.service.next-episode/libs/utils.py
@@ -206,22 +206,28 @@ def update_single_item(item):
             'hash': ADDON.getSetting('hash')
         }}
     if item['type'] == 'episode':
-        data['tvshows'] = [{
-            'thetvdb_id': get_tvdb_id(item['tvshowid']),
-            'season': str(item['season']),
-            'episode': str(item['episode']),
-            'watched': '1' if item['playcount'] else '0'
+        tvdb_id = get_tvdb_id(item['tvshowid'])
+        if tvdb_id is not None:
+            data['tvshows'] = [{
+                'thetvdb_id': tvdb_id,
+                'season': str(item['season']),
+                'episode': str(item['episode']),
+                'watched': '1' if item['playcount'] else '0'
             }]
     elif item['type'] == 'movie':
-        data['movies'] = [{
-            'watched': '1' if item['playcount'] else '0'
-        }]
+        imdb_id = None
         if 'tt' in item['imdbnumber']:
-            data['imdb_id'] = item['imdbnumber']
-        else:
-            data['imdb_id'] = item['uniqueid']['imdb']
-    log_data_sent(data)
-    send_data(data)
+            imdb_id = item['imdbnumber']
+        elif 'uniqueid' in item and item['uniqueid'].get('imdb'):
+            imdb_id = item['uniqueid']['imdb']
+        if imdb_id is not None:
+            data['movies'] = [{
+                'imdb_id': imdb_id,
+                'watched': '1' if item['playcount'] else '0'
+            }]
+    if data.get('movies') or data.get('tvshows'):
+        log_data_sent(data)
+        send_data(data)
 
 
 def login():


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: Next Episode (next-episode.net)
  - Add-on ID: script.service.next-episode
  - Version number: 1.2.5
  - Kodi/repository version: krypton

- **Code location**
  - URL: https://github.com/santah/next-episode-kodi
  
The next-episode.net service for Kodi allows to add your movies and TV episodes from media library to your inventory on next-episode.net. The service also monitors video playback and updates 'watched' status of your movies and episodes on next-episode.net.[CR][B]Note:[/B] The addon works only with Kodi medialibrary!

### Description of changes:

1.2.5:
- Fixed crashes when movies do not have IMDB ID.

1.2.4:
- Fixed compatibility with Kodi 20 "Nexus".

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
