### PR TITLE
[script.tubecast@krypton] 1.4.6

### DIFF
--- a/script.tubecast/addon.xml
+++ b/script.tubecast/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.tubecast" name="TubeCast" version="1.4.5" provider-name="enen92">
+<addon id="script.tubecast" name="TubeCast" version="1.4.6" provider-name="enen92">
     <requires>
         <import addon="xbmc.python" version="2.25.0"/>
         <import addon="script.module.bottle" version="0.12.0"/>
@@ -12,21 +12,24 @@
         <summary lang="en_GB">Cast videos from the Youtube application to Kodi</summary>
         <summary lang="pt_PT">Cast de vídeos a partir da aplicação móvel Youtube para o Kodi</summary>
         <summary lang="es_ES">Transmitir videos desde la aplicación de Youtube a Kodi</summary>
+	<summary lang="ru_RU">Транслируйте видео из приложения Youtube в Kodi</summary>
         <description lang="en_GB">An implementation of the Cast V1 protocol in Kodi to act as a player for the Youtube mobile application</description>
         <description lang="pt_PT">Uma implementação do protocolo Cast V1 no Kodi para este funcionar como player externo remotamente controlado pela aplicação móvel do YouTube</description>
         <description lang="es_ES">Una implementación del protocolo Cast V1 en Kodi para actuar como reproductor externo para la aplicación móvil de Youtube</description>
+	<description lang="ru_RU">Реализация протокола Cast V1 для работы в качестве проигрывателя в мобильном приложении Youtube</description>
         <platform>all</platform>
         <license>MIT</license>
         <forum>https://forum.kodi.tv/showthread.php?tid=329153</forum>
         <email>enen92@kodi.tv</email>
         <source>https://github.com/enen92/script.tubecast</source>
         <news>
-            [fix] missing ctt key (tks romainreignier)
-            [fix] add default id if friendlyname is missing
+            [fix] Fix cast with new youtube app (tks @ivanich @Chalanxe @patrickkfkan)
+            [new] russian translation (tks @DimmKG)
         </news>
         <disclaimer lang="en_GB">This is not a full chromecast implementation nor will it ever be. It will only work as long as Google keep backwards compatibility with the cast v1 protocol in the Youtube application. Deeply inspired by Leapcast and gotubecast projects</disclaimer>
         <disclaimer lang="pt_PT">Este addon não é uma implementação completa do protocolo cast nem nunca será. Apenas funcionará enquanto a Google mantiver a retrocompatibilidade com o protocolo cast v1 na aplicação móvel do youtube. Inspirado no Leapcast e gotubecast</disclaimer>
-	    <disclaimer lang="es_ES">Esta no es una implementación completa de Chromecast ni lo será nunca. Solo funcionará mientras Google mantenga la compatibilidad con el protocolo Cast v1 en la aplicación Youtube. Profundamente inspirado por los proyectos Leapcast y gotubecast</disclaimer>
+	<disclaimer lang="es_ES">Esta no es una implementación completa de Chromecast ni lo será nunca. Solo funcionará mientras Google mantenga la compatibilidad con el protocolo Cast v1 en la aplicación Youtube. Profundamente inspirado por los proyectos Leapcast y gotubecast</disclaimer>
+	<disclaimer lang="ru_RU">Это не полная реализация протокола Chromecast и не будет таковой. Это будет работать только до тех пор, пока Google не прекратит поддержку обратной совместимости с протоколом cast v1 в приложении Youtube. Вдохновленный проектами Leapcast и gotubecast</disclaimer>
         <assets>
             <icon>resources/img/icon.png</icon>
             <fanart>resources/img/fanart.jpg</fanart>

--- a/script.tubecast/resources/language/resource.language.ru_ru/strings.po
+++ b/script.tubecast/resources/language/resource.language.ru_ru/strings.po
@@ -1,0 +1,81 @@
+# Kodi Media Center language file
+# Addon Name: TubeCast
+# Addon id: script.tubecast
+# Addon Provider: enen92
+msgid ""
+msgstr ""
+"Project-Id-Version: XBMC Addons\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
+"POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"PO-Revision-Date: 2021-06-21 01:15+0700\n"
+"Last-Translator: Dmitry Petrov <dimakrm361@gmail.com>\n"
+"Language: ru_ru\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"Language-Team: \n"
+
+msgctxt "#32000"
+msgid "TubeCast"
+msgstr "TubeCast"
+
+msgctxt "#32001"
+msgid "Getting pairing code..."
+msgstr "Получение кода..."
+
+msgctxt "#32002"
+msgid "Please insert the following code in YouTube app settings"
+msgstr "Пожалуйста введите указанный ниже код в приложении Youtube"
+
+msgctxt "#32003"
+msgid "General"
+msgstr "Общие"
+
+msgctxt "#32004"
+msgid "Enable service discovery (SSDP)"
+msgstr "Включить протокол обнаружения SSDP"
+
+msgctxt "#32005"
+msgid "Debug SSDP datagrams"
+msgstr "Отладка SSDP датаграмм"
+
+msgctxt "#32006"
+msgid "connected"
+msgstr "подключен"
+
+msgctxt "#32007"
+msgid "disconnected"
+msgstr "отключен"
+
+msgctxt "#32008"
+msgid "Do you want to generate a new pairing code?"
+msgstr "Вы хотите получить новый код для подключения?"
+
+msgctxt "#32009"
+msgid "Yes"
+msgstr "Да"
+
+msgctxt "#32010"
+msgid "No"
+msgstr "Нет"
+
+msgctxt "#32011"
+msgid "Debug youtube cmds"
+msgstr "Отладка команд youtube"
+
+msgctxt "#32012"
+msgid "Debug"
+msgstr "Отладка"
+
+msgctxt "#32013"
+msgid "Verify SSL connections"
+msgstr "Проверять SSL соединения"
+
+msgctxt "#32014"
+msgid "Debug HTTP requests"
+msgstr "Отладка HTTP запросов"
+
+msgctxt "#32015"
+msgid "Kodi advertisement name (fallback)"
+msgstr "Имя устройства (альтернатива)"

--- a/script.tubecast/resources/lib/tubecast/youtube/app.py
+++ b/script.tubecast/resources/lib/tubecast/youtube/app.py
@@ -235,7 +235,8 @@ class YoutubeCastV1(object):
                 "app": self.default_screen_app,
                 "pairing_code": pairing_code,
                 "screen_id": self.screen_id,
-                "screen_name": self.default_screen_name
+                "screen_name": self.default_screen_name,
+                "device_id": self.default_screen_name
             },
             verify=get_setting_as_bool("verify-ssl")
         )
@@ -249,7 +250,8 @@ class YoutubeCastV1(object):
                 "app": self.default_screen_app,
                 "lounge_token": self.lounge_token,
                 "screen_id": self.screen_id,
-                "screen_name": self.default_screen_name
+                "screen_name": self.default_screen_name,
+                "device_id": self.default_screen_name
             },
             verify=get_setting_as_bool("verify-ssl")
         )


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: TubeCast
  - Add-on ID: script.tubecast
  - Version number: 1.4.6
  - Kodi/repository version: krypton

- **Code location**
  - URL: https://github.com/enen92/script.tubecast
  
An implementation of the Cast V1 protocol in Kodi to act as a player for the Youtube mobile application

### Description of changes:


            [fix] Fix cast with new youtube app (tks @ivanich @Chalanxe @patrickkfkan)
            [new] russian translation (tks @DimmKG)
        

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
