### PR TITLE
[script.service.checkpreviousepisode@matrix] 0.4.4

### DIFF
--- a/script.service.checkpreviousepisode/addon.xml
+++ b/script.service.checkpreviousepisode/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.service.checkpreviousepisode" version="0.4.3" name="Kodi Check Previous Episode" provider-name="bossanova808, Razzeee, Lucleonhart" >
+<addon id="script.service.checkpreviousepisode" version="0.4.4" name="Kodi Check Previous Episode" provider-name="bossanova808, Razzeee, Lucleonhart" >
   <requires>
     <import addon="xbmc.python" version="3.0.0" />
     <import addon="script.module.yaml" version="3.11.0" />
@@ -16,9 +16,8 @@
     <forum>https://forum.kodi.tv/showthread.php?tid=355464</forum>
     <website>https://kodi.wiki/view/Add-on:XBMC_Check_Previous_Episode</website>
     <source>https://github.com/bossanova808/script.service.checkpreviousepisode</source>
-    <news>v0.4.3
-    - Re-write to modern Python (PEP8 etc) and to match my other addons (global store, use common.py, minimal entry point etc.)
-    - Add option to force browse to the 'All Seasons' view      
+    <news>v0.4.4
+    - Handle apparently possible scenario of Kodi playing an episode without an id    
     </news>
   <assets>
      <icon>icon.png</icon>

--- a/script.service.checkpreviousepisode/changelog.txt
+++ b/script.service.checkpreviousepisode/changelog.txt
@@ -1,3 +1,6 @@
+v0.4.4
+- Handle apparently possible scenario of Kodi playing an episode without an id
+
 v0.4.3
 - Re-write to modern Python & to match my other addons
 - Add option to force browse to the 'All Seasons' view

--- a/script.service.checkpreviousepisode/resources/lib/player.py
+++ b/script.service.checkpreviousepisode/resources/lib/player.py
@@ -46,7 +46,11 @@ class KodiPlayer(xbmc.Player):
             # Only do something is this is an episode of a TV show
             if json_object['result']['item']['type'] == 'episode':
 
-                log("A TV show episode is playing.")
+                if 'id' not in json_object['result']['item']:
+                    log("An episode is playing, but it doesn't have an id, so can't check previous episode in Kodi library.")
+                    return
+
+                log(f"A TV show episode is playing (id: {json_object['result']['item']['id']}).")
 
                 command = json.dumps({
                     "jsonrpc": "2.0",


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: Kodi Check Previous Episode
  - Add-on ID: script.service.checkpreviousepisode
  - Version number: 0.4.4
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/bossanova808/script.service.checkpreviousepisode
  
This service helps prevent spoilers by checking if the previous episode in a series has been watched. If not, it will pause playback and warn you.  Specific shows can be marked to be ignored if episode order does not matter.

### Description of changes:

v0.4.4
    - Handle apparently possible scenario of Kodi playing an episode without an id    
    

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
