### PR TITLE
[service.autostop] 1.0.1

### DIFF
--- a/service.autostop/README.md
+++ b/service.autostop/README.md
@@ -9,5 +9,5 @@ Features:
 - Automatically engage Kodi screensaver when stopping paused playback.
 - Ability to change sleep timer by calling addon from favourites or keyboard.xml (see Readme)
 
-<img src="/resources/icon.png" width="40%">
+<img src="resources/icon.png" width="40%">
 

--- a/service.autostop/addon.xml
+++ b/service.autostop/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon  id="service.autostop" name="Autostop" version="1.0.0" provider-name="jeff@thebinks.com">
+<addon  id="service.autostop" name="Autostop" version="1.0.1" provider-name="jeff@thebinks.com">
   <requires>
     <import addon="xbmc.python" version="3.0.0"/>
   </requires>    

--- a/service.autostop/changelog.txt
+++ b/service.autostop/changelog.txt
@@ -1,3 +1,8 @@
+1.0.1
+-  Fixed exception bug which could occur if Kodi stopped 
+   playing a file at exactly the same time the addon 
+   attempted to stop playback.
+
 1.0.0
 - Initial Matrix release
 

--- a/service.autostop/service.py
+++ b/service.autostop/service.py
@@ -51,63 +51,69 @@ player = XBMCPlayer()
  
 monitor = xbmc.Monitor()      
  
-#while True:
 while not monitor.abortRequested():
 
     pacount += 1
     if pacount % 10 == 0:                          # Check for paused video every 10 seconds
-        pastoptime = int(settings('pastop'))
-        xbmc.log('Autostop pause count and stop time ' + str(pacount) + ' ' + str(pastoptime) +    \
-        ' ' + str(player.paflag), xbmc.LOGDEBUG)
-        if pastoptime > 0 and pacount >= pastoptime * 60 and player.paflag == 1:
-            if xbmc.Player().isPlayingVideo():
-                ptag = xbmc.Player().getVideoInfoTag()
-                ptitle = ptag.getTitle()
-            elif xbmc.Player().isPlayingAudio():
-                ptag = xbmc.Player().getMusicInfoTag()
-                ptitle = ptag.getTitle()                
-            else:
-                ptitle = "playing file"
-            pos = xbmc.Player().getTime()
-            xbmc.Player().stop()
-            pacount = 0
-            mgenlog ='Autostop stopped paused playback: ' + ptitle +     \
-            ' at: ' + time.strftime("%H:%M:%S", time.gmtime(pos))
-            xbmc.log(mgenlog, xbmc.LOGINFO)
-            dialog = xbmcgui.Dialog()
-            dialog.notification('Autostop Paused Timer', mgenlog, xbmcgui.NOTIFICATION_INFO, 5000)
-            if settings('screensaver') == 'true':  #  Active screensaver if option selected
-                xbmc.executebuiltin('ActivateScreensaver')
-        elif player.paflag == 0:
-            pacount = 0
+        try:
+            pastoptime = int(settings('pastop'))
+            xbmc.log('Autostop pause count and stop time ' + str(pacount) + ' ' + str(pastoptime) +    \
+            ' ' + str(player.paflag), xbmc.LOGDEBUG)
+            if pastoptime > 0 and pacount >= pastoptime * 60 and player.paflag == 1:
+                if xbmc.Player().isPlayingVideo():
+                    ptag = xbmc.Player().getVideoInfoTag()
+                    ptitle = ptag.getTitle()
+                elif xbmc.Player().isPlayingAudio():
+                    ptag = xbmc.Player().getMusicInfoTag()
+                    ptitle = ptag.getTitle()                
+                else:
+                    ptitle = "playing file"
+                pos = xbmc.Player().getTime()
+                xbmc.Player().stop()
+                pacount = 0
+                mgenlog ='Autostop stopped paused playback: ' + ptitle +     \
+                ' at: ' + time.strftime("%H:%M:%S", time.gmtime(pos))
+                xbmc.log(mgenlog, xbmc.LOGINFO)
+                dialog = xbmcgui.Dialog()
+                dialog.notification('Autostop Paused Timer', mgenlog, xbmcgui.NOTIFICATION_INFO, 5000)
+                if settings('screensaver') == 'true':  #  Active screensaver if option selected
+                    xbmc.executebuiltin('ActivateScreensaver')
+            elif player.paflag == 0:
+                pacount = 0
+        except:
+            xbmc.log('Autostop pause count and stop time exception error' + str(pacount) + ' ' + str(pastoptime) +    \
+            ' ' + str(player.paflag), xbmc.LOGINFO)            
 
     plcount += 1 
     if plcount % 10 == 0:                          # Check for playing video every 10 seconds
-        plstoptime = int(settings('plstop'))
-        xbmc.log('Autostop play count and stop time ' + str(plcount) + ' ' + str(plstoptime) +    \
-        ' ' + str(player.plflag), xbmc.LOGDEBUG)
-        if plstoptime > 0 and plcount >= plstoptime * 60 and player.plflag == 1:
-            if xbmc.Player().isPlayingVideo():
-                ptag = xbmc.Player().getVideoInfoTag()
-                ptitle = ptag.getTitle()
-            elif xbmc.Player().isPlayingAudio():
-                ptag = xbmc.Player().getMusicInfoTag()
-                ptitle = ptag.getTitle()                
-            else:
-                ptitle = "playing file"
-            pos = xbmc.Player().getTime()
-            xbmc.Player().stop()
-            plcount = 0
-            mgenlog ='Autostop stopped current playback: ' + ptitle +     \
-            ' at: ' + time.strftime("%H:%M:%S", time.gmtime(pos))
-            xbmc.log(mgenlog, xbmc.LOGINFO)
-            dialog = xbmcgui.Dialog()
-            dialog.notification('Autostop Sleep Timer', mgenlog, xbmcgui.NOTIFICATION_INFO, 5000)
-            if settings('screensaver') == 'true':  #  Active screensaver if option selected
-                xbmc.executebuiltin('ActivateScreensaver')
-        elif player.plflag == 0:
-            plcount = 0
-
+        try:
+            plstoptime = int(settings('plstop'))
+            xbmc.log('Autostop play count and stop time ' + str(plcount) + ' ' + str(plstoptime) +    \
+            ' ' + str(player.plflag), xbmc.LOGDEBUG)
+            if plstoptime > 0 and plcount >= plstoptime * 60 and player.plflag == 1:
+                if xbmc.Player().isPlayingVideo():
+                    ptag = xbmc.Player().getVideoInfoTag()
+                    ptitle = ptag.getTitle()
+                elif xbmc.Player().isPlayingAudio():
+                    ptag = xbmc.Player().getMusicInfoTag()
+                    ptitle = ptag.getTitle()                
+                else:
+                    ptitle = "playing file"
+                pos = xbmc.Player().getTime()
+                xbmc.Player().stop()
+                plcount = 0
+                mgenlog ='Autostop stopped current playback: ' + ptitle +     \
+                ' at: ' + time.strftime("%H:%M:%S", time.gmtime(pos))
+                xbmc.log(mgenlog, xbmc.LOGINFO)
+                dialog = xbmcgui.Dialog()
+                dialog.notification('Autostop Sleep Timer', mgenlog, xbmcgui.NOTIFICATION_INFO, 5000)
+                if settings('screensaver') == 'true':  #  Active screensaver if option selected
+                    xbmc.executebuiltin('ActivateScreensaver')
+            elif player.plflag == 0:
+                plcount = 0
+        except:
+            xbmc.log('Autostop play count and stop time exception error' + str(pacount) + ' ' + str(pastoptime) +    \
+            ' ' + str(player.paflag), xbmc.LOGINFO)         
 
     if monitor.waitForAbort(1): # Sleep/wait for abort for 1 second.
         xbmc.log("Autostop addon service stopped." , xbmc.LOGINFO)


### PR DESCRIPTION
Description

v1.0.1 - Fixed exception bug which could occur if Kodi stopped playing a file 
at exactly the same time the addon attempted to stop playback.

This is a simple Kodi service addon which monitors video and music playback. It allows users
to selectively stop paused or current playback after a certain amount of time.
Checklist:

- [x] My code follows the add-on rules and piracy stance of this project.
- [x] I have read the CONTRIBUTING document
- [x] Each add-on submission should be a single commit with using the following style: [script.foo.bar] v1.0.0
- [x] My code follows the add-on rules and piracy stance of this project.
- [x] I have read the CONTRIBUTING document

Each add-on submission should be a single commit with using the following style: [script.foo.bar] 1.0.0

Additional information :

Submitting your add-on to this specific branch makes it available to any Kodi version equal or higher than the branch name with the applicable Kodi dependencies limits.
add-on development wiki page.
Kodi pydocs provide information about the Python API
PEP8 codingstyle which is considered best practise but not mandatory.
This add-on repository has automated code guideline check which could help you improve your coding. You can find the results of these check at Codacy. You can create your own account as well to continuously monitor your python coding before submitting to repo.
Development questions can be asked in the add-on development section on the Kodi forum.
