### PR TITLE
[script.tubecast@matrix] 1.4.7+matrix.1

### DIFF
--- a/script.tubecast/README.md
+++ b/script.tubecast/README.md
@@ -34,6 +34,10 @@ Support will only be provided via the forum thread in [Kodi's Forums](https://fo
 
 None, for now at least :)
 
+### Translations
+
+You can help translating this addon at [Kodi's weblate](https://kodi.weblate.cloud/projects/kodi-add-ons-scripts/script-tubecast/)
+
 ### Notes
 
 - Tubecast uses the `System.FriendlyName` infolabel to get the name to be advertised to the youtube application. In some systems this value is not available and the value defined for the setting `Kodi advertisement name (fallback)` will be used instead

--- a/script.tubecast/addon.xml
+++ b/script.tubecast/addon.xml
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.tubecast" name="TubeCast" version="1.4.6+matrix.0" provider-name="enen92">
+<addon id="script.tubecast" name="TubeCast" version="1.4.7+matrix.1" provider-name="enen92">
     <requires>
         <import addon="xbmc.python" version="3.0.0"/>
         <import addon="script.module.bottle" version="0.12.0"/>
-        <import addon="script.module.requests" version="2.12.4"/>
-        <import addon="plugin.video.tubed" version="1.0.1+matrix.1"/>
+        <import addon="script.module.requests" version="2.25.1+matrix.1"/>
+        <import addon="plugin.video.tubed" version="1.0.1+matrix.1" optional="true"/>
+        <import addon="plugin.video.youtube" version="6.8.16+matrix.1" optional="true"/>
     </requires>
     <extension point="xbmc.python.script" library="script.py" />
     <extension point="xbmc.service" library="main.py"/>
@@ -12,22 +13,27 @@
         <summary lang="en_GB">Cast videos from the Youtube application to Kodi</summary>
         <summary lang="pt_PT">Cast de vídeos a partir da aplicação móvel Youtube para o Kodi</summary>
         <summary lang="es_ES">Transmitir videos desde la aplicación de Youtube a Kodi</summary>
+        <summary lang="ru_RU">Транслируйте видео из приложения Youtube в Kodi</summary>
         <description lang="en_GB">An implementation of the Cast V1 protocol in Kodi to act as a player for the Youtube mobile application</description>
         <description lang="pt_PT">Uma implementação do protocolo Cast V1 no Kodi para este funcionar como player externo remotamente controlado pela aplicação móvel do YouTube</description>
         <description lang="es_ES">Una implementación del protocolo Cast V1 en Kodi para actuar como reproductor externo para la aplicación móvil de Youtube</description>
+        <description lang="ru_RU">Реализация протокола Cast V1 для работы в качестве проигрывателя в мобильном приложении Youtube</description>
         <platform>all</platform>
         <license>MIT</license>
         <forum>https://forum.kodi.tv/showthread.php?tid=329153</forum>
         <email>enen92@kodi.tv</email>
         <source>https://github.com/enen92/script.tubecast</source>
         <news>
-            [new] use tubed instead of youtube
-            [new] branch based CI strategy
-            [del] python2 support
+            [fix] Fix cast with new youtube app (tks @ivanich @Chalanxe @patrickkfkan)
+            [fix] Bump requirements
+            [new] Added translation support via weblate
+            [new] russian translation (tks @DimmKG)
+            [new] Add setting to allow the use of youtube instead of tubed
         </news>
         <disclaimer lang="en_GB">This is not a full chromecast implementation nor will it ever be. It will only work as long as Google keep backwards compatibility with the cast v1 protocol in the Youtube application. Deeply inspired by Leapcast and gotubecast projects</disclaimer>
         <disclaimer lang="pt_PT">Este addon não é uma implementação completa do protocolo cast nem nunca será. Apenas funcionará enquanto a Google mantiver a retrocompatibilidade com o protocolo cast v1 na aplicação móvel do youtube. Inspirado no Leapcast e gotubecast</disclaimer>
-	    <disclaimer lang="es_ES">Esta no es una implementación completa de Chromecast ni lo será nunca. Solo funcionará mientras Google mantenga la compatibilidad con el protocolo Cast v1 en la aplicación Youtube. Profundamente inspirado por los proyectos Leapcast y gotubecast</disclaimer>
+        <disclaimer lang="es_ES">Esta no es una implementación completa de Chromecast ni lo será nunca. Solo funcionará mientras Google mantenga la compatibilidad con el protocolo Cast v1 en la aplicación Youtube. Profundamente inspirado por los proyectos Leapcast y gotubecast</disclaimer>
+        <disclaimer lang="ru_RU">Это не полная реализация протокола Chromecast и не будет таковой. Это будет работать только до тех пор, пока Google не прекратит поддержку обратной совместимости с протоколом cast v1 в приложении Youtube. Вдохновленный проектами Leapcast и gotubecast</disclaimer>
         <assets>
             <icon>resources/img/icon.png</icon>
             <fanart>resources/img/fanart.jpg</fanart>

--- a/script.tubecast/resources/language/resource.language.en_gb/strings.po
+++ b/script.tubecast/resources/language/resource.language.en_gb/strings.po
@@ -80,3 +80,15 @@ msgstr ""
 msgctxt "#32015"
 msgid "Kodi advertisement name (fallback)"
 msgstr ""
+
+msgctxt "#32016"
+msgid "Playback adddon"
+msgstr ""
+
+msgctxt "#32017"
+msgid "Tubed"
+msgstr ""
+
+msgctxt "#32018"
+msgid "Youtube"
+msgstr ""

--- a/script.tubecast/resources/language/resource.language.pt_pt/strings.po
+++ b/script.tubecast/resources/language/resource.language.pt_pt/strings.po
@@ -80,3 +80,15 @@ msgstr "Depuração de pedidos HTTP"
 msgctxt "#32015"
 msgid "Kodi advertisement name (fallback)"
 msgstr "Nome para o Kodi (fallback)"
+
+msgctxt "#32016"
+msgid "Playback addon"
+msgstr "Addon para playback"
+
+msgctxt "#32017"
+msgid "Tubed"
+msgstr "Tubed"
+
+msgctxt "#32018"
+msgid "Youtube"
+msgstr "Youtube"

--- a/script.tubecast/resources/language/resource.language.ru_ru/strings.po
+++ b/script.tubecast/resources/language/resource.language.ru_ru/strings.po
@@ -7,15 +7,14 @@ msgstr ""
 "Project-Id-Version: XBMC Addons\n"
 "Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: roliverosc\n"
-"Language-Team: Spanish (http://www.transifex.com/projects/p/xbmc-addons/language/es/)\n"
+"PO-Revision-Date: 2021-06-21 01:15+0700\n"
+"Last-Translator: Dmitry Petrov <dimakrm361@gmail.com>\n"
+"Language: ru_ru\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: es_ES\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
-
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"Language-Team: \n"
 
 msgctxt "#32000"
 msgid "TubeCast"
@@ -23,64 +22,67 @@ msgstr "TubeCast"
 
 msgctxt "#32001"
 msgid "Getting pairing code..."
-msgstr "Obteniendo código de emparejamiento"
+msgstr "Получение кода..."
 
 msgctxt "#32002"
 msgid "Please insert the following code in YouTube app settings"
-msgstr "Por favor, inserte el siguiente código en los ajustes de la aplicación YouTube"
+msgstr "Пожалуйста введите указанный ниже код в приложении Youtube"
 
 msgctxt "#32003"
 msgid "General"
-msgstr "General"
+msgstr "Общие"
 
 msgctxt "#32004"
 msgid "Enable service discovery (SSDP)"
-msgstr "Habilitar servicio de descubrimiento (SSDP)"
+msgstr "Включить протокол обнаружения SSDP"
 
 msgctxt "#32005"
 msgid "Debug SSDP datagrams"
-msgstr "Mostrar datagramas SSDP"
+msgstr "Отладка SSDP датаграмм"
 
 msgctxt "#32006"
 msgid "connected"
-msgstr "Conectado"
+msgstr "подключен"
 
 msgctxt "#32007"
 msgid "disconnected"
-msgstr "Desconectado"
+msgstr "отключен"
 
 msgctxt "#32008"
 msgid "Do you want to generate a new pairing code?"
-msgstr "¿Quieré generar un nuevo código de emparejamiento?"
+msgstr "Вы хотите получить новый код для подключения?"
 
 msgctxt "#32009"
 msgid "Yes"
-msgstr "Si"
+msgstr "Да"
 
 msgctxt "#32010"
 msgid "No"
-msgstr "No"
+msgstr "Нет"
 
 msgctxt "#32011"
 msgid "Debug youtube cmds"
-msgstr "Mostrar comandos YouTube"
+msgstr "Отладка команд youtube"
 
 msgctxt "#32012"
 msgid "Debug"
-msgstr "Depuración"
+msgstr "Отладка"
 
 msgctxt "#32013"
 msgid "Verify SSL connections"
-msgstr "Verificar conexiones SSL"
+msgstr "Проверять SSL соединения"
 
 msgctxt "#32014"
 msgid "Debug HTTP requests"
-msgstr "Mostrar solicitudes HTTP"
+msgstr "Отладка HTTP запросов"
+
+msgctxt "#32015"
+msgid "Kodi advertisement name (fallback)"
+msgstr "Имя устройства (альтернатива)"
 
 msgctxt "#32016"
 msgid "Playback addon"
 msgstr ""
-
 
 msgctxt "#32017"
 msgid "Tubed"

--- a/script.tubecast/resources/lib/tubecast/youtube/app.py
+++ b/script.tubecast/resources/lib/tubecast/youtube/app.py
@@ -231,7 +231,8 @@ class YoutubeCastV1(object):
                 "app": self.default_screen_app,
                 "pairing_code": pairing_code,
                 "screen_id": self.screen_id,
-                "screen_name": self.default_screen_name
+                "screen_name": self.default_screen_name,
+                "device_id": self.default_screen_name
             },
             verify=get_setting_as_bool("verify-ssl")
         )

--- a/script.tubecast/resources/lib/tubecast/youtube/kodibrigde.py
+++ b/script.tubecast/resources/lib/tubecast/youtube/kodibrigde.py
@@ -17,8 +17,12 @@ def set_kodi_volume(volume):
 
 
 def get_youtube_plugin_path(videoid, seek=0):  # type: (str, str) -> str
-    return "plugin://plugin.video.tubed/?mode=play&video_id={}&start_offset={}".format(
-        videoid, float(seek))
+    if utils.get_setting("playback-addon") == "Tubed":
+        return "plugin://plugin.video.tubed/?mode=play&video_id={}&start_offset={}".format(
+            videoid, float(seek))
+    else:
+        return "plugin://plugin.video.youtube/play/?video_id={}&seek={}".format(
+            videoid, float(seek))
 
 
 def remote_connected(name):

--- a/script.tubecast/resources/settings.xml
+++ b/script.tubecast/resources/settings.xml
@@ -3,7 +3,8 @@
 	<category label="32003">
 		<setting label="32004" type="bool" id="enable-ssdp" default="true"/>
 		<setting label="32013" type="bool" id="verify-ssl" default="true"/>
-		<setting label="32015" type="text" id="kodi-advertise" default="Kodi-TV" />
+		<setting label="32015" type="text" id="kodi-advertise" default="Kodi-TV"/>
+		<setting label="32016" type="labelenum" id="playback-addon" lvalues="32017|32018"/>
 	</category>
 	<category label="32012">
 		<setting label="32005" type="bool" id="debug-ssdp" default="false"/>


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: TubeCast
  - Add-on ID: script.tubecast
  - Version number: 1.4.7+matrix.1
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/enen92/script.tubecast
  
An implementation of the Cast V1 protocol in Kodi to act as a player for the Youtube mobile application

### Description of changes:


            [fix] Fix cast with new youtube app (tks @ivanich @Chalanxe @patrickkfkan)
            [fix] Bump requirements
            [new] Added translation support via weblate
            [new] russian translation (tks @DimmKG)
            [new] Add setting to allow the use of youtube instead of tubed
        

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
