### PR TITLE
[script.service.playbackresumer@matrix] 2.0.4

### DIFF
--- a/script.service.playbackresumer/addon.xml
+++ b/script.service.playbackresumer/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.service.playbackresumer" name="Kodi Playback Resumer" version="2.0.3" provider-name="bossanova808, bradvido88">
+<addon id="script.service.playbackresumer" name="Kodi Playback Resumer" version="2.0.4" provider-name="bossanova808, bradvido88">
   <requires>
     <import addon="xbmc.python" version="3.0.0"/>
   </requires>
@@ -15,13 +15,8 @@
     <source>https://github.com/bossanova808/script.service.playbackresumer</source>
     <forum>https://forum.kodi.tv/showthread.php?tid=355383</forum>
     <email>bossanova808@gmail.com</email>
-    <news>v2.0.3
-      - Bug fix for playing non-library videos
-      - Use common code, better logging
-      v2.0.2
-      - Complete re-write into more modular, modern Python 3
-      - Add support for advancedsettings ignoresecondsatstart and ignorepercentatend
-      - Handle player seeking past end of file more gracefully
+    <news>v2.0.4
+      - Handle unicode characters in video names
     </news>
     <assets>
       <icon>icon.png</icon>

--- a/script.service.playbackresumer/changelog.txt
+++ b/script.service.playbackresumer/changelog.txt
@@ -1,3 +1,6 @@
+v2.0.4
+- Handle unicode characters in video names
+
 v2.0.3
 - Bug fix for playing non-library videos
 - Use common code, better logging

--- a/script.service.playbackresumer/resources/lib/store.py
+++ b/script.service.playbackresumer/resources/lib/store.py
@@ -87,7 +87,7 @@ class Store:
         Store.type_of_video = None
         Store.paused_time = None
         Store.length_of_currently_playing_file = None
-        with open(Store.file_to_store_last_played, 'w+') as f:
+        with open(Store.file_to_store_last_played, 'w+', encoding='utf-8') as f:
             f.write('')
         with open(Store.file_to_store_resume_point, 'w+') as f:
             f.write('')
@@ -170,7 +170,7 @@ class Store:
         Store.currently_playing_file_path = filepath
 
         # write the full path to a file for persistent tracking
-        with open(Store.file_to_store_last_played, 'w+') as f:
+        with open(Store.file_to_store_last_played, 'w+', encoding='utf8') as f:
             f.write(filepath)
 
         log(f'Last played file set to: {filepath}')


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: Kodi Playback Resumer
  - Add-on ID: script.service.playbackresumer
  - Version number: 2.0.4
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/bossanova808/script.service.playbackresumer
  

        Runs as a service and will periodically update the resume point while videos are playing, so you can re-start from where you were in the event of a crash.  It can also automatically resume a video if Kodi was shutdown while playing it. See setting to configure how often the resume point is set, and whether to automatically resume.
    

### Description of changes:

v2.0.4
      - Handle unicode characters in video names
    

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
