### PR TITLE
[script.timers] 2.1.0

### DIFF
--- a/script.timers/addon.py
+++ b/script.timers/addon.py
@@ -29,8 +29,12 @@ if __name__ == "__main__":
         import ctypes
         ctypes.windll.kernel32.SetThreadExecutionState(0x80000002)
 
-    scheduler.start()
+    try:
+        scheduler.start()
 
-    if xbmc.getCondVisibility("system.platform.windows") and "true" == addon.getSetting("windows_unlock"):
-        import ctypes
-        ctypes.windll.kernel32.SetThreadExecutionState(0x80000000)
+    finally:
+        scheduler.reset_powermanagement_displaysoff()
+
+        if xbmc.getCondVisibility("system.platform.windows") and "true" == addon.getSetting("windows_unlock"):
+            import ctypes
+            ctypes.windll.kernel32.SetThreadExecutionState(0x80000000)

--- a/script.timers/addon.xml
+++ b/script.timers/addon.xml
@@ -1,23 +1,27 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.timers" name="Timers" version="2.0.3" provider-name="Heckie">
+<addon id="script.timers" name="Timers" version="2.1.0" provider-name="Heckie">
 	<requires>
-		<import addon="xbmc.python" version="3.0.0"/>
+		<import addon="xbmc.python" version="3.0.0" />
 	</requires>
 	<extension point="xbmc.service" library="addon.py" />
-	<extension point="xbmc.python.script" library="program.py"/>
+	<extension point="xbmc.python.script" library="program.py" />
 	<extension point="kodi.context.item">
 		<menu id="kodi.core.main">
 			<item library="context_setsleep.py">
-				<label>32009</label>
+				<label>32004</label>
 				<visible>true</visible>
 			</item>
 			<item library="context_setsnooze.py">
-				<label>32010</label>
+				<label>32005</label>
 				<visible>Window.IsMedia+!ListItem.IsFolder</visible>
 			</item>
 			<item library="context_settimer.py">
 				<label>32000</label>
 				<visible>Window.IsMedia+!ListItem.IsFolder</visible>
+			</item>
+			<item library="context_setquickepgtimer.py">
+				<label>32117</label>
+				<visible>Window.IsVisible(tvguide)|Window.IsVisible(radioguide)</visible>
 			</item>
 		</menu>
 	</extension>
@@ -25,10 +29,11 @@
 		<summary lang="en_GB">Timers</summary>
 		<summary lang="de_DE">Timers</summary>
 		<description lang="en_GB">A powerful timer addon with the following features
-* 10 timer slots. All of them can be quickly set up by using context menu
+* 15 timer slots. All of them can be quickly set up by using context menu
 * 2 additional slots for sleep and doze timers with single-click-setup 
 * Timers can play any ressource that it available in Kodi, e.g. music, video files, TV/radio programs, ressources from 3rd party plugins, e.g. Zattoo channels. 
 * Timers can be set from TV / Radio EPG
+* One-click-setup from epg (Quick Timer)
 * Different schedule modes: once, everyday, Mon-Fri, Fri-Sat, Sat-Sun, Sun-Thu, Mon-Thu, specific weekday and many more
 * Date change is supported, e.g. from 23:30 (p.m.) until 1:30 (a.m.) 
 * Two end modes, i.e. duration or specific time
@@ -36,12 +41,14 @@
 * Linear fading in timer period: fade-in, fade-out, no fading. Min and max volume can be set for each timer
 * Custom label for timer
 * After KODI startup timers, that are in period, start retroactivly altought KODI was not running at start time. Fading volume is calculated correctly.
+* Feature in order to prevent that display is turned off if Kodi idles but is not in fullscreen mode
 * MS Windows only: Feature in order to prevent that Windows displays lock screen if Kodi idles
 		</description>
 		<description lang="de_DE">Timer Addon mit folgenden Funktionen
-* 10 Timer, die eingestellt werden können. Alle Timer können über das Kontextmenü geöffnet werden
+* 15 Timer, die eingestellt werden können. Alle Timer können über das Kontextmenü geöffnet werden
 * 2 zusätzliche Timer für "Einschlaf"- und "Schlummer"-Timer mit nur einem Klick 
 * Timer können alle Medien starten, die in Kodi sind wie Musik, Video, TV/Radio programme, andere Addons, z.B. Zattoo. 
+* Einstellung mit nur einem Klick aus EPG (Quick Timer)
 * Verschiedene Zeitplanungen möglich: einmalig, pro Wochentag, Mo-Fr, Fr-Sa, Sa-So, So-Do, Mo-Do u.v.m.
 * Tageswechsel wird unterstützt, z.B. Timer von 23:30 bis 1:30 am nächsten Tag
 * Dauer kann über Zeitraum oder Zeitpunkt eingestellt werden
@@ -49,6 +56,7 @@
 * Lautstärke während der Laufzeit ein-/ausblenden. Einstellung pro Timer mit max. und minimaler Lautstärke
 * Beschriftung der Timer
 * Nachdem Kodi startet, werden aktive Timer ebenfalls gestartet.
+* Feature um Kodi darin zu hindern den Bildschirm abzuschalten, wenn Kodi nicht im Vollbildmodus ist
 * MS Windows: Feature um Windows daran zu hindern in den Sperrbildschirm zu schalten, während Kodi keine Medien abspielt 
 		</description>
 		<language>en_GB</language>
@@ -58,6 +66,15 @@
 		<website>https://github.com/Heckie75/kodi-addon-timers</website>
 		<source>https://github.com/Heckie75/kodi-addon-timers</source>
 		<news>
+v2.1.0 (2021-11-20):
+- Improved start and stop action in case that multiple timers are running in parallel, see also https://github.com/Heckie75/kodi-addon-timers/issues/5 
+- One-click-setup from epg (Quick Timer)
+- Improved procedure of update state after one-time-timers have run out or settings have been changed
+- Added 5 more timer slots
+- Added feature in order to prevent that display is turned off if Kodi idles but is not in fullscreen mode
+- Migrated to new XML settings format
+- Major refactoring, better structured code
+
 v2.0.3 (2021-10-31)
 - Fixed issue related to reset to default settings after one-time timers has finished
 - Fixed issue that wrong pvr channel was taken from epg if some channels are deactivated in PVR

--- a/script.timers/context_setquickepgtimer.py
+++ b/script.timers/context_setquickepgtimer.py
@@ -1,0 +1,6 @@
+import sys
+
+from resources.lib.timer.set_quick_epg_timer import SetQuickEpgTimer
+
+if __name__ == "__main__":
+    SetQuickEpgTimer(sys.listitem)

--- a/script.timers/program.py
+++ b/script.timers/program.py
@@ -18,7 +18,7 @@ def play(timer):
             addon_dir, "resources", "assets", "icon_sleep.png")
 
         xbmcgui.Dialog().notification(addon.getLocalizedString(
-            32027), addon.getLocalizedString(32110) % addon.getLocalizedString(32009 + timer),
+            32027), addon.getLocalizedString(32110) % addon.getLocalizedString(32004 + timer),
             icon=icon_file)
 
         xbmc.Player().play(path)

--- a/script.timers/resources/language/resource.language.de_de/strings.po
+++ b/script.timers/resources/language/resource.language.de_de/strings.po
@@ -21,53 +21,77 @@ msgctxt "#32001"
 msgid "Restart Kodi in order to activate timer addon"
 msgstr "Neustart erforderlich um Timer Addon neu zu laden"
 
-msgctxt "#32009"
+msgctxt "#32002"
+msgid "Extras"
+msgstr "Extras"
+
+msgctxt "#32004"
 msgid "Sleep timer"
 msgstr "Einschlafen"
 
-msgctxt "#32010"
+msgctxt "#32005"
 msgid "Snooze timer"
 msgstr "Schlummern"
 
-msgctxt "#32011"
+msgctxt "#32006"
 msgid "Timer 1"
 msgstr "Timer 1"
 
-msgctxt "#32012"
+msgctxt "#32007"
 msgid "Timer 2"
 msgstr "Timer 2"
 
-msgctxt "#32013"
+msgctxt "#32008"
 msgid "Timer 3"
 msgstr "Timer 3"
 
-msgctxt "#32014"
+msgctxt "#32009"
 msgid "Timer 4"
 msgstr "Timer 4"
 
-msgctxt "#32015"
+msgctxt "#32010"
 msgid "Timer 5"
 msgstr "Timer 5"
 
-msgctxt "#32016"
+msgctxt "#32011"
 msgid "Timer 6"
 msgstr "Timer 6"
 
-msgctxt "#32017"
+msgctxt "#32012"
 msgid "Timer 7"
 msgstr "Timer 7"
 
-msgctxt "#32018"
+msgctxt "#32013"
 msgid "Timer 8"
 msgstr "Timer 8"
 
-msgctxt "#32019"
+msgctxt "#32014"
 msgid "Timer 9"
 msgstr "Timer 9"
 
-msgctxt "#32020"
+msgctxt "#32015"
 msgid "Timer 10"
 msgstr "Timer 10"
+
+msgctxt "#32016"
+msgid "Timer 11"
+msgstr "Timer 11"
+
+msgctxt "#32017"
+msgid "Timer 12"
+msgstr "Timer 12"
+
+msgctxt "#32018"
+msgid "Timer 13"
+msgstr "Timer 13"
+
+msgctxt "#32019"
+msgid "Timer 14"
+msgstr "Timer 14"
+
+msgctxt "#32020"
+msgid "Timer 15"
+msgstr "Timer 15"
 
 msgctxt "#32021"
 msgid "Edit"
@@ -365,6 +389,18 @@ msgctxt "#32114"
 msgid "Select media and set timer via context menu first."
 msgstr "Wähle zuerst Media über Timer Kontext Menü aus!"
 
+msgctxt "#32115"
+msgid "No free timer slots."
+msgstr "Kein freier Timer mehr vorhanden."
+
+msgctxt "#32116"
+msgid "Quick %s"
+msgstr "Quick %s"
+
+msgctxt "#32117"
+msgid "Quick Timer"
+msgstr "Quick Timer"
+
 msgctxt "#32120"
 msgid "off"
 msgstr "aus"
@@ -380,3 +416,111 @@ msgstr "ausblenden"
 msgctxt "#32123"
 msgid "fade out from current"
 msgstr "ausblenden von aktueller Lautstärke"
+
+msgctxt "#32130"
+msgid "Put display only in fullscreen mode to sleep"
+msgstr "Ruhezustand des Bildschirms bei Vollbild"
+
+msgctxt "#32131"
+msgid "acc. system setting"
+msgstr "entspr. Systemeinstellung"
+
+msgctxt "#32132"
+msgid "5 min"
+msgstr "5 min"
+
+msgctxt "#32133"
+msgid "10 min"
+msgstr "10 min"
+
+msgctxt "#32134"
+msgid "15 min"
+msgstr "15 min"
+
+msgctxt "#32135"
+msgid "20 min"
+msgstr "20 min"
+
+msgctxt "#32136"
+msgid "25 min"
+msgstr "25 min"
+
+msgctxt "#32137"
+msgid "30 min"
+msgstr "30 min"
+
+msgctxt "#32138"
+msgid "35 min"
+msgstr "35 min"
+
+msgctxt "#32139"
+msgid "40 min"
+msgstr "40 min"
+
+msgctxt "#32140"
+msgid "45 min"
+msgstr "45 min"
+
+msgctxt "#32141"
+msgid "50 min"
+msgstr "50 min"
+
+msgctxt "#32142"
+msgid "55 min"
+msgstr "55 min"
+
+msgctxt "#32143"
+msgid "60 min"
+msgstr "60 min"
+
+msgctxt "#32144"
+msgid "65 min"
+msgstr "65 min"
+
+msgctxt "#32145"
+msgid "70 min"
+msgstr "70 min"
+
+msgctxt "#32146"
+msgid "75 min"
+msgstr "75 min"
+
+msgctxt "#32147"
+msgid "80 min"
+msgstr "80 min"
+
+msgctxt "#32148"
+msgid "85 min"
+msgstr "85 min"
+
+msgctxt "#32149"
+msgid "90 min"
+msgstr "90 min"
+
+msgctxt "#32150"
+msgid "95 min"
+msgstr "95 min"
+
+msgctxt "#32151"
+msgid "100 min"
+msgstr "100 min"
+
+msgctxt "#32152"
+msgid "105 min"
+msgstr "105 min"
+
+msgctxt "#32153"
+msgid "110 min"
+msgstr "110 min"
+
+msgctxt "#32154"
+msgid "115 min"
+msgstr "115 min"
+
+msgctxt "#32155"
+msgid "120 min"
+msgstr "120 min"
+
+msgctxt "#32156"
+msgid "Mondays to Saturdays"
+msgstr "Montags bis Samstags"

--- a/script.timers/resources/language/resource.language.en_gb/strings.po
+++ b/script.timers/resources/language/resource.language.en_gb/strings.po
@@ -21,53 +21,77 @@ msgctxt "#32001"
 msgid "Restart Kodi in order to reload timer addon"
 msgstr ""
 
-msgctxt "#32009"
-msgid "Sleep timer"
+msgctxt "#32002"
+msgid "Extras"
 msgstr ""
+
+msgctxt "#32004"
+msgid "Sleep timer"
+msgstr "Einschlafen"
+
+msgctxt "#32005"
+msgid "Snooze timer"
+msgstr "Schlummern"
+
+msgctxt "#32006"
+msgid "Timer 1"
+msgstr "Timer 1"
+
+msgctxt "#32007"
+msgid "Timer 2"
+msgstr "Timer 2"
+
+msgctxt "#32008"
+msgid "Timer 3"
+msgstr "Timer 3"
+
+msgctxt "#32009"
+msgid "Timer 4"
+msgstr "Timer 4"
 
 msgctxt "#32010"
-msgid "Snooze timer"
-msgstr ""
+msgid "Timer 5"
+msgstr "Timer 5"
 
 msgctxt "#32011"
-msgid "Timer 1"
-msgstr ""
+msgid "Timer 6"
+msgstr "Timer 6"
 
 msgctxt "#32012"
-msgid "Timer 2"
-msgstr ""
+msgid "Timer 7"
+msgstr "Timer 7"
 
 msgctxt "#32013"
-msgid "Timer 3"
-msgstr ""
+msgid "Timer 8"
+msgstr "Timer 8"
 
 msgctxt "#32014"
-msgid "Timer 4"
-msgstr ""
+msgid "Timer 9"
+msgstr "Timer 9"
 
 msgctxt "#32015"
-msgid "Timer 5"
-msgstr ""
+msgid "Timer 10"
+msgstr "Timer 10"
 
 msgctxt "#32016"
-msgid "Timer 6"
-msgstr ""
+msgid "Timer 11"
+msgstr "Timer 11"
 
 msgctxt "#32017"
-msgid "Timer 7"
-msgstr ""
+msgid "Timer 12"
+msgstr "Timer 12"
 
 msgctxt "#32018"
-msgid "Timer 8"
-msgstr ""
+msgid "Timer 13"
+msgstr "Timer 13"
 
 msgctxt "#32019"
-msgid "Timer 9"
-msgstr ""
+msgid "Timer 14"
+msgstr "Timer 14"
 
 msgctxt "#32020"
-msgid "Timer 10"
-msgstr ""
+msgid "Timer 15"
+msgstr "Timer 15"
 
 msgctxt "#32021"
 msgid "Edit"
@@ -369,6 +393,18 @@ msgctxt "#32114"
 msgid "Select media and set timer via context menu first."
 msgstr ""
 
+msgctxt "#32115"
+msgid "No free timer slots."
+msgstr ""
+
+msgctxt "#32116"
+msgid "Quick %s"
+msgstr ""
+
+msgctxt "#32117"
+msgid "Quick Timer"
+msgstr ""
+
 msgctxt "#32120"
 msgid "off"
 msgstr ""
@@ -383,4 +419,112 @@ msgstr ""
 
 msgctxt "#32123"
 msgid "fade out from current"
+msgstr ""
+
+msgctxt "#32130"
+msgid "Put display only in fullscreen mode to sleep"
+msgstr ""
+
+msgctxt "#32131"
+msgid "acc. system setting"
+msgstr ""
+
+msgctxt "#32132"
+msgid "5 min"
+msgstr ""
+
+msgctxt "#32133"
+msgid "10 min"
+msgstr ""
+
+msgctxt "#32134"
+msgid "15 min"
+msgstr ""
+
+msgctxt "#32135"
+msgid "20 min"
+msgstr ""
+
+msgctxt "#32136"
+msgid "25 min"
+msgstr ""
+
+msgctxt "#32137"
+msgid "30 min"
+msgstr ""
+
+msgctxt "#32138"
+msgid "35 min"
+msgstr ""
+
+msgctxt "#32139"
+msgid "40 min"
+msgstr ""
+
+msgctxt "#32140"
+msgid "45 min"
+msgstr ""
+
+msgctxt "#32141"
+msgid "50 min"
+msgstr ""
+
+msgctxt "#32142"
+msgid "55 min"
+msgstr ""
+
+msgctxt "#32143"
+msgid "60 min"
+msgstr ""
+
+msgctxt "#32144"
+msgid "65 min"
+msgstr ""
+
+msgctxt "#32145"
+msgid "70 min"
+msgstr ""
+
+msgctxt "#32146"
+msgid "75 min"
+msgstr ""
+
+msgctxt "#32147"
+msgid "80 min"
+msgstr ""
+
+msgctxt "#32148"
+msgid "85 min"
+msgstr ""
+
+msgctxt "#32149"
+msgid "90 min"
+msgstr ""
+
+msgctxt "#32150"
+msgid "95 min"
+msgstr ""
+
+msgctxt "#32151"
+msgid "100 min"
+msgstr ""
+
+msgctxt "#32152"
+msgid "105 min"
+msgstr ""
+
+msgctxt "#32153"
+msgid "110 min"
+msgstr ""
+
+msgctxt "#32154"
+msgid "115 min"
+msgstr ""
+
+msgctxt "#32155"
+msgid "120 min"
+msgstr ""
+
+msgctxt "#32156"
+msgid "Mondays to Saturdays"
 msgstr ""

--- a/script.timers/resources/lib/timer/abstract_set_timer.py
+++ b/script.timers/resources/lib/timer/abstract_set_timer.py
@@ -4,7 +4,7 @@ from datetime import datetime
 import xbmc
 import xbmcaddon
 from resources.lib.timer import util
-from resources.lib.timer.scheduler import (ACTION_START_STOP, END_TYPE_DURATION,
+from resources.lib.timer.timer import (ACTION_START_STOP, END_TYPE_DURATION,
                                            END_TYPE_NO, END_TYPE_TIME)
 
 DURATION_NO = util.DEFAULT_TIME
@@ -18,10 +18,12 @@ CONFIRM_EDIT = 2
 class AbstractSetTimer:
 
     addon = None
+    listitem = None
 
     def __init__(self, listitem):
 
         self.addon = xbmcaddon.Addon()
+        self.listitem = listitem
 
         timer = self.ask_timer()
         if timer == None:
@@ -29,6 +31,10 @@ class AbstractSetTimer:
 
         preselection = self._get_timer_preselection(timer, listitem)
         path = preselection["path"]
+
+        ok = self.perform_ahead(preselection)
+        if not ok:
+            return
 
         label = self.ask_label(listitem, preselection)
         if label == None:
@@ -69,6 +75,10 @@ class AbstractSetTimer:
         else:
             self._apply(preselection)
             self.post_apply(preselection, confirm)
+
+    def perform_ahead(self, preselection):
+
+        return True
 
     def ask_label(self, listitem, preselection):
 
@@ -121,6 +131,9 @@ class AbstractSetTimer:
         self.addon.setSetting("timer_%s_end" % timer, selection["endtime"])
         self.addon.setSetting("timer_%s_action" % timer, selection["action"])
         self.addon.setSetting("timer_%s_filename" % timer, selection["path"])
+        if selection["fade"] is not None:
+            self.addon.setSetting("timer_%s_fade" % timer, str(selection["fade"]))
+
         util.activateOnSettingsChangedEvents(self.addon)
 
     def post_apply(self, selection, confirm):
@@ -170,5 +183,6 @@ class AbstractSetTimer:
             "duration": duration,
             "endtime": endTime,
             "action": action,
-            "epg": is_epg
+            "epg": is_epg,
+            "fade" : None
         }

--- a/script.timers/resources/lib/timer/scheduler.py
+++ b/script.timers/resources/lib/timer/scheduler.py
@@ -7,400 +7,221 @@ import xbmcgui
 import xbmcvfs
 from resources.lib.timer import util
 from resources.lib.timer.player import Player
-from resources.lib.timer.util import DEFAULT_TIME
+from resources.lib.timer.timer import (ACTION_POWERDOWN_AT_END,
+                                       ACTION_START_AT_END, ACTION_STOP,
+                                       END_TYPE_NO, FADE_IN_FROM_MIN,
+                                       FADE_OUT_FROM_CURRENT, TIMER_ONCE,
+                                       Timer)
 
 CHECK_INTERVAL = 10
 
-TIMERS = 12
-SLEEP_TIMER = 0
-SNOOZE_TIMER = 1
-
-TIMER_ONCE = [str(i) for i in range(7)]
-TIMER_OFF = "25"
-
-TIMER_DAYS_PRESETS = {
-    "0": [0],                     # mon
-    "1": [1],                     # tue
-    "2": [2],                     # wed
-    "3": [3],                     # thu
-    "4": [4],                     # fri
-    "5": [5],                     # sat
-    "6": [6],                     # sun
-    "7": [0],                     # mons
-    "8": [1],                     # tues
-    "9": [2],                     # weds
-    "10": [3],                    # thus
-    "11": [4],                    # fris
-    "12": [5],                    # sats
-    "13": [6],                    # suns
-    "14": [0, 1, 2, 3],           # mon-thu
-    "15": [0, 1, 2, 3, 4],        # mon-fri
-    "16": [1, 2, 3, 4],           # tue-fri
-    "17": [3, 4, 5],              # thu-sat
-    "18": [4, 5],                 # fri-sat
-    "19": [4, 5, 6],              # fri-sun
-    "20": [5, 6],                 # sat-sun
-    "21": [5, 6, 0],              # sat-mon
-    "22": [6, 0, 1, 2],           # sun-wed
-    "23": [6, 0, 1, 2, 3],        # sun-thu
-    "24": [0, 1, 2, 3, 4, 5, 6],  # everyday
-    "25": [],                     # off
-    "" : []                       # off
-}
-
-END_TYPE_NO = "0"
-END_TYPE_DURATION = "1"
-END_TYPE_TIME = "2"
-
-ACTION_NO = "0"
-ACTION_START_STOP = "1"
-ACTION_START = "2"
-ACTION_START_AT_END = "3"
-ACTION_STOP = "4"
-ACTION_STOP_AT_END = "5"
-ACTION_POWERDOWN_AT_END = "6"
-
-FADE_OFF = "0"
-FADE_IN_FROM_MIN = "1"
-FADE_OUT_FROM_MAX = "2"
-FADE_OUT_FROM_CURRENT = "3"
+TIMERS = 17
 
 
 class Scheduler(xbmc.Monitor):
 
-    addon = None
-    addon_dir = None
+    _addon = None
+    _addon_dir = None
 
-    player = None
+    _timers = None
 
-    _timer_state = {
-        "t_now": None,
-        "td_now": None,
-        "i_default_vol": 100,
-        "timers": [
-            {
-                "i_timer": 0,
-                "s_schedule": TIMER_OFF,
-                "days": [],
-                "s_label": "",
-                "s_start": DEFAULT_TIME,
-                "s_end_type": END_TYPE_NO,
-                "s_end": DEFAULT_TIME,
-                "s_duration": DEFAULT_TIME,
-                "td_duration": None,
-                "s_action": ACTION_NO,
-                "s_filename": "",
-                "s_fade": FADE_OFF,
-                "i_vol_min": 0,
-                "i_vol_max": 100,
-                "i_return_vol": 100,
-                "periods": [],
-                "b_in_period": False,
-                "b_active": False,
-                "b_notify": True
-            }] * TIMERS
-    }
+    _player = None
+
+    _default_vol = None
+    _resume = None
+    _powermanagement_displaysoff = 0
+    _disabled_powermanagement_displaysoff = False
 
     def __init__(self, addon):
 
         super().__init__()
-        self.addon = addon
-        self.addon_dir = xbmcvfs.translatePath(addon.getAddonInfo('path'))
+        self._addon = addon
+        self._addon_dir = xbmcvfs.translatePath(
+            self._addon.getAddonInfo('path'))
 
-        self.player = Player()
+        self._player = Player()
 
-        self._timer_state["i_default_vol"] = int(
-            self.addon.getSetting("vol_default"))
-
-        xbmc.executebuiltin("SetVolume(%i)" %
-                            self._timer_state["i_default_vol"])
+        self._timers = [Timer(i) for i in range(TIMERS)]
 
         self._update()
 
+        util.set_volume(self._default_vol)
+
+    def onSettingsChanged(self):
+
+        if util.isSettingsChangedEvents(self._addon):
+            self._update()
+
+    def _update(self):
+
+        for i, timer in enumerate(self._timers):
+            self._timers[i] = timer.update_or_replace_from_settings()
+
+        self._default_vol = int("0%s" % self._addon.getSetting("vol_default"))
+        self._resume = ("true" == self._addon.getSetting("resume"))
+        self._powermanagement_displaysoff = int(
+            "0%s" % self._addon.getSetting("powermanagement_displaysoff"))
+        self.reset_powermanagement_displaysoff()
+
     def start(self):
+
+        def _check_timers(t_now):
+
+            td_now = timedelta(hours=t_now.tm_hour,
+                               minutes=t_now.tm_min,
+                               seconds=t_now.tm_sec,
+                               days=t_now.tm_wday)
+
+            beginners, enders, parallels = list(), list(), list()
+            stopper = None
+            fader = None
+
+            for timer in self._timers:
+                period = timer.get_matching_period(td_now)
+
+                if period is not None and not timer.b_active:
+                    beginners.append((timer, period[0]))
+
+                elif period is None and timer.b_active:
+                    enders.append((timer, td_now - timer.td_duration))
+
+                elif period is not None and timer.is_starting_timer() and timer.is_stopping_timer():
+                    parallels.append((timer, period[0]))
+                    if stopper == None or period[0] < stopper[1]:
+                        stopper = (timer, period[0])
+
+                if period is not None and timer.is_fading_timer():
+                    if fader == None or period[0] < fader[1]:
+                        fader = (timer, period[0], period[1])
+
+            has_stopped_player = False
+            for e in enders:
+                has_stopped_player |= _end_timer(timer=e[0], reset_vol=(fader is None),
+                                                 stop_player=(not stopper or stopper[1] < e[1]))
+
+            if has_stopped_player:
+                beginners.extend(parallels)
+
+            starter = None
+            beginners.sort(key=lambda b: b[1])
+            for b in beginners:
+                starter = b[0] if b[0].is_starting_timer(
+                ) else starter
+
+            for b in beginners:
+                _begin_timer(
+                    timer=b[0],
+                    td_now=td_now,
+                    start_player=(b[0] == starter),
+                    force_return_vol=fader[0].i_return_vol if fader is not None and fader[0] != b[0] else None)
+
+            if fader:
+                _fade_timer(timer=fader[0], td_now=td_now,
+                            td_start=fader[1], td_end=fader[2])
+
+        def _begin_timer(timer, td_now, force_return_vol=None, start_player=True):
+
+            if timer.is_fading_timer():
+                if force_return_vol is not None:
+                    timer.i_return_vol = force_return_vol
+                else:
+                    timer.i_return_vol = util.get_volume(
+                        or_default=self._default_vol)
+
+            if start_player and timer.is_starting_timer():
+                if self._resume:
+                    td_start = util.parse_time(
+                        timer.s_start, datetime.today().weekday())
+                    delta_now_start = util.abs_time_diff(td_now, td_start)
+                    self._player.playWithSeekTime(
+                        timer.s_filename, seektime=delta_now_start)
+                else:
+                    self._player.play(timer.s_filename)
+
+            elif timer.s_action in [ACTION_STOP, ACTION_START_AT_END]:
+                self._player.stop()
+
+            if timer.b_notify:
+                icon_file = os.path.join(self._addon_dir,
+                                         "resources",
+                                         "assets", "icon_alarm.png" if timer.s_end_type == END_TYPE_NO else "icon_sleep.png")
+                xbmcgui.Dialog().notification(self._addon.getLocalizedString(
+                    32100), timer.s_label, icon=icon_file)
+
+            timer.b_active = True
+
+        def _end_timer(timer, reset_vol=True, stop_player=True):
+
+            has_stopped_player = False
+            if stop_player and timer.is_stopping_timer():
+                self._player.stop()
+                has_stopped_player = True
+
+            elif timer.s_action == ACTION_START_AT_END and timer.s_filename != "":
+                self._player.play(timer.s_filename)
+
+            if timer.b_notify and timer.s_end_type != END_TYPE_NO:
+                xbmcgui.Dialog().notification(self._addon.getLocalizedString(
+                    32101), timer.s_label)
+
+            if reset_vol and timer.is_fading_timer():
+                xbmc.sleep(3000)
+                util.set_volume(timer.i_return_vol)
+
+            timer.b_active = False
+
+            if timer.s_schedule in TIMER_ONCE:
+                Timer(timer.i_timer).save_to_settings()
+
+            if timer.s_action == ACTION_POWERDOWN_AT_END:
+                xbmc.shutdown()
+
+            return has_stopped_player
+
+        def _fade_timer(timer, td_now, td_start, td_end):
+
+            if not timer.is_fading_timer():
+                return
+
+            delta_now_start = util.abs_time_diff(td_now, td_start)
+            delta_end_start = util.abs_time_diff(td_end, td_start)
+            delta_percent = delta_now_start / delta_end_start
+
+            vol_min = timer.i_vol_min
+            vol_max = timer.i_return_vol if timer.s_fade == FADE_OUT_FROM_CURRENT else timer.i_vol_max
+            vol_diff = vol_max - vol_min
+
+            if timer.s_fade == FADE_IN_FROM_MIN:
+                new_vol = int(vol_min + vol_diff * delta_percent)
+            else:
+                new_vol = int(vol_max - vol_diff * delta_percent)
+
+            util.set_volume(new_vol)
 
         while not self.abortRequested():
 
             t_now = time.localtime()
+            _check_timers(t_now)
+
+            if self._powermanagement_displaysoff:
+                self._prevent_powermanagement_displaysoff()
+
             if self.waitForAbort(
                     CHECK_INTERVAL - t_now.tm_sec % CHECK_INTERVAL):
                 break
 
-            self.check_timers()
+    def _prevent_powermanagement_displaysoff(self):
 
-    def onSettingsChanged(self):
+        if not util.is_fullscreen():
+            self._disabled_powermanagement_displaysoff = True
+            util.set_powermanagement_displaysoff(0)
 
-        if util.isSettingsChangedEvents(self.addon):
-            self._update()
-            xbmcgui.Dialog().notification(self.addon.getLocalizedString(
-                32027), self.addon.getLocalizedString(32028))
+        elif self._disabled_powermanagement_displaysoff:
+            self.reset_powermanagement_displaysoff()
 
-    def _update(self):
+    def reset_powermanagement_displaysoff(self):
 
-        self._set_now()
-        timers = self._timer_state["timers"]
-        for i in range(len(timers)):
-
-            s_label = self.addon.getSetting("timer_%i_label" % i)
-
-            s_action = self.addon.getSetting("timer_%i_action" % i)
-
-            s_fade = self.addon.getSetting("timer_%i_fade" % i)
-
-            i_vol_min = int("0%s" % self.addon.getSetting(
-                "timer_%i_vol_min" % i))
-
-            i_vol_max = int("0%s" % self.addon.getSetting(
-                "timer_%i_vol_max" % i))
-
-            s_filename = self.addon.getSetting("timer_%i_filename" % i)
-
-            s_schedule = self.addon.getSetting("timer_%i" % i)
-
-            s_start = self.addon.getSetting("timer_%i_start" % i)
-
-            s_end_type = self.addon.getSetting("timer_%i_end_type" % i)
-
-            s_end = self.addon.getSetting("timer_%i_end" % i)
-
-            s_duration = self.addon.getSetting("timer_%i_duration" % i)
-
-            td_duration = util.parse_time(s_duration)
-
-            b_notify = ("true" == self.addon.getSetting("timer_%i_notify" % i))
-
-            periods = list()
-            for i_day in TIMER_DAYS_PRESETS[s_schedule]:
-                td_start = util.parse_time(s_start, i_day)
-                td_end = self._build_end_time(td_start,
-                                              s_end_type,
-                                              td_duration,
-                                              s_end)
-
-                periods.append({
-                    "td_start": td_start,
-                    "td_end": td_end
-                })
-
-            timers[i] = {
-                "i_timer": i,
-                "s_schedule": s_schedule,
-                "days": TIMER_DAYS_PRESETS[s_schedule],
-                "s_label": s_label,
-                "s_start": s_start,
-                "s_end_type": s_end_type,
-                "s_end": s_end,
-                "s_duration": s_duration,
-                "td_duration": td_duration,
-                "s_action": s_action,
-                "s_filename": s_filename,
-                "s_fade": s_fade,
-                "i_vol_min": i_vol_min,
-                "i_vol_max": i_vol_max,
-                "periods": periods,
-                "b_in_period": False,
-                "b_active": False,
-                "b_notify": b_notify
-            }
-
-    def _set_now(self, t_now=None):
-
-        if t_now == None:
-            t_now = time.localtime()
-
-        td_now = timedelta(hours=t_now.tm_hour,
-                           minutes=t_now.tm_min,
-                           seconds=t_now.tm_sec,
-                           days=t_now.tm_wday)
-
-        self._timer_state["t_now"] = t_now
-        self._timer_state["td_now"] = td_now
-
-        return t_now, td_now
-
-    def _build_end_time(self, td_start, s_end_type, td_duration, s_end):
-
-        if s_end_type == END_TYPE_DURATION:
-            td_end = td_start + td_duration
-
-        elif s_end_type == END_TYPE_TIME:
-            td_end = util.parse_time(s_end, td_start.days)
-
-            if td_end < td_start:
-                td_end += timedelta(days=1)
-
-        else:  # END_TYPE_NO
-            td_end = td_start + timedelta(seconds=CHECK_INTERVAL)
-
-        return td_end
-
-    def _get_current_volume(self):
-
-        try:
-            _result = util.json_rpc("Application.GetProperties", {
-                "properties": ["volume"]})
-            return _result["volume"]
-
-        except:
-            xbmc.log(
-                "jsonrpc call failed in order to get current volume: Application.GetProperties", xbmc.LOGERROR)
-            return int(self.addon.getSetting("vol_default"))
-
-    def _start_action(self, timer, td_now, force_return_vol=None):
-
-        if self._is_fading_timer(timer):
-            if force_return_vol is not None:
-                timer["i_return_vol"] = force_return_vol
-            else:
-                timer["i_return_vol"] = self._get_current_volume()
-
-        if timer["s_action"] in [ACTION_START_STOP, ACTION_START] and timer["s_filename"] != "":
-            if self.addon.getSetting("resume") == "true":
-                td_start = util.parse_time(
-                    timer["s_start"], datetime.today().weekday())
-                delta_now_start = util.abs_time_diff(td_now, td_start)
-                self.player.playWithSeekTime(
-                    timer["s_filename"], seektime=delta_now_start)
-            else:
-                self.player.play(timer["s_filename"])
-
-        elif timer["s_action"] in [ACTION_STOP, ACTION_START_AT_END]:
-            self.player.stop()
-
-        if timer["b_notify"]:
-            icon_file = os.path.join(self.addon_dir,
-                                     "resources",
-                                     "assets", "icon_alarm.png" if timer["s_end_type"] == END_TYPE_NO else "icon_sleep.png")
-            xbmcgui.Dialog().notification(self.addon.getLocalizedString(
-                32100), timer["s_label"], icon=icon_file)
-
-        timer["b_active"] = True
-
-    def _stop_action(self, timer, reset_vol=True):
-
-        if timer["s_action"] in [ACTION_START_STOP, ACTION_STOP_AT_END]:
-            self.player.stop()
-
-        elif timer["s_action"] == ACTION_START_AT_END and timer["s_filename"] != "":
-            self.player.play(timer["s_filename"])
-
-        if timer["b_notify"] and timer["s_end_type"] != END_TYPE_NO:
-            xbmcgui.Dialog().notification(self.addon.getLocalizedString(
-                32101), timer["s_label"])
-
-        if self._is_fading_timer(timer) and reset_vol:
-            xbmc.sleep(3000)
-            xbmc.executebuiltin("SetVolume(%s)" % timer["i_return_vol"])
-
-        timer["b_active"] = False
-
-        if timer["s_schedule"] in TIMER_ONCE:
-            self._reset_settings(timer)
-
-        if timer["s_action"] in [ACTION_POWERDOWN_AT_END]:
-            xbmc.shutdown()
-
-    def _reset_settings(self, timer):
-
-        timer["s_schedule"] == TIMER_OFF
-
-        i = timer["i_timer"]
-        util.deactivateOnSettingsChangedEvents(self.addon)
-        self.addon.setSetting("timer_%i_label" %
-                              i, self.addon.getLocalizedString(32009 + i))
-        self.addon.setSetting("timer_%i" % i, TIMER_OFF)
-        self.addon.setSetting("timer_%i_start" % i, DEFAULT_TIME)
-        self.addon.setSetting("timer_%i_end_type" % i, END_TYPE_NO)
-        self.addon.setSetting("timer_%i_duration" % i, "00:10")
-        self.addon.setSetting("timer_%i_end" % i, DEFAULT_TIME)
-        self.addon.setSetting("timer_%i_action" % i, ACTION_START_STOP)
-        self.addon.setSetting("timer_%i_filename" % i, "")
-        if i != SLEEP_TIMER:
-            self.addon.setSetting("timer_%i_fade" % i, FADE_OFF)
-        util.activateOnSettingsChangedEvents(self.addon)
-
-    def _is_fading_timer(self, timer):
-
-        return timer["s_fade"] != FADE_OFF and timer["s_end_type"] != END_TYPE_NO
-
-    def _fade(self, timer, td_now, td_start, td_end):
-
-        if not self._is_fading_timer(timer):
-            return
-
-        if "i_return_vol" not in timer:
-            timer["i_return_vol"] = self._get_current_volume()
-
-        delta_now_start = util.abs_time_diff(td_now, td_start)
-        delta_end_start = util.abs_time_diff(td_end, td_start)
-        delta_percent = delta_now_start / delta_end_start
-
-        vol_min = timer["i_vol_min"]
-        vol_max = timer["i_return_vol"] if timer["s_fade"] == FADE_OUT_FROM_CURRENT else timer["i_vol_max"]
-        vol_diff = vol_max - vol_min
-
-        if timer["s_fade"] == FADE_IN_FROM_MIN:
-            new_vol = int(vol_min + vol_diff * delta_percent)
-        else:
-            new_vol = int(vol_max - vol_diff * delta_percent)
-
-        try:
-            _result = util.json_rpc("Application.GetProperties",
-                                    {"properties": ["volume"]})
-            current_vol = _result["volume"]
-            if current_vol != new_vol:
-                xbmc.executebuiltin("SetVolume(%i)" % new_vol)
-
-        except:
-            xbmc.log(
-                "jsonrpc call failed in order to get current volume: Application.GetProperties", xbmc.LOGERROR)
-            xbmc.executebuiltin("SetVolume(%i)" % new_vol)
-
-    def _check_period(self, timer, td_now):
-
-        for period in timer["periods"]:
-
-            in_period = period["td_start"] <= td_now < period["td_end"]
-            if in_period:
-                timer["b_in_period"] = True
-                return in_period, period["td_start"], period["td_end"]
-
-        timer["b_in_period"] = False
-        return False, None, None
-
-    def check_timers(self, t_now=None):
-
-        t_now, td_now = self._set_now(t_now)
-
-        starters, stoppers = list(), list()
-
-        timer_to_fade = None
-        timer_to_fade_td_start = None
-        timer_to_fade_td_end = None
-
-        timers = self._timer_state["timers"]
-        for timer in timers:
-            in_period, td_start, td_end = self._check_period(timer, td_now)
-
-            if in_period and not timer["b_active"]:
-                starters.append(timer)
-
-            elif not in_period and timer["b_active"]:
-                stoppers.append(timer)
-
-            if in_period and self._is_fading_timer(timer):
-                if timer_to_fade_td_start == None or td_start < timer_to_fade_td_start:
-                    timer_to_fade = timer
-                    timer_to_fade_td_start = td_start
-                    timer_to_fade_td_end = td_end
-
-        for t in stoppers:
-            self._stop_action(t, reset_vol=(timer_to_fade is None))
-
-        for t in starters:
-            self._start_action(
-                t, td_now, force_return_vol=timer_to_fade["i_return_vol"] if timer_to_fade is not None and timer_to_fade != t else None)
-
-        if timer_to_fade:
-            self._fade(timer=timer_to_fade, td_now=td_now,
-                       td_start=timer_to_fade_td_start, td_end=timer_to_fade_td_end)
+        if self._powermanagement_displaysoff:
+            util.set_powermanagement_displaysoff(
+                self._powermanagement_displaysoff)
+            self._disabled_powermanagement_displaysoff = False

--- a/script.timers/resources/lib/timer/set_quick_epg_timer.py
+++ b/script.timers/resources/lib/timer/set_quick_epg_timer.py
@@ -1,0 +1,55 @@
+import xbmcgui
+from resources.lib.timer.abstract_set_timer import (CONFIRM_YES,
+                                                    AbstractSetTimer)
+from resources.lib.timer.scheduler import TIMERS
+from resources.lib.timer.set_timer import SetTimer
+from resources.lib.timer.timer import TIMER_OFF
+
+
+class SetQuickEpgTimer(AbstractSetTimer):
+
+    def perform_ahead(self, preselection):
+
+        found = -1
+        for i in range(2, TIMERS):
+            if found == -1 and self.addon.getSetting("timer_%i" % i) == str(preselection["activation"]) and preselection["starttime"] == self.addon.getSetting("timer_%s_start" % i) and preselection["path"] == self.addon.getSetting("timer_%s_filename" % i):
+                found = i
+
+        if found != -1:
+            preselection["timer"] = found
+
+        preselection["fade"] = 0
+        return True
+
+    def ask_timer(self):
+
+        free_slots = [i for i in range(2, TIMERS) if self.addon.getSetting(
+            "timer_%i" % i) == TIMER_OFF]
+
+        if len(free_slots) > 0:
+            return free_slots[0]
+
+        xbmcgui.Dialog().notification(self.addon.getLocalizedString(
+            32027), self.addon.getLocalizedString(32115))
+
+        SetTimer(self.listitem)
+
+        return None
+
+    def ask_duration(self, listitem, preselection):
+
+        return preselection["duration"]
+
+    def confirm(self, preselection):
+
+        line1 = preselection["label"]
+
+        line2 = (self.addon.getLocalizedString(32024)) % (
+            self.addon.getLocalizedString(32034 + preselection["activation"]),
+            preselection["starttime"],
+            preselection["endtime"])
+
+        xbmcgui.Dialog().notification(self.addon.getLocalizedString(
+            32116) % self.addon.getLocalizedString(32004 + preselection["timer"]), "\n".join([line1, line2]))
+
+        return CONFIRM_YES

--- a/script.timers/resources/lib/timer/set_sleep.py
+++ b/script.timers/resources/lib/timer/set_sleep.py
@@ -2,9 +2,8 @@ import xbmc
 import xbmcgui
 from resources.lib.timer import util
 from resources.lib.timer.abstract_set_timer import AbstractSetTimer
-from resources.lib.timer.scheduler import (ACTION_STOP_AT_END,
-                                           END_TYPE_DURATION, END_TYPE_TIME,
-                                           SLEEP_TIMER)
+from resources.lib.timer.timer import (ACTION_STOP_AT_END, END_TYPE_DURATION,
+                                       END_TYPE_TIME, SLEEP_TIMER)
 
 
 class SetSleep(AbstractSetTimer):
@@ -15,7 +14,7 @@ class SetSleep(AbstractSetTimer):
 
     def ask_label(self, listitem, preselection):
 
-        return self.addon.getLocalizedString(32009)
+        return self.addon.getLocalizedString(32004)
 
     def ask_duration(self, listitem, preselection):
 

--- a/script.timers/resources/lib/timer/set_snooze.py
+++ b/script.timers/resources/lib/timer/set_snooze.py
@@ -3,9 +3,9 @@ import xbmcgui
 from resources.lib.timer import util
 from resources.lib.timer.abstract_set_timer import (DURATION_NO,
                                                     AbstractSetTimer)
-from resources.lib.timer.scheduler import (ACTION_START, ACTION_START_AT_END,
-                                           END_TYPE_DURATION, END_TYPE_TIME,
-                                           SNOOZE_TIMER)
+from resources.lib.timer.timer import (ACTION_START, ACTION_START_AT_END,
+                                       END_TYPE_DURATION, END_TYPE_TIME,
+                                       SNOOZE_TIMER)
 
 
 class SetSnooze(AbstractSetTimer):
@@ -16,7 +16,7 @@ class SetSnooze(AbstractSetTimer):
 
     def ask_label(self, listitem, preselection):
 
-        return self.addon.getLocalizedString(32010)
+        return self.addon.getLocalizedString(32005)
 
     def ask_duration(self, listitem, preselection):
 

--- a/script.timers/resources/lib/timer/set_timer.py
+++ b/script.timers/resources/lib/timer/set_timer.py
@@ -1,9 +1,10 @@
 import xbmc
 import xbmcgui
-from resources.lib.timer.abstract_set_timer import AbstractSetTimer, CONFIRM_EDIT, DURATION_NO
-from resources.lib.timer.scheduler import (ACTION_START_STOP, ACTION_START,
-                                           TIMER_DAYS_PRESETS, TIMER_OFF,
-                                           TIMERS)
+from resources.lib.timer.abstract_set_timer import (CONFIRM_EDIT, DURATION_NO,
+                                                    AbstractSetTimer)
+from resources.lib.timer.scheduler import TIMERS
+from resources.lib.timer.timer import (ACTION_START, ACTION_START_STOP,
+                                       TIMER_DAYS_PRESETS, TIMER_OFF)
 
 
 class SetTimer(AbstractSetTimer):
@@ -25,7 +26,8 @@ class SetTimer(AbstractSetTimer):
         if selection == -1:
             return None
         elif selection == 0:
-            xbmc.executebuiltin("Addon.OpenSettings(%s)" % self.addon.getAddonInfo("id"))
+            xbmc.executebuiltin("Addon.OpenSettings(%s)" %
+                                self.addon.getAddonInfo("id"))
             return None
         else:
             return selection + 1
@@ -90,7 +92,7 @@ class SetTimer(AbstractSetTimer):
         line4 = "%s: %s" % (self.addon.getLocalizedString(32091),
                             self.addon.getLocalizedString(32120 + int(self.addon.getSetting("timer_%i_fade" % preselection["timer"]))))
 
-        return xbmcgui.Dialog().yesnocustom(self.addon.getLocalizedString(32107) % self.addon.getLocalizedString(32011 + preselection["timer"] - 2),
+        return xbmcgui.Dialog().yesnocustom(self.addon.getLocalizedString(32107) % self.addon.getLocalizedString(32009 + preselection["timer"] - 2),
                                             "\n".join(
                                                 [line1, line2, line3, line4]),
                                             self.addon.getLocalizedString(
@@ -102,4 +104,5 @@ class SetTimer(AbstractSetTimer):
     def post_apply(self, selection, confirm):
 
         if confirm == CONFIRM_EDIT:
-            xbmc.executebuiltin("Addon.OpenSettings(%s)" % self.addon.getAddonInfo("id"))
+            xbmc.executebuiltin("Addon.OpenSettings(%s)" %
+                                self.addon.getAddonInfo("id"))

--- a/script.timers/resources/lib/timer/timer.py
+++ b/script.timers/resources/lib/timer/timer.py
@@ -1,0 +1,226 @@
+from datetime import timedelta
+
+import xbmcaddon
+from resources.lib.timer import util
+
+SLEEP_TIMER = 0
+SNOOZE_TIMER = 1
+
+TIMER_ONCE = [str(i) for i in range(7)]
+TIMER_OFF = "25"
+
+TIMER_DAYS_PRESETS = {
+    "0": [0],                     # mon
+    "1": [1],                     # tue
+    "2": [2],                     # wed
+    "3": [3],                     # thu
+    "4": [4],                     # fri
+    "5": [5],                     # sat
+    "6": [6],                     # sun
+    "7": [0],                     # mons
+    "8": [1],                     # tues
+    "9": [2],                     # weds
+    "10": [3],                    # thus
+    "11": [4],                    # fris
+    "12": [5],                    # sats
+    "13": [6],                    # suns
+    "14": [0, 1, 2, 3],           # mon-thu
+    "15": [0, 1, 2, 3, 4],        # mon-fri
+    "26": [0, 1, 2, 3, 4, 5],     # mon-sat
+    "16": [1, 2, 3, 4],           # tue-fri
+    "17": [3, 4, 5],              # thu-sat
+    "18": [4, 5],                 # fri-sat
+    "19": [4, 5, 6],              # fri-sun
+    "20": [5, 6],                 # sat-sun
+    "21": [5, 6, 0],              # sat-mon
+    "22": [6, 0, 1, 2],           # sun-wed
+    "23": [6, 0, 1, 2, 3],        # sun-thu
+    "24": [0, 1, 2, 3, 4, 5, 6],  # everyday
+    "25": [],                     # off
+    "": []                        # off
+}
+
+END_TYPE_NO = "0"
+END_TYPE_DURATION = "1"
+END_TYPE_TIME = "2"
+
+ACTION_NO = "0"
+ACTION_START_STOP = "1"
+ACTION_START = "2"
+ACTION_START_AT_END = "3"
+ACTION_STOP = "4"
+ACTION_STOP_AT_END = "5"
+ACTION_POWERDOWN_AT_END = "6"
+
+FADE_OFF = "0"
+FADE_IN_FROM_MIN = "1"
+FADE_OUT_FROM_MAX = "2"
+FADE_OUT_FROM_CURRENT = "3"
+
+
+class Timer():
+
+    _addon = None
+
+    i_timer = None
+
+    s_label = ""
+    s_schedule = TIMER_OFF
+    s_start = util.DEFAULT_TIME
+    s_end_type = END_TYPE_NO
+    s_duration = util.DEFAULT_TIME
+    s_end = util.DEFAULT_TIME
+    s_action = ACTION_START
+    s_filename = ""
+    s_fade = FADE_OFF
+    i_vol_min = 75
+    i_vol_max = 100
+    b_notify = True
+
+    i_return_vol = 100
+    b_active = False
+    periods = list()
+    days = list()
+    td_duration = timedelta()
+
+    def __init__(self, i):
+
+        self._addon = xbmcaddon.Addon()
+
+        self.s_label = self._addon.getLocalizedString(32004 + i)
+        self.i_timer = i
+        self.s_duration = ["01:00", "00:10"][i] if i < 2 else "00:00"
+        self.s_action = [ACTION_STOP,
+                         ACTION_START_AT_END][i] if i < 2 else ACTION_START
+        self.s_fade = FADE_OUT_FROM_CURRENT if i == SLEEP_TIMER else FADE_OFF
+
+    @staticmethod
+    def init_from_settings(i):
+
+        def _build_end_time(td_start, s_end_type, td_duration, s_end):
+
+            if s_end_type == END_TYPE_DURATION:
+                td_end = td_start + td_duration
+
+            elif s_end_type == END_TYPE_TIME:
+                td_end = util.parse_time(s_end, td_start.days)
+
+                if td_end < td_start:
+                    td_end += timedelta(days=1)
+
+            else:  # END_TYPE_NO
+                td_end = td_start + timedelta(seconds=1)
+
+            return td_end, td_end - td_start
+
+        addon = xbmcaddon.Addon()
+
+        timer = Timer(i)
+        timer.s_label = addon.getSetting("timer_%i_label" % i)
+        timer.s_action = addon.getSetting("timer_%i_action" % i)
+        timer.s_fade = addon.getSetting("timer_%i_fade" % i)
+        timer.i_vol_min = int(
+            "0%s" % addon.getSetting("timer_%i_vol_min" % i))
+        timer.i_vol_max = int(
+            "0%s" % addon.getSetting("timer_%i_vol_max" % i))
+        timer.s_filename = addon.getSetting("timer_%i_filename" % i)
+        timer.s_schedule = addon.getSetting("timer_%i" % i)
+        timer.days = TIMER_DAYS_PRESETS[timer.s_schedule]
+        timer.s_start = addon.getSetting("timer_%i_start" % i)
+        timer.s_end_type = addon.getSetting("timer_%i_end_type" % i)
+        timer.s_end = addon.getSetting("timer_%i_end" % i)
+        timer.s_duration = addon.getSetting("timer_%i_duration" % i)
+        timer.td_duration = util.parse_time(timer.s_duration)
+        timer.b_notify = (
+            "true" == addon.getSetting("timer_%i_notify" % i))
+
+        timer.i_return_vol = None
+        timer.b_active = False
+
+        timer.periods = list()
+        for i_day in TIMER_DAYS_PRESETS[timer.s_schedule]:
+            td_start = util.parse_time(timer.s_start, i_day)
+            td_end, timer.td_duration = _build_end_time(td_start,
+                                                        timer.s_end_type,
+                                                        timer.td_duration,
+                                                        timer.s_end)
+
+            timer.periods.append((td_start, td_end))
+
+        return timer
+
+    def update_or_replace_from_settings(self):
+
+        timer_from_settings = Timer.init_from_settings(self.i_timer)
+
+        changed = (timer_from_settings.s_schedule != self.s_schedule)
+        changed |= (timer_from_settings.s_start != self.s_start)
+        changed |= (timer_from_settings.s_end_type != self.s_end_type)
+        if self.s_end_type == END_TYPE_DURATION:
+            changed |= (timer_from_settings.s_duration != self.s_duration)
+        elif self.s_end_type == END_TYPE_TIME:
+            changed |= (timer_from_settings.s_end != self.s_end)
+
+        changed |= (timer_from_settings.s_action != self.s_action)
+        if self.s_action in [ACTION_START_STOP, ACTION_START, ACTION_START_AT_END]:
+            changed |= (timer_from_settings.s_filename != self.s_filename)
+
+        changed |= (timer_from_settings.s_fade != self.s_fade)
+        if self.is_fading_timer():
+            changed |= (timer_from_settings.i_vol_min != self.i_vol_min)
+            changed |= (timer_from_settings.i_vol_max != self.i_vol_max)
+
+        if changed:
+            return timer_from_settings
+        else:
+            self.s_label = timer_from_settings.s_label
+            self.b_notify = timer_from_settings.b_notify
+            return self
+
+    def save_to_settings(self):
+
+        util.deactivateOnSettingsChangedEvents(self._addon)
+        self._addon.setSetting("timer_%i_label" %
+                               self.i_timer, self.s_label)
+        self._addon.setSetting("timer_%i" % self.i_timer, self.s_schedule)
+        self._addon.setSetting("timer_%i_start" %
+                               self.i_timer, self.s_start)
+        self._addon.setSetting("timer_%i_end_type" %
+                               self.i_timer, self.s_end_type)
+        self._addon.setSetting("timer_%i_duration" %
+                               self.i_timer, self.s_duration)
+        self._addon.setSetting("timer_%i_end" % self.i_timer, self.s_end)
+        self._addon.setSetting("timer_%i_action" %
+                               self.i_timer, self.s_action)
+        self._addon.setSetting("timer_%i_filename" %
+                               self.i_timer, self.s_filename)
+        self._addon.setSetting("timer_%i_fade" % self.i_timer, self.s_fade)
+        self._addon.setSetting("timer_%i_vol_min" %
+                               self.i_timer, str(self.i_vol_min))
+        self._addon.setSetting("timer_%i_vol_max" %
+                               self.i_timer, str(self.i_vol_max))
+        self._addon.setSetting("timer_%i_notify" %
+                               self.i_timer, "true" if self.b_notify else "false")
+        util.activateOnSettingsChangedEvents(self._addon)
+
+    def get_matching_period(self, time_):
+
+        for period in self.periods:
+
+            in_period = period[0] <= time_ < period[1]
+            if in_period:
+                return period
+
+        return None
+
+    def is_fading_timer(self):
+
+        return self.s_fade != FADE_OFF and self.s_end_type != END_TYPE_NO
+
+    def is_starting_timer(self):
+
+        return self.s_action in [ACTION_START_STOP, ACTION_START] and self.s_filename
+
+    def is_stopping_timer(self):
+
+        return self.s_action in [ACTION_START_STOP, ACTION_STOP_AT_END]

--- a/script.timers/resources/lib/timer/util.py
+++ b/script.timers/resources/lib/timer/util.py
@@ -99,6 +99,11 @@ def get_current_epg_view():
         return None
 
 
+def is_fullscreen():
+
+    return xbmc.getCondVisibility("System.IsFullscreen")
+
+
 def get_pvr_channel_path(type, channelno):
 
     try:
@@ -112,7 +117,8 @@ def get_pvr_channel_path(type, channelno):
 
         _result = json_rpc("PVR.GetChannels", {
             "channelgroupid": "all%s" % type, "properties": ["uniqueid", "clientid", "channelnumber"]})
-        channel = next(filter(lambda c: c["channelnumber"] == channelno, _result["channels"]), None)
+        channel = next(
+            filter(lambda c: c["channelnumber"] == channelno, _result["channels"]), None)
 
         if not channel:
             return None
@@ -127,6 +133,30 @@ def get_pvr_channel_path(type, channelno):
         pass
 
     return None
+
+
+def get_volume(or_default=100):
+
+    try:
+        _result = json_rpc("Application.GetProperties",
+                           {"properties": ["volume"]})
+        return _result["volume"]
+
+    except:
+        xbmc.log(
+            "jsonrpc call failed in order to get current volume: Application.GetProperties", xbmc.LOGERROR)
+        return or_default
+
+
+def set_volume(vol):
+
+    xbmc.executebuiltin("SetVolume(%i)" % vol)
+
+
+def set_powermanagement_displaysoff(value):
+
+    json_rpc("Settings.SetSettingValue", {
+             "setting": "powermanagement.displaysoff", "value": value})
 
 
 def json_rpc(jsonmethod, params=None):

--- a/script.timers/resources/settings.xml
+++ b/script.timers/resources/settings.xml
@@ -1,322 +1,3796 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<settings>
-
-  <category label="32030">
-    <setting label="32113" type="bool" id="resume" default="false" />
-    <setting visible="System.Platform.Windows" label="32032" type="bool" id="windows_unlock" default="true" />
-    <setting label="32031" type="slider" id="vol_default" default="100" range="0,1,100" option="int" />
-    <setting label="32111" type="action" action="RunScript($ID,reset_volume)" />
-    <setting visible="false" id="onSettingChangeEvents" type="number" default="0" />
-  </category>
-
-  <category label="32009">
-    <setting label="32026" type="text" id="timer_0_label" default="Sleep Timer" />
-
-    <setting label="32060" type="lsep" />
-    <setting label="32033" type="enum" id="timer_0" lvalues="32034|32035|32036|32037|32038|32039|32040|32041|32042|32043|32044|32045|32046|32047|32048|32049|32050|32051|32052|32053|32054|32055|32056|32057|32058|32059" default="25" />
-    <setting enable="!eq(-1,25)" label="32061" type="time" default="00:00" id="timer_0_start" />
-    <setting enable="!eq(-2,25)" label="32062" type="enum" id="timer_0_end_type" lvalues="32063|32064|32065" default="0" />
-    <setting enable="!eq(-3,25)" visible="eq(-1,1)" label="32064" type="time" default="01:00" id="timer_0_duration" />
-    <setting enable="!eq(-4,25)" visible="eq(-2,2)" label="32065" type="time" default="00:00" id="timer_0_end" />
-
-    <setting label="32070" type="lsep" />
-    <setting label="32070" type="enum" id="timer_0_action" lvalues="32071|32072|32073|32074|32075|32076|32077" default="1" />
-    <setting visible="false" label="32082" type="text" id="timer_0_filename" default="" />
-    <setting visible="eq(-1,) + gt(-2,0) + lt(-2,4)" enable="false" label="32114" type="text" />
-    <setting enable="!eq(-2,)" label="32108" type="action" action="RunScript($ID,play,0)" />
-
-    <setting label="32090" type="lsep" />
-    <setting enable="!eq(-9,0)" label="32091" type="enum" id="timer_0_fade" lvalues="32120|32121|32122|32123" default="0" />
-    <setting visible="!eq(-1,0)" label="32095" type="slider" id="timer_0_vol_min" default="50" range="0,1,100" option="int" />
-    <setting visible="!eq(-2,0) + !eq(-2,3)" label="32096" type="slider" id="timer_0_vol_max" default="100" range="0,1,100" option="int" />
-
-    <setting label="32097" type="lsep" />
-    <setting label="32098" type="bool" id="timer_0_notify" default="true" />
-
-  </category>
-
-  <category label="32010">
-    <setting label="32026" type="text" id="timer_1_label" default="Snooze Timer" />
-
-    <setting label="32060" type="lsep" />
-    <setting label="32033" type="enum" id="timer_1" lvalues="32034|32035|32036|32037|32038|32039|32040|32041|32042|32043|32044|32045|32046|32047|32048|32049|32050|32051|32052|32053|32054|32055|32056|32057|32058|32059" default="25" />
-    <setting enable="!eq(-1,25)" label="32061" type="time" default="00:00" id="timer_1_start" />
-    <setting enable="!eq(-2,25)" label="32062" type="enum" id="timer_1_end_type" lvalues="32063|32064|32065" default="0" />
-    <setting enable="!eq(-3,25)" visible="eq(-1,1)" label="32064" type="time" default="00:10" id="timer_1_duration" />
-    <setting enable="!eq(-4,25)" visible="eq(-2,2)" label="32065" type="time" default="00:00" id="timer_1_end" />
-
-    <setting label="32070" type="lsep" />
-    <setting label="32070" type="enum" id="timer_1_action" lvalues="32071|32072|32073|32074|32075|32076|32077" default="1" />
-    <setting visible="false" label="32082" type="text" id="timer_1_filename" default="" />
-    <setting visible="eq(-1,) + gt(-2,0) + lt(-2,4)" enable="false" label="32114" type="text" />
-    <setting enable="!eq(-2,)" label="32108" type="action" action="RunScript($ID,play,1)" />
-
-    <setting label="32090" type="lsep" />
-    <setting enable="!eq(-9,0)" label="32091" type="enum" id="timer_1_fade" lvalues="32120|32121|32122|32123" default="0" />
-    <setting visible="!eq(-1,0)" label="32095" type="slider" id="timer_1_vol_min" default="50" range="0,1,100" option="int" />
-    <setting visible="!eq(-2,0) + !eq(-2,3)" label="32096" type="slider" id="timer_1_vol_max" default="100" range="0,1,100" option="int" />
-
-    <setting label="32097" type="lsep" />
-    <setting label="32098" type="bool" id="timer_1_notify" default="true" />
-  </category>
-
-  <category label="32011">
-    <setting label="32026" type="text" id="timer_2_label" default="Timer 1" />
-
-    <setting label="32060" type="lsep" />
-    <setting label="32033" type="enum" id="timer_2" lvalues="32034|32035|32036|32037|32038|32039|32040|32041|32042|32043|32044|32045|32046|32047|32048|32049|32050|32051|32052|32053|32054|32055|32056|32057|32058|32059" default="25" />
-    <setting enable="!eq(-1,25)" label="32061" type="time" default="00:00" id="timer_2_start" />
-    <setting enable="!eq(-2,25)" label="32062" type="enum" id="timer_2_end_type" lvalues="32063|32064|32065" default="0" />
-    <setting enable="!eq(-3,25)" visible="eq(-1,1)" label="32064" type="time" default="00:00" id="timer_2_duration" />
-    <setting enable="!eq(-4,25)" visible="eq(-2,2)" label="32065" type="time" default="00:00" id="timer_2_end" />
-
-    <setting label="32070" type="lsep" />
-    <setting label="32070" type="enum" id="timer_2_action" lvalues="32071|32072|32073|32074|32075|32076|32077" default="1" />
-    <setting visible="false" label="32082" type="text" id="timer_2_filename" default="" />
-    <setting visible="eq(-1,) + gt(-2,0) + lt(-2,4)" enable="false" label="32114" type="text" />
-    <setting enable="!eq(-2,)" label="32108" type="action" action="RunScript($ID,play,2)" />
-
-    <setting label="32090" type="lsep" />
-    <setting enable="!eq(-9,0)" label="32091" type="enum" id="timer_2_fade" lvalues="32120|32121|32122|32123" default="0" />
-    <setting visible="!eq(-1,0)" label="32095" type="slider" id="timer_2_vol_min" default="50" range="0,1,100" option="int" />
-    <setting visible="!eq(-2,0) + !eq(-2,3)" label="32096" type="slider" id="timer_2_vol_max" default="100" range="0,1,100" option="int" />
-
-    <setting label="32097" type="lsep" />
-    <setting label="32098" type="bool" id="timer_2_notify" default="true" />
-
-  </category>
-
-  <category label="32012">
-    <setting label="32026" type="text" id="timer_3_label" default="Timer 2" />
-
-    <setting label="32060" type="lsep" />
-    <setting label="32033" type="enum" id="timer_3" lvalues="32034|32035|32036|32037|32038|32039|32040|32041|32042|32043|32044|32045|32046|32047|32048|32049|32050|32051|32052|32053|32054|32055|32056|32057|32058|32059" default="25" />
-    <setting enable="!eq(-1,25)" label="32061" type="time" default="00:00" id="timer_3_start" />
-    <setting enable="!eq(-2,25)" label="32062" type="enum" id="timer_3_end_type" lvalues="32063|32064|32065" default="0" />
-    <setting enable="!eq(-3,25)" visible="eq(-1,1)" label="32064" type="time" default="00:00" id="timer_3_duration" />
-    <setting enable="!eq(-4,25)" visible="eq(-2,2)" label="32065" type="time" default="00:00" id="timer_3_end" />
-
-    <setting label="32070" type="lsep" />
-    <setting label="32070" type="enum" id="timer_3_action" lvalues="32071|32072|32073|32074|32075|32076|32077" default="1" />
-    <setting visible="false" label="32082" type="text" id="timer_3_filename" default="" />
-    <setting visible="eq(-1,) + gt(-2,0) + lt(-2,4)" enable="false" label="32114" type="text" />
-    <setting enable="!eq(-2,)" label="32108" type="action" action="RunScript($ID,play,3)" />
-
-    <setting label="32090" type="lsep" />
-    <setting enable="!eq(-9,0)" label="32091" type="enum" id="timer_3_fade" lvalues="32120|32121|32122|32123" default="0" />
-    <setting visible="!eq(-1,0)" label="32095" type="slider" id="timer_3_vol_min" default="50" range="0,1,100" option="int" />
-    <setting visible="!eq(-2,0) + !eq(-2,3)" label="32096" type="slider" id="timer_3_vol_max" default="100" range="0,1,100" option="int" />
-
-    <setting label="32097" type="lsep" />
-    <setting label="32098" type="bool" id="timer_3_notify" default="true" />
-
-  </category>
-
-  <category label="32013">
-    <setting label="32026" type="text" id="timer_4_label" default="Timer 3" />
-
-    <setting label="32060" type="lsep" />
-    <setting label="32033" type="enum" id="timer_4" lvalues="32034|32035|32036|32037|32038|32039|32040|32041|32042|32043|32044|32045|32046|32047|32048|32049|32050|32051|32052|32053|32054|32055|32056|32057|32058|32059" default="25" />
-    <setting enable="!eq(-1,25)" label="32061" type="time" default="00:00" id="timer_4_start" />
-    <setting enable="!eq(-2,25)" label="32062" type="enum" id="timer_4_end_type" lvalues="32063|32064|32065" default="0" />
-    <setting enable="!eq(-3,25)" visible="eq(-1,1)" label="32064" type="time" default="00:00" id="timer_4_duration" />
-    <setting enable="!eq(-4,25)" visible="eq(-2,2)" label="32065" type="time" default="00:00" id="timer_4_end" />
-
-    <setting label="32070" type="lsep" />
-    <setting label="32070" type="enum" id="timer_4_action" lvalues="32071|32072|32073|32074|32075|32076|32077" default="1" />
-    <setting visible="false" label="32082" type="text" id="timer_4_filename" default="" />
-    <setting visible="eq(-1,) + gt(-2,0) + lt(-2,4)" enable="false" label="32114" type="text" />
-    <setting enable="!eq(-2,)" label="32108" type="action" action="RunScript($ID,play,4)" />
-
-    <setting label="32090" type="lsep" />
-    <setting enable="!eq(-9,0)" label="32091" type="enum" id="timer_4_fade" lvalues="32120|32121|32122|32123" default="0" />
-    <setting visible="!eq(-1,0)" label="32095" type="slider" id="timer_4_vol_min" default="50" range="0,1,100" option="int" />
-    <setting visible="!eq(-2,0) + !eq(-2,3)" label="32096" type="slider" id="timer_4_vol_max" default="100" range="0,1,100" option="int" />
-
-    <setting label="32097" type="lsep" />
-    <setting label="32098" type="bool" id="timer_4_notify" default="true" />
-
-  </category>
-
-  <category label="32014">
-    <setting label="32026" type="text" id="timer_5_label" default="Timer 4" />
-
-    <setting label="32060" type="lsep" />
-    <setting label="32033" type="enum" id="timer_5" lvalues="32034|32035|32036|32037|32038|32039|32040|32041|32042|32043|32044|32045|32046|32047|32048|32049|32050|32051|32052|32053|32054|32055|32056|32057|32058|32059" default="25" />
-    <setting enable="!eq(-1,25)" label="32061" type="time" default="00:00" id="timer_5_start" />
-    <setting enable="!eq(-2,25)" label="32062" type="enum" id="timer_5_end_type" lvalues="32063|32064|32065" default="0" />
-    <setting enable="!eq(-3,25)" visible="eq(-1,1)" label="32064" type="time" default="00:00" id="timer_5_duration" />
-    <setting enable="!eq(-4,25)" visible="eq(-2,2)" label="32065" type="time" default="00:00" id="timer_5_end" />
-
-    <setting label="32070" type="lsep" />
-    <setting label="32070" type="enum" id="timer_5_action" lvalues="32071|32072|32073|32074|32075|32076|32077" default="1" />
-    <setting visible="false" label="32082" type="text" id="timer_5_filename" default="" />
-    <setting visible="eq(-1,) + gt(-2,0) + lt(-2,4)" enable="false" label="32114" type="text" />
-    <setting enable="!eq(-2,)" label="32108" type="action" action="RunScript($ID,play,5)" />
-
-    <setting label="32090" type="lsep" />
-    <setting enable="!eq(-9,0)" label="32091" type="enum" id="timer_5_fade" lvalues="32120|32121|32122|32123" default="0" />
-    <setting visible="!eq(-1,0)" label="32095" type="slider" id="timer_5_vol_min" default="50" range="0,1,100" option="int" />
-    <setting visible="!eq(-2,0) + !eq(-2,3)" label="32096" type="slider" id="timer_5_vol_max" default="100" range="0,1,100" option="int" />
-
-    <setting label="32097" type="lsep" />
-    <setting label="32098" type="bool" id="timer_5_notify" default="true" />
-
-  </category>
-
-  <category label="32015">
-    <setting label="32026" type="text" id="timer_6_label" default="Timer 5" />
-
-    <setting label="32060" type="lsep" />
-    <setting label="32033" type="enum" id="timer_6" lvalues="32034|32035|32036|32037|32038|32039|32040|32041|32042|32043|32044|32045|32046|32047|32048|32049|32050|32051|32052|32053|32054|32055|32056|32057|32058|32059" default="25" />
-    <setting enable="!eq(-1,25)" label="32061" type="time" default="00:00" id="timer_6_start" />
-    <setting enable="!eq(-2,25)" label="32062" type="enum" id="timer_6_end_type" lvalues="32063|32064|32065" default="0" />
-    <setting enable="!eq(-3,25)" visible="eq(-1,1)" label="32064" type="time" default="00:00" id="timer_6_duration" />
-    <setting enable="!eq(-4,25)" visible="eq(-2,2)" label="32065" type="time" default="00:00" id="timer_6_end" />
-
-    <setting label="32070" type="lsep" />
-    <setting label="32070" type="enum" id="timer_6_action" lvalues="32071|32072|32073|32074|32075|32076|32077" default="1" />
-    <setting visible="false" label="32082" type="text" id="timer_6_filename" default="" />
-    <setting visible="eq(-1,) + gt(-2,0) + lt(-2,4)" enable="false" label="32114" type="text" />
-    <setting enable="!eq(-2,)" label="32108" type="action" action="RunScript($ID,play,6)" />
-
-    <setting label="32090" type="lsep" />
-    <setting enable="!eq(-9,0)" label="32091" type="enum" id="timer_6_fade" lvalues="32120|32121|32122|32123" default="0" />
-    <setting visible="!eq(-1,0)" label="32095" type="slider" id="timer_6_vol_min" default="50" range="0,1,100" option="int" />
-    <setting visible="!eq(-2,0) + !eq(-2,3)" label="32096" type="slider" id="timer_6_vol_max" default="100" range="0,1,100" option="int" />
-
-    <setting label="32097" type="lsep" />
-    <setting label="32098" type="bool" id="timer_6_notify" default="true" />
-
-  </category>
-
-  <category label="32016">
-    <setting label="32026" type="text" id="timer_7_label" default="Timer 6" />
-
-    <setting label="32060" type="lsep" />
-    <setting label="32033" type="enum" id="timer_7" lvalues="32034|32035|32036|32037|32038|32039|32040|32041|32042|32043|32044|32045|32046|32047|32048|32049|32050|32051|32052|32053|32054|32055|32056|32057|32058|32059" default="25" />
-    <setting enable="!eq(-1,25)" label="32061" type="time" default="00:00" id="timer_7_start" />
-    <setting enable="!eq(-2,25)" label="32062" type="enum" id="timer_7_end_type" lvalues="32063|32064|32065" default="0" />
-    <setting enable="!eq(-3,25)" visible="eq(-1,1)" label="32064" type="time" default="00:00" id="timer_7_duration" />
-    <setting enable="!eq(-4,25)" visible="eq(-2,2)" label="32065" type="time" default="00:00" id="timer_7_end" />
-
-    <setting label="32070" type="lsep" />
-    <setting label="32070" type="enum" id="timer_7_action" lvalues="32071|32072|32073|32074|32075|32076|32077" default="1" />
-    <setting visible="false" label="32082" type="text" id="timer_7_filename" default="" />
-    <setting enable="!eq(-1,)" label="32108" type="action" action="RunScript($ID,play,7)" />
-
-    <setting label="32090" type="lsep" />
-    <setting enable="!eq(-9,0)" label="32091" type="enum" id="timer_7_fade" lvalues="32120|32121|32122|32123" default="0" />
-    <setting visible="!eq(-1,0)" label="32095" type="slider" id="timer_7_vol_min" default="50" range="0,1,100" option="int" />
-    <setting visible="eq(-1,) + gt(-2,0) + lt(-2,4)" enable="false" label="32114" type="text" />
-
-    <setting label="32097" type="lsep" />
-    <setting label="32098" type="bool" id="timer_7_notify" default="true" />
-
-  </category>
-
-  <category label="32017">
-    <setting label="32026" type="text" id="timer_8_label" default="Timer 7" />
-
-    <setting label="32060" type="lsep" />
-    <setting label="32033" type="enum" id="timer_8" lvalues="32034|32035|32036|32037|32038|32039|32040|32041|32042|32043|32044|32045|32046|32047|32048|32049|32050|32051|32052|32053|32054|32055|32056|32057|32058|32059" default="25" />
-    <setting enable="!eq(-1,25)" label="32061" type="time" default="00:00" id="timer_8_start" />
-    <setting enable="!eq(-2,25)" label="32062" type="enum" id="timer_8_end_type" lvalues="32063|32064|32065" default="0" />
-    <setting enable="!eq(-3,25)" visible="eq(-1,1)" label="32064" type="time" default="00:00" id="timer_8_duration" />
-    <setting enable="!eq(-4,25)" visible="eq(-2,2)" label="32065" type="time" default="00:00" id="timer_8_end" />
-
-    <setting label="32070" type="lsep" />
-    <setting label="32070" type="enum" id="timer_8_action" lvalues="32071|32072|32073|32074|32075|32076|32077" default="1" />
-    <setting visible="false" label="32082" type="text" id="timer_8_filename" default="" />
-    <setting visible="eq(-1,) + gt(-2,0) + lt(-2,4)" enable="false" label="32114" type="text" />
-    <setting enable="!eq(-2,)" label="32108" type="action" action="RunScript($ID,play,8)" />
-
-    <setting label="32090" type="lsep" />
-    <setting enable="!eq(-9,0)" label="32091" type="enum" id="timer_8_fade" lvalues="32120|32121|32122|32123" default="0" />
-    <setting visible="!eq(-1,0)" label="32095" type="slider" id="timer_8_vol_min" default="50" range="0,1,100" option="int" />
-    <setting visible="!eq(-2,0) + !eq(-2,3)" label="32096" type="slider" id="timer_8_vol_max" default="100" range="0,1,100" option="int" />
-
-    <setting label="32097" type="lsep" />
-    <setting label="32098" type="bool" id="timer_8_notify" default="true" />
-
-  </category>
-
-  <category label="32018">
-    <setting label="32026" type="text" id="timer_9_label" default="Timer 8" />
-
-    <setting label="32060" type="lsep" />
-    <setting label="32033" type="enum" id="timer_9" lvalues="32034|32035|32036|32037|32038|32039|32040|32041|32042|32043|32044|32045|32046|32047|32048|32049|32050|32051|32052|32053|32054|32055|32056|32057|32058|32059" default="25" />
-    <setting enable="!eq(-1,25)" label="32061" type="time" default="00:00" id="timer_9_start" />
-    <setting enable="!eq(-2,25)" label="32062" type="enum" id="timer_9_end_type" lvalues="32063|32064|32065" default="0" />
-    <setting enable="!eq(-3,25)" visible="eq(-1,1)" label="32064" type="time" default="00:00" id="timer_9_duration" />
-    <setting enable="!eq(-4,25)" visible="eq(-2,2)" label="32065" type="time" default="00:00" id="timer_9_end" />
-
-    <setting label="32070" type="lsep" />
-    <setting label="32070" type="enum" id="timer_9_action" lvalues="32071|32072|32073|32074|32075|32076|32077" default="1" />
-    <setting visible="false" label="32082" type="text" id="timer_9_filename" default="" />
-    <setting visible="eq(-1,) + gt(-2,0) + lt(-2,4)" enable="false" label="32114" type="text" />
-    <setting enable="!eq(-2,)" label="32108" type="action" action="RunScript($ID,play,9)" />
-
-    <setting label="32090" type="lsep" />
-    <setting enable="!eq(-9,0)" label="32091" type="enum" id="timer_9_fade" lvalues="32120|32121|32122|32123" default="0" />
-    <setting visible="!eq(-1,0)" label="32095" type="slider" id="timer_9_vol_min" default="50" range="0,1,100" option="int" />
-    <setting visible="!eq(-2,0) + !eq(-2,3)" label="32096" type="slider" id="timer_9_vol_max" default="100" range="0,1,100" option="int" />
-
-    <setting label="32097" type="lsep" />
-    <setting label="32098" type="bool" id="timer_9_notify" default="true" />
-
-  </category>
-
-  <category label="32019">
-    <setting label="32026" type="text" id="timer_10_label" default="Timer 9" />
-
-    <setting label="32060" type="lsep" />
-    <setting label="32033" type="enum" id="timer_10" lvalues="32034|32035|32036|32037|32038|32039|32040|32041|32042|32043|32044|32045|32046|32047|32048|32049|32050|32051|32052|32053|32054|32055|32056|32057|32058|32059" default="25" />
-    <setting enable="!eq(-1,25)" label="32061" type="time" default="00:00" id="timer_10_start" />
-    <setting enable="!eq(-2,25)" label="32062" type="enum" id="timer_10_end_type" lvalues="32063|32064|32065" default="0" />
-    <setting enable="!eq(-3,25)" visible="eq(-1,1)" label="32064" type="time" default="00:00" id="timer_10_duration" />
-    <setting enable="!eq(-4,25)" visible="eq(-2,2)" label="32065" type="time" default="00:00" id="timer_10_end" />
-
-    <setting label="32070" type="lsep" />
-    <setting label="32070" type="enum" id="timer_10_action" lvalues="32071|32072|32073|32074|32075|32076|32077" default="1" />
-    <setting visible="false" label="32082" type="text" id="timer_10_filename" default="" />
-    <setting visible="eq(-1,) + gt(-2,0) + lt(-2,4)" enable="false" label="32114" type="text" />
-    <setting enable="!eq(-2,)" label="32108" type="action" action="RunScript($ID,play,10)" />
-
-    <setting label="32090" type="lsep" />
-    <setting enable="!eq(-9,0)" label="32091" type="enum" id="timer_10_fade" lvalues="32120|32121|32122|32123" default="0" />
-    <setting visible="!eq(-1,0)" label="32095" type="slider" id="timer_10_vol_min" default="50" range="0,1,100" option="int" />
-    <setting visible="!eq(-2,0) + !eq(-2,3)" label="32096" type="slider" id="timer_10_vol_max" default="100" range="0,1,100" option="int" />
-
-    <setting label="32097" type="lsep" />
-    <setting label="32098" type="bool" id="timer_10_notify" default="true" />
-
-  </category>
-
-  <category label="32020">
-    <setting label="32026" type="text" id="timer_11_label" default="Timer 10" />
-
-    <setting label="32060" type="lsep" />
-    <setting label="32033" type="enum" id="timer_11" lvalues="32034|32035|32036|32037|32038|32039|32040|32041|32042|32043|32044|32045|32046|32047|32048|32049|32050|32051|32052|32053|32054|32055|32056|32057|32058|32059" default="25" />
-    <setting enable="!eq(-1,25)" label="32061" type="time" default="00:00" id="timer_11_start" />
-    <setting enable="!eq(-2,25)" label="32062" type="enum" id="timer_11_end_type" lvalues="32063|32064|32065" default="0" />
-    <setting enable="!eq(-3,25)" visible="eq(-1,1)" label="32064" type="time" default="00:00" id="timer_11_duration" />
-    <setting enable="!eq(-4,25)" visible="eq(-2,2)" label="32065" type="time" default="00:00" id="timer_11_end" />
-
-    <setting label="32070" type="lsep" />
-    <setting label="32070" type="enum" id="timer_11_action" lvalues="32071|32072|32073|32074|32075|32076|32077" default="1" />
-    <setting visible="false" label="32082" type="text" id="timer_11_filename" default="" />
-    <setting visible="eq(-1,) + gt(-2,0) + lt(-2,4)" enable="false" label="32114" type="text" />
-    <setting enable="!eq(-2,)" label="32108" type="action" action="RunScript($ID,play,11)" />
-
-    <setting label="32090" type="lsep" />
-    <setting enable="!eq(-9,0)" label="32091" type="enum" id="timer_11_fade" lvalues="32120|32121|32122|32123" default="0" />
-    <setting visible="!eq(-1,0)" label="32095" type="slider" id="timer_11_vol_min" default="50" range="0,1,100" option="int" />
-    <setting visible="!eq(-2,0) + !eq(-2,3)" label="32096" type="slider" id="timer_11_vol_max" default="100" range="0,1,100" option="int" />
-
-    <setting label="32097" type="lsep" />
-    <setting label="32098" type="bool" id="timer_11_notify" default="true" />
-
-  </category>
-
+<settings version="1">
+  <section id="script.timers">
+    <category id="general" label="32030" help="">
+      <group id="g_vol_default" label="32031">
+        <setting id="vol_default" type="integer" label="32031" help="">
+          <level>0</level>
+          <default>100</default>
+          <constraints>
+            <minimum>0</minimum>
+            <step>1</step>
+            <maximum>100</maximum>
+          </constraints>
+          <control type="slider" format="integer">
+            <popup>false</popup>
+          </control>
+        </setting>
+        <setting id="resetvol" type="action" label="32111" help="">
+          <level>0</level>
+          <data>RunScript($ID,reset_volume)</data>
+          <control type="button" format="action">
+            <close>false</close>
+          </control>
+        </setting>
+        <setting id="onSettingChangeEvents" type="integer" label="32000" help="">
+          <level>0</level>
+          <default>0</default>
+          <control type="edit" format="integer">
+            <heading>32000</heading>
+          </control>
+          <visible>false</visible>
+        </setting>
+      </group>
+      <group id="g_resume" label="32082">
+        <setting id="resume" type="boolean" label="32113" help="">
+          <level>1</level>
+          <default>false</default>
+          <control type="toggle" />
+        </setting>
+      </group>
+      <group id="g_extras" label="32002">
+        <setting id="powermanagement_displaysoff" type="integer" label="32130" help="">
+          <level>3</level>
+          <default>0</default>
+          <constraints>
+            <options>
+              <option label="32131">0</option>
+              <option label="32132">5</option>
+              <option label="32133">10</option>
+              <option label="32134">15</option>
+              <option label="32135">20</option>
+              <option label="32136">25</option>
+              <option label="32137">30</option>
+              <option label="32138">35</option>
+              <option label="32139">40</option>
+              <option label="32140">45</option>
+              <option label="32141">50</option>
+              <option label="32142">55</option>
+              <option label="32143">60</option>
+              <option label="32144">65</option>
+              <option label="32145">70</option>
+              <option label="32146">75</option>
+              <option label="32147">80</option>
+              <option label="32148">85</option>
+              <option label="32149">90</option>
+              <option label="32150">95</option>
+              <option label="32151">100</option>
+              <option label="32152">105</option>
+              <option label="32153">110</option>
+              <option label="32154">115</option>
+              <option label="32155">120</option>
+            </options>
+          </constraints>
+          <control type="spinner" format="string" />
+          <dependencies>
+            <dependency type="visible" on="property" operator="!is" name="infobool">system.isstandalone</dependency>
+          </dependencies>
+        </setting>
+        <setting id="windows_unlock" type="boolean" label="32032" help="">
+          <level>3</level>
+          <default>false</default>
+          <control type="toggle" />
+          <dependencies>
+            <dependency type="visible" on="property" operator="is" name="infobool">system.platform.windows</dependency>
+          </dependencies>
+        </setting>
+      </group>
+    </category>
+    <category id="c_timer_0" label="32004" help="">
+      <group id="g_timer_0" label="32004">
+        <setting id="timer_0_label" type="string" label="32026" help="">
+          <level>0</level>
+          <default>Sleep Timer</default>
+          <constraints>
+            <allowempty>false</allowempty>
+          </constraints>
+          <control type="edit" format="string">
+            <heading>32026</heading>
+          </control>
+        </setting>
+      </group>
+      <group id="g_timer_0_schedule" label="32060">
+        <setting id="timer_0" type="integer" label="32033" help="">
+          <level>0</level>
+          <default>25</default>
+          <constraints>
+            <options>
+              <option label="32034">0</option>
+              <option label="32035">1</option>
+              <option label="32036">2</option>
+              <option label="32037">3</option>
+              <option label="32038">4</option>
+              <option label="32039">5</option>
+              <option label="32040">6</option>
+              <option label="32041">7</option>
+              <option label="32042">8</option>
+              <option label="32043">9</option>
+              <option label="32044">10</option>
+              <option label="32045">11</option>
+              <option label="32046">12</option>
+              <option label="32047">13</option>
+              <option label="32048">14</option>
+              <option label="32049">15</option>
+              <option label="32156">26</option>
+              <option label="32050">16</option>
+              <option label="32051">17</option>
+              <option label="32052">18</option>
+              <option label="32053">19</option>
+              <option label="32054">20</option>
+              <option label="32055">21</option>
+              <option label="32056">22</option>
+              <option label="32057">23</option>
+              <option label="32058">24</option>
+              <option label="32059">25</option>
+            </options>
+          </constraints>
+          <control type="spinner" format="string" />
+        </setting>
+        <setting id="timer_0_start" type="time" label="32061" help="">
+          <level>0</level>
+          <default>00:00</default>
+          <control type="button" format="time">
+            <heading>32061</heading>
+          </control>
+          <dependencies>
+            <dependency type="enable" setting="timer_0" operator="!is">25</dependency>
+          </dependencies>
+        </setting>
+        <setting id="timer_0_end_type" type="integer" label="32062" help="">
+          <level>0</level>
+          <default>1</default>
+          <constraints>
+            <options>
+              <option label="32063">0</option>
+              <option label="32064">1</option>
+              <option label="32065">2</option>
+            </options>
+          </constraints>
+          <control type="spinner" format="string" />
+          <dependencies>
+            <dependency type="enable" setting="timer_0" operator="!is">25</dependency>
+          </dependencies>
+        </setting>
+        <setting id="timer_0_duration" type="time" label="32064" help="">
+          <level>0</level>
+          <default>01:00</default>
+          <control type="button" format="time">
+            <heading>32064</heading>
+          </control>
+          <dependencies>
+            <dependency type="enable" setting="timer_0" operator="!is">25</dependency>
+            <dependency type="visible" setting="timer_0_end_type" operator="is">1</dependency>
+          </dependencies>
+        </setting>
+        <setting id="timer_0_end" type="time" label="32065" help="">
+          <level>0</level>
+          <default>00:00</default>
+          <control type="button" format="time">
+            <heading>32065</heading>
+          </control>
+          <dependencies>
+            <dependency type="enable" setting="timer_0" operator="!is">25</dependency>
+            <dependency type="visible" setting="timer_0_end_type" operator="is">2</dependency>
+          </dependencies>
+        </setting>
+      </group>
+      <group id="g_timer_0_action" label="32070">
+        <setting id="timer_0_action" type="integer" label="32070" help="">
+          <level>0</level>
+          <default>5</default>
+          <constraints>
+            <options>
+              <option label="32071">0</option>
+              <option label="32072">1</option>
+              <option label="32073">2</option>
+              <option label="32074">3</option>
+              <option label="32075">4</option>
+              <option label="32076">5</option>
+              <option label="32077">6</option>
+            </options>
+          </constraints>
+          <control type="spinner" format="string" />
+        </setting>
+        <setting id="timer_0_filename" type="string" label="32082" help="">
+          <level>0</level>
+          <default />
+          <constraints>
+            <allowempty>true</allowempty>
+          </constraints>
+          <control type="edit" format="string">
+            <heading>32082</heading>
+          </control>
+          <visible>false</visible>
+        </setting>
+        <setting id="timer_0_hint" type="string" label="32114" help="">
+          <level>0</level>
+          <default />
+          <constraints>
+            <allowempty>true</allowempty>
+          </constraints>
+          <control type="edit" format="string">
+            <heading>32114</heading>
+          </control>
+          <enable>false</enable>
+          <dependencies>
+            <dependency type="visible">
+              <and>
+                <condition setting="timer_0_filename" operator="is"></condition>
+                <condition setting="timer_0_action" operator="gt">0</condition>
+                <condition setting="timer_0_action" operator="lt">4</condition>
+              </and>
+            </dependency>
+          </dependencies>
+        </setting>
+        <setting id="timer_0_test" type="action" label="32108" help="">
+          <level>0</level>
+          <data>RunScript($ID,play,0)</data>
+          <control type="button" format="action">
+            <close>false</close>
+          </control>
+          <dependencies>
+            <dependency type="enable" setting="timer_0_filename" operator="!is"></dependency>
+          </dependencies>
+        </setting>
+      </group>
+      <group id="g_timer_0_fade" label="32090">
+        <setting id="timer_0_fade" type="integer" label="32091" help="">
+          <level>0</level>
+          <default>0</default>
+          <constraints>
+            <options>
+              <option label="32120">0</option>
+              <option label="32121">1</option>
+              <option label="32122">2</option>
+              <option label="32123">3</option>
+            </options>
+          </constraints>
+          <dependencies>
+            <dependency type="enable" setting="timer_0_end_type" operator="!is">0</dependency>
+          </dependencies>
+          <control type="spinner" format="string" />
+        </setting>
+        <setting id="timer_0_vol_min" type="integer" label="32095" help="">
+          <level>0</level>
+          <default>75</default>
+          <constraints>
+            <minimum>0</minimum>
+            <step>1</step>
+            <maximum>100</maximum>
+          </constraints>
+          <control type="slider" format="integer">
+            <popup>false</popup>
+          </control>
+          <dependencies>
+            <dependency type="visible" setting="timer_0_fade" operator="!is">0</dependency>
+          </dependencies>
+        </setting>
+        <setting id="timer_0_vol_max" type="integer" label="32096" help="">
+          <level>0</level>
+          <default>100</default>
+          <constraints>
+            <minimum>0</minimum>
+            <step>1</step>
+            <maximum>100</maximum>
+          </constraints>
+          <control type="slider" format="integer">
+            <popup>false</popup>
+          </control>
+          <dependencies>
+            <dependency type="visible">
+              <and>
+                <condition setting="timer_0_fade" operator="!is">0</condition>
+                <condition setting="timer_0_fade" operator="!is">3</condition>
+              </and>
+            </dependency>
+          </dependencies>
+        </setting>
+      </group>
+      <group id="g_timer_0_notify" label="32097">
+        <setting id="timer_0_notify" type="boolean" label="32098" help="">
+          <level>1</level>
+          <default>true</default>
+          <control type="toggle" />
+        </setting>
+      </group>
+    </category>
+    <category id="c_timer_1" label="32005" help="">
+      <group id="g_timer_1" label="32005">
+        <setting id="timer_1_label" type="string" label="32026" help="">
+          <level>0</level>
+          <default>Snooze Timer</default>
+          <constraints>
+            <allowempty>false</allowempty>
+          </constraints>
+          <control type="edit" format="string">
+            <heading>32026</heading>
+          </control>
+        </setting>
+      </group>
+      <group id="g_timer_1_schedule" label="32060">
+        <setting id="timer_1" type="integer" label="32033" help="">
+          <level>0</level>
+          <default>25</default>
+          <constraints>
+            <options>
+              <option label="32034">0</option>
+              <option label="32035">1</option>
+              <option label="32036">2</option>
+              <option label="32037">3</option>
+              <option label="32038">4</option>
+              <option label="32039">5</option>
+              <option label="32040">6</option>
+              <option label="32041">7</option>
+              <option label="32042">8</option>
+              <option label="32043">9</option>
+              <option label="32044">10</option>
+              <option label="32045">11</option>
+              <option label="32046">12</option>
+              <option label="32047">13</option>
+              <option label="32048">14</option>
+              <option label="32049">15</option>
+              <option label="32156">26</option>
+              <option label="32050">16</option>
+              <option label="32051">17</option>
+              <option label="32052">18</option>
+              <option label="32053">19</option>
+              <option label="32054">20</option>
+              <option label="32055">21</option>
+              <option label="32056">22</option>
+              <option label="32057">23</option>
+              <option label="32058">24</option>
+              <option label="32059">25</option>
+            </options>
+          </constraints>
+          <control type="spinner" format="string" />
+        </setting>
+        <setting id="timer_1_start" type="time" label="32061" help="">
+          <level>0</level>
+          <default>00:00</default>
+          <control type="button" format="time">
+            <heading>32061</heading>
+          </control>
+          <dependencies>
+            <dependency type="enable" setting="timer_1" operator="!is">25</dependency>
+          </dependencies>
+        </setting>
+        <setting id="timer_1_end_type" type="integer" label="32062" help="">
+          <level>0</level>
+          <default>1</default>
+          <constraints>
+            <options>
+              <option label="32063">0</option>
+              <option label="32064">1</option>
+              <option label="32065">2</option>
+            </options>
+          </constraints>
+          <control type="spinner" format="string" />
+          <dependencies>
+            <dependency type="enable" setting="timer_1" operator="!is">25</dependency>
+          </dependencies>
+        </setting>
+        <setting id="timer_1_duration" type="time" label="32064" help="">
+          <level>0</level>
+          <default>01:00</default>
+          <control type="button" format="time">
+            <heading>32064</heading>
+          </control>
+          <dependencies>
+            <dependency type="enable" setting="timer_1" operator="!is">25</dependency>
+            <dependency type="visible" setting="timer_1_end_type" operator="is">1</dependency>
+          </dependencies>
+        </setting>
+        <setting id="timer_1_end" type="time" label="32065" help="">
+          <level>0</level>
+          <default>00:00</default>
+          <control type="button" format="time">
+            <heading>32065</heading>
+          </control>
+          <dependencies>
+            <dependency type="enable" setting="timer_1" operator="!is">25</dependency>
+            <dependency type="visible" setting="timer_1_end_type" operator="is">2</dependency>
+          </dependencies>
+        </setting>
+      </group>
+      <group id="g_timer_1_action" label="32070">
+        <setting id="timer_1_action" type="integer" label="32070" help="">
+          <level>0</level>
+          <default>3</default>
+          <constraints>
+            <options>
+              <option label="32071">0</option>
+              <option label="32072">1</option>
+              <option label="32073">2</option>
+              <option label="32074">3</option>
+              <option label="32075">4</option>
+              <option label="32076">5</option>
+              <option label="32077">6</option>
+            </options>
+          </constraints>
+          <control type="spinner" format="string" />
+        </setting>
+        <setting id="timer_1_filename" type="string" label="32082" help="">
+          <level>0</level>
+          <default />
+          <constraints>
+            <allowempty>true</allowempty>
+          </constraints>
+          <control type="edit" format="string">
+            <heading>32082</heading>
+          </control>
+          <visible>false</visible>
+        </setting>
+        <setting id="timer_1_hint" type="string" label="32114" help="">
+          <level>0</level>
+          <default />
+          <constraints>
+            <allowempty>true</allowempty>
+          </constraints>
+          <control type="edit" format="string">
+            <heading>32114</heading>
+          </control>
+          <enable>false</enable>
+          <dependencies>
+            <dependency type="visible">
+              <and>
+                <condition setting="timer_1_filename" operator="is"></condition>
+                <condition setting="timer_1_action" operator="gt">0</condition>
+                <condition setting="timer_1_action" operator="lt">4</condition>
+              </and>
+            </dependency>
+          </dependencies>
+        </setting>
+        <setting id="timer_1_test" type="action" label="32108" help="">
+          <level>0</level>
+          <data>RunScript($ID,play,1)</data>
+          <control type="button" format="action">
+            <close>false</close>
+          </control>
+          <dependencies>
+            <dependency type="enable" setting="timer_1_filename" operator="!is"></dependency>
+          </dependencies>
+        </setting>
+      </group>
+      <group id="g_timer_1_fade" label="32090">
+        <setting id="timer_1_fade" type="integer" label="32091" help="">
+          <level>0</level>
+          <default>0</default>
+          <constraints>
+            <options>
+              <option label="32120">0</option>
+              <option label="32121">1</option>
+              <option label="32122">2</option>
+              <option label="32123">3</option>
+            </options>
+          </constraints>
+          <dependencies>
+            <dependency type="enable" setting="timer_1_end_type" operator="!is">0</dependency>
+          </dependencies>
+          <control type="spinner" format="string" />
+        </setting>
+        <setting id="timer_1_vol_min" type="integer" label="32095" help="">
+          <level>0</level>
+          <default>75</default>
+          <constraints>
+            <minimum>0</minimum>
+            <step>1</step>
+            <maximum>100</maximum>
+          </constraints>
+          <control type="slider" format="integer">
+            <popup>false</popup>
+          </control>
+          <dependencies>
+            <dependency type="visible" setting="timer_1_fade" operator="!is">0</dependency>
+          </dependencies>
+        </setting>
+        <setting id="timer_1_vol_max" type="integer" label="32096" help="">
+          <level>0</level>
+          <default>100</default>
+          <constraints>
+            <minimum>0</minimum>
+            <step>1</step>
+            <maximum>100</maximum>
+          </constraints>
+          <control type="slider" format="integer">
+            <popup>false</popup>
+          </control>
+          <dependencies>
+            <dependency type="visible">
+              <and>
+                <condition setting="timer_1_fade" operator="!is">0</condition>
+                <condition setting="timer_1_fade" operator="!is">3</condition>
+              </and>
+            </dependency>
+          </dependencies>
+        </setting>
+      </group>
+      <group id="g_timer_1_notify" label="32097">
+        <setting id="timer_1_notify" type="boolean" label="32098" help="">
+          <level>1</level>
+          <default>true</default>
+          <control type="toggle" />
+        </setting>
+      </group>
+    </category>
+    <category id="c_timer_2" label="32006" help="">
+      <group id="g_timer_2" label="32006">
+        <setting id="timer_2_label" type="string" label="32026" help="">
+          <level>0</level>
+          <default>Timer 1</default>
+          <constraints>
+            <allowempty>false</allowempty>
+          </constraints>
+          <control type="edit" format="string">
+            <heading>32026</heading>
+          </control>
+        </setting>
+      </group>
+      <group id="g_timer_2_schedule" label="32060">
+        <setting id="timer_2" type="integer" label="32033" help="">
+          <level>0</level>
+          <default>25</default>
+          <constraints>
+            <options>
+              <option label="32034">0</option>
+              <option label="32035">1</option>
+              <option label="32036">2</option>
+              <option label="32037">3</option>
+              <option label="32038">4</option>
+              <option label="32039">5</option>
+              <option label="32040">6</option>
+              <option label="32041">7</option>
+              <option label="32042">8</option>
+              <option label="32043">9</option>
+              <option label="32044">10</option>
+              <option label="32045">11</option>
+              <option label="32046">12</option>
+              <option label="32047">13</option>
+              <option label="32048">14</option>
+              <option label="32049">15</option>
+              <option label="32156">26</option>
+              <option label="32050">16</option>
+              <option label="32051">17</option>
+              <option label="32052">18</option>
+              <option label="32053">19</option>
+              <option label="32054">20</option>
+              <option label="32055">21</option>
+              <option label="32056">22</option>
+              <option label="32057">23</option>
+              <option label="32058">24</option>
+              <option label="32059">25</option>
+            </options>
+          </constraints>
+          <control type="spinner" format="string" />
+        </setting>
+        <setting id="timer_2_start" type="time" label="32061" help="">
+          <level>0</level>
+          <default>00:00</default>
+          <control type="button" format="time">
+            <heading>32061</heading>
+          </control>
+          <dependencies>
+            <dependency type="enable" setting="timer_2" operator="!is">25</dependency>
+          </dependencies>
+        </setting>
+        <setting id="timer_2_end_type" type="integer" label="32062" help="">
+          <level>0</level>
+          <default>0</default>
+          <constraints>
+            <options>
+              <option label="32063">0</option>
+              <option label="32064">1</option>
+              <option label="32065">2</option>
+            </options>
+          </constraints>
+          <control type="spinner" format="string" />
+          <dependencies>
+            <dependency type="enable" setting="timer_2" operator="!is">25</dependency>
+          </dependencies>
+        </setting>
+        <setting id="timer_2_duration" type="time" label="32064" help="">
+          <level>0</level>
+          <default>01:00</default>
+          <control type="button" format="time">
+            <heading>32064</heading>
+          </control>
+          <dependencies>
+            <dependency type="enable" setting="timer_2" operator="!is">25</dependency>
+            <dependency type="visible" setting="timer_2_end_type" operator="is">1</dependency>
+          </dependencies>
+        </setting>
+        <setting id="timer_2_end" type="time" label="32065" help="">
+          <level>0</level>
+          <default>00:00</default>
+          <control type="button" format="time">
+            <heading>32065</heading>
+          </control>
+          <dependencies>
+            <dependency type="enable" setting="timer_2" operator="!is">25</dependency>
+            <dependency type="visible" setting="timer_2_end_type" operator="is">2</dependency>
+          </dependencies>
+        </setting>
+      </group>
+      <group id="g_timer_2_action" label="32070">
+        <setting id="timer_2_action" type="integer" label="32070" help="">
+          <level>0</level>
+          <default>2</default>
+          <constraints>
+            <options>
+              <option label="32071">0</option>
+              <option label="32072">1</option>
+              <option label="32073">2</option>
+              <option label="32074">3</option>
+              <option label="32075">4</option>
+              <option label="32076">5</option>
+              <option label="32077">6</option>
+            </options>
+          </constraints>
+          <control type="spinner" format="string" />
+        </setting>
+        <setting id="timer_2_filename" type="string" label="32082" help="">
+          <level>0</level>
+          <default />
+          <constraints>
+            <allowempty>true</allowempty>
+          </constraints>
+          <control type="edit" format="string">
+            <heading>32082</heading>
+          </control>
+          <visible>false</visible>
+        </setting>
+        <setting id="timer_2_hint" type="string" label="32114" help="">
+          <level>0</level>
+          <default />
+          <constraints>
+            <allowempty>true</allowempty>
+          </constraints>
+          <control type="edit" format="string">
+            <heading>32114</heading>
+          </control>
+          <enable>false</enable>
+          <dependencies>
+            <dependency type="visible">
+              <and>
+                <condition setting="timer_2_filename" operator="is"></condition>
+                <condition setting="timer_2_action" operator="gt">0</condition>
+                <condition setting="timer_2_action" operator="lt">4</condition>
+              </and>
+            </dependency>
+          </dependencies>
+        </setting>
+        <setting id="timer_2_test" type="action" label="32108" help="">
+          <level>0</level>
+          <data>RunScript($ID,play,2)</data>
+          <control type="button" format="action">
+            <close>false</close>
+          </control>
+          <dependencies>
+            <dependency type="enable" setting="timer_2_filename" operator="!is"></dependency>
+          </dependencies>
+        </setting>
+      </group>
+      <group id="g_timer_2_fade" label="32090">
+        <setting id="timer_2_fade" type="integer" label="32091" help="">
+          <level>0</level>
+          <default>0</default>
+          <constraints>
+            <options>
+              <option label="32120">0</option>
+              <option label="32121">1</option>
+              <option label="32122">2</option>
+              <option label="32123">3</option>
+            </options>
+          </constraints>
+          <dependencies>
+            <dependency type="enable" setting="timer_2_end_type" operator="!is">0</dependency>
+          </dependencies>
+          <control type="spinner" format="string" />
+        </setting>
+        <setting id="timer_2_vol_min" type="integer" label="32095" help="">
+          <level>0</level>
+          <default>75</default>
+          <constraints>
+            <minimum>0</minimum>
+            <step>1</step>
+            <maximum>100</maximum>
+          </constraints>
+          <control type="slider" format="integer">
+            <popup>false</popup>
+          </control>
+          <dependencies>
+            <dependency type="visible" setting="timer_2_fade" operator="!is">0</dependency>
+          </dependencies>
+        </setting>
+        <setting id="timer_2_vol_max" type="integer" label="32096" help="">
+          <level>0</level>
+          <default>100</default>
+          <constraints>
+            <minimum>0</minimum>
+            <step>1</step>
+            <maximum>100</maximum>
+          </constraints>
+          <control type="slider" format="integer">
+            <popup>false</popup>
+          </control>
+          <dependencies>
+            <dependency type="visible">
+              <and>
+                <condition setting="timer_2_fade" operator="!is">0</condition>
+                <condition setting="timer_2_fade" operator="!is">3</condition>
+              </and>
+            </dependency>
+          </dependencies>
+        </setting>
+      </group>
+      <group id="g_timer_2_notify" label="32097">
+        <setting id="timer_2_notify" type="boolean" label="32098" help="">
+          <level>1</level>
+          <default>true</default>
+          <control type="toggle" />
+        </setting>
+      </group>
+    </category>
+    <category id="c_timer_3" label="32007" help="">
+      <group id="g_timer_3" label="32007">
+        <setting id="timer_3_label" type="string" label="32026" help="">
+          <level>0</level>
+          <default>Timer 2</default>
+          <constraints>
+            <allowempty>false</allowempty>
+          </constraints>
+          <control type="edit" format="string">
+            <heading>32026</heading>
+          </control>
+        </setting>
+      </group>
+      <group id="g_timer_3_schedule" label="32060">
+        <setting id="timer_3" type="integer" label="32033" help="">
+          <level>0</level>
+          <default>25</default>
+          <constraints>
+            <options>
+              <option label="32034">0</option>
+              <option label="32035">1</option>
+              <option label="32036">2</option>
+              <option label="32037">3</option>
+              <option label="32038">4</option>
+              <option label="32039">5</option>
+              <option label="32040">6</option>
+              <option label="32041">7</option>
+              <option label="32042">8</option>
+              <option label="32043">9</option>
+              <option label="32044">10</option>
+              <option label="32045">11</option>
+              <option label="32046">12</option>
+              <option label="32047">13</option>
+              <option label="32048">14</option>
+              <option label="32049">15</option>
+              <option label="32156">26</option>
+              <option label="32050">16</option>
+              <option label="32051">17</option>
+              <option label="32052">18</option>
+              <option label="32053">19</option>
+              <option label="32054">20</option>
+              <option label="32055">21</option>
+              <option label="32056">22</option>
+              <option label="32057">23</option>
+              <option label="32058">24</option>
+              <option label="32059">25</option>
+            </options>
+          </constraints>
+          <control type="spinner" format="string" />
+        </setting>
+        <setting id="timer_3_start" type="time" label="32061" help="">
+          <level>0</level>
+          <default>00:00</default>
+          <control type="button" format="time">
+            <heading>32061</heading>
+          </control>
+          <dependencies>
+            <dependency type="enable" setting="timer_3" operator="!is">25</dependency>
+          </dependencies>
+        </setting>
+        <setting id="timer_3_end_type" type="integer" label="32062" help="">
+          <level>0</level>
+          <default>0</default>
+          <constraints>
+            <options>
+              <option label="32063">0</option>
+              <option label="32064">1</option>
+              <option label="32065">2</option>
+            </options>
+          </constraints>
+          <control type="spinner" format="string" />
+          <dependencies>
+            <dependency type="enable" setting="timer_3" operator="!is">25</dependency>
+          </dependencies>
+        </setting>
+        <setting id="timer_3_duration" type="time" label="32064" help="">
+          <level>0</level>
+          <default>01:00</default>
+          <control type="button" format="time">
+            <heading>32064</heading>
+          </control>
+          <dependencies>
+            <dependency type="enable" setting="timer_3" operator="!is">25</dependency>
+            <dependency type="visible" setting="timer_3_end_type" operator="is">1</dependency>
+          </dependencies>
+        </setting>
+        <setting id="timer_3_end" type="time" label="32065" help="">
+          <level>0</level>
+          <default>00:00</default>
+          <control type="button" format="time">
+            <heading>32065</heading>
+          </control>
+          <dependencies>
+            <dependency type="enable" setting="timer_3" operator="!is">25</dependency>
+            <dependency type="visible" setting="timer_3_end_type" operator="is">2</dependency>
+          </dependencies>
+        </setting>
+      </group>
+      <group id="g_timer_3_action" label="32070">
+        <setting id="timer_3_action" type="integer" label="32070" help="">
+          <level>0</level>
+          <default>2</default>
+          <constraints>
+            <options>
+              <option label="32071">0</option>
+              <option label="32072">1</option>
+              <option label="32073">2</option>
+              <option label="32074">3</option>
+              <option label="32075">4</option>
+              <option label="32076">5</option>
+              <option label="32077">6</option>
+            </options>
+          </constraints>
+          <control type="spinner" format="string" />
+        </setting>
+        <setting id="timer_3_filename" type="string" label="32082" help="">
+          <level>0</level>
+          <default />
+          <constraints>
+            <allowempty>true</allowempty>
+          </constraints>
+          <control type="edit" format="string">
+            <heading>32082</heading>
+          </control>
+          <visible>false</visible>
+        </setting>
+        <setting id="timer_3_hint" type="string" label="32114" help="">
+          <level>0</level>
+          <default />
+          <constraints>
+            <allowempty>true</allowempty>
+          </constraints>
+          <control type="edit" format="string">
+            <heading>32114</heading>
+          </control>
+          <enable>false</enable>
+          <dependencies>
+            <dependency type="visible">
+              <and>
+                <condition setting="timer_3_filename" operator="is"></condition>
+                <condition setting="timer_3_action" operator="gt">0</condition>
+                <condition setting="timer_3_action" operator="lt">4</condition>
+              </and>
+            </dependency>
+          </dependencies>
+        </setting>
+        <setting id="timer_3_test" type="action" label="32108" help="">
+          <level>0</level>
+          <data>RunScript($ID,play,3)</data>
+          <control type="button" format="action">
+            <close>false</close>
+          </control>
+          <dependencies>
+            <dependency type="enable" setting="timer_3_filename" operator="!is"></dependency>
+          </dependencies>
+        </setting>
+      </group>
+      <group id="g_timer_3_fade" label="32090">
+        <setting id="timer_3_fade" type="integer" label="32091" help="">
+          <level>0</level>
+          <default>0</default>
+          <constraints>
+            <options>
+              <option label="32120">0</option>
+              <option label="32121">1</option>
+              <option label="32122">2</option>
+              <option label="32123">3</option>
+            </options>
+          </constraints>
+          <dependencies>
+            <dependency type="enable" setting="timer_3_end_type" operator="!is">0</dependency>
+          </dependencies>
+          <control type="spinner" format="string" />
+        </setting>
+        <setting id="timer_3_vol_min" type="integer" label="32095" help="">
+          <level>0</level>
+          <default>75</default>
+          <constraints>
+            <minimum>0</minimum>
+            <step>1</step>
+            <maximum>100</maximum>
+          </constraints>
+          <control type="slider" format="integer">
+            <popup>false</popup>
+          </control>
+          <dependencies>
+            <dependency type="visible" setting="timer_3_fade" operator="!is">0</dependency>
+          </dependencies>
+        </setting>
+        <setting id="timer_3_vol_max" type="integer" label="32096" help="">
+          <level>0</level>
+          <default>100</default>
+          <constraints>
+            <minimum>0</minimum>
+            <step>1</step>
+            <maximum>100</maximum>
+          </constraints>
+          <control type="slider" format="integer">
+            <popup>false</popup>
+          </control>
+          <dependencies>
+            <dependency type="visible">
+              <and>
+                <condition setting="timer_3_fade" operator="!is">0</condition>
+                <condition setting="timer_3_fade" operator="!is">3</condition>
+              </and>
+            </dependency>
+          </dependencies>
+        </setting>
+      </group>
+      <group id="g_timer_3_notify" label="32097">
+        <setting id="timer_3_notify" type="boolean" label="32098" help="">
+          <level>1</level>
+          <default>true</default>
+          <control type="toggle" />
+        </setting>
+      </group>
+    </category>
+    <category id="c_timer_4" label="32008" help="">
+      <group id="g_timer_4" label="32008">
+        <setting id="timer_4_label" type="string" label="32026" help="">
+          <level>0</level>
+          <default>Timer 3</default>
+          <constraints>
+            <allowempty>false</allowempty>
+          </constraints>
+          <control type="edit" format="string">
+            <heading>32026</heading>
+          </control>
+        </setting>
+      </group>
+      <group id="g_timer_4_schedule" label="32060">
+        <setting id="timer_4" type="integer" label="32033" help="">
+          <level>0</level>
+          <default>25</default>
+          <constraints>
+            <options>
+              <option label="32034">0</option>
+              <option label="32035">1</option>
+              <option label="32036">2</option>
+              <option label="32037">3</option>
+              <option label="32038">4</option>
+              <option label="32039">5</option>
+              <option label="32040">6</option>
+              <option label="32041">7</option>
+              <option label="32042">8</option>
+              <option label="32043">9</option>
+              <option label="32044">10</option>
+              <option label="32045">11</option>
+              <option label="32046">12</option>
+              <option label="32047">13</option>
+              <option label="32048">14</option>
+              <option label="32049">15</option>
+              <option label="32156">26</option>
+              <option label="32050">16</option>
+              <option label="32051">17</option>
+              <option label="32052">18</option>
+              <option label="32053">19</option>
+              <option label="32054">20</option>
+              <option label="32055">21</option>
+              <option label="32056">22</option>
+              <option label="32057">23</option>
+              <option label="32058">24</option>
+              <option label="32059">25</option>
+            </options>
+          </constraints>
+          <control type="spinner" format="string" />
+        </setting>
+        <setting id="timer_4_start" type="time" label="32061" help="">
+          <level>0</level>
+          <default>00:00</default>
+          <control type="button" format="time">
+            <heading>32061</heading>
+          </control>
+          <dependencies>
+            <dependency type="enable" setting="timer_4" operator="!is">25</dependency>
+          </dependencies>
+        </setting>
+        <setting id="timer_4_end_type" type="integer" label="32062" help="">
+          <level>0</level>
+          <default>0</default>
+          <constraints>
+            <options>
+              <option label="32063">0</option>
+              <option label="32064">1</option>
+              <option label="32065">2</option>
+            </options>
+          </constraints>
+          <control type="spinner" format="string" />
+          <dependencies>
+            <dependency type="enable" setting="timer_4" operator="!is">25</dependency>
+          </dependencies>
+        </setting>
+        <setting id="timer_4_duration" type="time" label="32064" help="">
+          <level>0</level>
+          <default>01:00</default>
+          <control type="button" format="time">
+            <heading>32064</heading>
+          </control>
+          <dependencies>
+            <dependency type="enable" setting="timer_4" operator="!is">25</dependency>
+            <dependency type="visible" setting="timer_4_end_type" operator="is">1</dependency>
+          </dependencies>
+        </setting>
+        <setting id="timer_4_end" type="time" label="32065" help="">
+          <level>0</level>
+          <default>00:00</default>
+          <control type="button" format="time">
+            <heading>32065</heading>
+          </control>
+          <dependencies>
+            <dependency type="enable" setting="timer_4" operator="!is">25</dependency>
+            <dependency type="visible" setting="timer_4_end_type" operator="is">2</dependency>
+          </dependencies>
+        </setting>
+      </group>
+      <group id="g_timer_4_action" label="32070">
+        <setting id="timer_4_action" type="integer" label="32070" help="">
+          <level>0</level>
+          <default>2</default>
+          <constraints>
+            <options>
+              <option label="32071">0</option>
+              <option label="32072">1</option>
+              <option label="32073">2</option>
+              <option label="32074">3</option>
+              <option label="32075">4</option>
+              <option label="32076">5</option>
+              <option label="32077">6</option>
+            </options>
+          </constraints>
+          <control type="spinner" format="string" />
+        </setting>
+        <setting id="timer_4_filename" type="string" label="32082" help="">
+          <level>0</level>
+          <default />
+          <constraints>
+            <allowempty>true</allowempty>
+          </constraints>
+          <control type="edit" format="string">
+            <heading>32082</heading>
+          </control>
+          <visible>false</visible>
+        </setting>
+        <setting id="timer_4_hint" type="string" label="32114" help="">
+          <level>0</level>
+          <default />
+          <constraints>
+            <allowempty>true</allowempty>
+          </constraints>
+          <control type="edit" format="string">
+            <heading>32114</heading>
+          </control>
+          <enable>false</enable>
+          <dependencies>
+            <dependency type="visible">
+              <and>
+                <condition setting="timer_4_filename" operator="is"></condition>
+                <condition setting="timer_4_action" operator="gt">0</condition>
+                <condition setting="timer_4_action" operator="lt">4</condition>
+              </and>
+            </dependency>
+          </dependencies>
+        </setting>
+        <setting id="timer_4_test" type="action" label="32108" help="">
+          <level>0</level>
+          <data>RunScript($ID,play,4)</data>
+          <control type="button" format="action">
+            <close>false</close>
+          </control>
+          <dependencies>
+            <dependency type="enable" setting="timer_4_filename" operator="!is"></dependency>
+          </dependencies>
+        </setting>
+      </group>
+      <group id="g_timer_4_fade" label="32090">
+        <setting id="timer_4_fade" type="integer" label="32091" help="">
+          <level>0</level>
+          <default>0</default>
+          <constraints>
+            <options>
+              <option label="32120">0</option>
+              <option label="32121">1</option>
+              <option label="32122">2</option>
+              <option label="32123">3</option>
+            </options>
+          </constraints>
+          <dependencies>
+            <dependency type="enable" setting="timer_4_end_type" operator="!is">0</dependency>
+          </dependencies>
+          <control type="spinner" format="string" />
+        </setting>
+        <setting id="timer_4_vol_min" type="integer" label="32095" help="">
+          <level>0</level>
+          <default>75</default>
+          <constraints>
+            <minimum>0</minimum>
+            <step>1</step>
+            <maximum>100</maximum>
+          </constraints>
+          <control type="slider" format="integer">
+            <popup>false</popup>
+          </control>
+          <dependencies>
+            <dependency type="visible" setting="timer_4_fade" operator="!is">0</dependency>
+          </dependencies>
+        </setting>
+        <setting id="timer_4_vol_max" type="integer" label="32096" help="">
+          <level>0</level>
+          <default>100</default>
+          <constraints>
+            <minimum>0</minimum>
+            <step>1</step>
+            <maximum>100</maximum>
+          </constraints>
+          <control type="slider" format="integer">
+            <popup>false</popup>
+          </control>
+          <dependencies>
+            <dependency type="visible">
+              <and>
+                <condition setting="timer_4_fade" operator="!is">0</condition>
+                <condition setting="timer_4_fade" operator="!is">3</condition>
+              </and>
+            </dependency>
+          </dependencies>
+        </setting>
+      </group>
+      <group id="g_timer_4_notify" label="32097">
+        <setting id="timer_4_notify" type="boolean" label="32098" help="">
+          <level>1</level>
+          <default>true</default>
+          <control type="toggle" />
+        </setting>
+      </group>
+    </category>
+    <category id="c_timer_5" label="32009" help="">
+      <group id="g_timer_5" label="32009">
+        <setting id="timer_5_label" type="string" label="32026" help="">
+          <level>0</level>
+          <default>Timer 4</default>
+          <constraints>
+            <allowempty>false</allowempty>
+          </constraints>
+          <control type="edit" format="string">
+            <heading>32026</heading>
+          </control>
+        </setting>
+      </group>
+      <group id="g_timer_5_schedule" label="32060">
+        <setting id="timer_5" type="integer" label="32033" help="">
+          <level>0</level>
+          <default>25</default>
+          <constraints>
+            <options>
+              <option label="32034">0</option>
+              <option label="32035">1</option>
+              <option label="32036">2</option>
+              <option label="32037">3</option>
+              <option label="32038">4</option>
+              <option label="32039">5</option>
+              <option label="32040">6</option>
+              <option label="32041">7</option>
+              <option label="32042">8</option>
+              <option label="32043">9</option>
+              <option label="32044">10</option>
+              <option label="32045">11</option>
+              <option label="32046">12</option>
+              <option label="32047">13</option>
+              <option label="32048">14</option>
+              <option label="32049">15</option>
+              <option label="32156">26</option>
+              <option label="32050">16</option>
+              <option label="32051">17</option>
+              <option label="32052">18</option>
+              <option label="32053">19</option>
+              <option label="32054">20</option>
+              <option label="32055">21</option>
+              <option label="32056">22</option>
+              <option label="32057">23</option>
+              <option label="32058">24</option>
+              <option label="32059">25</option>
+            </options>
+          </constraints>
+          <control type="spinner" format="string" />
+        </setting>
+        <setting id="timer_5_start" type="time" label="32061" help="">
+          <level>0</level>
+          <default>00:00</default>
+          <control type="button" format="time">
+            <heading>32061</heading>
+          </control>
+          <dependencies>
+            <dependency type="enable" setting="timer_5" operator="!is">25</dependency>
+          </dependencies>
+        </setting>
+        <setting id="timer_5_end_type" type="integer" label="32062" help="">
+          <level>0</level>
+          <default>0</default>
+          <constraints>
+            <options>
+              <option label="32063">0</option>
+              <option label="32064">1</option>
+              <option label="32065">2</option>
+            </options>
+          </constraints>
+          <control type="spinner" format="string" />
+          <dependencies>
+            <dependency type="enable" setting="timer_5" operator="!is">25</dependency>
+          </dependencies>
+        </setting>
+        <setting id="timer_5_duration" type="time" label="32064" help="">
+          <level>0</level>
+          <default>01:00</default>
+          <control type="button" format="time">
+            <heading>32064</heading>
+          </control>
+          <dependencies>
+            <dependency type="enable" setting="timer_5" operator="!is">25</dependency>
+            <dependency type="visible" setting="timer_5_end_type" operator="is">1</dependency>
+          </dependencies>
+        </setting>
+        <setting id="timer_5_end" type="time" label="32065" help="">
+          <level>0</level>
+          <default>00:00</default>
+          <control type="button" format="time">
+            <heading>32065</heading>
+          </control>
+          <dependencies>
+            <dependency type="enable" setting="timer_5" operator="!is">25</dependency>
+            <dependency type="visible" setting="timer_5_end_type" operator="is">2</dependency>
+          </dependencies>
+        </setting>
+      </group>
+      <group id="g_timer_5_action" label="32070">
+        <setting id="timer_5_action" type="integer" label="32070" help="">
+          <level>0</level>
+          <default>2</default>
+          <constraints>
+            <options>
+              <option label="32071">0</option>
+              <option label="32072">1</option>
+              <option label="32073">2</option>
+              <option label="32074">3</option>
+              <option label="32075">4</option>
+              <option label="32076">5</option>
+              <option label="32077">6</option>
+            </options>
+          </constraints>
+          <control type="spinner" format="string" />
+        </setting>
+        <setting id="timer_5_filename" type="string" label="32082" help="">
+          <level>0</level>
+          <default />
+          <constraints>
+            <allowempty>true</allowempty>
+          </constraints>
+          <control type="edit" format="string">
+            <heading>32082</heading>
+          </control>
+          <visible>false</visible>
+        </setting>
+        <setting id="timer_5_hint" type="string" label="32114" help="">
+          <level>0</level>
+          <default />
+          <constraints>
+            <allowempty>true</allowempty>
+          </constraints>
+          <control type="edit" format="string">
+            <heading>32114</heading>
+          </control>
+          <enable>false</enable>
+          <dependencies>
+            <dependency type="visible">
+              <and>
+                <condition setting="timer_5_filename" operator="is"></condition>
+                <condition setting="timer_5_action" operator="gt">0</condition>
+                <condition setting="timer_5_action" operator="lt">4</condition>
+              </and>
+            </dependency>
+          </dependencies>
+        </setting>
+        <setting id="timer_5_test" type="action" label="32108" help="">
+          <level>0</level>
+          <data>RunScript($ID,play,5)</data>
+          <control type="button" format="action">
+            <close>false</close>
+          </control>
+          <dependencies>
+            <dependency type="enable" setting="timer_5_filename" operator="!is"></dependency>
+          </dependencies>
+        </setting>
+      </group>
+      <group id="g_timer_5_fade" label="32090">
+        <setting id="timer_5_fade" type="integer" label="32091" help="">
+          <level>0</level>
+          <default>0</default>
+          <constraints>
+            <options>
+              <option label="32120">0</option>
+              <option label="32121">1</option>
+              <option label="32122">2</option>
+              <option label="32123">3</option>
+            </options>
+          </constraints>
+          <dependencies>
+            <dependency type="enable" setting="timer_5_end_type" operator="!is">0</dependency>
+          </dependencies>
+          <control type="spinner" format="string" />
+        </setting>
+        <setting id="timer_5_vol_min" type="integer" label="32095" help="">
+          <level>0</level>
+          <default>75</default>
+          <constraints>
+            <minimum>0</minimum>
+            <step>1</step>
+            <maximum>100</maximum>
+          </constraints>
+          <control type="slider" format="integer">
+            <popup>false</popup>
+          </control>
+          <dependencies>
+            <dependency type="visible" setting="timer_5_fade" operator="!is">0</dependency>
+          </dependencies>
+        </setting>
+        <setting id="timer_5_vol_max" type="integer" label="32096" help="">
+          <level>0</level>
+          <default>100</default>
+          <constraints>
+            <minimum>0</minimum>
+            <step>1</step>
+            <maximum>100</maximum>
+          </constraints>
+          <control type="slider" format="integer">
+            <popup>false</popup>
+          </control>
+          <dependencies>
+            <dependency type="visible">
+              <and>
+                <condition setting="timer_5_fade" operator="!is">0</condition>
+                <condition setting="timer_5_fade" operator="!is">3</condition>
+              </and>
+            </dependency>
+          </dependencies>
+        </setting>
+      </group>
+      <group id="g_timer_5_notify" label="32097">
+        <setting id="timer_5_notify" type="boolean" label="32098" help="">
+          <level>1</level>
+          <default>true</default>
+          <control type="toggle" />
+        </setting>
+      </group>
+    </category>
+    <category id="c_timer_6" label="32010" help="">
+      <group id="g_timer_6" label="32010">
+        <setting id="timer_6_label" type="string" label="32026" help="">
+          <level>0</level>
+          <default>Timer 5</default>
+          <constraints>
+            <allowempty>false</allowempty>
+          </constraints>
+          <control type="edit" format="string">
+            <heading>32026</heading>
+          </control>
+        </setting>
+      </group>
+      <group id="g_timer_6_schedule" label="32060">
+        <setting id="timer_6" type="integer" label="32033" help="">
+          <level>0</level>
+          <default>25</default>
+          <constraints>
+            <options>
+              <option label="32034">0</option>
+              <option label="32035">1</option>
+              <option label="32036">2</option>
+              <option label="32037">3</option>
+              <option label="32038">4</option>
+              <option label="32039">5</option>
+              <option label="32040">6</option>
+              <option label="32041">7</option>
+              <option label="32042">8</option>
+              <option label="32043">9</option>
+              <option label="32044">10</option>
+              <option label="32045">11</option>
+              <option label="32046">12</option>
+              <option label="32047">13</option>
+              <option label="32048">14</option>
+              <option label="32049">15</option>
+              <option label="32156">26</option>
+              <option label="32050">16</option>
+              <option label="32051">17</option>
+              <option label="32052">18</option>
+              <option label="32053">19</option>
+              <option label="32054">20</option>
+              <option label="32055">21</option>
+              <option label="32056">22</option>
+              <option label="32057">23</option>
+              <option label="32058">24</option>
+              <option label="32059">25</option>
+            </options>
+          </constraints>
+          <control type="spinner" format="string" />
+        </setting>
+        <setting id="timer_6_start" type="time" label="32061" help="">
+          <level>0</level>
+          <default>00:00</default>
+          <control type="button" format="time">
+            <heading>32061</heading>
+          </control>
+          <dependencies>
+            <dependency type="enable" setting="timer_6" operator="!is">25</dependency>
+          </dependencies>
+        </setting>
+        <setting id="timer_6_end_type" type="integer" label="32062" help="">
+          <level>0</level>
+          <default>0</default>
+          <constraints>
+            <options>
+              <option label="32063">0</option>
+              <option label="32064">1</option>
+              <option label="32065">2</option>
+            </options>
+          </constraints>
+          <control type="spinner" format="string" />
+          <dependencies>
+            <dependency type="enable" setting="timer_6" operator="!is">25</dependency>
+          </dependencies>
+        </setting>
+        <setting id="timer_6_duration" type="time" label="32064" help="">
+          <level>0</level>
+          <default>01:00</default>
+          <control type="button" format="time">
+            <heading>32064</heading>
+          </control>
+          <dependencies>
+            <dependency type="enable" setting="timer_6" operator="!is">25</dependency>
+            <dependency type="visible" setting="timer_6_end_type" operator="is">1</dependency>
+          </dependencies>
+        </setting>
+        <setting id="timer_6_end" type="time" label="32065" help="">
+          <level>0</level>
+          <default>00:00</default>
+          <control type="button" format="time">
+            <heading>32065</heading>
+          </control>
+          <dependencies>
+            <dependency type="enable" setting="timer_6" operator="!is">25</dependency>
+            <dependency type="visible" setting="timer_6_end_type" operator="is">2</dependency>
+          </dependencies>
+        </setting>
+      </group>
+      <group id="g_timer_6_action" label="32070">
+        <setting id="timer_6_action" type="integer" label="32070" help="">
+          <level>0</level>
+          <default>2</default>
+          <constraints>
+            <options>
+              <option label="32071">0</option>
+              <option label="32072">1</option>
+              <option label="32073">2</option>
+              <option label="32074">3</option>
+              <option label="32075">4</option>
+              <option label="32076">5</option>
+              <option label="32077">6</option>
+            </options>
+          </constraints>
+          <control type="spinner" format="string" />
+        </setting>
+        <setting id="timer_6_filename" type="string" label="32082" help="">
+          <level>0</level>
+          <default />
+          <constraints>
+            <allowempty>true</allowempty>
+          </constraints>
+          <control type="edit" format="string">
+            <heading>32082</heading>
+          </control>
+          <visible>false</visible>
+        </setting>
+        <setting id="timer_6_hint" type="string" label="32114" help="">
+          <level>0</level>
+          <default />
+          <constraints>
+            <allowempty>true</allowempty>
+          </constraints>
+          <control type="edit" format="string">
+            <heading>32114</heading>
+          </control>
+          <enable>false</enable>
+          <dependencies>
+            <dependency type="visible">
+              <and>
+                <condition setting="timer_6_filename" operator="is"></condition>
+                <condition setting="timer_6_action" operator="gt">0</condition>
+                <condition setting="timer_6_action" operator="lt">4</condition>
+              </and>
+            </dependency>
+          </dependencies>
+        </setting>
+        <setting id="timer_6_test" type="action" label="32108" help="">
+          <level>0</level>
+          <data>RunScript($ID,play,6)</data>
+          <control type="button" format="action">
+            <close>false</close>
+          </control>
+          <dependencies>
+            <dependency type="enable" setting="timer_6_filename" operator="!is"></dependency>
+          </dependencies>
+        </setting>
+      </group>
+      <group id="g_timer_6_fade" label="32090">
+        <setting id="timer_6_fade" type="integer" label="32091" help="">
+          <level>0</level>
+          <default>0</default>
+          <constraints>
+            <options>
+              <option label="32120">0</option>
+              <option label="32121">1</option>
+              <option label="32122">2</option>
+              <option label="32123">3</option>
+            </options>
+          </constraints>
+          <dependencies>
+            <dependency type="enable" setting="timer_6_end_type" operator="!is">0</dependency>
+          </dependencies>
+          <control type="spinner" format="string" />
+        </setting>
+        <setting id="timer_6_vol_min" type="integer" label="32095" help="">
+          <level>0</level>
+          <default>75</default>
+          <constraints>
+            <minimum>0</minimum>
+            <step>1</step>
+            <maximum>100</maximum>
+          </constraints>
+          <control type="slider" format="integer">
+            <popup>false</popup>
+          </control>
+          <dependencies>
+            <dependency type="visible" setting="timer_6_fade" operator="!is">0</dependency>
+          </dependencies>
+        </setting>
+        <setting id="timer_6_vol_max" type="integer" label="32096" help="">
+          <level>0</level>
+          <default>100</default>
+          <constraints>
+            <minimum>0</minimum>
+            <step>1</step>
+            <maximum>100</maximum>
+          </constraints>
+          <control type="slider" format="integer">
+            <popup>false</popup>
+          </control>
+          <dependencies>
+            <dependency type="visible">
+              <and>
+                <condition setting="timer_6_fade" operator="!is">0</condition>
+                <condition setting="timer_6_fade" operator="!is">3</condition>
+              </and>
+            </dependency>
+          </dependencies>
+        </setting>
+      </group>
+      <group id="g_timer_6_notify" label="32097">
+        <setting id="timer_6_notify" type="boolean" label="32098" help="">
+          <level>1</level>
+          <default>true</default>
+          <control type="toggle" />
+        </setting>
+      </group>
+    </category>
+    <category id="c_timer_7" label="32011" help="">
+      <group id="g_timer_7" label="32011">
+        <setting id="timer_7_label" type="string" label="32026" help="">
+          <level>0</level>
+          <default>Timer 6</default>
+          <constraints>
+            <allowempty>false</allowempty>
+          </constraints>
+          <control type="edit" format="string">
+            <heading>32026</heading>
+          </control>
+        </setting>
+      </group>
+      <group id="g_timer_7_schedule" label="32060">
+        <setting id="timer_7" type="integer" label="32033" help="">
+          <level>0</level>
+          <default>25</default>
+          <constraints>
+            <options>
+              <option label="32034">0</option>
+              <option label="32035">1</option>
+              <option label="32036">2</option>
+              <option label="32037">3</option>
+              <option label="32038">4</option>
+              <option label="32039">5</option>
+              <option label="32040">6</option>
+              <option label="32041">7</option>
+              <option label="32042">8</option>
+              <option label="32043">9</option>
+              <option label="32044">10</option>
+              <option label="32045">11</option>
+              <option label="32046">12</option>
+              <option label="32047">13</option>
+              <option label="32048">14</option>
+              <option label="32049">15</option>
+              <option label="32156">26</option>
+              <option label="32050">16</option>
+              <option label="32051">17</option>
+              <option label="32052">18</option>
+              <option label="32053">19</option>
+              <option label="32054">20</option>
+              <option label="32055">21</option>
+              <option label="32056">22</option>
+              <option label="32057">23</option>
+              <option label="32058">24</option>
+              <option label="32059">25</option>
+            </options>
+          </constraints>
+          <control type="spinner" format="string" />
+        </setting>
+        <setting id="timer_7_start" type="time" label="32061" help="">
+          <level>0</level>
+          <default>00:00</default>
+          <control type="button" format="time">
+            <heading>32061</heading>
+          </control>
+          <dependencies>
+            <dependency type="enable" setting="timer_7" operator="!is">25</dependency>
+          </dependencies>
+        </setting>
+        <setting id="timer_7_end_type" type="integer" label="32062" help="">
+          <level>0</level>
+          <default>0</default>
+          <constraints>
+            <options>
+              <option label="32063">0</option>
+              <option label="32064">1</option>
+              <option label="32065">2</option>
+            </options>
+          </constraints>
+          <control type="spinner" format="string" />
+          <dependencies>
+            <dependency type="enable" setting="timer_7" operator="!is">25</dependency>
+          </dependencies>
+        </setting>
+        <setting id="timer_7_duration" type="time" label="32064" help="">
+          <level>0</level>
+          <default>01:00</default>
+          <control type="button" format="time">
+            <heading>32064</heading>
+          </control>
+          <dependencies>
+            <dependency type="enable" setting="timer_7" operator="!is">25</dependency>
+            <dependency type="visible" setting="timer_7_end_type" operator="is">1</dependency>
+          </dependencies>
+        </setting>
+        <setting id="timer_7_end" type="time" label="32065" help="">
+          <level>0</level>
+          <default>00:00</default>
+          <control type="button" format="time">
+            <heading>32065</heading>
+          </control>
+          <dependencies>
+            <dependency type="enable" setting="timer_7" operator="!is">25</dependency>
+            <dependency type="visible" setting="timer_7_end_type" operator="is">2</dependency>
+          </dependencies>
+        </setting>
+      </group>
+      <group id="g_timer_7_action" label="32070">
+        <setting id="timer_7_action" type="integer" label="32070" help="">
+          <level>0</level>
+          <default>2</default>
+          <constraints>
+            <options>
+              <option label="32071">0</option>
+              <option label="32072">1</option>
+              <option label="32073">2</option>
+              <option label="32074">3</option>
+              <option label="32075">4</option>
+              <option label="32076">5</option>
+              <option label="32077">6</option>
+            </options>
+          </constraints>
+          <control type="spinner" format="string" />
+        </setting>
+        <setting id="timer_7_filename" type="string" label="32082" help="">
+          <level>0</level>
+          <default />
+          <constraints>
+            <allowempty>true</allowempty>
+          </constraints>
+          <control type="edit" format="string">
+            <heading>32082</heading>
+          </control>
+          <visible>false</visible>
+        </setting>
+        <setting id="timer_7_hint" type="string" label="32114" help="">
+          <level>0</level>
+          <default />
+          <constraints>
+            <allowempty>true</allowempty>
+          </constraints>
+          <control type="edit" format="string">
+            <heading>32114</heading>
+          </control>
+          <enable>false</enable>
+          <dependencies>
+            <dependency type="visible">
+              <and>
+                <condition setting="timer_7_filename" operator="is"></condition>
+                <condition setting="timer_7_action" operator="gt">0</condition>
+                <condition setting="timer_7_action" operator="lt">4</condition>
+              </and>
+            </dependency>
+          </dependencies>
+        </setting>
+        <setting id="timer_7_test" type="action" label="32108" help="">
+          <level>0</level>
+          <data>RunScript($ID,play,7)</data>
+          <control type="button" format="action">
+            <close>false</close>
+          </control>
+          <dependencies>
+            <dependency type="enable" setting="timer_7_filename" operator="!is"></dependency>
+          </dependencies>
+        </setting>
+      </group>
+      <group id="g_timer_7_fade" label="32090">
+        <setting id="timer_7_fade" type="integer" label="32091" help="">
+          <level>0</level>
+          <default>0</default>
+          <constraints>
+            <options>
+              <option label="32120">0</option>
+              <option label="32121">1</option>
+              <option label="32122">2</option>
+              <option label="32123">3</option>
+            </options>
+          </constraints>
+          <dependencies>
+            <dependency type="enable" setting="timer_7_end_type" operator="!is">0</dependency>
+          </dependencies>
+          <control type="spinner" format="string" />
+        </setting>
+        <setting id="timer_7_vol_min" type="integer" label="32095" help="">
+          <level>0</level>
+          <default>75</default>
+          <constraints>
+            <minimum>0</minimum>
+            <step>1</step>
+            <maximum>100</maximum>
+          </constraints>
+          <control type="slider" format="integer">
+            <popup>false</popup>
+          </control>
+          <dependencies>
+            <dependency type="visible" setting="timer_7_fade" operator="!is">0</dependency>
+          </dependencies>
+        </setting>
+        <setting id="timer_7_vol_max" type="integer" label="32096" help="">
+          <level>0</level>
+          <default>100</default>
+          <constraints>
+            <minimum>0</minimum>
+            <step>1</step>
+            <maximum>100</maximum>
+          </constraints>
+          <control type="slider" format="integer">
+            <popup>false</popup>
+          </control>
+          <dependencies>
+            <dependency type="visible">
+              <and>
+                <condition setting="timer_7_fade" operator="!is">0</condition>
+                <condition setting="timer_7_fade" operator="!is">3</condition>
+              </and>
+            </dependency>
+          </dependencies>
+        </setting>
+      </group>
+      <group id="g_timer_7_notify" label="32097">
+        <setting id="timer_7_notify" type="boolean" label="32098" help="">
+          <level>1</level>
+          <default>true</default>
+          <control type="toggle" />
+        </setting>
+      </group>
+    </category>
+    <category id="c_timer_8" label="32012" help="">
+      <group id="g_timer_8" label="32012">
+        <setting id="timer_8_label" type="string" label="32026" help="">
+          <level>0</level>
+          <default>Timer 7</default>
+          <constraints>
+            <allowempty>false</allowempty>
+          </constraints>
+          <control type="edit" format="string">
+            <heading>32026</heading>
+          </control>
+        </setting>
+      </group>
+      <group id="g_timer_8_schedule" label="32060">
+        <setting id="timer_8" type="integer" label="32033" help="">
+          <level>0</level>
+          <default>25</default>
+          <constraints>
+            <options>
+              <option label="32034">0</option>
+              <option label="32035">1</option>
+              <option label="32036">2</option>
+              <option label="32037">3</option>
+              <option label="32038">4</option>
+              <option label="32039">5</option>
+              <option label="32040">6</option>
+              <option label="32041">7</option>
+              <option label="32042">8</option>
+              <option label="32043">9</option>
+              <option label="32044">10</option>
+              <option label="32045">11</option>
+              <option label="32046">12</option>
+              <option label="32047">13</option>
+              <option label="32048">14</option>
+              <option label="32049">15</option>
+              <option label="32156">26</option>
+              <option label="32050">16</option>
+              <option label="32051">17</option>
+              <option label="32052">18</option>
+              <option label="32053">19</option>
+              <option label="32054">20</option>
+              <option label="32055">21</option>
+              <option label="32056">22</option>
+              <option label="32057">23</option>
+              <option label="32058">24</option>
+              <option label="32059">25</option>
+            </options>
+          </constraints>
+          <control type="spinner" format="string" />
+        </setting>
+        <setting id="timer_8_start" type="time" label="32061" help="">
+          <level>0</level>
+          <default>00:00</default>
+          <control type="button" format="time">
+            <heading>32061</heading>
+          </control>
+          <dependencies>
+            <dependency type="enable" setting="timer_8" operator="!is">25</dependency>
+          </dependencies>
+        </setting>
+        <setting id="timer_8_end_type" type="integer" label="32062" help="">
+          <level>0</level>
+          <default>0</default>
+          <constraints>
+            <options>
+              <option label="32063">0</option>
+              <option label="32064">1</option>
+              <option label="32065">2</option>
+            </options>
+          </constraints>
+          <control type="spinner" format="string" />
+          <dependencies>
+            <dependency type="enable" setting="timer_8" operator="!is">25</dependency>
+          </dependencies>
+        </setting>
+        <setting id="timer_8_duration" type="time" label="32064" help="">
+          <level>0</level>
+          <default>01:00</default>
+          <control type="button" format="time">
+            <heading>32064</heading>
+          </control>
+          <dependencies>
+            <dependency type="enable" setting="timer_8" operator="!is">25</dependency>
+            <dependency type="visible" setting="timer_8_end_type" operator="is">1</dependency>
+          </dependencies>
+        </setting>
+        <setting id="timer_8_end" type="time" label="32065" help="">
+          <level>0</level>
+          <default>00:00</default>
+          <control type="button" format="time">
+            <heading>32065</heading>
+          </control>
+          <dependencies>
+            <dependency type="enable" setting="timer_8" operator="!is">25</dependency>
+            <dependency type="visible" setting="timer_8_end_type" operator="is">2</dependency>
+          </dependencies>
+        </setting>
+      </group>
+      <group id="g_timer_8_action" label="32070">
+        <setting id="timer_8_action" type="integer" label="32070" help="">
+          <level>0</level>
+          <default>2</default>
+          <constraints>
+            <options>
+              <option label="32071">0</option>
+              <option label="32072">1</option>
+              <option label="32073">2</option>
+              <option label="32074">3</option>
+              <option label="32075">4</option>
+              <option label="32076">5</option>
+              <option label="32077">6</option>
+            </options>
+          </constraints>
+          <control type="spinner" format="string" />
+        </setting>
+        <setting id="timer_8_filename" type="string" label="32082" help="">
+          <level>0</level>
+          <default />
+          <constraints>
+            <allowempty>true</allowempty>
+          </constraints>
+          <control type="edit" format="string">
+            <heading>32082</heading>
+          </control>
+          <visible>false</visible>
+        </setting>
+        <setting id="timer_8_hint" type="string" label="32114" help="">
+          <level>0</level>
+          <default />
+          <constraints>
+            <allowempty>true</allowempty>
+          </constraints>
+          <control type="edit" format="string">
+            <heading>32114</heading>
+          </control>
+          <enable>false</enable>
+          <dependencies>
+            <dependency type="visible">
+              <and>
+                <condition setting="timer_8_filename" operator="is"></condition>
+                <condition setting="timer_8_action" operator="gt">0</condition>
+                <condition setting="timer_8_action" operator="lt">4</condition>
+              </and>
+            </dependency>
+          </dependencies>
+        </setting>
+        <setting id="timer_8_test" type="action" label="32108" help="">
+          <level>0</level>
+          <data>RunScript($ID,play,8)</data>
+          <control type="button" format="action">
+            <close>false</close>
+          </control>
+          <dependencies>
+            <dependency type="enable" setting="timer_8_filename" operator="!is"></dependency>
+          </dependencies>
+        </setting>
+      </group>
+      <group id="g_timer_8_fade" label="32090">
+        <setting id="timer_8_fade" type="integer" label="32091" help="">
+          <level>0</level>
+          <default>0</default>
+          <constraints>
+            <options>
+              <option label="32120">0</option>
+              <option label="32121">1</option>
+              <option label="32122">2</option>
+              <option label="32123">3</option>
+            </options>
+          </constraints>
+          <dependencies>
+            <dependency type="enable" setting="timer_8_end_type" operator="!is">0</dependency>
+          </dependencies>
+          <control type="spinner" format="string" />
+        </setting>
+        <setting id="timer_8_vol_min" type="integer" label="32095" help="">
+          <level>0</level>
+          <default>75</default>
+          <constraints>
+            <minimum>0</minimum>
+            <step>1</step>
+            <maximum>100</maximum>
+          </constraints>
+          <control type="slider" format="integer">
+            <popup>false</popup>
+          </control>
+          <dependencies>
+            <dependency type="visible" setting="timer_8_fade" operator="!is">0</dependency>
+          </dependencies>
+        </setting>
+        <setting id="timer_8_vol_max" type="integer" label="32096" help="">
+          <level>0</level>
+          <default>100</default>
+          <constraints>
+            <minimum>0</minimum>
+            <step>1</step>
+            <maximum>100</maximum>
+          </constraints>
+          <control type="slider" format="integer">
+            <popup>false</popup>
+          </control>
+          <dependencies>
+            <dependency type="visible">
+              <and>
+                <condition setting="timer_8_fade" operator="!is">0</condition>
+                <condition setting="timer_8_fade" operator="!is">3</condition>
+              </and>
+            </dependency>
+          </dependencies>
+        </setting>
+      </group>
+      <group id="g_timer_8_notify" label="32097">
+        <setting id="timer_8_notify" type="boolean" label="32098" help="">
+          <level>1</level>
+          <default>true</default>
+          <control type="toggle" />
+        </setting>
+      </group>
+    </category>
+    <category id="c_timer_9" label="32013" help="">
+      <group id="g_timer_9" label="32013">
+        <setting id="timer_9_label" type="string" label="32026" help="">
+          <level>0</level>
+          <default>Timer 8</default>
+          <constraints>
+            <allowempty>false</allowempty>
+          </constraints>
+          <control type="edit" format="string">
+            <heading>32026</heading>
+          </control>
+        </setting>
+      </group>
+      <group id="g_timer_9_schedule" label="32060">
+        <setting id="timer_9" type="integer" label="32033" help="">
+          <level>0</level>
+          <default>25</default>
+          <constraints>
+            <options>
+              <option label="32034">0</option>
+              <option label="32035">1</option>
+              <option label="32036">2</option>
+              <option label="32037">3</option>
+              <option label="32038">4</option>
+              <option label="32039">5</option>
+              <option label="32040">6</option>
+              <option label="32041">7</option>
+              <option label="32042">8</option>
+              <option label="32043">9</option>
+              <option label="32044">10</option>
+              <option label="32045">11</option>
+              <option label="32046">12</option>
+              <option label="32047">13</option>
+              <option label="32048">14</option>
+              <option label="32049">15</option>
+              <option label="32156">26</option>
+              <option label="32050">16</option>
+              <option label="32051">17</option>
+              <option label="32052">18</option>
+              <option label="32053">19</option>
+              <option label="32054">20</option>
+              <option label="32055">21</option>
+              <option label="32056">22</option>
+              <option label="32057">23</option>
+              <option label="32058">24</option>
+              <option label="32059">25</option>
+            </options>
+          </constraints>
+          <control type="spinner" format="string" />
+        </setting>
+        <setting id="timer_9_start" type="time" label="32061" help="">
+          <level>0</level>
+          <default>00:00</default>
+          <control type="button" format="time">
+            <heading>32061</heading>
+          </control>
+          <dependencies>
+            <dependency type="enable" setting="timer_9" operator="!is">25</dependency>
+          </dependencies>
+        </setting>
+        <setting id="timer_9_end_type" type="integer" label="32062" help="">
+          <level>0</level>
+          <default>0</default>
+          <constraints>
+            <options>
+              <option label="32063">0</option>
+              <option label="32064">1</option>
+              <option label="32065">2</option>
+            </options>
+          </constraints>
+          <control type="spinner" format="string" />
+          <dependencies>
+            <dependency type="enable" setting="timer_9" operator="!is">25</dependency>
+          </dependencies>
+        </setting>
+        <setting id="timer_9_duration" type="time" label="32064" help="">
+          <level>0</level>
+          <default>01:00</default>
+          <control type="button" format="time">
+            <heading>32064</heading>
+          </control>
+          <dependencies>
+            <dependency type="enable" setting="timer_9" operator="!is">25</dependency>
+            <dependency type="visible" setting="timer_9_end_type" operator="is">1</dependency>
+          </dependencies>
+        </setting>
+        <setting id="timer_9_end" type="time" label="32065" help="">
+          <level>0</level>
+          <default>00:00</default>
+          <control type="button" format="time">
+            <heading>32065</heading>
+          </control>
+          <dependencies>
+            <dependency type="enable" setting="timer_9" operator="!is">25</dependency>
+            <dependency type="visible" setting="timer_9_end_type" operator="is">2</dependency>
+          </dependencies>
+        </setting>
+      </group>
+      <group id="g_timer_9_action" label="32070">
+        <setting id="timer_9_action" type="integer" label="32070" help="">
+          <level>0</level>
+          <default>2</default>
+          <constraints>
+            <options>
+              <option label="32071">0</option>
+              <option label="32072">1</option>
+              <option label="32073">2</option>
+              <option label="32074">3</option>
+              <option label="32075">4</option>
+              <option label="32076">5</option>
+              <option label="32077">6</option>
+            </options>
+          </constraints>
+          <control type="spinner" format="string" />
+        </setting>
+        <setting id="timer_9_filename" type="string" label="32082" help="">
+          <level>0</level>
+          <default />
+          <constraints>
+            <allowempty>true</allowempty>
+          </constraints>
+          <control type="edit" format="string">
+            <heading>32082</heading>
+          </control>
+          <visible>false</visible>
+        </setting>
+        <setting id="timer_9_hint" type="string" label="32114" help="">
+          <level>0</level>
+          <default />
+          <constraints>
+            <allowempty>true</allowempty>
+          </constraints>
+          <control type="edit" format="string">
+            <heading>32114</heading>
+          </control>
+          <enable>false</enable>
+          <dependencies>
+            <dependency type="visible">
+              <and>
+                <condition setting="timer_9_filename" operator="is"></condition>
+                <condition setting="timer_9_action" operator="gt">0</condition>
+                <condition setting="timer_9_action" operator="lt">4</condition>
+              </and>
+            </dependency>
+          </dependencies>
+        </setting>
+        <setting id="timer_9_test" type="action" label="32108" help="">
+          <level>0</level>
+          <data>RunScript($ID,play,9)</data>
+          <control type="button" format="action">
+            <close>false</close>
+          </control>
+          <dependencies>
+            <dependency type="enable" setting="timer_9_filename" operator="!is"></dependency>
+          </dependencies>
+        </setting>
+      </group>
+      <group id="g_timer_9_fade" label="32090">
+        <setting id="timer_9_fade" type="integer" label="32091" help="">
+          <level>0</level>
+          <default>0</default>
+          <constraints>
+            <options>
+              <option label="32120">0</option>
+              <option label="32121">1</option>
+              <option label="32122">2</option>
+              <option label="32123">3</option>
+            </options>
+          </constraints>
+          <dependencies>
+            <dependency type="enable" setting="timer_9_end_type" operator="!is">0</dependency>
+          </dependencies>
+          <control type="spinner" format="string" />
+        </setting>
+        <setting id="timer_9_vol_min" type="integer" label="32095" help="">
+          <level>0</level>
+          <default>75</default>
+          <constraints>
+            <minimum>0</minimum>
+            <step>1</step>
+            <maximum>100</maximum>
+          </constraints>
+          <control type="slider" format="integer">
+            <popup>false</popup>
+          </control>
+          <dependencies>
+            <dependency type="visible" setting="timer_9_fade" operator="!is">0</dependency>
+          </dependencies>
+        </setting>
+        <setting id="timer_9_vol_max" type="integer" label="32096" help="">
+          <level>0</level>
+          <default>100</default>
+          <constraints>
+            <minimum>0</minimum>
+            <step>1</step>
+            <maximum>100</maximum>
+          </constraints>
+          <control type="slider" format="integer">
+            <popup>false</popup>
+          </control>
+          <dependencies>
+            <dependency type="visible">
+              <and>
+                <condition setting="timer_9_fade" operator="!is">0</condition>
+                <condition setting="timer_9_fade" operator="!is">3</condition>
+              </and>
+            </dependency>
+          </dependencies>
+        </setting>
+      </group>
+      <group id="g_timer_9_notify" label="32097">
+        <setting id="timer_9_notify" type="boolean" label="32098" help="">
+          <level>1</level>
+          <default>true</default>
+          <control type="toggle" />
+        </setting>
+      </group>
+    </category>
+    <category id="c_timer_10" label="32014" help="">
+      <group id="g_timer_10" label="32014">
+        <setting id="timer_10_label" type="string" label="32026" help="">
+          <level>0</level>
+          <default>Timer 9</default>
+          <constraints>
+            <allowempty>false</allowempty>
+          </constraints>
+          <control type="edit" format="string">
+            <heading>32026</heading>
+          </control>
+        </setting>
+      </group>
+      <group id="g_timer_10_schedule" label="32060">
+        <setting id="timer_10" type="integer" label="32033" help="">
+          <level>0</level>
+          <default>25</default>
+          <constraints>
+            <options>
+              <option label="32034">0</option>
+              <option label="32035">1</option>
+              <option label="32036">2</option>
+              <option label="32037">3</option>
+              <option label="32038">4</option>
+              <option label="32039">5</option>
+              <option label="32040">6</option>
+              <option label="32041">7</option>
+              <option label="32042">8</option>
+              <option label="32043">9</option>
+              <option label="32044">10</option>
+              <option label="32045">11</option>
+              <option label="32046">12</option>
+              <option label="32047">13</option>
+              <option label="32048">14</option>
+              <option label="32049">15</option>
+              <option label="32156">26</option>
+              <option label="32050">16</option>
+              <option label="32051">17</option>
+              <option label="32052">18</option>
+              <option label="32053">19</option>
+              <option label="32054">20</option>
+              <option label="32055">21</option>
+              <option label="32056">22</option>
+              <option label="32057">23</option>
+              <option label="32058">24</option>
+              <option label="32059">25</option>
+            </options>
+          </constraints>
+          <control type="spinner" format="string" />
+        </setting>
+        <setting id="timer_10_start" type="time" label="32061" help="">
+          <level>0</level>
+          <default>00:00</default>
+          <control type="button" format="time">
+            <heading>32061</heading>
+          </control>
+          <dependencies>
+            <dependency type="enable" setting="timer_10" operator="!is">25</dependency>
+          </dependencies>
+        </setting>
+        <setting id="timer_10_end_type" type="integer" label="32062" help="">
+          <level>0</level>
+          <default>0</default>
+          <constraints>
+            <options>
+              <option label="32063">0</option>
+              <option label="32064">1</option>
+              <option label="32065">2</option>
+            </options>
+          </constraints>
+          <control type="spinner" format="string" />
+          <dependencies>
+            <dependency type="enable" setting="timer_10" operator="!is">25</dependency>
+          </dependencies>
+        </setting>
+        <setting id="timer_10_duration" type="time" label="32064" help="">
+          <level>0</level>
+          <default>01:00</default>
+          <control type="button" format="time">
+            <heading>32064</heading>
+          </control>
+          <dependencies>
+            <dependency type="enable" setting="timer_10" operator="!is">25</dependency>
+            <dependency type="visible" setting="timer_10_end_type" operator="is">1</dependency>
+          </dependencies>
+        </setting>
+        <setting id="timer_10_end" type="time" label="32065" help="">
+          <level>0</level>
+          <default>00:00</default>
+          <control type="button" format="time">
+            <heading>32065</heading>
+          </control>
+          <dependencies>
+            <dependency type="enable" setting="timer_10" operator="!is">25</dependency>
+            <dependency type="visible" setting="timer_10_end_type" operator="is">2</dependency>
+          </dependencies>
+        </setting>
+      </group>
+      <group id="g_timer_10_action" label="32070">
+        <setting id="timer_10_action" type="integer" label="32070" help="">
+          <level>0</level>
+          <default>2</default>
+          <constraints>
+            <options>
+              <option label="32071">0</option>
+              <option label="32072">1</option>
+              <option label="32073">2</option>
+              <option label="32074">3</option>
+              <option label="32075">4</option>
+              <option label="32076">5</option>
+              <option label="32077">6</option>
+            </options>
+          </constraints>
+          <control type="spinner" format="string" />
+        </setting>
+        <setting id="timer_10_filename" type="string" label="32082" help="">
+          <level>0</level>
+          <default />
+          <constraints>
+            <allowempty>true</allowempty>
+          </constraints>
+          <control type="edit" format="string">
+            <heading>32082</heading>
+          </control>
+          <visible>false</visible>
+        </setting>
+        <setting id="timer_10_hint" type="string" label="32114" help="">
+          <level>0</level>
+          <default />
+          <constraints>
+            <allowempty>true</allowempty>
+          </constraints>
+          <control type="edit" format="string">
+            <heading>32114</heading>
+          </control>
+          <enable>false</enable>
+          <dependencies>
+            <dependency type="visible">
+              <and>
+                <condition setting="timer_10_filename" operator="is"></condition>
+                <condition setting="timer_10_action" operator="gt">0</condition>
+                <condition setting="timer_10_action" operator="lt">4</condition>
+              </and>
+            </dependency>
+          </dependencies>
+        </setting>
+        <setting id="timer_10_test" type="action" label="32108" help="">
+          <level>0</level>
+          <data>RunScript($ID,play,10)</data>
+          <control type="button" format="action">
+            <close>false</close>
+          </control>
+          <dependencies>
+            <dependency type="enable" setting="timer_10_filename" operator="!is"></dependency>
+          </dependencies>
+        </setting>
+      </group>
+      <group id="g_timer_10_fade" label="32090">
+        <setting id="timer_10_fade" type="integer" label="32091" help="">
+          <level>0</level>
+          <default>0</default>
+          <constraints>
+            <options>
+              <option label="32120">0</option>
+              <option label="32121">1</option>
+              <option label="32122">2</option>
+              <option label="32123">3</option>
+            </options>
+          </constraints>
+          <dependencies>
+            <dependency type="enable" setting="timer_10_end_type" operator="!is">0</dependency>
+          </dependencies>
+          <control type="spinner" format="string" />
+        </setting>
+        <setting id="timer_10_vol_min" type="integer" label="32095" help="">
+          <level>0</level>
+          <default>75</default>
+          <constraints>
+            <minimum>0</minimum>
+            <step>1</step>
+            <maximum>100</maximum>
+          </constraints>
+          <control type="slider" format="integer">
+            <popup>false</popup>
+          </control>
+          <dependencies>
+            <dependency type="visible" setting="timer_10_fade" operator="!is">0</dependency>
+          </dependencies>
+        </setting>
+        <setting id="timer_10_vol_max" type="integer" label="32096" help="">
+          <level>0</level>
+          <default>100</default>
+          <constraints>
+            <minimum>0</minimum>
+            <step>1</step>
+            <maximum>100</maximum>
+          </constraints>
+          <control type="slider" format="integer">
+            <popup>false</popup>
+          </control>
+          <dependencies>
+            <dependency type="visible">
+              <and>
+                <condition setting="timer_10_fade" operator="!is">0</condition>
+                <condition setting="timer_10_fade" operator="!is">3</condition>
+              </and>
+            </dependency>
+          </dependencies>
+        </setting>
+      </group>
+      <group id="g_timer_10_notify" label="32097">
+        <setting id="timer_10_notify" type="boolean" label="32098" help="">
+          <level>1</level>
+          <default>true</default>
+          <control type="toggle" />
+        </setting>
+      </group>
+    </category>
+    <category id="c_timer_11" label="32015" help="">
+      <group id="g_timer_11" label="32015">
+        <setting id="timer_11_label" type="string" label="32026" help="">
+          <level>0</level>
+          <default>Timer 10</default>
+          <constraints>
+            <allowempty>false</allowempty>
+          </constraints>
+          <control type="edit" format="string">
+            <heading>32026</heading>
+          </control>
+        </setting>
+      </group>
+      <group id="g_timer_11_schedule" label="32060">
+        <setting id="timer_11" type="integer" label="32033" help="">
+          <level>0</level>
+          <default>25</default>
+          <constraints>
+            <options>
+              <option label="32034">0</option>
+              <option label="32035">1</option>
+              <option label="32036">2</option>
+              <option label="32037">3</option>
+              <option label="32038">4</option>
+              <option label="32039">5</option>
+              <option label="32040">6</option>
+              <option label="32041">7</option>
+              <option label="32042">8</option>
+              <option label="32043">9</option>
+              <option label="32044">10</option>
+              <option label="32045">11</option>
+              <option label="32046">12</option>
+              <option label="32047">13</option>
+              <option label="32048">14</option>
+              <option label="32049">15</option>
+              <option label="32156">26</option>
+              <option label="32050">16</option>
+              <option label="32051">17</option>
+              <option label="32052">18</option>
+              <option label="32053">19</option>
+              <option label="32054">20</option>
+              <option label="32055">21</option>
+              <option label="32056">22</option>
+              <option label="32057">23</option>
+              <option label="32058">24</option>
+              <option label="32059">25</option>
+            </options>
+          </constraints>
+          <control type="spinner" format="string" />
+        </setting>
+        <setting id="timer_11_start" type="time" label="32061" help="">
+          <level>0</level>
+          <default>00:00</default>
+          <control type="button" format="time">
+            <heading>32061</heading>
+          </control>
+          <dependencies>
+            <dependency type="enable" setting="timer_11" operator="!is">25</dependency>
+          </dependencies>
+        </setting>
+        <setting id="timer_11_end_type" type="integer" label="32062" help="">
+          <level>0</level>
+          <default>0</default>
+          <constraints>
+            <options>
+              <option label="32063">0</option>
+              <option label="32064">1</option>
+              <option label="32065">2</option>
+            </options>
+          </constraints>
+          <control type="spinner" format="string" />
+          <dependencies>
+            <dependency type="enable" setting="timer_11" operator="!is">25</dependency>
+          </dependencies>
+        </setting>
+        <setting id="timer_11_duration" type="time" label="32064" help="">
+          <level>0</level>
+          <default>01:00</default>
+          <control type="button" format="time">
+            <heading>32064</heading>
+          </control>
+          <dependencies>
+            <dependency type="enable" setting="timer_11" operator="!is">25</dependency>
+            <dependency type="visible" setting="timer_11_end_type" operator="is">1</dependency>
+          </dependencies>
+        </setting>
+        <setting id="timer_11_end" type="time" label="32065" help="">
+          <level>0</level>
+          <default>00:00</default>
+          <control type="button" format="time">
+            <heading>32065</heading>
+          </control>
+          <dependencies>
+            <dependency type="enable" setting="timer_11" operator="!is">25</dependency>
+            <dependency type="visible" setting="timer_11_end_type" operator="is">2</dependency>
+          </dependencies>
+        </setting>
+      </group>
+      <group id="g_timer_11_action" label="32070">
+        <setting id="timer_11_action" type="integer" label="32070" help="">
+          <level>0</level>
+          <default>2</default>
+          <constraints>
+            <options>
+              <option label="32071">0</option>
+              <option label="32072">1</option>
+              <option label="32073">2</option>
+              <option label="32074">3</option>
+              <option label="32075">4</option>
+              <option label="32076">5</option>
+              <option label="32077">6</option>
+            </options>
+          </constraints>
+          <control type="spinner" format="string" />
+        </setting>
+        <setting id="timer_11_filename" type="string" label="32082" help="">
+          <level>0</level>
+          <default />
+          <constraints>
+            <allowempty>true</allowempty>
+          </constraints>
+          <control type="edit" format="string">
+            <heading>32082</heading>
+          </control>
+          <visible>false</visible>
+        </setting>
+        <setting id="timer_11_hint" type="string" label="32114" help="">
+          <level>0</level>
+          <default />
+          <constraints>
+            <allowempty>true</allowempty>
+          </constraints>
+          <control type="edit" format="string">
+            <heading>32114</heading>
+          </control>
+          <enable>false</enable>
+          <dependencies>
+            <dependency type="visible">
+              <and>
+                <condition setting="timer_11_filename" operator="is"></condition>
+                <condition setting="timer_11_action" operator="gt">0</condition>
+                <condition setting="timer_11_action" operator="lt">4</condition>
+              </and>
+            </dependency>
+          </dependencies>
+        </setting>
+        <setting id="timer_11_test" type="action" label="32108" help="">
+          <level>0</level>
+          <data>RunScript($ID,play,11)</data>
+          <control type="button" format="action">
+            <close>false</close>
+          </control>
+          <dependencies>
+            <dependency type="enable" setting="timer_11_filename" operator="!is"></dependency>
+          </dependencies>
+        </setting>
+      </group>
+      <group id="g_timer_11_fade" label="32090">
+        <setting id="timer_11_fade" type="integer" label="32091" help="">
+          <level>0</level>
+          <default>0</default>
+          <constraints>
+            <options>
+              <option label="32120">0</option>
+              <option label="32121">1</option>
+              <option label="32122">2</option>
+              <option label="32123">3</option>
+            </options>
+          </constraints>
+          <dependencies>
+            <dependency type="enable" setting="timer_11_end_type" operator="!is">0</dependency>
+          </dependencies>
+          <control type="spinner" format="string" />
+        </setting>
+        <setting id="timer_11_vol_min" type="integer" label="32095" help="">
+          <level>0</level>
+          <default>75</default>
+          <constraints>
+            <minimum>0</minimum>
+            <step>1</step>
+            <maximum>100</maximum>
+          </constraints>
+          <control type="slider" format="integer">
+            <popup>false</popup>
+          </control>
+          <dependencies>
+            <dependency type="visible" setting="timer_11_fade" operator="!is">0</dependency>
+          </dependencies>
+        </setting>
+        <setting id="timer_11_vol_max" type="integer" label="32096" help="">
+          <level>0</level>
+          <default>100</default>
+          <constraints>
+            <minimum>0</minimum>
+            <step>1</step>
+            <maximum>100</maximum>
+          </constraints>
+          <control type="slider" format="integer">
+            <popup>false</popup>
+          </control>
+          <dependencies>
+            <dependency type="visible">
+              <and>
+                <condition setting="timer_11_fade" operator="!is">0</condition>
+                <condition setting="timer_11_fade" operator="!is">3</condition>
+              </and>
+            </dependency>
+          </dependencies>
+        </setting>
+      </group>
+      <group id="g_timer_11_notify" label="32097">
+        <setting id="timer_11_notify" type="boolean" label="32098" help="">
+          <level>1</level>
+          <default>true</default>
+          <control type="toggle" />
+        </setting>
+      </group>
+    </category>
+    <category id="c_timer_12" label="32016" help="">
+      <group id="g_timer_12" label="32016">
+        <setting id="timer_12_label" type="string" label="32026" help="">
+          <level>0</level>
+          <default>Timer 11</default>
+          <constraints>
+            <allowempty>false</allowempty>
+          </constraints>
+          <control type="edit" format="string">
+            <heading>32026</heading>
+          </control>
+        </setting>
+      </group>
+      <group id="g_timer_12_schedule" label="32060">
+        <setting id="timer_12" type="integer" label="32033" help="">
+          <level>0</level>
+          <default>25</default>
+          <constraints>
+            <options>
+              <option label="32034">0</option>
+              <option label="32035">1</option>
+              <option label="32036">2</option>
+              <option label="32037">3</option>
+              <option label="32038">4</option>
+              <option label="32039">5</option>
+              <option label="32040">6</option>
+              <option label="32041">7</option>
+              <option label="32042">8</option>
+              <option label="32043">9</option>
+              <option label="32044">10</option>
+              <option label="32045">11</option>
+              <option label="32046">12</option>
+              <option label="32047">13</option>
+              <option label="32048">14</option>
+              <option label="32049">15</option>
+              <option label="32156">26</option>
+              <option label="32050">16</option>
+              <option label="32051">17</option>
+              <option label="32052">18</option>
+              <option label="32053">19</option>
+              <option label="32054">20</option>
+              <option label="32055">21</option>
+              <option label="32056">22</option>
+              <option label="32057">23</option>
+              <option label="32058">24</option>
+              <option label="32059">25</option>
+            </options>
+          </constraints>
+          <control type="spinner" format="string" />
+        </setting>
+        <setting id="timer_12_start" type="time" label="32061" help="">
+          <level>0</level>
+          <default>00:00</default>
+          <control type="button" format="time">
+            <heading>32061</heading>
+          </control>
+          <dependencies>
+            <dependency type="enable" setting="timer_12" operator="!is">25</dependency>
+          </dependencies>
+        </setting>
+        <setting id="timer_12_end_type" type="integer" label="32062" help="">
+          <level>0</level>
+          <default>0</default>
+          <constraints>
+            <options>
+              <option label="32063">0</option>
+              <option label="32064">1</option>
+              <option label="32065">2</option>
+            </options>
+          </constraints>
+          <control type="spinner" format="string" />
+          <dependencies>
+            <dependency type="enable" setting="timer_12" operator="!is">25</dependency>
+          </dependencies>
+        </setting>
+        <setting id="timer_12_duration" type="time" label="32064" help="">
+          <level>0</level>
+          <default>01:00</default>
+          <control type="button" format="time">
+            <heading>32064</heading>
+          </control>
+          <dependencies>
+            <dependency type="enable" setting="timer_12" operator="!is">25</dependency>
+            <dependency type="visible" setting="timer_12_end_type" operator="is">1</dependency>
+          </dependencies>
+        </setting>
+        <setting id="timer_12_end" type="time" label="32065" help="">
+          <level>0</level>
+          <default>00:00</default>
+          <control type="button" format="time">
+            <heading>32065</heading>
+          </control>
+          <dependencies>
+            <dependency type="enable" setting="timer_12" operator="!is">25</dependency>
+            <dependency type="visible" setting="timer_12_end_type" operator="is">2</dependency>
+          </dependencies>
+        </setting>
+      </group>
+      <group id="g_timer_12_action" label="32070">
+        <setting id="timer_12_action" type="integer" label="32070" help="">
+          <level>0</level>
+          <default>2</default>
+          <constraints>
+            <options>
+              <option label="32071">0</option>
+              <option label="32072">1</option>
+              <option label="32073">2</option>
+              <option label="32074">3</option>
+              <option label="32075">4</option>
+              <option label="32076">5</option>
+              <option label="32077">6</option>
+            </options>
+          </constraints>
+          <control type="spinner" format="string" />
+        </setting>
+        <setting id="timer_12_filename" type="string" label="32082" help="">
+          <level>0</level>
+          <default />
+          <constraints>
+            <allowempty>true</allowempty>
+          </constraints>
+          <control type="edit" format="string">
+            <heading>32082</heading>
+          </control>
+          <visible>false</visible>
+        </setting>
+        <setting id="timer_12_hint" type="string" label="32114" help="">
+          <level>0</level>
+          <default />
+          <constraints>
+            <allowempty>true</allowempty>
+          </constraints>
+          <control type="edit" format="string">
+            <heading>32114</heading>
+          </control>
+          <enable>false</enable>
+          <dependencies>
+            <dependency type="visible">
+              <and>
+                <condition setting="timer_12_filename" operator="is"></condition>
+                <condition setting="timer_12_action" operator="gt">0</condition>
+                <condition setting="timer_12_action" operator="lt">4</condition>
+              </and>
+            </dependency>
+          </dependencies>
+        </setting>
+        <setting id="timer_12_test" type="action" label="32108" help="">
+          <level>0</level>
+          <data>RunScript($ID,play,12)</data>
+          <control type="button" format="action">
+            <close>false</close>
+          </control>
+          <dependencies>
+            <dependency type="enable" setting="timer_12_filename" operator="!is"></dependency>
+          </dependencies>
+        </setting>
+      </group>
+      <group id="g_timer_12_fade" label="32090">
+        <setting id="timer_12_fade" type="integer" label="32091" help="">
+          <level>0</level>
+          <default>0</default>
+          <constraints>
+            <options>
+              <option label="32120">0</option>
+              <option label="32121">1</option>
+              <option label="32122">2</option>
+              <option label="32123">3</option>
+            </options>
+          </constraints>
+          <dependencies>
+            <dependency type="enable" setting="timer_12_end_type" operator="!is">0</dependency>
+          </dependencies>
+          <control type="spinner" format="string" />
+        </setting>
+        <setting id="timer_12_vol_min" type="integer" label="32095" help="">
+          <level>0</level>
+          <default>75</default>
+          <constraints>
+            <minimum>0</minimum>
+            <step>1</step>
+            <maximum>100</maximum>
+          </constraints>
+          <control type="slider" format="integer">
+            <popup>false</popup>
+          </control>
+          <dependencies>
+            <dependency type="visible" setting="timer_12_fade" operator="!is">0</dependency>
+          </dependencies>
+        </setting>
+        <setting id="timer_12_vol_max" type="integer" label="32096" help="">
+          <level>0</level>
+          <default>100</default>
+          <constraints>
+            <minimum>0</minimum>
+            <step>1</step>
+            <maximum>100</maximum>
+          </constraints>
+          <control type="slider" format="integer">
+            <popup>false</popup>
+          </control>
+          <dependencies>
+            <dependency type="visible">
+              <and>
+                <condition setting="timer_12_fade" operator="!is">0</condition>
+                <condition setting="timer_12_fade" operator="!is">3</condition>
+              </and>
+            </dependency>
+          </dependencies>
+        </setting>
+      </group>
+      <group id="g_timer_12_notify" label="32097">
+        <setting id="timer_12_notify" type="boolean" label="32098" help="">
+          <level>1</level>
+          <default>true</default>
+          <control type="toggle" />
+        </setting>
+      </group>
+    </category>
+    <category id="c_timer_13" label="32017" help="">
+      <group id="g_timer_13" label="32017">
+        <setting id="timer_13_label" type="string" label="32026" help="">
+          <level>0</level>
+          <default>Timer 12</default>
+          <constraints>
+            <allowempty>false</allowempty>
+          </constraints>
+          <control type="edit" format="string">
+            <heading>32026</heading>
+          </control>
+        </setting>
+      </group>
+      <group id="g_timer_13_schedule" label="32060">
+        <setting id="timer_13" type="integer" label="32033" help="">
+          <level>0</level>
+          <default>25</default>
+          <constraints>
+            <options>
+              <option label="32034">0</option>
+              <option label="32035">1</option>
+              <option label="32036">2</option>
+              <option label="32037">3</option>
+              <option label="32038">4</option>
+              <option label="32039">5</option>
+              <option label="32040">6</option>
+              <option label="32041">7</option>
+              <option label="32042">8</option>
+              <option label="32043">9</option>
+              <option label="32044">10</option>
+              <option label="32045">11</option>
+              <option label="32046">12</option>
+              <option label="32047">13</option>
+              <option label="32048">14</option>
+              <option label="32049">15</option>
+              <option label="32156">26</option>
+              <option label="32050">16</option>
+              <option label="32051">17</option>
+              <option label="32052">18</option>
+              <option label="32053">19</option>
+              <option label="32054">20</option>
+              <option label="32055">21</option>
+              <option label="32056">22</option>
+              <option label="32057">23</option>
+              <option label="32058">24</option>
+              <option label="32059">25</option>
+            </options>
+          </constraints>
+          <control type="spinner" format="string" />
+        </setting>
+        <setting id="timer_13_start" type="time" label="32061" help="">
+          <level>0</level>
+          <default>00:00</default>
+          <control type="button" format="time">
+            <heading>32061</heading>
+          </control>
+          <dependencies>
+            <dependency type="enable" setting="timer_13" operator="!is">25</dependency>
+          </dependencies>
+        </setting>
+        <setting id="timer_13_end_type" type="integer" label="32062" help="">
+          <level>0</level>
+          <default>0</default>
+          <constraints>
+            <options>
+              <option label="32063">0</option>
+              <option label="32064">1</option>
+              <option label="32065">2</option>
+            </options>
+          </constraints>
+          <control type="spinner" format="string" />
+          <dependencies>
+            <dependency type="enable" setting="timer_13" operator="!is">25</dependency>
+          </dependencies>
+        </setting>
+        <setting id="timer_13_duration" type="time" label="32064" help="">
+          <level>0</level>
+          <default>01:00</default>
+          <control type="button" format="time">
+            <heading>32064</heading>
+          </control>
+          <dependencies>
+            <dependency type="enable" setting="timer_13" operator="!is">25</dependency>
+            <dependency type="visible" setting="timer_13_end_type" operator="is">1</dependency>
+          </dependencies>
+        </setting>
+        <setting id="timer_13_end" type="time" label="32065" help="">
+          <level>0</level>
+          <default>00:00</default>
+          <control type="button" format="time">
+            <heading>32065</heading>
+          </control>
+          <dependencies>
+            <dependency type="enable" setting="timer_13" operator="!is">25</dependency>
+            <dependency type="visible" setting="timer_13_end_type" operator="is">2</dependency>
+          </dependencies>
+        </setting>
+      </group>
+      <group id="g_timer_13_action" label="32070">
+        <setting id="timer_13_action" type="integer" label="32070" help="">
+          <level>0</level>
+          <default>2</default>
+          <constraints>
+            <options>
+              <option label="32071">0</option>
+              <option label="32072">1</option>
+              <option label="32073">2</option>
+              <option label="32074">3</option>
+              <option label="32075">4</option>
+              <option label="32076">5</option>
+              <option label="32077">6</option>
+            </options>
+          </constraints>
+          <control type="spinner" format="string" />
+        </setting>
+        <setting id="timer_13_filename" type="string" label="32082" help="">
+          <level>0</level>
+          <default />
+          <constraints>
+            <allowempty>true</allowempty>
+          </constraints>
+          <control type="edit" format="string">
+            <heading>32082</heading>
+          </control>
+          <visible>false</visible>
+        </setting>
+        <setting id="timer_13_hint" type="string" label="32114" help="">
+          <level>0</level>
+          <default />
+          <constraints>
+            <allowempty>true</allowempty>
+          </constraints>
+          <control type="edit" format="string">
+            <heading>32114</heading>
+          </control>
+          <enable>false</enable>
+          <dependencies>
+            <dependency type="visible">
+              <and>
+                <condition setting="timer_13_filename" operator="is"></condition>
+                <condition setting="timer_13_action" operator="gt">0</condition>
+                <condition setting="timer_13_action" operator="lt">4</condition>
+              </and>
+            </dependency>
+          </dependencies>
+        </setting>
+        <setting id="timer_13_test" type="action" label="32108" help="">
+          <level>0</level>
+          <data>RunScript($ID,play,13)</data>
+          <control type="button" format="action">
+            <close>false</close>
+          </control>
+          <dependencies>
+            <dependency type="enable" setting="timer_13_filename" operator="!is"></dependency>
+          </dependencies>
+        </setting>
+      </group>
+      <group id="g_timer_13_fade" label="32090">
+        <setting id="timer_13_fade" type="integer" label="32091" help="">
+          <level>0</level>
+          <default>0</default>
+          <constraints>
+            <options>
+              <option label="32120">0</option>
+              <option label="32121">1</option>
+              <option label="32122">2</option>
+              <option label="32123">3</option>
+            </options>
+          </constraints>
+          <dependencies>
+            <dependency type="enable" setting="timer_13_end_type" operator="!is">0</dependency>
+          </dependencies>
+          <control type="spinner" format="string" />
+        </setting>
+        <setting id="timer_13_vol_min" type="integer" label="32095" help="">
+          <level>0</level>
+          <default>75</default>
+          <constraints>
+            <minimum>0</minimum>
+            <step>1</step>
+            <maximum>100</maximum>
+          </constraints>
+          <control type="slider" format="integer">
+            <popup>false</popup>
+          </control>
+          <dependencies>
+            <dependency type="visible" setting="timer_13_fade" operator="!is">0</dependency>
+          </dependencies>
+        </setting>
+        <setting id="timer_13_vol_max" type="integer" label="32096" help="">
+          <level>0</level>
+          <default>100</default>
+          <constraints>
+            <minimum>0</minimum>
+            <step>1</step>
+            <maximum>100</maximum>
+          </constraints>
+          <control type="slider" format="integer">
+            <popup>false</popup>
+          </control>
+          <dependencies>
+            <dependency type="visible">
+              <and>
+                <condition setting="timer_13_fade" operator="!is">0</condition>
+                <condition setting="timer_13_fade" operator="!is">3</condition>
+              </and>
+            </dependency>
+          </dependencies>
+        </setting>
+      </group>
+      <group id="g_timer_13_notify" label="32097">
+        <setting id="timer_13_notify" type="boolean" label="32098" help="">
+          <level>1</level>
+          <default>true</default>
+          <control type="toggle" />
+        </setting>
+      </group>
+    </category>
+    <category id="c_timer_14" label="32018" help="">
+      <group id="g_timer_14" label="32018">
+        <setting id="timer_14_label" type="string" label="32026" help="">
+          <level>0</level>
+          <default>Timer 13</default>
+          <constraints>
+            <allowempty>false</allowempty>
+          </constraints>
+          <control type="edit" format="string">
+            <heading>32026</heading>
+          </control>
+        </setting>
+      </group>
+      <group id="g_timer_14_schedule" label="32060">
+        <setting id="timer_14" type="integer" label="32033" help="">
+          <level>0</level>
+          <default>25</default>
+          <constraints>
+            <options>
+              <option label="32034">0</option>
+              <option label="32035">1</option>
+              <option label="32036">2</option>
+              <option label="32037">3</option>
+              <option label="32038">4</option>
+              <option label="32039">5</option>
+              <option label="32040">6</option>
+              <option label="32041">7</option>
+              <option label="32042">8</option>
+              <option label="32043">9</option>
+              <option label="32044">10</option>
+              <option label="32045">11</option>
+              <option label="32046">12</option>
+              <option label="32047">13</option>
+              <option label="32048">14</option>
+              <option label="32049">15</option>
+              <option label="32156">26</option>
+              <option label="32050">16</option>
+              <option label="32051">17</option>
+              <option label="32052">18</option>
+              <option label="32053">19</option>
+              <option label="32054">20</option>
+              <option label="32055">21</option>
+              <option label="32056">22</option>
+              <option label="32057">23</option>
+              <option label="32058">24</option>
+              <option label="32059">25</option>
+            </options>
+          </constraints>
+          <control type="spinner" format="string" />
+        </setting>
+        <setting id="timer_14_start" type="time" label="32061" help="">
+          <level>0</level>
+          <default>00:00</default>
+          <control type="button" format="time">
+            <heading>32061</heading>
+          </control>
+          <dependencies>
+            <dependency type="enable" setting="timer_14" operator="!is">25</dependency>
+          </dependencies>
+        </setting>
+        <setting id="timer_14_end_type" type="integer" label="32062" help="">
+          <level>0</level>
+          <default>0</default>
+          <constraints>
+            <options>
+              <option label="32063">0</option>
+              <option label="32064">1</option>
+              <option label="32065">2</option>
+            </options>
+          </constraints>
+          <control type="spinner" format="string" />
+          <dependencies>
+            <dependency type="enable" setting="timer_14" operator="!is">25</dependency>
+          </dependencies>
+        </setting>
+        <setting id="timer_14_duration" type="time" label="32064" help="">
+          <level>0</level>
+          <default>01:00</default>
+          <control type="button" format="time">
+            <heading>32064</heading>
+          </control>
+          <dependencies>
+            <dependency type="enable" setting="timer_14" operator="!is">25</dependency>
+            <dependency type="visible" setting="timer_14_end_type" operator="is">1</dependency>
+          </dependencies>
+        </setting>
+        <setting id="timer_14_end" type="time" label="32065" help="">
+          <level>0</level>
+          <default>00:00</default>
+          <control type="button" format="time">
+            <heading>32065</heading>
+          </control>
+          <dependencies>
+            <dependency type="enable" setting="timer_14" operator="!is">25</dependency>
+            <dependency type="visible" setting="timer_14_end_type" operator="is">2</dependency>
+          </dependencies>
+        </setting>
+      </group>
+      <group id="g_timer_14_action" label="32070">
+        <setting id="timer_14_action" type="integer" label="32070" help="">
+          <level>0</level>
+          <default>2</default>
+          <constraints>
+            <options>
+              <option label="32071">0</option>
+              <option label="32072">1</option>
+              <option label="32073">2</option>
+              <option label="32074">3</option>
+              <option label="32075">4</option>
+              <option label="32076">5</option>
+              <option label="32077">6</option>
+            </options>
+          </constraints>
+          <control type="spinner" format="string" />
+        </setting>
+        <setting id="timer_14_filename" type="string" label="32082" help="">
+          <level>0</level>
+          <default />
+          <constraints>
+            <allowempty>true</allowempty>
+          </constraints>
+          <control type="edit" format="string">
+            <heading>32082</heading>
+          </control>
+          <visible>false</visible>
+        </setting>
+        <setting id="timer_14_hint" type="string" label="32114" help="">
+          <level>0</level>
+          <default />
+          <constraints>
+            <allowempty>true</allowempty>
+          </constraints>
+          <control type="edit" format="string">
+            <heading>32114</heading>
+          </control>
+          <enable>false</enable>
+          <dependencies>
+            <dependency type="visible">
+              <and>
+                <condition setting="timer_14_filename" operator="is"></condition>
+                <condition setting="timer_14_action" operator="gt">0</condition>
+                <condition setting="timer_14_action" operator="lt">4</condition>
+              </and>
+            </dependency>
+          </dependencies>
+        </setting>
+        <setting id="timer_14_test" type="action" label="32108" help="">
+          <level>0</level>
+          <data>RunScript($ID,play,13)</data>
+          <control type="button" format="action">
+            <close>false</close>
+          </control>
+          <dependencies>
+            <dependency type="enable" setting="timer_14_filename" operator="!is"></dependency>
+          </dependencies>
+        </setting>
+      </group>
+      <group id="g_timer_14_fade" label="32090">
+        <setting id="timer_14_fade" type="integer" label="32091" help="">
+          <level>0</level>
+          <default>0</default>
+          <constraints>
+            <options>
+              <option label="32120">0</option>
+              <option label="32121">1</option>
+              <option label="32122">2</option>
+              <option label="32123">3</option>
+            </options>
+          </constraints>
+          <dependencies>
+            <dependency type="enable" setting="timer_14_end_type" operator="!is">0</dependency>
+          </dependencies>
+          <control type="spinner" format="string" />
+        </setting>
+        <setting id="timer_14_vol_min" type="integer" label="32095" help="">
+          <level>0</level>
+          <default>75</default>
+          <constraints>
+            <minimum>0</minimum>
+            <step>1</step>
+            <maximum>100</maximum>
+          </constraints>
+          <control type="slider" format="integer">
+            <popup>false</popup>
+          </control>
+          <dependencies>
+            <dependency type="visible" setting="timer_14_fade" operator="!is">0</dependency>
+          </dependencies>
+        </setting>
+        <setting id="timer_14_vol_max" type="integer" label="32096" help="">
+          <level>0</level>
+          <default>100</default>
+          <constraints>
+            <minimum>0</minimum>
+            <step>1</step>
+            <maximum>100</maximum>
+          </constraints>
+          <control type="slider" format="integer">
+            <popup>false</popup>
+          </control>
+          <dependencies>
+            <dependency type="visible">
+              <and>
+                <condition setting="timer_14_fade" operator="!is">0</condition>
+                <condition setting="timer_14_fade" operator="!is">3</condition>
+              </and>
+            </dependency>
+          </dependencies>
+        </setting>
+      </group>
+      <group id="g_timer_14_notify" label="32097">
+        <setting id="timer_14_notify" type="boolean" label="32098" help="">
+          <level>1</level>
+          <default>true</default>
+          <control type="toggle" />
+        </setting>
+      </group>
+    </category>
+    <category id="c_timer_15" label="32019" help="">
+      <group id="g_timer_15" label="32019">
+        <setting id="timer_15_label" type="string" label="32026" help="">
+          <level>0</level>
+          <default>Timer 14</default>
+          <constraints>
+            <allowempty>false</allowempty>
+          </constraints>
+          <control type="edit" format="string">
+            <heading>32026</heading>
+          </control>
+        </setting>
+      </group>
+      <group id="g_timer_15_schedule" label="32060">
+        <setting id="timer_15" type="integer" label="32033" help="">
+          <level>0</level>
+          <default>25</default>
+          <constraints>
+            <options>
+              <option label="32034">0</option>
+              <option label="32035">1</option>
+              <option label="32036">2</option>
+              <option label="32037">3</option>
+              <option label="32038">4</option>
+              <option label="32039">5</option>
+              <option label="32040">6</option>
+              <option label="32041">7</option>
+              <option label="32042">8</option>
+              <option label="32043">9</option>
+              <option label="32044">10</option>
+              <option label="32045">11</option>
+              <option label="32046">12</option>
+              <option label="32047">13</option>
+              <option label="32048">14</option>
+              <option label="32049">15</option>
+              <option label="32156">26</option>
+              <option label="32050">16</option>
+              <option label="32051">17</option>
+              <option label="32052">18</option>
+              <option label="32053">19</option>
+              <option label="32054">20</option>
+              <option label="32055">21</option>
+              <option label="32056">22</option>
+              <option label="32057">23</option>
+              <option label="32058">24</option>
+              <option label="32059">25</option>
+            </options>
+          </constraints>
+          <control type="spinner" format="string" />
+        </setting>
+        <setting id="timer_15_start" type="time" label="32061" help="">
+          <level>0</level>
+          <default>00:00</default>
+          <control type="button" format="time">
+            <heading>32061</heading>
+          </control>
+          <dependencies>
+            <dependency type="enable" setting="timer_15" operator="!is">25</dependency>
+          </dependencies>
+        </setting>
+        <setting id="timer_15_end_type" type="integer" label="32062" help="">
+          <level>0</level>
+          <default>0</default>
+          <constraints>
+            <options>
+              <option label="32063">0</option>
+              <option label="32064">1</option>
+              <option label="32065">2</option>
+            </options>
+          </constraints>
+          <control type="spinner" format="string" />
+          <dependencies>
+            <dependency type="enable" setting="timer_15" operator="!is">25</dependency>
+          </dependencies>
+        </setting>
+        <setting id="timer_15_duration" type="time" label="32064" help="">
+          <level>0</level>
+          <default>01:00</default>
+          <control type="button" format="time">
+            <heading>32064</heading>
+          </control>
+          <dependencies>
+            <dependency type="enable" setting="timer_15" operator="!is">25</dependency>
+            <dependency type="visible" setting="timer_15_end_type" operator="is">1</dependency>
+          </dependencies>
+        </setting>
+        <setting id="timer_15_end" type="time" label="32065" help="">
+          <level>0</level>
+          <default>00:00</default>
+          <control type="button" format="time">
+            <heading>32065</heading>
+          </control>
+          <dependencies>
+            <dependency type="enable" setting="timer_15" operator="!is">25</dependency>
+            <dependency type="visible" setting="timer_15_end_type" operator="is">2</dependency>
+          </dependencies>
+        </setting>
+      </group>
+      <group id="g_timer_15_action" label="32070">
+        <setting id="timer_15_action" type="integer" label="32070" help="">
+          <level>0</level>
+          <default>2</default>
+          <constraints>
+            <options>
+              <option label="32071">0</option>
+              <option label="32072">1</option>
+              <option label="32073">2</option>
+              <option label="32074">3</option>
+              <option label="32075">4</option>
+              <option label="32076">5</option>
+              <option label="32077">6</option>
+            </options>
+          </constraints>
+          <control type="spinner" format="string" />
+        </setting>
+        <setting id="timer_15_filename" type="string" label="32082" help="">
+          <level>0</level>
+          <default />
+          <constraints>
+            <allowempty>true</allowempty>
+          </constraints>
+          <control type="edit" format="string">
+            <heading>32082</heading>
+          </control>
+          <visible>false</visible>
+        </setting>
+        <setting id="timer_15_hint" type="string" label="32114" help="">
+          <level>0</level>
+          <default />
+          <constraints>
+            <allowempty>true</allowempty>
+          </constraints>
+          <control type="edit" format="string">
+            <heading>32114</heading>
+          </control>
+          <enable>false</enable>
+          <dependencies>
+            <dependency type="visible">
+              <and>
+                <condition setting="timer_15_filename" operator="is"></condition>
+                <condition setting="timer_15_action" operator="gt">0</condition>
+                <condition setting="timer_15_action" operator="lt">4</condition>
+              </and>
+            </dependency>
+          </dependencies>
+        </setting>
+        <setting id="timer_15_test" type="action" label="32108" help="">
+          <level>0</level>
+          <data>RunScript($ID,play,13)</data>
+          <control type="button" format="action">
+            <close>false</close>
+          </control>
+          <dependencies>
+            <dependency type="enable" setting="timer_15_filename" operator="!is"></dependency>
+          </dependencies>
+        </setting>
+      </group>
+      <group id="g_timer_15_fade" label="32090">
+        <setting id="timer_15_fade" type="integer" label="32091" help="">
+          <level>0</level>
+          <default>0</default>
+          <constraints>
+            <options>
+              <option label="32120">0</option>
+              <option label="32121">1</option>
+              <option label="32122">2</option>
+              <option label="32123">3</option>
+            </options>
+          </constraints>
+          <dependencies>
+            <dependency type="enable" setting="timer_15_end_type" operator="!is">0</dependency>
+          </dependencies>
+          <control type="spinner" format="string" />
+        </setting>
+        <setting id="timer_15_vol_min" type="integer" label="32095" help="">
+          <level>0</level>
+          <default>75</default>
+          <constraints>
+            <minimum>0</minimum>
+            <step>1</step>
+            <maximum>100</maximum>
+          </constraints>
+          <control type="slider" format="integer">
+            <popup>false</popup>
+          </control>
+          <dependencies>
+            <dependency type="visible" setting="timer_15_fade" operator="!is">0</dependency>
+          </dependencies>
+        </setting>
+        <setting id="timer_15_vol_max" type="integer" label="32096" help="">
+          <level>0</level>
+          <default>100</default>
+          <constraints>
+            <minimum>0</minimum>
+            <step>1</step>
+            <maximum>100</maximum>
+          </constraints>
+          <control type="slider" format="integer">
+            <popup>false</popup>
+          </control>
+          <dependencies>
+            <dependency type="visible">
+              <and>
+                <condition setting="timer_15_fade" operator="!is">0</condition>
+                <condition setting="timer_15_fade" operator="!is">3</condition>
+              </and>
+            </dependency>
+          </dependencies>
+        </setting>
+      </group>
+      <group id="g_timer_15_notify" label="32097">
+        <setting id="timer_15_notify" type="boolean" label="32098" help="">
+          <level>1</level>
+          <default>true</default>
+          <control type="toggle" />
+        </setting>
+      </group>
+    </category>
+    <category id="c_timer_16" label="32020" help="">
+      <group id="g_timer_16" label="32020">
+        <setting id="timer_16_label" type="string" label="32026" help="">
+          <level>0</level>
+          <default>Timer 15</default>
+          <constraints>
+            <allowempty>false</allowempty>
+          </constraints>
+          <control type="edit" format="string">
+            <heading>32026</heading>
+          </control>
+        </setting>
+      </group>
+      <group id="g_timer_16_schedule" label="32060">
+        <setting id="timer_16" type="integer" label="32033" help="">
+          <level>0</level>
+          <default>25</default>
+          <constraints>
+            <options>
+              <option label="32034">0</option>
+              <option label="32035">1</option>
+              <option label="32036">2</option>
+              <option label="32037">3</option>
+              <option label="32038">4</option>
+              <option label="32039">5</option>
+              <option label="32040">6</option>
+              <option label="32041">7</option>
+              <option label="32042">8</option>
+              <option label="32043">9</option>
+              <option label="32044">10</option>
+              <option label="32045">11</option>
+              <option label="32046">12</option>
+              <option label="32047">13</option>
+              <option label="32048">14</option>
+              <option label="32049">15</option>
+              <option label="32156">26</option>
+              <option label="32050">16</option>
+              <option label="32051">17</option>
+              <option label="32052">18</option>
+              <option label="32053">19</option>
+              <option label="32054">20</option>
+              <option label="32055">21</option>
+              <option label="32056">22</option>
+              <option label="32057">23</option>
+              <option label="32058">24</option>
+              <option label="32059">25</option>
+            </options>
+          </constraints>
+          <control type="spinner" format="string" />
+        </setting>
+        <setting id="timer_16_start" type="time" label="32061" help="">
+          <level>0</level>
+          <default>00:00</default>
+          <control type="button" format="time">
+            <heading>32061</heading>
+          </control>
+          <dependencies>
+            <dependency type="enable" setting="timer_16" operator="!is">25</dependency>
+          </dependencies>
+        </setting>
+        <setting id="timer_16_end_type" type="integer" label="32062" help="">
+          <level>0</level>
+          <default>0</default>
+          <constraints>
+            <options>
+              <option label="32063">0</option>
+              <option label="32064">1</option>
+              <option label="32065">2</option>
+            </options>
+          </constraints>
+          <control type="spinner" format="string" />
+          <dependencies>
+            <dependency type="enable" setting="timer_16" operator="!is">25</dependency>
+          </dependencies>
+        </setting>
+        <setting id="timer_16_duration" type="time" label="32064" help="">
+          <level>0</level>
+          <default>01:00</default>
+          <control type="button" format="time">
+            <heading>32064</heading>
+          </control>
+          <dependencies>
+            <dependency type="enable" setting="timer_16" operator="!is">25</dependency>
+            <dependency type="visible" setting="timer_16_end_type" operator="is">1</dependency>
+          </dependencies>
+        </setting>
+        <setting id="timer_16_end" type="time" label="32065" help="">
+          <level>0</level>
+          <default>00:00</default>
+          <control type="button" format="time">
+            <heading>32065</heading>
+          </control>
+          <dependencies>
+            <dependency type="enable" setting="timer_16" operator="!is">25</dependency>
+            <dependency type="visible" setting="timer_16_end_type" operator="is">2</dependency>
+          </dependencies>
+        </setting>
+      </group>
+      <group id="g_timer_16_action" label="32070">
+        <setting id="timer_16_action" type="integer" label="32070" help="">
+          <level>0</level>
+          <default>2</default>
+          <constraints>
+            <options>
+              <option label="32071">0</option>
+              <option label="32072">1</option>
+              <option label="32073">2</option>
+              <option label="32074">3</option>
+              <option label="32075">4</option>
+              <option label="32076">5</option>
+              <option label="32077">6</option>
+            </options>
+          </constraints>
+          <control type="spinner" format="string" />
+        </setting>
+        <setting id="timer_16_filename" type="string" label="32082" help="">
+          <level>0</level>
+          <default />
+          <constraints>
+            <allowempty>true</allowempty>
+          </constraints>
+          <control type="edit" format="string">
+            <heading>32082</heading>
+          </control>
+          <visible>false</visible>
+        </setting>
+        <setting id="timer_16_hint" type="string" label="32114" help="">
+          <level>0</level>
+          <default />
+          <constraints>
+            <allowempty>true</allowempty>
+          </constraints>
+          <control type="edit" format="string">
+            <heading>32114</heading>
+          </control>
+          <enable>false</enable>
+          <dependencies>
+            <dependency type="visible">
+              <and>
+                <condition setting="timer_16_filename" operator="is"></condition>
+                <condition setting="timer_16_action" operator="gt">0</condition>
+                <condition setting="timer_16_action" operator="lt">4</condition>
+              </and>
+            </dependency>
+          </dependencies>
+        </setting>
+        <setting id="timer_16_test" type="action" label="32108" help="">
+          <level>0</level>
+          <data>RunScript($ID,play,13)</data>
+          <control type="button" format="action">
+            <close>false</close>
+          </control>
+          <dependencies>
+            <dependency type="enable" setting="timer_16_filename" operator="!is"></dependency>
+          </dependencies>
+        </setting>
+      </group>
+      <group id="g_timer_16_fade" label="32090">
+        <setting id="timer_16_fade" type="integer" label="32091" help="">
+          <level>0</level>
+          <default>0</default>
+          <constraints>
+            <options>
+              <option label="32120">0</option>
+              <option label="32121">1</option>
+              <option label="32122">2</option>
+              <option label="32123">3</option>
+            </options>
+          </constraints>
+          <dependencies>
+            <dependency type="enable" setting="timer_16_end_type" operator="!is">0</dependency>
+          </dependencies>
+          <control type="spinner" format="string" />
+        </setting>
+        <setting id="timer_16_vol_min" type="integer" label="32095" help="">
+          <level>0</level>
+          <default>75</default>
+          <constraints>
+            <minimum>0</minimum>
+            <step>1</step>
+            <maximum>100</maximum>
+          </constraints>
+          <control type="slider" format="integer">
+            <popup>false</popup>
+          </control>
+          <dependencies>
+            <dependency type="visible" setting="timer_16_fade" operator="!is">0</dependency>
+          </dependencies>
+        </setting>
+        <setting id="timer_16_vol_max" type="integer" label="32096" help="">
+          <level>0</level>
+          <default>100</default>
+          <constraints>
+            <minimum>0</minimum>
+            <step>1</step>
+            <maximum>100</maximum>
+          </constraints>
+          <control type="slider" format="integer">
+            <popup>false</popup>
+          </control>
+          <dependencies>
+            <dependency type="visible">
+              <and>
+                <condition setting="timer_16_fade" operator="!is">0</condition>
+                <condition setting="timer_16_fade" operator="!is">3</condition>
+              </and>
+            </dependency>
+          </dependencies>
+        </setting>
+      </group>
+      <group id="g_timer_16_notify" label="32097">
+        <setting id="timer_16_notify" type="boolean" label="32098" help="">
+          <level>1</level>
+          <default>true</default>
+          <control type="toggle" />
+        </setting>
+      </group>
+    </category>            
+  </section>
 </settings>


### PR DESCRIPTION
### Description
v2.1.0 (2021-11-20):
- Improved start and stop action in case that multiple timers are running in parallel, see also https://github.com/Heckie75/kodi-addon-timers/issues/5 
- One-click-setup from epg (Quick Timer)
- Improved procedure of update state after one-time-timers have run out or settings have been changed
- Added 5 more timer slots
- Added feature in order to prevent that display is turned off if Kodi idles but is not in fullscreen mode
- Migrated to new XML settings format
- Major refactoring, better structured code

### Checklist:
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [script.foo.bar] 1.0.0