### PR TITLE
[script.playrandomvideos@matrix] 2.1.0

### DIFF
--- a/script.playrandomvideos/addon.xml
+++ b/script.playrandomvideos/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.playrandomvideos" name="Play Random Videos" version="2.0.0" provider-name="rmrector">
+<addon id="script.playrandomvideos" name="Play Random Videos" version="2.1.0" provider-name="rmrector">
 	<requires>
 		<import addon="xbmc.python" version="3.0.0" />
 	</requires>
@@ -19,7 +19,11 @@
 	<extension point="xbmc.addon.metadata">
 		<summary lang="en_GB">Plays random videos from all sorts of lists.</summary>
 		<description lang="en_GB">This add-on can quickly play random episodes from TV shows, movies from genres/sets/years/tags, and videos from playlists, the filesystem, and just about anything else, other than plugins.</description>
-		<news>v2.0.0 (2021-01-29)
+		<news>v2.1.0 (2022-02-20)
+- Feature: option to filter out recently played videos
+- Feature: add more metadata to playlist items
+
+v2.0.0 (2021-01-29)
 - Kodi 19 Matrix / Python 3 compatibility. Breaks compatibility with previous versions of Kodi.</news>
 		<platform>all</platform>
 		<source>https://github.com/rmrector/script.playrandomvideos</source>

--- a/script.playrandomvideos/changelog.txt
+++ b/script.playrandomvideos/changelog.txt
@@ -1,3 +1,8 @@
+v2.1.0 (2022-02-20)
+- Feature: option to filter out recently played videos
+- Feature: add more metadata to playlist items
+- Fix: Pytohn 3.10 support - use `collections.abc`
+
 v2.0.0 (2021-01-29)
 - Kodi 19 Matrix / Python 3 compatibility. Breaks compatibility with previous versions of Kodi.
 

--- a/script.playrandomvideos/python/lib/listitembuilder.py
+++ b/script.playrandomvideos/python/lib/listitembuilder.py
@@ -1,8 +1,16 @@
 import collections
+from collections import abc
 import xbmcgui
 
-# JSON keys that don't match info labels
+
 infokey_map = {
+    'title': 'title',
+    'season': 'season',
+    'episode': 'episode',
+    'playcount': 'playcount',
+    'rating': 'rating',
+    'userrating': 'userrating',
+    # JSON keys that don't match info labels
     'track': 'tracknumber',
     'runtime': 'duration',
     'showtitle': 'tvshowtitle',
@@ -20,7 +28,7 @@ def build_video_listitem(item):
 
     infolabels = {}
     for key, value in item.items():
-        if isinstance(value, collections.Mapping):
+        if isinstance(value, abc.Mapping):
             continue
         if key in infokey_map:
             infolabels[infokey_map[key]] = value

--- a/script.playrandomvideos/python/lib/pykodi.py
+++ b/script.playrandomvideos/python/lib/pykodi.py
@@ -1,4 +1,5 @@
 import collections
+from collections import abc
 import json
 import xbmc
 import xbmcaddon
@@ -94,7 +95,7 @@ class LogJSONEncoder(json.JSONEncoder):
         super(LogJSONEncoder, self).__init__(*args, **kwargs)
 
     def default(self, obj):
-        if isinstance(obj, collections.Mapping):
+        if isinstance(obj, abc.Mapping):
             return dict((key, obj[key]) for key in obj.keys())
         if isinstance(obj, collections.Iterable):
             return list(obj)

--- a/script.playrandomvideos/python/lib/quickjson.py
+++ b/script.playrandomvideos/python/lib/quickjson.py
@@ -21,7 +21,7 @@ def get_random_episodes(tvshow_id=None, season=None, filters=None, limit=None):
         if season is not None:
             json_request['params']['season'] = season
     json_request['params']['sort'] = {'method': 'random'}
-    json_request['params']['properties'] = ['file']
+    json_request['params']['properties'] = ['file', 'title', 'season', 'episode', 'showtitle', 'playcount', 'rating', 'userrating']
     if limit:
         json_request['params']['limits'] = {'end': limit}
 

--- a/script.playrandomvideos/resources/language/resource.language.en_gb/strings.po
+++ b/script.playrandomvideos/resources/language/resource.language.en_gb/strings.po
@@ -48,6 +48,14 @@ msgctxt "#32905"
 msgid "Hide busy notification before first video"
 msgstr ""
 
+msgctxt "#32909"
+msgid "Ignore videos played in the last x months"
+msgstr ""
+
+msgctxt "#32910"
+msgid "Not played recently"
+msgstr ""
+
 #  heading
 msgctxt "#32900"
 msgid "Watched Filters"

--- a/script.playrandomvideos/resources/settings.xml
+++ b/script.playrandomvideos/resources/settings.xml
@@ -70,11 +70,22 @@
 							<option label="16100">0</option>
 							<option label="16101">1</option>
 							<option label="16102">2</option>
-							<option label="36521">3</option>
+                                                        <option label="32910">3</option>
+							<option label="36521">4</option>
 						</options>
 					</constraints>
 					<control type="spinner" format="string"/>
 				</setting>
+                                <setting id="movieplayedmonths" type="integer" label="32909" help="" parent="watchmodemovies">
+                                        <level>0</level>
+                                        <default>12</default>
+                                        <dependencies>
+                                                <dependency type="enable" setting="watchmodemovies">3</dependency>
+                                        </dependencies>
+                                        <control type="edit" format="integer">
+                                                <heading>32909</heading>
+                                        </control>
+                                </setting>
 				<setting id="watchmodetvshows" type="integer" label="32902" help="">
 					<level>0</level>
 					<default>0</default>
@@ -83,11 +94,22 @@
 							<option label="16100">0</option>
 							<option label="16101">1</option>
 							<option label="16102">2</option>
-							<option label="36521">3</option>
+                                                        <option label="32910">3</option>
+							<option label="36521">4</option>
 						</options>
 					</constraints>
 					<control type="spinner" format="string"/>
 				</setting>
+                                <setting id="tvplayedmonths" type="integer" label="32909" help="" parent="watchmodetvshows">
+                                        <level>0</level>
+                                        <default>6</default>
+                                        <dependencies>
+                                                <dependency type="enable" setting="watchmodetvshows">3</dependency>
+                                        </dependencies>
+                                        <control type="edit" format="integer">
+                                                <heading>32909</heading>
+                                        </control>
+                                </setting>
 				<setting id="watchmodemusicvideos" type="integer" label="32903" help="">
 					<level>0</level>
 					<default>0</default>


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: Play Random Videos
  - Add-on ID: script.playrandomvideos
  - Version number: 2.1.0
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/rmrector/script.playrandomvideos
  
This add-on can quickly play random episodes from TV shows, movies from genres/sets/years/tags, and videos from playlists, the filesystem, and just about anything else, other than plugins.

### Description of changes:

v2.1.0 (2022-02-20)
- Feature: option to filter out recently played videos
- Feature: add more metadata to playlist items

v2.0.0 (2021-01-29)
- Kodi 19 Matrix / Python 3 compatibility. Breaks compatibility with previous versions of Kodi.

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
