### PR TITLE
[script.radioparadise] 1.0.3

### DIFF
--- a/script.radioparadise/CHANGELOG.md
+++ b/script.radioparadise/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v1.0.3
+
+- Add mix selection by script parameter
+
 ## v1.0.2
 
 - Handle missing stream metadata

--- a/script.radioparadise/README.md
+++ b/script.radioparadise/README.md
@@ -2,6 +2,8 @@
 
 Plays [Radio Paradise][] music mixes, accompanied by the HD slideshow.
 
+[radio paradise]: https://radioparadise.com/
+
 ## Features
 
 - Radio Paradise music mixes in AAC or FLAC
@@ -10,7 +12,28 @@ Plays [Radio Paradise][] music mixes, accompanied by the HD slideshow.
 
 ## Requirements
 
-- Kodi [release] v19 or later
+- Kodi [release][] v19 or later
 
-[radio paradise]: https://radioparadise.com/
 [release]: https://kodi.wiki/view/Releases
+
+## Mix Selection by Script Parameter
+
+In addition to the Auto Play feature, the addon script can be called with a
+parameter to start a particular RP mix:
+
+```python
+RunScript('script.radioparadise', 1)
+```
+
+Mix parameter:
+
+| Value | Mix |
+| --- | --- |
+| 0 | RP Main Mix |
+| 1 | RP Mellow Mix |
+| 2 | RP Rock Mix |
+| 3 | RP World/Etc Mix |
+
+This can be used to add shortcuts for RP mixes in [favourites.xml][].
+
+[favourites.xml]: https://kodi.wiki/view/Favourites.xml

--- a/script.radioparadise/addon.xml
+++ b/script.radioparadise/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.radioparadise" name="Radio Paradise" version="1.0.2" provider-name="Alexander Dietrich">
+<addon id="script.radioparadise" name="Radio Paradise" version="1.0.3" provider-name="Alexander Dietrich">
     <requires>
         <import addon="xbmc.python" version="3.0.0"/>
         <import addon="script.module.requests" version="2.0.0"/>

--- a/script.radioparadise/script.py
+++ b/script.radioparadise/script.py
@@ -1,3 +1,5 @@
+import sys
+
 import xbmc
 import xbmcaddon
 import xbmcgui
@@ -42,9 +44,12 @@ def play_channel(channel_number):
 
 if __name__ == '__main__':
     addon = xbmcaddon.Addon()
-    addon_path = addon.getAddonInfo('path')
-    auto_play = addon.getSettingInt('auto_play')
+    if len(sys.argv) == 2:
+        auto_play = int(sys.argv[1])
+    else:
+        auto_play = addon.getSettingInt('auto_play')
     if auto_play == -1:
+        addon_path = addon.getAddonInfo('path')
         window = Window('script-radioparadise.xml', addon_path)
         window.doModal()
         del window


### PR DESCRIPTION
### Description

Add script parameter for playing a particular Radio Paradise stream directly.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [script.foo.bar] 1.0.0

Additional information :
- Submitting your add-on to this specific branch makes it available to any Kodi version equal or higher than the branch name with the applicable Kodi dependencies limits.
- [add-on development](http://kodi.wiki/view/Add-on_development) wiki page.
- Kodi [pydocs](http://kodi.wiki/view/PyDocs) provide information about the Python API
- [PEP8](https://www.python.org/dev/peps/pep-0008/) codingstyle which is considered best practise but not mandatory.
- This add-on repository has automated code guideline check which could help you improve your coding. You can find the results of these check at [Codacy](https://www.codacy.com/app/Kodi/repo-scripts/dashboard). You can create your own account as well to continuously monitor your python coding before submitting to repo.
- Development questions can be asked in the [add-on development](http://forum.kodi.tv/forumdisplay.php?fid=26) section on the Kodi forum.
