### PR TITLE
[script.timers] 2.0.2

### DIFF
--- a/script.timers/addon.py
+++ b/script.timers/addon.py
@@ -5,6 +5,7 @@ import datetime
 import _strptime
 import xbmc
 import xbmcaddon
+import xbmcgui
 
 from resources.lib.timer.scheduler import CHECK_INTERVAL, Scheduler
 
@@ -15,7 +16,12 @@ if __name__ == "__main__":
 
     # prevent Error: Failed to import _strptime because the import locks held by another thread.
     # see https://www.raspberrypi.org/forums/viewtopic.php?t=166912
-    datetime.datetime.strptime("2016", "%Y")
+    try:
+        datetime.datetime.strptime("2016", "%Y")
+    except:
+        xbmcgui.Dialog().notification(addon.getLocalizedString(
+            32000), addon.getLocalizedString(32001))
+        exit(1)
 
     scheduler = Scheduler(addon)
 

--- a/script.timers/addon.xml
+++ b/script.timers/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.timers" name="Timers" version="2.0.1" provider-name="Heckie">
+<addon id="script.timers" name="Timers" version="2.0.2" provider-name="Heckie">
 	<requires>
 		<import addon="xbmc.python" version="3.0.0"/>
 	</requires>
@@ -58,6 +58,11 @@
 		<website>https://github.com/Heckie75/kodi-addon-timers</website>
 		<source>https://github.com/Heckie75/kodi-addon-timers</source>
 		<news>
+v2.0.2 (2021-10-03)
+- Improvement: prevent multiple fading action of overlapping fading timers. Strategy is 'First starts first served.'
+- reset to default settings after one-time timers finished
+- minor refactoring
+
 v2.0.1 (2021-09-12)
 - Bugfix: actions in settings dialog don't work, i.e. 'reset volume' and 'play now'
 

--- a/script.timers/resources/language/resource.language.de_de/strings.po
+++ b/script.timers/resources/language/resource.language.de_de/strings.po
@@ -17,6 +17,10 @@ msgctxt "#32000"
 msgid "Timers"
 msgstr "Timer"
 
+msgctxt "#32001"
+msgid "Restart Kodi in order to activate timer addon"
+msgstr "Neustart erforderlich um Timer Addon neu zu laden"
+
 msgctxt "#32009"
 msgid "Sleep timer"
 msgstr "Einschlafen"

--- a/script.timers/resources/language/resource.language.en_gb/strings.po
+++ b/script.timers/resources/language/resource.language.en_gb/strings.po
@@ -17,6 +17,10 @@ msgctxt "#32000"
 msgid "Timers"
 msgstr ""
 
+msgctxt "#32001"
+msgid "Restart Kodi in order to reload timer addon"
+msgstr ""
+
 msgctxt "#32009"
 msgid "Sleep timer"
 msgstr ""

--- a/script.timers/resources/lib/timer/abstract_set_timer.py
+++ b/script.timers/resources/lib/timer/abstract_set_timer.py
@@ -4,9 +4,8 @@ from datetime import datetime
 import xbmc
 import xbmcaddon
 from resources.lib.timer import util
-from resources.lib.timer.scheduler import (ACTION_PLAY, END_TYPE_DURATION,
-                                           END_TYPE_NO, END_TYPE_TIME,
-                                           TIMER_OFF)
+from resources.lib.timer.scheduler import (ACTION_START_STOP, END_TYPE_DURATION,
+                                           END_TYPE_NO, END_TYPE_TIME)
 
 DURATION_NO = util.DEFAULT_TIME
 
@@ -101,7 +100,7 @@ class AbstractSetTimer:
 
     def ask_action(self, listitem, preselection):
 
-        return ACTION_PLAY
+        return ACTION_START_STOP
 
     def confirm(self, preselection):
 

--- a/script.timers/resources/lib/timer/set_timer.py
+++ b/script.timers/resources/lib/timer/set_timer.py
@@ -1,7 +1,7 @@
 import xbmc
 import xbmcgui
 from resources.lib.timer.abstract_set_timer import AbstractSetTimer, CONFIRM_EDIT, DURATION_NO
-from resources.lib.timer.scheduler import (ACTION_PLAY, ACTION_START,
+from resources.lib.timer.scheduler import (ACTION_START_STOP, ACTION_START,
                                            TIMER_DAYS_PRESETS, TIMER_OFF,
                                            TIMERS)
 
@@ -71,7 +71,7 @@ class SetTimer(AbstractSetTimer):
 
     def ask_action(self, listitem, preselection):
 
-        return ACTION_PLAY if preselection["duration"] != DURATION_NO else ACTION_START
+        return ACTION_START_STOP if preselection["duration"] != DURATION_NO else ACTION_START
 
     def confirm(self, preselection):
 


### PR DESCRIPTION
### Description
v2.0.2 (2021-10-03)
- Improvement: prevent multiple fading action of overlapping fading timers. Strategy is 'First starts first served.'
- reset to default settings after one-time timers finished
- minor refactoring

### Checklist:
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [script.foo.bar] 1.0.0