### PR TITLE
[script.module.inputstreamhelper@krypton] 0.5.8

### DIFF
--- a/script.module.inputstreamhelper/README.md
+++ b/script.module.inputstreamhelper/README.md
@@ -91,6 +91,11 @@ Please report any issues or bug reports on the [GitHub Issues](https://github.co
 This module is licensed under the **The MIT License**. Please see the [LICENSE.txt](LICENSE.txt) file for details.
 
 ## Releases
+### v0.5.8 (2021-09-09)
+- Simplify Widevine CDM installation on ARM hardware (@horstle, @mediaminister)
+- Update Chrome OS ARM hardware id's (@mediaminister)
+- Update Japanese and Korean translations (@Thunderbird2086)
+
 ### v0.5.7 (2021-07-02)
 - Further improve Widevine CDM installation on ARM hardware (@horstle)
 

--- a/script.module.inputstreamhelper/addon.xml
+++ b/script.module.inputstreamhelper/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.module.inputstreamhelper" name="InputStream Helper" version="0.5.7" provider-name="emilsvennesson, dagwieers, mediaminister, horstle">
+<addon id="script.module.inputstreamhelper" name="InputStream Helper" version="0.5.8" provider-name="emilsvennesson, dagwieers, mediaminister, horstle">
   <requires>
     <!--py3 compliant-->
     <import addon="xbmc.python" version="2.25.0"/>
@@ -23,6 +23,11 @@
     <description lang="fr_FR">Un simple module Kodi qui simplifie la vie des développeurs de modules complémentaires en s’appuyant sur des modules complémentaires basés sur InputStream et sur la lecture de DRM.</description>
     <description lang="es_ES">Un módulo Kodi simple que hace la vida más fácil para los desarrolladores de complementos que dependen de complementos basados en InputStream y reproducción de DRM.</description>
     <news>
+v0.5.8 (2021-09-09)
+- Simplify Widevine CDM installation on ARM hardware
+- Update Chrome OS ARM hardware id's
+- Update Japanese and Korean translations
+
 v0.5.7 (2021-07-02)
 - Further improve Widevine CDM installation on ARM hardware
 

--- a/script.module.inputstreamhelper/lib/inputstreamhelper/__init__.py
+++ b/script.module.inputstreamhelper/lib/inputstreamhelper/__init__.py
@@ -10,7 +10,7 @@ from .kodiutils import (addon_version, delete, exists, get_proxies, get_setting,
                         kodi_to_ascii, kodi_version, listdir, localize, log, notification, ok_dialog, progress_dialog, select_dialog,
                         set_setting, set_setting_bool, textviewer, translate_path, yesno_dialog)
 from .utils import arch, http_download, remove_tree, run_cmd, store, system_os, temp_path, unzip
-from .widevine.arm import install_widevine_arm, unmount
+from .widevine.arm import install_widevine_arm
 from .widevine.widevine import (backup_path, has_widevinecdm, ia_cdm_path, install_cdm_from_backup, latest_available_widevine_from_repo,
                                 latest_widevine_version, load_widevine_config, missing_widevine_libs, widevine_config_path, widevine_eula, widevinecdm_path)
 from .unicodes import compat_path
@@ -332,15 +332,6 @@ class Helper:
     @staticmethod
     def cleanup():
         """Clean up function after Widevine CDM installation"""
-        unmount()
-        if store('attached_loop_dev'):
-            cmd = ['losetup', '-d', store('loop_dev')]
-            unattach_output = run_cmd(cmd, sudo=True)
-            if unattach_output['success']:
-                store('loop_dev', False)
-                store('attached_loop_dev', False)
-        if store('modprobe_loop'):
-            notification(localize(30035), localize(30036))  # Unload by hand in CLI
         if not has_widevinecdm():
             remove_tree(ia_cdm_path())
 

--- a/script.module.inputstreamhelper/lib/inputstreamhelper/config.py
+++ b/script.module.inputstreamhelper/lib/inputstreamhelper/config.py
@@ -67,15 +67,6 @@ WIDEVINE_MINIMUM_KODI_VERSION = {
     'Darwin': '18.0'
 }
 
-HARDCODED_CHROMEOS_IMAGE = {
-    'hwid': 'FIEVEL',
-    'hwidmatch': '^FIEVEL .*',
-    'url': 'https://dl.google.com/dl/edgedl/chromeos/recovery/chromeos_13505.73.0_veyron-fievel_recovery_stable-channel_fievel-mp.bin.zip',
-    'sha1': '9904e3141a2537f28469c7653c62200c1b03b057',
-    'version': '13505.73.0',
-    'zipfilesize': '1032442523'
-}
-
 WIDEVINE_VERSIONS_URL = 'https://dl.google.com/widevine-cdm/versions.txt'
 
 WIDEVINE_DOWNLOAD_URL = 'https://dl.google.com/widevine-cdm/{version}-{os}-{arch}.zip'
@@ -91,7 +82,7 @@ CHROMEOS_RECOVERY_URL = 'https://dl.google.com/dl/edgedl/chromeos/recovery/recov
 # To keep the Chrome OS ARM hardware ID list up to date, the following resources can be used:
 # https://www.chromium.org/chromium-os/developer-information-for-chrome-os-devices
 # https://cros-updates-serving.appspot.com/
-# Last updated: 2021-05-05
+# Last updated: 2021-09-06
 CHROMEOS_RECOVERY_ARM_HWIDS = [
     'BOB',
     'BURNET',
@@ -100,6 +91,8 @@ CHROMEOS_RECOVERY_ARM_HWIDS = [
     'DUMO',
     'ELM',
     'ESCHE',
+    'FENNEL',
+    'FENNEL14',
     'FIEVEL',
     'HANA',
     'JUNIPER-HVPU',
@@ -110,7 +103,8 @@ CHROMEOS_RECOVERY_ARM_HWIDS = [
     'KODAMA',
     'KRANE-ZDKS',
     'LAZOR',
-    'POMPOM',
+    'LIMOZEEN',
+    'POMPOM-MZVS',
     'SCARLET',
     'TIGER',
     'WILLOW-TFIY',

--- a/script.module.inputstreamhelper/lib/inputstreamhelper/widevine/widevine.py
+++ b/script.module.inputstreamhelper/lib/inputstreamhelper/widevine/widevine.py
@@ -160,13 +160,9 @@ def latest_widevine_version(eula=False):
         versions = http_get(url)
         return versions.split()[-1]
 
-    from .arm import chromeos_config, hardcoded_chromeos_image, select_best_chromeos_image, supports_widevine_arm64tls
-    # Return hardcoded Chrome OS version for systems not supporting newer Widevine CDM's
-    if not supports_widevine_arm64tls():
-        arm_device = hardcoded_chromeos_image()
-    else:
-        devices = chromeos_config()
-        arm_device = select_best_chromeos_image(devices)
+    from .arm import chromeos_config, select_best_chromeos_image
+    devices = chromeos_config()
+    arm_device = select_best_chromeos_image(devices)
     if arm_device is None:
         log(4, 'We could not find an ARM device in the Chrome OS recovery.json')
         ok_dialog(localize(30004), localize(30005))

--- a/script.module.inputstreamhelper/resources/language/resource.language.en_gb/strings.po
+++ b/script.module.inputstreamhelper/resources/language/resource.language.en_gb/strings.po
@@ -145,14 +145,6 @@ msgctxt "#30034"
 msgid "Update"
 msgstr ""
 
-msgctxt "#30035"
-msgid "[B]loop[/B] is still loaded"
-msgstr ""
-
-msgctxt "#30036"
-msgid "Unload it by running [B]modprobe -r loop[/B] in the terminal."
-msgstr ""
-
 msgctxt "#30037"
 msgid "Success!"
 msgstr ""
@@ -241,10 +233,6 @@ msgctxt "#30058"
 msgid "Time remaining: {mins:d}:{secs:02d}"
 msgstr ""
 
-msgctxt "#30059"
-msgid "Meanwhile, should we try extracting Widevine CDM using the legacy method?"
-msgstr ""
-
 msgctxt "#30060"
 msgid "Identifying wanted partition..."
 msgstr ""
@@ -268,19 +256,6 @@ msgstr ""
 msgctxt "#30065"
 msgid "Shall we try again?"
 msgstr ""
-
-msgctxt "#30066"
-msgid "Warning"
-msgstr ""
-
-msgctxt "#30067"
-msgid "{os} probably doesn't support the newest Widevine CDM. Would you try to install an older Widevine CDM instead?"
-msgstr ""
-
-msgctxt "#30068"
-msgid "You're going to install an older Widevine CDM. Please note that Google will remove support for older Widevine CDM's at some point."
-msgstr ""
-
 
 
 ### INFORMATION DIALOG

--- a/script.module.inputstreamhelper/resources/language/resource.language.ja_jp/strings.po
+++ b/script.module.inputstreamhelper/resources/language/resource.language.ja_jp/strings.po
@@ -145,14 +145,6 @@ msgctxt "#30034"
 msgid "Update"
 msgstr "アップデート"
 
-msgctxt "#30035"
-msgid "[B]loop[/B] is still loaded"
-msgstr "[B]loop[/B]がまだロードされている。"
-
-msgctxt "#30036"
-msgid "Unload it by running [B]modprobe -r loop[/B] in the terminal."
-msgstr "アンロードするには、ターミナルで[B]modprobe -r loop[/B]を実行してください。"
-
 msgctxt "#30037"
 msgid "Success!"
 msgstr "成功！"
@@ -241,10 +233,6 @@ msgctxt "#30058"
 msgid "Time remaining: {mins:d}:{secs:02d}"
 msgstr "残り時間: {mins:d}:{secs:02d}"
 
-msgctxt "#30059"
-msgid "Meanwhile, should we try extracting Widevine CDM using the legacy method?"
-msgstr "そしたら、Widevine CDMを既存の方法で抽出しましょうか。"
-
 msgctxt "#30060"
 msgid "Identifying wanted partition..."
 msgstr "パーティション確認中。。。"
@@ -268,6 +256,19 @@ msgstr "ダウンロードを終えませんでした。"
 msgctxt "#30065"
 msgid "Shall we try again?"
 msgstr "もう一度やって見ましょうか。"
+
+msgctxt "#30066"
+msgid "Warning"
+msgstr "警告"
+
+msgctxt "#30067"
+msgid "{os} probably doesn't support the newest Widevine CDM. Would you try to install an older Widevine CDM instead?"
+msgstr "{os}は最新のWidevine CDMをサーポートしないかも知れないので少し古いのをインストールしましょうか。"
+
+msgctxt "#30068"
+msgid "You're going to install an older Widevine CDM. Please note that Google will remove support for older Widevine CDM's at some point."
+msgstr "古いWidevine CDMをインストールしようとします。グーグルが突然サーポートをしなくなる場合もあります。"
+
 
 
 ### INFORMATION DIALOG

--- a/script.module.inputstreamhelper/resources/language/resource.language.ko_kr/strings.po
+++ b/script.module.inputstreamhelper/resources/language/resource.language.ko_kr/strings.po
@@ -145,14 +145,6 @@ msgctxt "#30034"
 msgid "Update"
 msgstr "업데이트"
 
-msgctxt "#30035"
-msgid "[B]loop[/B] is still loaded"
-msgstr "[B]loop[/B]이 아직 올라와 있습니다 "
-
-msgctxt "#30036"
-msgid "Unload it by running [B]modprobe -r loop[/B] in the terminal."
-msgstr "터미널에서 [B]modprobe -r loop[/B]을 이용하여 내리십시오."
-
 msgctxt "#30037"
 msgid "Success!"
 msgstr "성공!"
@@ -241,10 +233,6 @@ msgctxt "#30058"
 msgid "Time remaining: {mins:d}:{secs:02d}"
 msgstr "남은 시간: {mins:d}:{secs:02d}"
 
-msgctxt "#30059"
-msgid "Meanwhile, should we try extracting Widevine CDM using the legacy method?"
-msgstr "그러면, Widevine CDM을 예전방식으로 풀어낼까요?"
-
 msgctxt "#30060"
 msgid "Identifying wanted partition..."
 msgstr "파티션 확인 중..."
@@ -268,6 +256,19 @@ msgstr "내려받기를 끝내지 못 했습니다."
 msgctxt "#30065"
 msgid "Shall we try again?"
 msgstr "다시 할까요?"
+
+msgctxt "#30066"
+msgid "Warning"
+msgstr "경고"
+
+msgctxt "#30067"
+msgid "{os} probably doesn't support the newest Widevine CDM. Would you try to install an older Widevine CDM instead?"
+msgstr "{os}에서는 최신의 Widevine CDM을 사용하지 못할 수 있으니, 이전의 Widevine CDM을 설치할까요?"
+
+msgctxt "#30068"
+msgid "You're going to install an older Widevine CDM. Please note that Google will remove support for older Widevine CDM's at some point."
+msgstr "이전의 Widevine CDM을 설치하려고 합니다. Google이 어느 시점에 지원을 중단할 수 있습니다."
+
 
 
 ### INFORMATION DIALOG


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: InputStream Helper
  - Add-on ID: script.module.inputstreamhelper
  - Version number: 0.5.8
  - Kodi/repository version: krypton

- **Code location**
  - URL: https://github.com/emilsvennesson/script.module.inputstreamhelper
  
A simple Kodi module that makes life easier for add-on developers relying on InputStream based add-ons and DRM playback.

### Description of changes:


v0.5.8 (2021-09-09)
- Simplify Widevine CDM installation on ARM hardware
- Update Chrome OS ARM hardware id's
- Update Japanese and Korean translations

v0.5.7 (2021-07-02)
- Further improve Widevine CDM installation on ARM hardware

v0.5.6 (2021-06-24)
- Improve Widevine CDM installation on ARM hardware
- Postpone Widevine CDM updates when user rejects

v0.5.5 (2021-06-02)
- Improve Widevine CDM installation on ARM hardware

v0.5.4 (2021-05-27)
- Fix Widevine CDM installation on ARM hardware

v0.5.3 (2021-05-10)
- Temporary fix for Widevine CDM installation on ARM hardware
- Fix Widevine CDM installation on 32-bit Linux

v0.5.2 (2020-12-13)
- Update Chrome OS ARM hardware id's

v0.5.1 (2020-10-02)
- Fix incorrect ARM HWIDs: PHASER and PHASER360
- Added Hebrew translations
- Updated Dutch, Japanese and Korean translations

v0.5.0 (2020-06-25)
- Extract Widevine CDM directly from Chrome OS, minimizing disk space usage and eliminating the need for root access
- Improve progress dialog while extracting Widevine CDM on ARM devices
- Support resuming interrupted downloads on unreliable internet connections
- Reshape InputStream Helper information dialog
- Updated Dutch, English, French, German, Greek, Hungarian, Romanian, Russian, Spanish and Swedish translations
    

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
