### PR TITLE
[screensaver.kaster@krypton] 1.3.6

### DIFF
--- a/screensaver.kaster/addon.xml
+++ b/screensaver.kaster/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="screensaver.kaster" name="Kaster" version="1.3.5" provider-name="enen92">
+<addon id="screensaver.kaster" name="Kaster" version="1.3.6" provider-name="enen92">
 	<requires>
 		<import addon="xbmc.python" version="2.25.0"/>
 		<import addon="script.module.requests" version="2.22.0"/>
@@ -20,8 +20,9 @@
 		<description lang="es_ES">Muestra bellas imágenes como las del protector de pantalla de chromecast. También puede mostrar sus propias fotos junto con su respectiva información.</description>
 		<description lang="nl_NL">Toon prachtige afbeeldingen afkomstig van de Chromecast screensaver. Je kunt ook je eigen foto's tonen met al hun informatie.</description>
 		<description lang="fr_FR">Affichez de jolies images provenant de l’écran de veille de Chromecast. Vous pouvez aussi afficher vos propres images avec leurs informations respectives.</description>
-		<news>v1.3.5 (23/12/2020)
-			[fix] Unicode fixes for python3 (tks @roidy)
+		<news>v1.3.6 (21/09/2021)
+			[fix] line2 does not get cleared with user photos (tks @fuse314)
+			[fix] allow pictures folder to be read-only (tks @fuse314)
 		</news>
 		<assets>
 			<icon>resources/images/icon.png</icon>

--- a/screensaver.kaster/changelog.txt
+++ b/screensaver.kaster/changelog.txt
@@ -1,3 +1,7 @@
+v1.3.6 (21/09/2021)
+ - [fix] line2 does not get cleared with user photos (tks @fuse314)
+ - [fix] allow pictures folder to be read-only (tks @fuse314)
+
 v1.3.5 (23/12/2020)
 - [fix] Unicode fixes for python3 (tks @roidy)
 

--- a/screensaver.kaster/resources/lib/screensaver.py
+++ b/screensaver.kaster/resources/lib/screensaver.py
@@ -98,7 +98,7 @@ class Kaster(xbmcgui.WindowXMLDialog):
                     if "line2" in self.images[rand_index]:
                         self.metadata_line3.setLabel(self.images[rand_index]["line2"])
                     else:
-                        self.metadata_line2.setLabel("")
+                        self.metadata_line3.setLabel("")
                 # Insert photo
                 self.backgroud.setImage(self.images[rand_index]["url"])
                 # Pop image and wait

--- a/screensaver.kaster/resources/settings.xml
+++ b/screensaver.kaster/resources/settings.xml
@@ -3,7 +3,7 @@
     <category label="32002">
         <setting label="32008" type="slider" id="wait-time-before-changing-image" default="20" range="10,1,3600" option="int" />
         <setting label="32003" type="enum" id="screensaver-mode" default="0" lvalues="32004|32005|32006"/>
-        <setting label="32009" type="folder" id="my-pictures-folder" source="auto" option="writeable" visible="eq(-1,1)|eq(-1,2)"/>
+        <setting label="32009" type="folder" id="my-pictures-folder" source="auto" visible="eq(-1,1)|eq(-1,2)"/>
         <setting label="32022" type="bool" id="enable-hq" default="false" visible="eq(-2,0)"/>
 	</category>
 	<category label="32011">


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: Kaster
  - Add-on ID: screensaver.kaster
  - Version number: 1.3.6
  - Kodi/repository version: krypton

- **Code location**
  - URL: https://github.com/enen92/screensaver.kaster
  
Display beautiful pictures originally from the chromecast screensaver. You can also display your own photos along with its respective information.

### Description of changes:

v1.3.6 (21/09/2021)
			[fix] line2 does not get cleared with user photos (tks @fuse314)
			[fix] allow pictures folder to be read-only (tks @fuse314)
		

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
