### PR TITLE
[script.module.tubed.api@matrix] 1.0.12

### DIFF
--- a/script.module.tubed.api/addon.xml
+++ b/script.module.tubed.api/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.module.tubed.api" name="Tubed API" version="1.0.11" provider-name="anxdpanic">
+<addon id="script.module.tubed.api" name="Tubed API" version="1.0.12" provider-name="anxdpanic">
     <requires>
         <import addon="xbmc.python" version="3.0.0"/>
         <import addon="script.module.requests" version="2.12.4"/>
@@ -8,8 +8,8 @@
     <extension point="xbmc.service" library="resources/lib/service.py"/>
     <extension point="xbmc.addon.metadata">
         <news>
-- fix general playback/throttling
-- updated translations from Weblate
+- fixup for age-gated material
+- fixup issue with mpd generation
         </news>
         <assets>
             <icon>resources/media/icon.png</icon>

--- a/script.module.tubed.api/resources/lib/src/tubed_api/usher/lib/mpeg_dash.py
+++ b/script.module.tubed.api/resources/lib/src/tubed_api/usher/lib/mpeg_dash.py
@@ -115,20 +115,29 @@ class ManifestGenerator:
             mime_webm = 'video/webm'
             if container == 'mp4' or (container == 'webm' and idx == 1):
                 discard_mime = mime_webm
-                discarded_mime_streams = data[mime_webm]
+                try:
+                    discarded_mime_streams = data[mime_webm]
+                except KeyError:
+                    discarded_mime_streams = []
 
                 selected_mime = mime_mp4
                 streams = deepcopy(data[mime_mp4])
             elif container == 'webm':
                 discard_mime = mime_mp4
-                discarded_mime_streams = data[mime_mp4]
+                try:
+                    discarded_mime_streams = data[mime_mp4]
+                except KeyError:
+                    discarded_mime_streams = []
 
                 selected_mime = mime_webm
                 streams = deepcopy(data[mime_webm])
 
                 if not streams:
                     discard_mime = mime_webm
-                    discarded_mime_streams = data[mime_webm]
+                    try:
+                        discarded_mime_streams = data[mime_webm]
+                    except KeyError:
+                        discarded_mime_streams = []
 
                     selected_mime = mime_mp4
                     streams = deepcopy(data[mime_mp4])

--- a/script.module.tubed.api/resources/lib/src/tubed_api/usher/lib/video_info.py
+++ b/script.module.tubed.api/resources/lib/src/tubed_api/usher/lib/video_info.py
@@ -40,7 +40,7 @@ class VideoInfo:
         from ... import ACCESS_TOKEN_TV  # pylint: disable=import-outside-toplevel
         from ... import API_KEY_TV  # pylint: disable=import-outside-toplevel
 
-        self._access_token_tv = b64decode(ACCESS_TOKEN_TV).decode('utf-8')
+        self._access_token_tv = ACCESS_TOKEN_TV
         self._api_key_tv = b64decode(API_KEY_TV).decode('utf-8')
         self._language = language
         self._region = region


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: Tubed API
  - Add-on ID: script.module.tubed.api
  - Version number: 1.0.12
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/anxdpanic/script.module.tubed.api
  
The Tubed API module provides a convenient way to access YouTube's Data API in Kodi 19+

### Description of changes:


- fixup for age-gated material
- fixup issue with mpd generation
        

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
