### PR TITLE
[service.autostop] 1.0.2

### DIFF
--- a/service.autostop/README.md
+++ b/service.autostop/README.md
@@ -2,11 +2,12 @@
 An addon for Kodi (XBMC) which monitors video and music playback.  It allows users to selectively stop paused playback or stop  current playback after a certain amount of time.
 
 
-Features:
+<b>Features:</b>
 - Kodi 19 compatible.
 - Autostop paused playback setting from 0 - 60 minutes in 5 minute intervals.
-- Autostop current playback setting from 0 - 120 minutes in 10 to 30 minute intervals.
+- Autostop current playback setting from 0 - 180 minutes in 10 to 60 minute intervals.
 - Automatically engage Kodi screensaver when stopping paused playback.
+- Adjustable GUI sleep timer notification with fixed and adjustable extension timer.
 - Ability to change sleep timer by calling addon from favourites or keyboard.xml (see Readme)
 
 <img src="resources/icon.png" width="40%">

--- a/service.autostop/addon.xml
+++ b/service.autostop/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon  id="service.autostop" name="Autostop" version="1.0.1" provider-name="jeff@thebinks.com">
+<addon  id="service.autostop" name="Autostop" version="1.0.2" provider-name="jbinkley60">
   <requires>
     <import addon="xbmc.python" version="3.0.0"/>
   </requires>    
@@ -16,6 +16,7 @@
     </assets>
     <summary lang="en_GB">Automatically gives you better control over paused and playing media.</summary>
     <description lang="en_GB">Autostop can automatically stop paused videos and music or set a sleep timer for them to stop playing after a set period of time.  You can also have Autostop automatically start the Kodi screensaver.</description>
-    <source>https://github.com/jbinkley60/service.autostop</source>
+    <forum>http://forum.kodi.tv/showthread.php?tid=211971</forum>
+    <source>https://forum.kodi.tv/showthread.php?tid=365429</source>
   </extension>
 </addon>

--- a/service.autostop/changelog.txt
+++ b/service.autostop/changelog.txt
@@ -1,3 +1,15 @@
+1.0.2
+
+-  Extended sleep timer settings to 180 minutes
+-  Added pause sleep timer adjust option to select what
+   to do with the sleep timer when playback is paused.
+     None - Do nothing and sleep counter continues
+     Pause - Pause sleep timer
+     Reset - Reset sleep timer to beginning
+-  Added 0 -180 secs adjustable GUI sleep timer notification 
+   feature with fixed and adjustable sleep timer extension.
+-  Added event logging option to aid troubleshooting  
+
 1.0.1
 -  Fixed exception bug which could occur if Kodi stopped 
    playing a file at exactly the same time the addon 

--- a/service.autostop/common.py
+++ b/service.autostop/common.py
@@ -1,6 +1,16 @@
 import xbmc
 import xbmcaddon
-import xbmcvfs
+import xbmcgui
+import xbmcplugin
+import time
+
+msgdialogprogress = xbmcgui.DialogProgress()
+addon = xbmcaddon.Addon()
+notifycount = 0
+
+def translate(text):
+    return addon.getLocalizedString(text)
+
 
 def settings(setting, value = None):
     # Get or add addon setting
@@ -8,3 +18,169 @@ def settings(setting, value = None):
         xbmcaddon.Addon().setSetting(setting, value)
     else:
         return xbmcaddon.Addon().getSetting(setting)
+
+
+def playCount(plcount, padjust, plflag, paflag, asevlog):       #  Calculate play counter
+
+    match = 0    
+    if plflag == 0 and paflag == 0:                             #  No file playing or paused
+        plcount = 0
+        match = 1
+    elif padjust == 'None':                                     #  Count uninterrupted by pause
+        plcount += 1
+        match = 2
+    elif padjust == 'Pause' and plflag == 1:                    #  Continue counter
+        plcount += 1
+        match = 3
+    elif padjust == 'Pause' and paflag == 1:                    #  Pause counter 
+        plcount = plcount
+        match = 4
+    elif padjust == 'Reset' and plflag == 1:                    #  Continue counter
+        plcount += 1
+        match = 5
+    elif padjust == 'Reset' and paflag == 1:                    #  Reset counter
+        plcount = 0
+        match = 6
+
+    if asevlog == 'true' and plcount % 10 == 0:
+        xbmc.log('Autostop playCount: ' + str(plcount) + ' ' + padjust + ' ' +   \
+        str(plflag) + ' ' + str(paflag) + ' ' + str(match), xbmc.LOGINFO)
+
+    return plcount
+
+
+def sleepNotify(plcount, plstoptime, plflag, plnotify, plextend, asevlog, paflag):
+
+    global notifycount
+    extime = float(settings('extime'))
+    notifyset = settings('notifyset')
+    varextnotify = settings('varextnotify')
+    totalstoptime = plstoptime + extime
+    if plstoptime > 0 and plcount + plnotify >= totalstoptime \
+    * 60 and (plflag > 0 or (plflag == 0 and paflag == 1)):     #  Set or update notification
+        xbmc.log('Autostop sleepNotify set notification.', xbmc.LOGDEBUG)
+        if notifyset == 'no' and varextnotify =='no':           #  Notifications not set
+            msgdialogprogress.create(translate(30307), translate(30308))
+            settings('notifyset', 'yes')
+            notifycount = 0
+            xbmc.log('Autostop notify counter started.', xbmc.LOGINFO)
+        elif notifyset == 'yes':                                # Update notification
+            notifycount += 1
+            if notifycount >= plnotify:                         # Upper bounds check
+                percent = 0
+                tremain = '0'
+                msgdialogprogress.close()
+            else:
+                percent = 100 - int(float(notifycount) / float(plnotify) * 100)
+                tremain = str(plnotify - notifycount)  
+            message = translate(30308) + tremain + translate(30311)           
+            msgdialogprogress.update(percent, message)
+            if asevlog == 'true' and plcount % 10 == 0:
+                xbmc.log('Autostop notify counter: ' + str(plcount) + ' ' + str(plnotify) + ' ' +   \
+                str(totalstoptime * 60) + ' ' + str(percent) + ' ' + str(notifycount) + ' ' +       \
+                str(plstoptime), xbmc.LOGINFO)
+            if (msgdialogprogress.iscanceled()):
+                if plextend > 0:                                # Fixed extension
+                    extime = extime + plextend
+                    settings('extime', str(extime))             # Extend sleep counter 
+                    extmins = str(plextend)
+                else:                                           # Get variable extension time
+                    extmins = varExtension(totalstoptime, plcount, asevlog)
+                    extime = extime + float(extmins) 
+                    settings('extime', str(extime))             
+                msgdialogprogress.close()
+                dialog = xbmcgui.Dialog()
+                mgenlog = translate(30309) + extmins + translate(30313)
+                xbmc.log(mgenlog, xbmc.LOGINFO)
+                dialog.notification(translate(30310), mgenlog, \
+                xbmcgui.NOTIFICATION_INFO, 3000)
+                settings('notifyset', 'no')                     # Clear notification flag
+    elif notifyset == 'yes' and plflag == 0 and paflag == 0:                    
+        msgdialogprogress.close()   
+        settings('notifyset', 'no')                             # Clear notification flag
+
+    if plflag > 0 and asevlog == 'true' and plcount % 10 == 0:  # Activity logging
+        xbmc.log('Autostop sleepNotify counter: ' +            \
+        str(plcount + plnotify) + ' ' +  str(plstoptime * 60)  \
+        + ' ' + str(totalstoptime * 60), xbmc.LOGINFO)
+
+    if plflag == 0 and paflag == 0 and extime > 0:              # Check for playback ended
+        settings('extime', '0')                                 # Temporary extension clear       
+
+
+def varExtension(plstoptime, plcount, asevlog):                 # Get variable extension time
+    
+    pselect = ["10 minutes", "20 minutes", "30 minutes", "40 minutes",           \
+    "50 minutes", "60 minutes", "90 minutes"]
+    remtime = checkTime(plstoptime, plcount, asevlog)           # Get remaining playback time 
+    if float(remtime) > 0:
+        pselect.extend(["End of current file (" + remtime + " mins)"])    
+    if settings('stopplay') == 'true':                          # Add stop now playback option       
+        pselect.extend(["[COLOR blue]Stop Playback Now[/COLOR]"]) 
+
+    ddialog = xbmcgui.Dialog()    
+    selection = ddialog.select(translate(30315), pselect)
+    if selection < 0:                                           # User cancel. Default is 5
+        extension = '5'                                         # minutes to avoid GUI loop
+    elif 'minutes' in (pselect[selection]):
+        extension = (pselect[selection])[:2]                    # Get minutes from selection
+    elif 'End' in (pselect[selection]):
+        extension = checkTime(plstoptime, plcount, asevlog)     # Get remaining playback time
+    elif 'Stop' in (pselect[selection]):
+        extension = '0'
+        notifymsg = 'Autostop Sleep Timer'
+        logmsg = 'Autostop user stopped current playback: '
+        stopPlayback(notifymsg, logmsg)                         # User requested stop playback
+
+    return extension
+
+
+def stopPlayback(notifymsg, logmsg):                            # Function to stop playback
+                                                                # log and notify user
+    try:
+        if xbmc.Player().isPlayingVideo():
+            ptag = xbmc.Player().getVideoInfoTag()
+            ptitle = ptag.getTitle()
+        elif xbmc.Player().isPlayingAudio():
+            ptag = xbmc.Player().getMusicInfoTag()
+            ptitle = ptag.getTitle()                
+        else:
+            ptitle = "playing file"
+        pos = xbmc.Player().getTime()
+        xbmc.Player().stop()
+        mgenlog = logmsg + ptitle + ' at: ' + time.strftime("%H:%M:%S",    \
+        time.gmtime(pos))
+        xbmc.log(mgenlog, xbmc.LOGINFO)
+        dialog = xbmcgui.Dialog()
+        dialog.notification(notifymsg, mgenlog, xbmcgui.NOTIFICATION_INFO, 5000)
+        if settings('screensaver') == 'true':                   #  Active screensaver if option selected
+            xbmc.executebuiltin('ActivateScreensaver')
+        settings('notifyset', 'no')                             # Clear notification flag
+        settings('varextnotify', 'no')                          # Clear notification flag
+    except:
+        xbmc.log('Autostop error when stopping playback.', xbmc.LOGINFO)        
+        pass
+
+
+def checkTime(plstoptime, plcount, asevlog):                    # Calculate remaining playback time
+
+    try:
+        currpos = xbmc.Player().getTime()
+        endpos = int(xbmc.Player().getTotalTime())
+        remaintime = endpos - currpos - (plstoptime * 60 - plcount) -   \
+        (10 - plcount % 10) - 1                                 # 1 second less than end time
+        if remaintime > 10800:                                  # Maximum 3 hrs
+            remaintime = 10800
+        extension = '{:.2f}'.format(remaintime / float(60))     # Calculate to .01 min
+        if asevlog == 'true':
+            xbmc.log('Autostop calculating extension time. ' + str(currpos) + ' ' +     \
+            str(endpos) + ' ' + str(plcount) + ' ' + str(remaintime) + ' ' + extension  \
+            + ' ' + str(plstoptime * 60), xbmc.LOGINFO)
+        settings('varextnotify', 'yes')                         # Only display progress bar once  
+        return extension
+    except:
+        xbmc.log('Autostop error getting remaining extension time.', xbmc.LOGINFO)
+        return '-1'
+        pass         
+
+

--- a/service.autostop/resources/language/resource.language.en_gb/strings.po
+++ b/service.autostop/resources/language/resource.language.en_gb/strings.po
@@ -32,6 +32,58 @@ msgctxt "#30303"
 msgid "Sleep Timer Minutes"
 msgstr ""
 
+msgctxt "#30304"
+msgid "Sleep Timer Pause Adjustment"
+msgstr ""
+
+msgctxt "#30305"
+msgid "Sleep Timer Notification 0-180 (seconds)"
+msgstr ""
+
+msgctxt "#30306"
+msgid "Sleep Timer Extension Minutes"
+msgstr ""
+
+msgctxt "#30307"
+msgid "Autostop Sleep Timer Notification"
+msgstr ""
+
+msgctxt "#30308"
+msgid "Click cancel to extend playback.  Playback will stop in "
+msgstr ""
+
+msgctxt "#30309"
+msgid "Autostop sleep timer extended "
+msgstr ""
+
+msgctxt "#30310"
+msgid "Autostop sleep timer"
+msgstr ""
+
+msgctxt "#30311"
+msgid "  seconds."
+msgstr ""
+
+msgctxt "#30312"
+msgid "Autostop Event Logging"
+msgstr ""
+
+msgctxt "#30313"
+msgid " minutes."
+msgstr ""
+
+msgctxt "#30314"
+msgid "Not visible"
+msgstr ""
+
+msgctxt "#30315"
+msgid "Autostop Sleep Timer Extension"
+msgstr ""
+
+msgctxt "#30316"
+msgid "Sleep Timer Playback Stop Option"
+msgstr ""
+
 msgctxt "#30501"
 msgid "Automatically stop paused video or music in minutes.  0 = never automatically stop paused playback."
 msgstr ""
@@ -42,4 +94,24 @@ msgstr ""
 
 msgctxt "#30503"
 msgid "Automatically stop playing video or music in minutes.  0 = never automatically stop playback."
+msgstr ""
+
+msgctxt "#30504"
+msgid "Adjust sleep timer when playback is paused.  None = no change to timer.  Pause = pause sleep timer during paused playback and resume when playback restarts.  Reset = pause sleep timer during paused playback and reset back to 0 when playback restarts."
+msgstr ""
+
+msgctxt "#30505"
+msgid "Display sleep timer notification prior to stopping playback.  0 = never and is default"
+msgstr ""
+
+msgctxt "#30506"
+msgid "Amount of time to extend sleep timer via notification popup.  This is like the amount of time on a snooze bar.  Variable allows selection of the the extension time when the notification appears."
+msgstr ""
+
+msgctxt "#30507"
+msgid "Enable event logging to recod Autostop sleep timer events.  Default is disabled."
+msgstr ""
+
+msgctxt "#30508"
+msgid "Adds option to stop playback when the sleep timer extension option is set to variable.  Default is disabled."
 msgstr ""

--- a/service.autostop/resources/settings.xml
+++ b/service.autostop/resources/settings.xml
@@ -39,6 +39,62 @@
                                                         <option>60</option>
                                                         <option>90</option>
                                                         <option>120</option>
+                                                        <option>180</option>
+						</options>
+					</constraints>
+					<control type="spinner" format="string"/>
+				</setting>
+				<setting id="plnotify" type="string" label="30305" help="30505">
+					<level>0</level>
+					<default>0</default>
+					<constraints>
+						<options>
+							<option>0</option>
+							<option>30</option>
+							<option>60</option>
+							<option>120</option>
+							<option>180</option>
+						</options>
+					</constraints>
+					<control type="spinner" format="string"/>
+				</setting>
+				<setting id="plextend" type="string" label="30306" help="30506">
+					<level>0</level>
+					<default>10</default>
+					<constraints>
+						<options>
+							<option label="Variable">0</option>
+							<option>10</option>
+                                                        <option>20</option>
+                                                        <option>30</option>
+                                                        <option>40</option>
+                                                        <option>50</option>
+                                                        <option>60</option>
+                                                        <option>90</option>
+                                                        <option>120</option>
+                                                        <option>180</option>
+						</options>
+					</constraints>
+					<dependencies>
+						<dependency type="enable">
+							<condition operator="!is" setting="plnotify">0</condition>
+						</dependency>
+					</dependencies>
+					<control type="spinner" format="string"/>
+				</setting>
+				<setting id="stopplay" type="boolean" label="30316" help="30508">
+					<level>0</level>
+					<default>false</default>
+					<control type="toggle"/>
+				</setting>
+				<setting id="padjust" type="string" label="30304" help="30504">
+					<level>0</level>
+					<default>None</default>
+					<constraints>
+						<options>
+							<option>None</option>
+							<option>Pause</option>
+							<option>Reset</option>
 						</options>
 					</constraints>
 					<control type="spinner" format="string"/>
@@ -47,6 +103,47 @@
 					<level>0</level>
 					<default>false</default>
 					<control type="toggle"/>
+				</setting>
+				<setting id="asevlog" type="boolean" label="30312" help="30507">
+					<level>3</level>
+					<default>false</default>
+					<control type="toggle"/>
+				</setting>
+				<setting id="notifyset" type="string" label="30314" help="">
+					<level>4</level>
+					<default>no</default>
+					<dependencies>
+						<dependency type="visible">
+							<condition on="property" name="InfoBool">false</condition>
+						</dependency>
+					</dependencies>
+					<control type="edit" format="string">
+						<heading>30314</heading>
+					</control>
+				</setting>
+				<setting id="extime" type="string" label="30314" help="">
+					<level>4</level>
+					<default>0</default>
+					<dependencies>
+						<dependency type="visible">
+							<condition on="property" name="InfoBool">false</condition>
+						</dependency>
+					</dependencies>
+					<control type="edit" format="string">
+						<heading>30314</heading>
+					</control>
+				</setting>
+				<setting id="varextnotify" type="string" label="30314" help="">
+					<level>4</level>
+					<default>0</default>
+					<dependencies>
+						<dependency type="visible">
+							<condition on="property" name="InfoBool">false</condition>
+						</dependency>
+					</dependencies>
+					<control type="edit" format="string">
+						<heading>30314</heading>
+					</control>
 				</setting>
 			</group>
 		</category>

--- a/service.autostop/service.py
+++ b/service.autostop/service.py
@@ -1,15 +1,23 @@
 import xbmc
-import time
 import xbmcaddon
 import xbmcgui
 import xbmcplugin
-from common import settings
+from common import settings, playCount, sleepNotify, stopPlayback
 
 pos = 0
 file = ''
 count = 0 
 pacount = 0
 plcount = 0
+extime = 0
+padjust = settings('padjust')
+plstoptime = int(settings('plstop'))
+plnotify = int(settings('plnotify'))
+plextend = int(settings('plextend'))
+settings('extime', '0')
+asevlog = settings('asevlog')
+settings('notifyset', 'no')
+settings('varextnotify', 'no')
 
 xbmc.log("Autostop addon service started." , xbmc.LOGINFO)
   
@@ -54,66 +62,48 @@ monitor = xbmc.Monitor()
 while not monitor.abortRequested():
 
     pacount += 1
-    if pacount % 10 == 0:                          # Check for paused video every 10 seconds
+    if pacount % 10 == 0:                            # Check for paused video every 10 seconds
         try:
             pastoptime = int(settings('pastop'))
             xbmc.log('Autostop pause count and stop time ' + str(pacount) + ' ' + str(pastoptime) +    \
             ' ' + str(player.paflag), xbmc.LOGDEBUG)
             if pastoptime > 0 and pacount >= pastoptime * 60 and player.paflag == 1:
-                if xbmc.Player().isPlayingVideo():
-                    ptag = xbmc.Player().getVideoInfoTag()
-                    ptitle = ptag.getTitle()
-                elif xbmc.Player().isPlayingAudio():
-                    ptag = xbmc.Player().getMusicInfoTag()
-                    ptitle = ptag.getTitle()                
-                else:
-                    ptitle = "playing file"
                 pos = xbmc.Player().getTime()
-                xbmc.Player().stop()
+                logmsg = 'Autostop stopped paused playback: '
+                notifymsg = 'Autostop Paused Timer'
                 pacount = 0
-                mgenlog ='Autostop stopped paused playback: ' + ptitle +     \
-                ' at: ' + time.strftime("%H:%M:%S", time.gmtime(pos))
-                xbmc.log(mgenlog, xbmc.LOGINFO)
-                dialog = xbmcgui.Dialog()
-                dialog.notification('Autostop Paused Timer', mgenlog, xbmcgui.NOTIFICATION_INFO, 5000)
-                if settings('screensaver') == 'true':  #  Active screensaver if option selected
-                    xbmc.executebuiltin('ActivateScreensaver')
+                stopPlayback(notifymsg, logmsg)      # Stop playback if paused too long
             elif player.paflag == 0:
                 pacount = 0
         except:
-            xbmc.log('Autostop pause count and stop time exception error' + str(pacount) + ' ' + str(pastoptime) +    \
-            ' ' + str(player.paflag), xbmc.LOGINFO)            
+            xbmc.log('Autostop pause count and stop time exception error' + str(pacount) + ' ' + \
+            str(pastoptime) + ' ' + str(player.paflag), xbmc.LOGINFO)
+            pass            
 
-    plcount += 1 
-    if plcount % 10 == 0:                          # Check for playing video every 10 seconds
+    plcount = playCount(plcount, padjust, player.plflag, player.paflag, asevlog)
+    sleepNotify(plcount, plstoptime, player.plflag, plnotify, plextend, asevlog, player.paflag) 
+    if plcount % 10 == 0:                            # Check for playing video every 10 seconds
         try:
             plstoptime = int(settings('plstop'))
-            xbmc.log('Autostop play count and stop time ' + str(plcount) + ' ' + str(plstoptime) +    \
-            ' ' + str(player.plflag), xbmc.LOGDEBUG)
-            if plstoptime > 0 and plcount >= plstoptime * 60 and player.plflag == 1:
-                if xbmc.Player().isPlayingVideo():
-                    ptag = xbmc.Player().getVideoInfoTag()
-                    ptitle = ptag.getTitle()
-                elif xbmc.Player().isPlayingAudio():
-                    ptag = xbmc.Player().getMusicInfoTag()
-                    ptitle = ptag.getTitle()                
-                else:
-                    ptitle = "playing file"
-                pos = xbmc.Player().getTime()
-                xbmc.Player().stop()
+            padjust = settings('padjust')
+            plnotify = int(settings('plnotify'))
+            plextend = int(settings('plextend'))
+            extime = float(settings('extime'))
+            asevlog = settings('asevlog')
+            totalstoptime = plstoptime + extime
+            if asevlog == 'true':
+                xbmc.log('Autostop play count and stop time ' + str(plcount) + ' ' +         \
+                str(plstoptime) + ' ' + str(player.plflag), xbmc.LOGINFO)
+            if plstoptime > 0 and plcount >= totalstoptime * 60 and (player.plflag > 0 or    \
+            (player.plflag == 0 and player.paflag == 1)):
+                logmsg = 'Autostop stopped current playback: '
+                notifymsg = 'Autostop Sleep Timer'
                 plcount = 0
-                mgenlog ='Autostop stopped current playback: ' + ptitle +     \
-                ' at: ' + time.strftime("%H:%M:%S", time.gmtime(pos))
-                xbmc.log(mgenlog, xbmc.LOGINFO)
-                dialog = xbmcgui.Dialog()
-                dialog.notification('Autostop Sleep Timer', mgenlog, xbmcgui.NOTIFICATION_INFO, 5000)
-                if settings('screensaver') == 'true':  #  Active screensaver if option selected
-                    xbmc.executebuiltin('ActivateScreensaver')
-            elif player.plflag == 0:
-                plcount = 0
+                stopPlayback(notifymsg, logmsg)      # Stop playback if playing too long
         except:
-            xbmc.log('Autostop play count and stop time exception error' + str(pacount) + ' ' + str(pastoptime) +    \
-            ' ' + str(player.paflag), xbmc.LOGINFO)         
+            xbmc.log('Autostop play count and stop time exception error' + str(pacount) + ' ' \
+            + str(pastoptime) + ' ' + str(player.paflag), xbmc.LOGINFO)
+            pass       
 
     if monitor.waitForAbort(1): # Sleep/wait for abort for 1 second.
         xbmc.log("Autostop addon service stopped." , xbmc.LOGINFO)

--- a/service.autostop/utilities.py
+++ b/service.autostop/utilities.py
@@ -12,6 +12,8 @@ def sleepTimer():
         newval = str(currval + 10)
     elif currval < 120 :
         newval = str(currval + 30)
+    elif currval < 180 :
+        newval = str(currval + 60)
     elif currval == 120 :
         newval = str('0')
     settings('plstop', newval)


### PR DESCRIPTION
Description

Updated Kodi Matrix addon service.autostop .

This update has the following feature enhancements:

-  Extended sleep timer settings to 180 minutes
-  Added pause sleep timer adjust option to select what
   to do with the sleep timer when playback is paused.
     None - Do nothing and sleep counter continues
     Pause - Pause sleep timer
     Reset - Reset sleep timer to beginning
-  Added 0 -180 secs adjustable GUI sleep timer notification 
   feature with fixed and adjustable sleep timer extension.
-  Added event logging option to aid troubleshooting  

Checklist:

[X ] My code follows the add-on rules and piracy stance of this project.
[X ] I have read the CONTRIBUTING document
[X ] Each add-on submission should be a single commit with using the following style: [script.foo.bar] v1.0.0
[X ] My code follows the add-on rules and piracy stance of this project.
[X ] I have read the CONTRIBUTING document
Each add-on submission should be a single commit with using the following style: [script.foo.bar] 1.0.0