### PR TITLE
[script.service.playbackresumer@matrix] 2.0.3

### DIFF
--- a/script.service.playbackresumer/addon.xml
+++ b/script.service.playbackresumer/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.service.playbackresumer" name="Kodi Playback Resumer" version="2.0.2" provider-name="bossanova808, bradvido88">
+<addon id="script.service.playbackresumer" name="Kodi Playback Resumer" version="2.0.3" provider-name="bossanova808, bradvido88">
   <requires>
     <import addon="xbmc.python" version="3.0.0"/>
   </requires>
@@ -15,7 +15,10 @@
     <source>https://github.com/bossanova808/script.service.playbackresumer</source>
     <forum>https://forum.kodi.tv/showthread.php?tid=355383</forum>
     <email>bossanova808@gmail.com</email>
-    <news>v2.0.2
+    <news>v2.0.3
+      - Bug fix for playing non-library videos
+      - Use common code, better logging
+      v2.0.2
       - Complete re-write into more modular, modern Python 3
       - Add support for advancedsettings ignoresecondsatstart and ignorepercentatend
       - Handle player seeking past end of file more gracefully

--- a/script.service.playbackresumer/changelog.txt
+++ b/script.service.playbackresumer/changelog.txt
@@ -1,3 +1,7 @@
+v2.0.3
+- Bug fix for playing non-library videos
+- Use common code, better logging
+
 v2.0.2
 - Complete re-write into more modular, modern Python 3
 - Add support for advancedsettings ignoresecondsatstart and ignorepercentatend

--- a/script.service.playbackresumer/resources/lib/player.py
+++ b/script.service.playbackresumer/resources/lib/player.py
@@ -52,6 +52,9 @@ class KodiPlayer(xbmc.Player):
     def onAVStarted(self):
         log("onAVStarted")
 
+        # Clean up - get rid of any data about any files previously played
+        Store.clear_old_play_details()
+
         if not self.isPlayingVideo():
             log("Not playing a video - skipping: " + self.getPlayingFile())
             return
@@ -101,11 +104,11 @@ class KodiPlayer(xbmc.Player):
 
                 if Store.kodi_event_monitor.abortRequested():
                     log("Kodi is shutting down, and will save resume point")
-                    # Kodi is shutting down while playing a video. We want to save the resume point.
+                    # Kodi is shutting down while playing a video.
                     return
 
                 if self.isPlaying():
-                    # a new video has started playing. Kodi is not shutting down
+                    # a new video has started playing. Kodi is not actually shutting down
                     break
 
                 xbmc.sleep(100)
@@ -116,30 +119,34 @@ class KodiPlayer(xbmc.Player):
                 f' setting of {Store.ignore_seconds_at_start}')
             return
 
-        # Short circuit if current time > Kodi's ignorepercentatend setting
+        # Short circuits
+
+        # No library ID or weird library ID
+        if not Store.library_id or Store.library_id < 0:
+            log(f"No/invalid library id ({Store.library_id}) for {Store.currently_playing_file_path} so can't set a resume point")
+            return
+        # Kodi doing its normal stopping thing
+        if seconds == -2:
+            log("Not updating Kodi native resume point because the file was stopped normally, so Kodi should do it itself")
+            return
+        # At this point if seconds is < 0, it is -1 meaning end of file/clear resume point
+        if seconds < 0:
+            # zero indicates to JSON-RPC to remove the resume point
+            seconds = 0
+
+        # if current time > Kodi's ignorepercentatend setting
         percent_played = int((seconds * 100) / Store.length_of_currently_playing_file)
         if percent_played > (100 - Store.ignore_percent_at_end):
             log(f'Not updating resume point as current percent played ({percent_played}) is above Kodi\'s ignorepercentatend'
                 f' setting of {Store.ignore_percent_at_end}')
             return
 
-        # OK, BELOW HERE, we're actually setting a resume point...
+        # OK, BELOW HERE, we're probably going to set a resume point
 
-        # First update the resume point in the tracker file for later retrieval
+        # First update the resume point in the tracker file for later retrieval if needed
         log(f'Setting custom resume seconds to {seconds}')
         with open(Store.file_to_store_resume_point, 'w') as f:
             f.write(str(seconds))
-
-        # Now, update the Kodi library resume point for this video via JSON-RPC API
-        if Store.library_id < 0:
-            log(f'Can\'t update Kodi native resume point because {Store.currently_playing_file_path} is not in the library')
-            return
-        if seconds == -2:
-            log("Not updating Kodi native resume point because the file was stopped normally, so Kodi will do it anyway")
-            return
-        if seconds < 0:
-            # zero indicates to JSON-RPC to remove the resume point
-            seconds = 0
 
         # Log what we are doing
         if seconds == 0:
@@ -150,18 +157,21 @@ class KodiPlayer(xbmc.Player):
         # Determine the JSON-RPC setFooDetails method to use and what the library id name is based of the type of video
         if Store.type_of_video == 'episode':
             method = 'SetEpisodeDetails'
+            get_method = 'GetEpisodeDetails'
             id_name = 'episodeid'
         elif Store.type_of_video == 'movie':
             method = 'SetMovieDetails'
+            get_method = 'GetMovieDetails'
             id_name = 'movieid'
         elif Store.type_of_video == 'musicvideo':
             method = 'SetMusicVideoDetails'
+            get_method = 'GetMusicVideoDetails'
             id_name = 'musicvideoid'
         else:
             log(f'Can\'t update resume point as did not recognise type of video [{Store.type_of_video}]')
             return
 
-        query = {
+        query = json.dumps({
             "jsonrpc": "2.0",
             "id": "setResumePoint",
             "method": "VideoLibrary." + method,
@@ -172,11 +182,20 @@ class KodiPlayer(xbmc.Player):
                     # "total": 0 # Not needed: https://forum.kodi.tv/showthread.php?tid=161912&pid=1596436#pid1596436
                 }
             }
-        }
+        })
+        send_kodi_json(f'Set resume point to {seconds}', query)
 
-        log(f'Executing JSON-RPC: {json.dumps(query)}')
-        json_response = json.loads(xbmc.executeJSONRPC(json.dumps(query)))
-        log(f'JSON-RPC VideoLibrary.{method} response: {json.dumps(json_response)}')
+        # For debugging - let's retrieve and log the current resume point...
+        query = json.dumps({
+            "jsonrpc": "2.0",
+            "id": "getResumePoint",
+            "method": "VideoLibrary." + get_method,
+            "params": {
+                id_name: Store.library_id,
+                "properties": ["resume"],
+            }
+        })
+        send_kodi_json(f'Get resume point for id {Store.library_id}', query)
 
     def resume_if_was_playing(self):
         """

--- a/script.service.playbackresumer/resources/lib/store.py
+++ b/script.service.playbackresumer/resources/lib/store.py
@@ -76,6 +76,23 @@ class Store:
         log(f"Using ignoresecondsatstart: {Store.ignore_seconds_at_start}, ignorepercentatend: {Store.ignore_percent_at_end}")
 
     @staticmethod
+    def clear_old_play_details():
+        """
+        As soon as a new file is played, clear out all old references to anything that was being stored as the currently playing file
+        :return:
+        """
+        log("New playback - clearing legacy now playing details")
+        Store.library_id = None
+        Store.currently_playing_file_path = None
+        Store.type_of_video = None
+        Store.paused_time = None
+        Store.length_of_currently_playing_file = None
+        with open(Store.file_to_store_last_played, 'w+') as f:
+            f.write('')
+        with open(Store.file_to_store_resume_point, 'w+') as f:
+            f.write('')
+
+    @staticmethod
     def load_config_from_settings():
         """
         Load in the addon settings, at start or reload them if they have been changed


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: Kodi Playback Resumer
  - Add-on ID: script.service.playbackresumer
  - Version number: 2.0.3
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/bossanova808/script.service.playbackresumer
  

        Runs as a service and will periodically update the resume point while videos are playing, so you can re-start from where you were in the event of a crash.  It can also automatically resume a video if Kodi was shutdown while playing it. See setting to configure how often the resume point is set, and whether to automatically resume.
    

### Description of changes:

v2.0.3
      - Bug fix for playing non-library videos
      - Use common code, better logging
      v2.0.2
      - Complete re-write into more modular, modern Python 3
      - Add support for advancedsettings ignoresecondsatstart and ignorepercentatend
      - Handle player seeking past end of file more gracefully
    

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
