### PR TITLE
[service.subtitles.rvm.addic7ed@matrix] 3.1.8+matrix.1

### DIFF
--- a/service.subtitles.rvm.addic7ed/addon.xml
+++ b/service.subtitles.rvm.addic7ed/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon id="service.subtitles.rvm.addic7ed"
   name="Addic7ed.com"
-  version="3.1.7+matrix.1"
+  version="3.1.8+matrix.1"
   provider-name="Roman V.M.">
 <requires>
   <import addon="xbmc.python" version="3.0.0"/>
@@ -32,11 +32,11 @@
     <icon>icon.png</icon>
     <fanart>fanart.jpg</fanart>
   </assets>
-  <news>3.1.7
-- Fixed crashes when playing non-medialibrary items.
-3.1.6:
-- Fixed compatibility with Kodi 20 "Nexus".
-- Various internal changes.</news>
-  <reuselanguageinvoker>false</reuselanguageinvoker>
+  <news>3.1.8:
+- Performance optimization.
+
+3.1.7:
+- Fixed crashes when playing non-medialibrary items.</news>
+  <reuselanguageinvoker>true</reuselanguageinvoker>
 </extension>
 </addon>


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: Addic7ed.com
  - Add-on ID: service.subtitles.rvm.addic7ed
  - Version number: 3.1.8+matrix.1
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/romanvm/service.addic7ed
  
Subtitles service for Addic7ed.com. It supports only TV shows.

### Description of changes:

3.1.8:
- Performance optimization.

3.1.7:
- Fixed crashes when playing non-medialibrary items.

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
