### PR TITLE
[service.autostop] 1.0.4

### DIFF
--- a/service.autostop/addon.xml
+++ b/service.autostop/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon  id="service.autostop" name="Autostop" version="1.0.3" provider-name="jbinkley60">
+<addon  id="service.autostop" name="Autostop" version="1.0.4" provider-name="jbinkley60">
   <requires>
     <import addon="xbmc.python" version="3.0.0"/>
   </requires>    

--- a/service.autostop/changelog.txt
+++ b/service.autostop/changelog.txt
@@ -1,3 +1,10 @@
+1.0.4
+
+- Fixed a bug where the sleep timer could execute prematurely
+  when calling timer change via keyboard.xml or favourites.xml
+  due to playcount timer running when the sleep timer was set
+  to 0. 
+
 1.0.3
 
 -  Fixed exception bug when Kodi begins but is unable to play

--- a/service.autostop/service.py
+++ b/service.autostop/service.py
@@ -97,6 +97,9 @@ while not monitor.abortRequested():
                 notifymsg = translate(30310)
                 plcount = 0
                 stopPlayback(notifymsg, logmsg)      # Stop playback if playing too long
+            if plstoptime == 0:                      # Don't increment plcount if sleep setting is 0
+                plcount = 0
+            #xbmc.log("Autostop plstoptime." + str(plstoptime) + ' ' + str(plcount), xbmc.LOGINFO)
         except:
             xbmc.log('Autostop play count and stop time exception error' + str(pacount) + ' ' \
             + str(pastoptime) + ' ' + str(player.paflag), xbmc.LOGINFO)


### PR DESCRIPTION
### Description
Updated Kodi Matrix addon service.autostop v1.0.4.

This update has the following fix:

- Fixed a bug where the sleep timer could execute prematurely
  when calling timer change via keyboard.xml or favourites.xml
  due to playcount timer running when the sleep timer was set
  to 0. 

### Checklist:

    [X ] My code follows the add-on rules and piracy stance of this project.
    [X ] I have read the CONTRIBUTING document
    [X ] Each add-on submission should be a single commit with using the following style: [script.foo.bar] 1.0.0


Additional information :
- Submitting your add-on to this specific branch makes it available to any Kodi version equal or higher than the branch name with the applicable Kodi dependencies limits.
- [add-on development](http://kodi.wiki/view/Add-on_development) wiki page.
- Kodi [pydocs](http://kodi.wiki/view/PyDocs) provide information about the Python API
- [PEP8](https://www.python.org/dev/peps/pep-0008/) codingstyle which is considered best practise but not mandatory.
- This add-on repository has automated code guideline check which could help you improve your coding. You can find the results of these check at [Codacy](https://www.codacy.com/app/Kodi/repo-scripts/dashboard). You can create your own account as well to continuously monitor your python coding before submitting to repo.
- Development questions can be asked in the [add-on development](http://forum.kodi.tv/forumdisplay.php?fid=26) section on the Kodi forum.
