### PR TITLE
[script.module.xbmcswift2@matrix] 19.0.7

### DIFF
--- a/script.module.xbmcswift2/addon.xml
+++ b/script.module.xbmcswift2/addon.xml
@@ -1,4 +1,4 @@
-<addon id="script.module.xbmcswift2" name="xbmcswift2" provider-name="Jonathan Beluch (jbel), enen92" version="19.0.6">
+<addon id="script.module.xbmcswift2" name="xbmcswift2" provider-name="Jonathan Beluch (jbel), enen92" version="19.0.7">
   <requires>
     <import addon="xbmc.python" version="3.0.0" />
   </requires>
@@ -9,7 +9,7 @@
     <license>GPL-3.0</license>
     <summary lang="en_GB">xbmcswift2 is a small framework to ease development of KODI addons.</summary>
     <description lang="en_GB">xbmcswift2 is a small framework to ease development of KODI addons.</description>
-    <news>Add container.refresh</news>
+    <news>Fixes for python 3.10 - move collections.MutableMapping to collections.abc.MutableMapping</news>
     <assets>
       <icon>icon.png</icon>
     </assets>

--- a/script.module.xbmcswift2/lib/xbmcswift2/storage.py
+++ b/script.module.xbmcswift2/lib/xbmcswift2/storage.py
@@ -107,7 +107,7 @@ class _PersistentDictMixin(object):
         raise NotImplementedError
 
 
-class _Storage(collections.MutableMapping, _PersistentDictMixin):
+class _Storage(collections.abc.MutableMapping, _PersistentDictMixin):
     '''Storage that acts like a dict but also can persist to disk.
 
     :param filename: An absolute filepath to reprsent the storage on disk. The
@@ -146,7 +146,7 @@ class _Storage(collections.MutableMapping, _PersistentDictMixin):
         '''Returns the wrapped dict'''
         return self._items
 
-    initial_update = collections.MutableMapping.update
+    initial_update = collections.abc.MutableMapping.update
 
     def clear(self):
         super(_Storage, self).clear()


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: xbmcswift2
  - Add-on ID: script.module.xbmcswift2
  - Version number: 19.0.7
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/XBMC-Addons/script.module.xbmcswift2
  
xbmcswift2 is a small framework to ease development of KODI addons.

### Description of changes:

Fixes for python 3.10 - move collections.MutableMapping to collections.abc.MutableMapping

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
