### PR TITLE
[script.service.checkpreviousepisode@matrix] 0.4.5

### DIFF
--- a/script.service.checkpreviousepisode/addon.xml
+++ b/script.service.checkpreviousepisode/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.service.checkpreviousepisode" version="0.4.4" name="Kodi Check Previous Episode" provider-name="bossanova808, Razzeee, Lucleonhart" >
+<addon id="script.service.checkpreviousepisode" version="0.4.5" name="Kodi Check Previous Episode" provider-name="bossanova808, Razzeee, Lucleonhart" >
   <requires>
     <import addon="xbmc.python" version="3.0.0" />
     <import addon="script.module.yaml" version="3.11.0" />
@@ -16,8 +16,8 @@
     <forum>https://forum.kodi.tv/showthread.php?tid=355464</forum>
     <website>https://kodi.wiki/view/Add-on:XBMC_Check_Previous_Episode</website>
     <source>https://github.com/bossanova808/script.service.checkpreviousepisode</source>
-    <news>v0.4.4
-    - Handle apparently possible scenario of Kodi playing an episode without an id    
+    <news>v0.4.5
+    - Fix logic of ignore if previous episode not actually in library 
     </news>
   <assets>
      <icon>icon.png</icon>

--- a/script.service.checkpreviousepisode/changelog.txt
+++ b/script.service.checkpreviousepisode/changelog.txt
@@ -1,3 +1,6 @@
+v0.4.5
+- Fix logic of ignore if previous episode not actually in library 
+    
 v0.4.4
 - Handle apparently possible scenario of Kodi playing an episode without an id
 

--- a/script.service.checkpreviousepisode/resources/lib/check_previous_episode.py
+++ b/script.service.checkpreviousepisode/resources/lib/check_previous_episode.py
@@ -56,8 +56,8 @@ def run(args):
     :return:
     """
     footprints()
-    # Initialiase the global store and load the addon settings
-    Store()
+    # Initialise the global store and load the addon settings
+    config = Store()
 
     # TWO RUN-MODES - we're either running as a service, or we're running the tool to manage ignored shows..
 

--- a/script.service.checkpreviousepisode/resources/lib/player.py
+++ b/script.service.checkpreviousepisode/resources/lib/player.py
@@ -72,7 +72,12 @@ class KodiPlayer(xbmc.Player):
                     playing_episode = json_object['result']['episodedetails']['episode']
                     log(f'Playing - title: {playing_tvshow_title} , id: {playing_tvshowid} , season: {playing_season}, episode: {playing_episode}')
 
-                    # Ignore first episodes...
+                    # Is show set to be ignored?
+                    if Store.ignored_shows and playing_tvshowid in Store.ignored_shows:
+                        log(f'Show {playing_tvshow_title} set to ignore, carry on...')
+                        return
+
+                    # We ignore first episodes...
                     if json_object['result']['episodedetails']['episode'] > 1:
 
                         command = json.dumps({
@@ -96,43 +101,48 @@ class KodiPlayer(xbmc.Player):
                                     playcount += episode['playcount']
                                     found = True
 
-                            log(f'Found: {found}, playcount: {playcount}')
+                            log(f'Found previous episode: {found}, playcount: {playcount}, ignore if absent: {Store.ignore_if_episode_absent_from_library}')
 
-                            if (not found and not Store.ignore_if_absent_from_library) or (found and playcount == 0):
+                            # If we couldn't find the previous episode in the library
+                            # AND the user has asked us to ignore this, we're done.
+                            if not found and Store.ignore_if_episode_absent_from_library:
+                                log("Previous episode was not found, and ignore if absent from library is true")
+                                return
 
-                                if Store.ignored_shows and playing_tvshowid in Store.ignored_shows:
-                                    log(f'Unplayed previous episode detected, but {playing_tvshow_title} set to ignore')
-                                else:
-                                    # Only trigger the pause if the player is actually playing as other addons may also have paused the player
-                                    if not is_playback_paused():
-                                        log("Prior episode not watched! -> pausing playback")
+                            # If we couldn't find the previous episode in the library,
+                            # OR we have found the previous episode AND it is unwatched...
+                            if not found or (found and playcount == 0):
+
+                                # Only trigger the pause if the player is actually playing as other addons may also have paused the player
+                                if not is_playback_paused():
+                                    log("Prior episode not watched! -> pausing playback")
+                                    self.pause()
+
+                                result = xbmcgui.Dialog().select(LANGUAGE(32020), [LANGUAGE(32021), LANGUAGE(32022), LANGUAGE(32023)], preselect=0)
+
+                                # User has requested we ignore this particular show from now on...
+                                if result == 2:
+                                    Store.write_ignored_shows_to_config(Store.ignored_shows, playing_tvshow_title, playing_tvshowid)
+
+                                if result == 1 or result == 2:
+                                    if is_playback_paused():
+                                        log("Unpausing playback due to user input")
                                         self.pause()
+                                else:
+                                    self.stop()
 
-                                    result = xbmcgui.Dialog().select(LANGUAGE(32020), [LANGUAGE(32021), LANGUAGE(32022), LANGUAGE(32023)], preselect=0)
+                                    if Store.force_browse:
+                                        # Special case is the user wants to go to the All Seasons view
+                                        if Store.force_all_seasons:
+                                            playing_season = -1
 
-                                    # User has requested we ignore this particular show from now on...
-                                    if result == 2:
-                                        Store.write_ignored_shows_to_config(Store.ignored_shows, playing_tvshow_title, playing_tvshowid)
-
-                                    if result == 1 or result == 2:
-                                        if is_playback_paused():
-                                            log("Unpausing playback due to user input")
-                                            self.pause()
-                                    else:
-                                        self.stop()
-
-                                        if Store.force_browse:
-                                            # Special case is the user wants to go to the All Seasons view
-                                            if Store.force_all_seasons:
-                                                playing_season = -1
-
-                                            command = json.dumps({
-                                                "jsonrpc": "2.0",
-                                                "id": 1,
-                                                "method": "GUI.ActivateWindow",
-                                                "params": {
-                                                    "window": "videos",
-                                                    "parameters": [f'videodb://tvshows/titles/{playing_tvshowid}/{playing_season}'],
-                                                }
-                                            })
-                                            send_kodi_json(f'Browse to {playing_tvshow_title}', command)
+                                        command = json.dumps({
+                                            "jsonrpc": "2.0",
+                                            "id": 1,
+                                            "method": "GUI.ActivateWindow",
+                                            "params": {
+                                                "window": "videos",
+                                                "parameters": [f'videodb://tvshows/titles/{playing_tvshowid}/{playing_season}'],
+                                            }
+                                        })
+                                        send_kodi_json(f'Browse to {playing_tvshow_title}', command)

--- a/script.service.checkpreviousepisode/resources/lib/store.py
+++ b/script.service.checkpreviousepisode/resources/lib/store.py
@@ -12,9 +12,9 @@ class Store:
     # https://docs.python.org/3/faq/programming.html#how-do-i-create-static-class-data-and-static-class-methods
     ignored_shows_file = None
     ignored_shows = {}
-    force_browse = False
-    force_all_seasons = False
-    ignore_if_absent_from_library = False
+    force_browse = None
+    force_all_seasons = None
+    ignore_if_episode_absent_from_library = None
 
     def __init__(self):
         """


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: Kodi Check Previous Episode
  - Add-on ID: script.service.checkpreviousepisode
  - Version number: 0.4.5
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/bossanova808/script.service.checkpreviousepisode
  
This service helps prevent spoilers by checking if the previous episode in a series has been watched. If not, it will pause playback and warn you.  Specific shows can be marked to be ignored if episode order does not matter.

### Description of changes:

v0.4.5
    - Fix logic of ignore if previous episode not actually in library 
    

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
