### PR TITLE
[script.module.libmediathek4] Replace deprecated inputstreamaddon

### DIFF
--- a/script.module.libmediathek4/lib/libmediathek4.py
+++ b/script.module.libmediathek4/lib/libmediathek4.py
@@ -215,7 +215,7 @@ class lm4:
 				streamType = 'AUDIO'
 		listitem = xbmcgui.ListItem(path=url)
 		if streamType == 'DASH':
-			listitem.setProperty('inputstreamaddon', 'inputstream.adaptive')
+			listitem.setProperty('inputstream', 'inputstream.adaptive')
 			listitem.setProperty('inputstream.adaptive.manifest_type', 'mpd')
 			if 'licenseserverurl' in item:
 				listitem.setProperty('inputstream.adaptive.license_type', 'com.widevine.alpha')


### PR DESCRIPTION
I couldn't find the original repository from the author (@sarbes) anymore and there have been no responses on the forum in these two threads where users report this issue:

https://forum.kodi.tv/showthread.php?tid=353903
https://forum.kodi.tv/showthread.php?tid=353560

As I found the fix described in the second thread above to be rather simple, I now created this PR. If this is not the proper way to submit the fix, please apologize. But fixing this would probably help quite a few users (at least the ones who want to use the filmfriend plugin, like me).

After applying this fix I had to [install the Widevine lib as described here](https://github.com/Sandmann79/xbmc/wiki/Manual-Widevine-installation) and now I can use the filmfriend plugin!