### PR TITLE
[script.xbmc.unpausejumpback@matrix] 3.0.3

### DIFF
--- a/script.xbmc.unpausejumpback/addon.xml
+++ b/script.xbmc.unpausejumpback/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.xbmc.unpausejumpback" name="Unpause Jumpback" version="3.0.2" provider-name="bossanova808,Memphiz,Lucleonhart,schumi2004,dkadioglu">
+<addon id="script.xbmc.unpausejumpback" name="Unpause Jumpback" version="3.0.3" provider-name="bossanova808,Memphiz,Lucleonhart,schumi2004,dkadioglu">
   <requires>
     <import addon="xbmc.python" version="3.0.0"/>
   </requires>
@@ -24,13 +24,8 @@
     <source>https://github.com/bossanova808/script.xbmc.unpausejumpback/</source>
     <forum>https://forum.kodi.tv/showthread.php?tid=355778</forum>
     <email>bossonav808@gmail.com</email>
-    <news>v3.0.2
-        [fix] "XBMC is not playing any media file" errors
-        v3.0.1
-        [fix] minor bugfix for http/s sources (plugins)
-        [fix] Update for changes to Kodi Matrix logging functions
-        v3.0.0
-        [new] Update for Kodi Matrix / Python 3, make unpause on resume vs. pause a choice, bugfixes and tidy up.
+    <news>v3.0.3
+      - Minor bugfix for http/s sources
     </news>
     <assets>
       <icon>icon.png</icon>

--- a/script.xbmc.unpausejumpback/changelog.txt
+++ b/script.xbmc.unpausejumpback/changelog.txt
@@ -1,33 +1,36 @@
-3.0.2
+v3.0.3
+- Minor bugfix for http/s sources
+
+v3.0.2
 - fix "Kodi is not playing any media file" when skipping beyond end of file
 
-3.0.1
+v3.0.1
 - Minor bugfix with http/s sources (plugins)
 
-3.0.0
+v3.0.0
 - Update for Matrix / Python3 (work borrowed from https://github.com/dkadioglu/script.xbmc.unpausejumpback)
 - Add setting for jump back occurring at time of un-pause vs. at time of pause
 - Bug fixes & tidy-ups
 
-2.3.3
+v2.3.3
 - fixed format of authors tag in addon.xml
 - removed the XBMC from the name
 
-2.3.2
+v2.3.2
 - jump back "in the background" when paused (i.e. while still paused instead of upon resuming)
 
-2.3.1
+v2.3.1
 - revert jumpback after playback started due to XBMC video timer bug - can not add this until xbmc properly reports the playback position immediately on playback start
 
-2.3.0
+v2.3.0
 - add jumpback after playback started from non zero starting time (needs gotham for working properly!)
 
-2.2.0
+v2.2.0
 - add exclude settings
 - add jumpback/forward after fwd or rwd based on the fwd/rwd speed (can be adjusted for each speed separately for fwd and rwd).
 
-2.1.0
+v2.1.0
 - add setting for specifying the minimum pause time before jumping back
 
-2.0.0
+v2.0.0
 - initial commit for frodo

--- a/script.xbmc.unpausejumpback/resources/lib/common.py
+++ b/script.xbmc.unpausejumpback/resources/lib/common.py
@@ -3,7 +3,7 @@
 Handy utility functions for Kodi Addons
 By bossanova808
 Free in all senses....
-VERSION 0.2.1 2021-06-06
+VERSION 0.2.3 2021-06-21
 (For Kodi Matrix & later)
 """
 import sys
@@ -62,10 +62,6 @@ if not xbmc.getUserAgent():
         if exception_instance:
             print(f'EXCPT: {traceback.format_exc(exception_instance)}')
 
-    def log_info(message, exception_instance=None):
-        log(f'INFO : {message}')
-        if exception_instance:
-            print(f'EXCPT: {traceback.format_exc(exception_instance)}')
 
 else:
 
@@ -75,7 +71,7 @@ else:
 
         :param message: required, the message to log
         :param exception_instance: optional, an instance of some Exception
-        :param level: optional, the Kodi log level to use, default LOGDEBUG
+        :param level: optional, the Kodi log level to use, default LOGDEBUG but can override with level=xbmc.LOGINFO
         """
 
         message = f'### {ADDON_NAME} {ADDON_VERSION} - {message}'
@@ -86,16 +82,6 @@ else:
         else:
             xbmc.log(message_with_exception, level)
 
-
-    def log_info(message, exception_instance=None):
-        """
-        Log a message at the LOGINFO level, i.e. even if Kodi debugging is not turned on. Use very sparingly.
-
-        :param message: required, the message to log
-        :param exception_instance: optional, an instance of some Exception
-        """
-        log(message, exception_instance, level=xbmc.LOGINFO)
-
     def set_property(window, name, value=""):
         """
         Set a property on a window.
@@ -105,6 +91,9 @@ else:
         :param name: Required.  Name of the property.
         :param value: Optional (defaults to "").  Set the property to this value.  An empty string clears the property.
         """
+        if value is None:
+            window.clearProperty(name)
+
         value = str(value)
         if value:
             log(f'Setting window property {name} to value {value}')
@@ -190,10 +179,10 @@ def footprints(startup=True):
     :param startup: optional, default True.  If true, log the startup of an addon, otherwise log the exit.
     """
     if startup:
-        log_info(f'Starting...')
-        log_info(f'Kodi Version: {KODI_VERSION}')
-        log_info(f'Addon arguments: {ADDON_ARGUMENTS}')
+        log(f'Starting...', level=xbmc.LOGINFO)
+        log(f'Kodi Version: {KODI_VERSION}', level=xbmc.LOGINFO)
+        log(f'Addon arguments: {ADDON_ARGUMENTS}', level=xbmc.LOGINFO)
     else:
-        log_info(f'Exiting...')
+        log(f'Exiting...', level=xbmc.LOGINFO)
 
 

--- a/script.xbmc.unpausejumpback/resources/lib/unpause_jumpback.py
+++ b/script.xbmc.unpausejumpback/resources/lib/unpause_jumpback.py
@@ -110,7 +110,7 @@ class MyPlayer(xbmc.Player):
             log("Video is playing via Live TV, which is set as an excluded location.")
             return True
 
-        if (full_path.find("http://") > -1) or (full_path.find("https://") > -1) and self.exclude_http:
+        if ((full_path.find("http://") > -1) or (full_path.find("https://") > -1)) and self.exclude_http:
             log("Video is playing via HTTP source, which is set as an excluded location.")
             return True
 


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: Unpause Jumpback
  - Add-on ID: script.xbmc.unpausejumpback
  - Version number: 3.0.3
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/bossanova808/script.xbmc.unpausejumpback/
  

        This addon will jump back a number of seconds whenever a video is un-paused - to make sure you don't miss anything.
        You can set the amount of seconds to jump back, and the minimum duration of the pause before the addon will trigger a jump back.
        It also allows to jump back or forward after rewind or fast-forward of a specified amount of seconds to compensate for over-shooting.
        (Originally created by Memphiz, up-keep taken over by bossanova808 in 2020 for Kodi Matrix and beyond).
    

### Description of changes:

v3.0.3
      - Minor bugfix for http/s sources
    

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
