### PR TITLE
[script.module.inputstreamhelper@krypton] 0.5.9

### DIFF
--- a/script.module.inputstreamhelper/README.md
+++ b/script.module.inputstreamhelper/README.md
@@ -29,7 +29,7 @@ import xbmcplugin
 
 PROTOCOL = 'mpd'
 DRM = 'com.widevine.alpha'
-STREAM_URL = 'https://demo.unified-streaming.com/video/tears-of-steel/tears-of-steel-dash-widevine.ism/.mpd'
+STREAM_URL = 'https://demo.unified-streaming.com/k8s/features/stable/video/tears-of-steel/tears-of-steel-dash-widevine.ism/.mpd'
 MIME_TYPE = 'application/dash+xml'
 LICENSE_URL = 'https://widevine-proxy.appspot.com/proxy'
 KODI_VERSION_MAJOR = int(xbmc.getInfoLabel('System.BuildVersion').split('.')[0])
@@ -91,6 +91,12 @@ Please report any issues or bug reports on the [GitHub Issues](https://github.co
 This module is licensed under the **The MIT License**. Please see the [LICENSE.txt](LICENSE.txt) file for details.
 
 ## Releases
+### v0.5.9 (2022-03-22)
+- Update Croatian translation (@dsardelic, @muzena)
+- Replace deprecated LooseVersion (@mediaminister, @MarkusVolk)
+- Fix http_get decode error (@archtur)
+- Option to install Widevine from specified source (@horstle)
+
 ### v0.5.8 (2021-09-09)
 - Simplify Widevine CDM installation on ARM hardware (@horstle, @mediaminister)
 - Update Chrome OS ARM hardware id's (@mediaminister)

--- a/script.module.inputstreamhelper/addon.xml
+++ b/script.module.inputstreamhelper/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.module.inputstreamhelper" name="InputStream Helper" version="0.5.8" provider-name="emilsvennesson, dagwieers, mediaminister, horstle">
+<addon id="script.module.inputstreamhelper" name="InputStream Helper" version="0.5.9" provider-name="emilsvennesson, dagwieers, mediaminister, horstle">
   <requires>
     <!--py3 compliant-->
     <import addon="xbmc.python" version="2.25.0"/>
@@ -11,18 +11,26 @@
   </extension>
   <extension point="xbmc.python.module" library="lib"/>
   <extension point="xbmc.addon.metadata">
-    <summary lang="en_GB">Kodi InputStream and DRM playback made easy</summary>
     <summary lang="de_DE">Kodi InputStream und DRM Wiedergabe einfach gemacht</summary>
     <summary lang="el_GR">Βοηθός Inputstream για το Kodi και εύκολη αναπαραγωγή DRM</summary>
-    <summary lang="fr_FR">La lecture Kodi InputStream et DRM en toute simplicité</summary>
+    <summary lang="en_GB">Kodi InputStream and DRM playback made easy</summary>
     <summary lang="es_ES">Kodi InputStream y reproducción DRM echa fácil</summary>
-    <description lang="en_GB">A simple Kodi module that makes life easier for add-on developers relying on InputStream based add-ons and DRM playback.</description>
+    <summary lang="fr_FR">La lecture Kodi InputStream et DRM en toute simplicité</summary>
+    <summary lang="hr_HR">Kodi InputStream olakšava reprodukciju DRM zaštićenog sadržaja</summary>
     <description lang="de_DE">Dieses einfache Kodi-Modul macht das Leben für Addon Entwickler einfacher, die auf InputStream basierte Addons und DRM Wiedergabe angewiesen sind.</description>
     <description lang="el_GR">Μία απλή μονάδα για το Kodi η οποία διευκολύνει την ζωή των προγραμματιστών οι οποίοι εξαρτώνται από τα πρόσθετσ InputStream και αναπαραγωγή τύπου DRM.</description>
-    <description lang="ru_RU">Простой модуль для Kodi, который облегчает жизнь разработчикам дополнений, с использованием InputStream дополнений и воспроизведения DRM контента.</description>
-    <description lang="fr_FR">Un simple module Kodi qui simplifie la vie des développeurs de modules complémentaires en s’appuyant sur des modules complémentaires basés sur InputStream et sur la lecture de DRM.</description>
+    <description lang="en_GB">A simple Kodi module that makes life easier for add-on developers relying on InputStream based add-ons and DRM playback.</description>
     <description lang="es_ES">Un módulo Kodi simple que hace la vida más fácil para los desarrolladores de complementos que dependen de complementos basados en InputStream y reproducción de DRM.</description>
+    <description lang="fr_FR">Un simple module Kodi qui simplifie la vie des développeurs de modules complémentaires en s’appuyant sur des modules complémentaires basés sur InputStream et sur la lecture de DRM.</description>
+    <description lang="hr_HR">Jednostavan Kodi modul koji olakšava razvijanje dodataka koji se temelje na InputStream dodatku i reprodukciji DRM zaštićenog sadržaja.</description>
+    <description lang="ru_RU">Простой модуль для Kodi, который облегчает жизнь разработчикам дополнений, с использованием InputStream дополнений и воспроизведения DRM контента.</description>
     <news>
+v0.5.9 (2022-03-22)
+- Update Croatian translation
+- Replace deprecated LooseVersion
+- Fix http_get decode error
+- Option to install Widevine from specified source
+
 v0.5.8 (2021-09-09)
 - Simplify Widevine CDM installation on ARM hardware
 - Update Chrome OS ARM hardware id's

--- a/script.module.inputstreamhelper/lib/inputstreamhelper/api.py
+++ b/script.module.inputstreamhelper/lib/inputstreamhelper/api.py
@@ -23,6 +23,8 @@ def run(params):
                 check_inputstream(params[2], drm=params[3])
         elif params[1] == 'info':
             info_dialog()
+        elif params[1] == 'widevine_install_from':
+            widevine_install_from()
         else:
             log(4, "Invalid API call method '{method}'", method=params[1])
 
@@ -40,6 +42,11 @@ def check_inputstream(protocol, drm=None):
 def widevine_install():
     """The API interface to install Widevine CDM"""
     Helper('mpd', drm='widevine').install_widevine()
+
+
+def widevine_install_from():
+    """The API interface to install Widevine CDM from a given resource (URL or local ChromeOS image)."""
+    Helper('mpd', drm='widevine').install_widevine_from()
 
 
 def widevine_remove():

--- a/script.module.inputstreamhelper/lib/inputstreamhelper/config.py
+++ b/script.module.inputstreamhelper/lib/inputstreamhelper/config.py
@@ -81,11 +81,13 @@ CHROMEOS_RECOVERY_URL = 'https://dl.google.com/dl/edgedl/chromeos/recovery/recov
 
 # To keep the Chrome OS ARM hardware ID list up to date, the following resources can be used:
 # https://www.chromium.org/chromium-os/developer-information-for-chrome-os-devices
-# https://cros-updates-serving.appspot.com/
-# Last updated: 2021-09-06
+# https://chromiumdash.appspot.com/serving-builds?deviceCategory=Chrome%20OS
+# Last updated: 2022-02-24
 CHROMEOS_RECOVERY_ARM_HWIDS = [
     'BOB',
     'BURNET',
+    'COACHZ',
+    'COZMO',
     'DAMU',
     'DRUWL',
     'DUMO',
@@ -93,20 +95,25 @@ CHROMEOS_RECOVERY_ARM_HWIDS = [
     'ESCHE',
     'FENNEL',
     'FENNEL14',
-    'FIEVEL',
     'HANA',
+    'HAYATO-YLRO',
+    'HOMESTAR-MBLE',
     'JUNIPER-HVPU',
     'KAKADU-WFIQ',
     'KAPPA',
+    'KAPPA-EWFK',
+    'KATSU',
     'KENZO-IGRW',
     'KEVIN',
     'KODAMA',
     'KRANE-ZDKS',
     'LAZOR',
     'LIMOZEEN',
+    'MAKOMO-UTTX',
+    'PICO-EXEM',
     'POMPOM-MZVS',
     'SCARLET',
-    'TIGER',
+    'SPHERION',
     'WILLOW-TFIY',
 ]
 

--- a/script.module.inputstreamhelper/lib/inputstreamhelper/utils.py
+++ b/script.module.inputstreamhelper/lib/inputstreamhelper/utils.py
@@ -51,7 +51,7 @@ def _http_request(url, headers=None, time_out=10):
         req = urlopen(request, timeout=time_out)
         log(0, 'Response code: {code}', code=req.getcode())
         if 400 <= req.getcode() < 600:
-            raise HTTPError('HTTP %s Error for url: %s' % (req.getcode(), url), response=req)
+            raise HTTPError('HTTP {} Error for url: {}'.format(req.getcode(), url), response=req)
     except (HTTPError, URLError) as err:
         log(2, 'Download failed with error {}'.format(err))
         if yesno_dialog(localize(30004), '{line1}\n{line2}'.format(line1=localize(30063), line2=localize(30065))):  # Internet down, try again?
@@ -70,7 +70,7 @@ def http_get(url):
     content = req.read()
     # NOTE: Do not log reponse (as could be large)
     # log(0, 'Response: {response}', response=content)
-    return content.decode()
+    return content.decode("utf-8")
 
 
 def http_head(url):
@@ -329,3 +329,13 @@ def remove_tree(path):
     """Remove an entire directory tree"""
     from shutil import rmtree
     rmtree(compat_path(path))
+
+
+def parse_version(version):
+    """Parse a version string and return a comparable version object"""
+    try:
+        from packaging.version import parse
+        return parse(version)
+    except ImportError:
+        from distutils.version import LooseVersion
+        return LooseVersion(version)

--- a/script.module.inputstreamhelper/lib/inputstreamhelper/widevine/widevine.py
+++ b/script.module.inputstreamhelper/lib/inputstreamhelper/widevine/widevine.py
@@ -8,7 +8,7 @@ from time import time
 
 from .. import config
 from ..kodiutils import addon_profile, exists, get_setting_int, listdir, localize, log, mkdirs, ok_dialog, open_file, set_setting, translate_path, yesno_dialog
-from ..utils import arch, cmd_exists, hardlink, http_download, http_get, http_head, remove_tree, run_cmd, store, system_os
+from ..utils import arch, cmd_exists, hardlink, http_download, http_get, http_head, parse_version, remove_tree, run_cmd, store, system_os
 from ..unicodes import compat_path, to_unicode
 
 
@@ -186,10 +186,8 @@ def latest_available_widevine_from_repo():
 
 def remove_old_backups(bpath):
     """Removes old Widevine backups, if number of allowed backups is exceeded"""
-    from distutils.version import LooseVersion  # pylint: disable=import-error,no-name-in-module,useless-suppression
-
     max_backups = get_setting_int('backups', 4)
-    versions = sorted([LooseVersion(version) for version in listdir(bpath)])
+    versions = sorted([parse_version(version) for version in listdir(bpath)])
 
     if len(versions) < 2:
         return
@@ -197,9 +195,9 @@ def remove_old_backups(bpath):
     installed_version = load_widevine_config()['version']
 
     while len(versions) > max_backups + 1:
-        remove_version = str(versions[1] if versions[0] == LooseVersion(installed_version) else versions[0])
+        remove_version = str(versions[1] if versions[0] == parse_version(installed_version) else versions[0])
         log(0, 'Removing oldest backup which is not installed: {version}', version=remove_version)
         remove_tree(os.path.join(bpath, remove_version))
-        versions = sorted([LooseVersion(version) for version in listdir(bpath)])
+        versions = sorted([parse_version(version) for version in listdir(bpath)])
 
     return

--- a/script.module.inputstreamhelper/resources/language/resource.language.en_gb/strings.po
+++ b/script.module.inputstreamhelper/resources/language/resource.language.en_gb/strings.po
@@ -257,6 +257,14 @@ msgctxt "#30065"
 msgid "Shall we try again?"
 msgstr ""
 
+msgctxt "#30066"
+msgid "Should the resource containing the Widevine library be downloaded from the URL specified in settings?\nNo means specifying the resource locally."
+msgstr ""
+
+msgctxt "#30067"
+msgid "Specify the resource Widevine should be extracted from."
+msgstr ""
+
 
 ### INFORMATION DIALOG
 msgctxt "#30800"
@@ -335,4 +343,16 @@ msgstr ""
 
 msgctxt "#30915"
 msgid "Restore Widevine CDM library..."
+msgstr ""
+
+msgctxt "#30950"
+msgid "Debug"
+msgstr ""
+
+msgctxt "#30953"
+msgid "Install Widevine from:"
+msgstr ""
+
+msgctxt "#30955"
+msgid "Install Widevine CDM library from specific source..."
 msgstr ""

--- a/script.module.inputstreamhelper/resources/language/resource.language.hr_hr/strings.po
+++ b/script.module.inputstreamhelper/resources/language/resource.language.hr_hr/strings.po
@@ -4,14 +4,15 @@ msgstr ""
 "Project-Id-Version: script.module.inputstreamhelper\n"
 "Report-Msgid-Bugs-To: https://github.com/emilsvennesson/script.module.inputstreamhelper\n"
 "POT-Creation-Date: 2013-11-18 16:15+0000\n"
-"PO-Revision-Date: 2019-11-27 15:50+0100\n"
+"PO-Revision-Date: 2022-02-09 00:40+0100\n"
 "Language-Team: Croatian\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language: hr\n"
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<12 || n%100>14) ? 1 : 2);\n"
-"Last-Translator: arvvoid\n"
+"Last-Translator: gogo <trebelnik2@gmail.com>\n"
+"X-Generator: Poedit 2.3\n"
 
 msgctxt "#30001"
 msgid "Information"
@@ -19,7 +20,7 @@ msgstr "Informacije"
 
 msgctxt "#30002"
 msgid "This add-on relies on the proprietary decryption module [B]Widevine CDM[/B] for playback."
-msgstr "Ovaj dodatak, za reprodukciju, se oslanja na vlasnički modul za dešifriranje [B]Widevine CDM[/B]"
+msgstr "Ovaj dodatak koristi [B]Widevine CDM[/B] vlasnički zaštićeni modul dekôdiranja za reprodukciju."
 
 msgctxt "#30004"
 msgid "Error"
@@ -27,87 +28,87 @@ msgstr "Greška"
 
 msgctxt "#30005"
 msgid "An error occurred while installing [B]Widevine CDM[/B]. Please enable debug logging and file a bug report at:[CR][CR]github.com/emilsvennesson/script.module.inputstreamhelper"
-msgstr "Došlo je do pogreške prilikom instaliranja [B]Widevine CDM[/B]. Omogućite evidentiranje pogrešaka (debug logging) i podnesite izvještaj o pogrešci na:[CR][CR]github.com/emilsvennesson/script.module.inputstreamhelper"
+msgstr "Došlo je do greške pri [B]Widevine CDM[/B] instalaciji. Omogućite zapisivanje grešaka i prijavite grešku na:[CR][CR]github.com/emilsvennesson/script.module.inputstreamhelper"
 
 msgctxt "#30006"
 msgid "Due to distribution rights, [B]Widevine CDM[/B] has to be extracted from a Chrome OS recovery image. This process requires at least [B]{diskspace}[/B] of free disk space. Do you wish to continue?"
-msgstr "Zbog prava distribucije, [B]Widevine CDM[/B] treba izvući iz preslike za oporavak Chrome OS-a. Za ovaj je postupak potrebno najmanje [B]{diskspace}[/B] slobodnog prostora na disku. Želite li nastaviti?"
+msgstr "Zbog distribucijskih prava, [B]Widevine CDM[/B] je potrebno izdvojiti iz slike oporavka Chrome OS-a. Ovaj postupak zahtijeva najmanje [B]{diskspace}[/B] slobodnog diskovnog prostora. Želite li nastaviti?"
 
 msgctxt "#30007"
 msgid "[B]Widevine CDM[/B] is unfortunately not available on this system architecture ([B]{arch}[/B])."
-msgstr "[B]Widevine CDM[/B] nažalost nije dostupan za ovu arhitekturu sustava ([B]{arch}[/B])."
+msgstr "[B]Widevine CDM[/B] nažalost nije dostupan na ([B]{arch}[/B]) arhitekturi sustava."
 
 msgctxt "#30008"
 msgid "[B]{addon}[/B] is missing on your Kodi install. This add-on is required to play this content."
-msgstr "[B]{addon}[/B] nedostaje na vašoj Kodi instalaciji. Ovaj je dodatak potreban za reprodukciju ovog sadržaja."
+msgstr "[B]{addon}[/B] nedostaje u vašoj Kodi instalaciji. Ovaj dodatak je potreban za reprodukciju ovog sadržaja."
 
 msgctxt "#30009"
 msgid "[B]{addon}[/B] is not enabled. This add-on is required to play this content.[CR][CR]Would you like to enable [B]{addon}[/B]?"
-msgstr "[B]{addon}[/B] nije omogućen. Ovaj dodatak potreban je za reprodukciju ovog sadržaja.[CR][CR]Želite li omogućiti [B]{addon}[/B]?"
+msgstr "[B]{addon}[/B] nije omogućen. Ovaj dodatak je potreban za reprodukciju ovog sadržaja.[CR][CR]Želite li ga omogućiti [B]{addon}[/B]?"
 
 msgctxt "#30010"
 msgid "[B]Kodi {version}[/B] or higher is required for [B]Widevine CDM[/B] content playback."
-msgstr "Potreban je [B]Kodi {verzija}[/B] ili noviji za reprodukciju sadržaja preko [B]Widevine CDM[/B]."
+msgstr "[B]Kodi {version}[/B] ili noviji je potreban za reprodukciju [B]Widevine CDM[/B] sadržaja."
 
 msgctxt "#30011"
 msgid "This operating system ([B]{os}[/B]) is not supported by [B]Widevine CDM[/B]."
-msgstr "[B]Widevine CDM[/B] ne podržava ovaj operativni sustav ([B]{os}[/B]) ."
+msgstr "[B]Widevine CDM[/B] ne podržava trenutni ([B]{os}[/B]) operativni sustav."
 
 msgctxt "#30012"
 msgid "The Windows Store version of Kodi does not support [B]Widevine CDM[/B].[CR][CR]Please use the installer from kodi.tv instead."
-msgstr "Verzija Kodi-a za Windows Store ne podržava [B]Widevine CDM[/B].[CR][CR]Molimo koristite instalacijski program sa kodi.tv."
+msgstr "Windows Store inačica Kodija ne podržava [B]Widevine CDM[/B].[CR][CR]Stoga koristite instalacijski program s kodi.tv."
 
 msgctxt "#30013"
 msgid "Failed to retrieve [B]{filename}[/B]."
-msgstr "Nemoguće dohvatiti [B]{filename}[/B]."
+msgstr "Neuspjelo [B]{filename}[/B] preuzimanje."
 
 msgctxt "#30014"
 msgid "Download in progress..."
-msgstr "Preuzimanje u tijeku…"
+msgstr "Preuzimanje u tijeku..."
 
 msgctxt "#30015"
 msgid "Downloading [B]{filename}[/B]..."
-msgstr "Preuzimanje [B]{filename}[/B]…"
+msgstr "Preuzimam [B]{filename}[/B]..."
 
 msgctxt "#30016"
 msgid "Failed to extract [B]Widevine CDM[/B] from zip file."
-msgstr "Nije uspjelo izdvajanje [B]Widevine CDM[/B]-a iz zip datoteke."
+msgstr "Neuspjelo [B]Widevine CDM[/B] raspakiravanje iz zip datoteke."
 
 msgctxt "#30017"
 msgid "[B]{addon}[/B] {version} or later is required to play this content."
-msgstr "[B]{addon}[/B] {verzija} ili novija verzija potrebna je za reprodukciju ovog sadržaja."
+msgstr "[B]{addon}[/B] {version} ili novija inačica je potrebna za reprodukciju ovog sadržaja."
 
 msgctxt "#30018"
 msgid "You do not have enough free disk space to install [B]Widevine CDM[/B]. Free up at least [B]{diskspace}[/B] and try again."
-msgstr "Nemate dovoljno slobodnog prostora na disku da biste instalirali [B]Widevine CDM[/B]. Oslobodite najmanje [B]{diskspace}[/B] i pokušajte ponovo."
+msgstr "Nedovoljno slobodnog diskovnog prostora za [B]Widevine CDM[/B] instalaciju. Oslobodite najmanje [B]{diskspace}[/B] i pokušajte ponovno."
 
 msgctxt "#30019"
 msgid "This operating system ([B]{os}[/B]) is not supported by [B]Widevine CDM[/B] for ARM devices."
-msgstr "[B]Widevine CDM[/B] za ARM uređaje ne podržava ovaj operativni sustav ([B]{os}[/B]) ."
+msgstr "[B]Widevine CDM[/B] ne podržava trenutni ([B]{os}[/B]) operativni sustav na ARM uređajima."
 
 msgctxt "#30020"
 msgid "[B]'{command1}'[/B] or [B]'{command2}'[/B] command needs to exist on system to extract the [B]Widevine CDM[/B]."
-msgstr "Naredba [B]’{command1}’[/B] ili [B]’{command2}’[/B] treba postojati na sustavu za otpakiranje [B]Widevine CDM[/B]-a."
+msgstr "[B]’{command1}’[/B] ili [B]’{command2}’[/B] naredbe moraju postojati na vašem sustavu za [B]Widevine CDM[/B] raspakiravanje."
 
 msgctxt "#30021"
 msgid "[B]'{command}'[/B] command needs to exist on system to extract the [B]Widevine CDM[/B]."
-msgstr "Naredba [B]’{command}’[/B] treba postojati na sustavu za otpakiranje [B]Widevine CDM[/B]-a."
+msgstr "[B]’{command}’[/B] naredba mora postojati na vašem sustavu za [B]Widevine CDM[/B] raspakiravanje."
 
 msgctxt "#30022"
 msgid "Downloading the Chrome OS recovery image..."
-msgstr "Preuzimanje Chrome OS preslike za oporavak …"
+msgstr "Preuzimanje Chrome OS slike oporavka..."
 
 msgctxt "#30023"
 msgid "Download completed!"
-msgstr "Preuzimanje je dovršeno!"
+msgstr "Preuzimanje završeno!"
 
 msgctxt "#30024"
 msgid "The installation now needs to unzip, mount and extract [B]Widevine CDM[/B] from the recovery image.[CR][CR]This process may take up to ten minutes to complete."
-msgstr "Instalacija sada treba raspakirati, montirati i izdvojiti [B]Widevine CDM[/B] iz preslike za oporavak.[CR][CR]Ovaj postupak može trajati do deset minuta."
+msgstr "Instalacija sada treba raspakirati, montirati i izdvojiti [B]Widevine CDM[/B] iz slike oporavaka.[CR][CR]Ovaj proces može potrajati do deset minuta."
 
 msgctxt "#30025"
 msgid "Acquiring EULA."
-msgstr "Preuzimam EULA."
+msgstr "EULA preuzimanje..."
 
 msgctxt "#30026"
 msgid "Widevine CDM EULA"
@@ -119,43 +120,35 @@ msgstr "Prihvaćam"
 
 msgctxt "#30028"
 msgid "Cancel"
-msgstr "Otkaži"
+msgstr "Odustani"
 
 msgctxt "#30029"
 msgid "OK"
-msgstr "OK"
+msgstr "U redu"
 
 msgctxt "#30030"
 msgid "The installation may need to run the following commands with root permissions: [B]{cmds}[/B]."
-msgstr "Instalacija će možda trebati pokrenuti sljedeće naredbe s ‘root’ dozvolama: [B]{cmds}[/B]."
+msgstr "Instalacija će možda trebati pokrenuti sljedeće naredbe s korijenskim ovlastima: [B]{cmds}[/B]."
 
 msgctxt "#30031"
 msgid "An update of [B]Widevine CDM[/B] is required to play this content."
-msgstr "Za reprodukciju ovog sadržaja potrebno je ažurirati [B]Widevine CDM[/B]."
+msgstr "Za reprodukciju ovog sadržaja potrebno je nadopuniti [B]Widevine CDM[/B]."
 
 msgctxt "#30032"
 msgid "Your system is missing the following libraries required by Widevine CDM: [B]{libs}[/B]. Install the libraries to play this content."
-msgstr "U vašem sustavu nedostaju sljedeće programske knjižnice koje traži Widevine CDM: [B]{libs}[/B]. Instalirajte programske knjižnice za reprodukciju ovog sadržaja."
+msgstr "U vašem sustavu nedostaju sljedeće biblioteke potrebne za Widevine CDM: [B]{libs}[/B]. Instalirajte biblioteke za reprodukciju ovog sadržaja."
 
 msgctxt "#30033"
 msgid "There is an update available for [B]Widevine CDM[/B]."
-msgstr "Dostupno je ažuriranje za [B]Widevine CDM[/B]."
+msgstr "Dostupna je nadopuna za [B]Widevine CDM[/B]."
 
 msgctxt "#30034"
 msgid "Update"
-msgstr "Ažuriraj"
-
-msgctxt "#30035"
-msgid "[B]loop[/B] is still loaded"
-msgstr "[B]petlja[/B] je još učitana"
-
-msgctxt "#30036"
-msgid "Unload it by running [B]modprobe -r loop[/B] in the terminal."
-msgstr "Oslobodite resurs pokretanjem [B]modprobe -r petlje[/B] u terminalu."
+msgstr "Nadopuni"
 
 msgctxt "#30037"
 msgid "Success!"
-msgstr "Uspjeh!"
+msgstr "Uspješno!"
 
 msgctxt "#30038"
 msgid "Install Widevine"
@@ -163,11 +156,11 @@ msgstr "Instaliraj Widevine"
 
 msgctxt "#30039"
 msgid "[B]Widevine CDM[/B] is currently not available natively on ARM64. Please switch to a 32-bit userspace for [B]Widevine CDM[/B] support."
-msgstr "[B]Widevine CDM[/B] trenutno nije dostupan izvorno na ARM64. Prebacite se na 32-bitni korisnički prostor za podršku [B]Widevine CDM[/B]-a."
+msgstr "[B]Widevine CDM[/B] trenutno nije izvorno dostupan na ARM64 arhitekturi. Prebacite se na 32-bitni korisnički prostor za [B]Widevine CDM[/B] podršku."
 
 msgctxt "#30040"
 msgid "Update available"
-msgstr "Dostupno ažuriranje"
+msgstr "Nadopuna dostupna"
 
 msgctxt "#30041"
 msgid "Widevine CDM is required"
@@ -175,47 +168,47 @@ msgstr "Potreban je Widevine CDM"
 
 msgctxt "#30042"
 msgid "Using a SOCKS proxy requires the PySocks library (script.module.pysocks) installed."
-msgstr "Korištenje SOCKS proxy zahtijeva instaliranje PySocks programske knjižnice (script.module.pysocks)."
+msgstr "Korištenje SOCKS proxyja zahtijeva instaliranu PySocks biblioteku (script.module.pysocks)."
 
 msgctxt "#30043"
 msgid "Extracting Widevine CDM"
-msgstr "Ekstrakcija Widevine CDM"
+msgstr "Widevine CDM raspakiravnje"
 
 msgctxt "#30044"
 msgid "Preparing downloaded image..."
-msgstr "Priprema preuzete preslike …"
+msgstr "Pripremanje preuzete slike..."
 
 msgctxt "#30045"
 msgid "Uncompressing image..."
-msgstr "Raspakiranje preslike u tijeku…"
+msgstr "Raspakiravanje slike..."
 
 msgctxt "#30046"
 msgid "This may take several minutes."
-msgstr "Ovo bi moglo potrajati nekoliko minuta."
+msgstr "Ovo može potrajati nekoliko minuta."
 
 msgctxt "#30047"
 msgid "[I]Please do not interrupt this process.[/I]"
-msgstr "[I]Molim vas, ne prekidajte ovaj postupak.[/I]"
+msgstr "[I]Ne prekidajte ovaj proces.[/I]"
 
 msgctxt "#30048"
 msgid "Extracting Widevine CDM from image..."
-msgstr "Ekstrakcija Widevine CDM iz preslike…"
+msgstr "Widevine CDM raspakiravanje iz slike..."
 
 msgctxt "#30049"
 msgid "Installing Widevine CDM..."
-msgstr "Instaliram Widevine CDM…"
+msgstr "Widevine CDM instalacija..."
 
 msgctxt "#30050"
 msgid "Finishing..."
-msgstr "Završavanje …"
+msgstr "Završavanje..."
 
 msgctxt "#30051"
 msgid "[B]Widevine CDM[/B] successfully installed."
-msgstr "[B]Widevine CDM[/B] uspješno je instaliran."
+msgstr "[B]Widevine CDM[/B] je uspješno instaliran."
 
 msgctxt "#30052"
 msgid "[B]Widevine CDM[/B] successfully removed."
-msgstr "[B]Widevine CDM[/B] uspješno je uklonjen."
+msgstr "[B]Widevine CDM[/B] je uspješno uklonjen."
 
 msgctxt "#30053"
 msgid "[B]Widevine CDM[/B] not found."
@@ -227,91 +220,85 @@ msgstr "onemogućeno"
 
 msgctxt "#30055"
 msgid "There is not enough free disk space in the current temporary directory. Would you like to specify a different one to temporarily use for the Chrome OS Recovery Image (e.g. on a USB)?"
-msgstr "U trenutnoj privremenoj mapi nema dovoljno slobodnog prostora na disku. Želite li odrediti neku drugu mapu koja bi se privremeno koristila za presliku za oporavak Chrome OS-a (npr. Na USB-u)?"
+msgstr "Nedovoljno je slobodnog diskovnog prostora u trenutnom privremenom direktoriju. Želite li odrediti drugi direktorij za privremeno korištenje slike oporavka Chrome OS-a (npr. na USB-u)?"
 
 msgctxt "#30056"
 msgid "No backups found!"
-msgstr "Nisu pronađene sigurnosne kopije!"
+msgstr "Nema pronađenih sigurnosnih kopija!"
 
 msgctxt "#30057"
 msgid "Choose a backup to restore"
-msgstr "Odaberite sigurnosnu kopiju za vraćanje"
+msgstr "Odaberite sigurnosnu kopiju za obnovu"
 
 msgctxt "#30058"
 msgid "Time remaining: {mins:d}:{secs:02d}"
-msgstr ""
-
-msgctxt "#30059"
-msgid "Meanwhile, should we try extracting Widevine CDM using the legacy method?"
-msgstr ""
+msgstr "Preostalo vrijeme: {mins:d}:{secs:02d}"
 
 msgctxt "#30060"
 msgid "Identifying wanted partition..."
-msgstr ""
+msgstr "Identifikacija željene particije..."
 
 msgctxt "#30061"
 msgid "Scanning the filesystem for the Widevine CDM..."
-msgstr ""
+msgstr "Pretraživanje Widevine CDM-a na datotečnom sustavu..."
 
 msgctxt "#30062"
 msgid "Widevine CDM found, analyzing..."
-msgstr ""
+msgstr "Widevine CDM pronađen, analiziranje..."
 
 msgctxt "#30063"
 msgid "Could not make the request. Your internet may be down."
-msgstr ""
+msgstr "Nemoguće slanje zahtjeva. Vaš pristup internetu je možda nedostupan."
 
 msgctxt "#30064"
 msgid "Could not finish the download."
-msgstr ""
+msgstr "Nemoguć završetak preuzimanja."
 
 msgctxt "#30065"
 msgid "Shall we try again?"
-msgstr ""
+msgstr "Hoćemo li pokušati ponovno?"
 
-
-### INFORMATION DIALOG
+# ## INFORMATION DIALOG
 msgctxt "#30800"
 msgid "[B]Kodi[/B] version [B]{version}[/B] is running on a [B]{system}[/B] system with [B]{arch}[/B] architecture."
-msgstr ""
+msgstr "[B]Kodi[/B] inačice [B]{version}[/B] je pokrenut unutar [B]{system}[/B] sustava na [B]{arch}[/B] arhitekturi."
 
 msgctxt "#30810"
 msgid "[B]InputStream Helper[/B] is at version [B]{version}[/B] {state}"
-msgstr ""
+msgstr "[B]InputStream Helper[/B] je [B]{version}[/B] {state}inačice"
 
 msgctxt "#30811"
 msgid "[B]InputStream Adaptive[/B] is at version [B]{version}[/B] {state}"
-msgstr ""
+msgstr "[B]InputStream Adaptive[/B] je [B]{version}[/B] {state} inačice"
 
 msgctxt "#30820"
 msgid "[B]Widevine CDM[/B] is [B]built into Android[/B]"
-msgstr ""
+msgstr "[B]Widevine CDM[/B] je [B]ugrađen u Androidu[/B]"
 
 msgctxt "#30821"
 msgid "[B]Widevine CDM[/B] is at version [B]{version}[/B] and was installed on [B]{date}[/B]"
-msgstr ""
+msgstr "[B]Widevine CDM[/B] je [B]{version}[/B] inačice a instaliran je [B]{date}[/B]"
 
 msgctxt "#30822"
 msgid "It was extracted from Chrome OS image [B]{name}[/B] with version [B]{version}[/B]"
-msgstr ""
+msgstr "Izdvojen je iz Chrome OS slike [B]{name}[/B] s [B]{version}[/B] inačice"
 
 msgctxt "#30823"
 msgid "It was last checked for updates on [B]{date}[/B]"
-msgstr ""
+msgstr "Posljednja provjera nadopune je [B]{date}[/B]"
 
 msgctxt "#30824"
 msgid "It is installed at [B]{path}[/B]"
-msgstr ""
+msgstr "Instaliran je u [B]{path}[/B]"
 
 msgctxt "#30830"
 msgid "Please report issues to: [COLOR yellow]{url}[/COLOR]"
-msgstr "Molim prijavite probleme na: [COLOR yellow]{url}[/COLOR]"
+msgstr "Probleme prijavite na: [COLOR yellow]{url}[/COLOR]"
 
-
-### SETTINGS
+# ## SETTINGS
 msgctxt "#30900"
 msgid "Expert"
-msgstr "Stručnjak"
+msgstr "Stručno"
 
 msgctxt "#30901"
 msgid "InputStream Helper information"
@@ -323,11 +310,11 @@ msgstr "Onemogući InputStream Helper"
 
 msgctxt "#30904"
 msgid "[I]When disabled, DRM playback may fail![/I]"
-msgstr "[I]Kada je onemogućeno, reprodukcija DRM-a možda neće uspjeti![/I]"
+msgstr "[I]Kada je onemogućeno, moguć je neuspjeh reprodukcije DRM zaštićenog sadržaja![/I]"
 
 msgctxt "#30905"
 msgid "Update frequency in days"
-msgstr "Učestalost ažuriranja u danima"
+msgstr "Učestalost nadopuna u danima"
 
 msgctxt "#30907"
 msgid "Temporary download directory"
@@ -335,11 +322,11 @@ msgstr "Privremeni direktorij preuzimanja"
 
 msgctxt "#30909"
 msgid "(Re)install Widevine CDM library..."
-msgstr "Ponovno instaliraj Widevine CDM…"
+msgstr "(Ponovno) instaliraj Widevine CDM biblioteku..."
 
 msgctxt "#30911"
 msgid "Remove Widevine CDM library..."
-msgstr "Ukloni Widevine CDM…"
+msgstr "Ukloni Widevine CDM biblioteku..."
 
 msgctxt "#30913"
 msgid "Number of backups"
@@ -347,4 +334,4 @@ msgstr "Broj sigurnosnih kopija"
 
 msgctxt "#30915"
 msgid "Restore Widevine CDM library..."
-msgstr "Vrati sigurnosnu kopiju Widevine CDM-a..."
+msgstr "Obnovi Widevine CDM biblioteku..."

--- a/script.module.inputstreamhelper/resources/settings.xml
+++ b/script.module.inputstreamhelper/resources/settings.xml
@@ -7,8 +7,6 @@
         <setting id="version" default="" visible="false"/>
         <setting label="30901" help="30902" type="action" action="RunScript(script.module.inputstreamhelper, info)"/>
         <setting type="sep"/>
-        <setting label="30903" help="30904" type="bool" id="disabled" default="false"/>
-        <setting label="30904" type="text" enable="false"/> <!-- disabled_warning -->
         <setting label="30905" help="30906" type="slider" id="update_frequency" default="31" range="1,3,90" option="int" enable="eq(-2,false)" visible="![System.Platform.Android | String.StartsWith(System.BuildVersion, 17)]"/>
         <setting label="30907" help="30908" type="folder" id="temp_path" source="" option="writeable" default="special://masterprofile/addon_data/script.module.inputstreamhelper" visible="![System.Platform.Android | String.StartsWith(System.BuildVersion, 17)]"/>
         <setting label="30913" help="30914" type="slider" id="backups" default="4" range="0,1,20" option="int" visible="![System.Platform.Android | String.StartsWith(System.BuildVersion, 17)]"/>
@@ -16,5 +14,11 @@
         <setting label="30909" help="30910" type="action" action="RunScript(script.module.inputstreamhelper, widevine_install)" enable="String.StartsWith(System.BuildVersion,18) + System.HasAddon(inputstream.adaptive) | System.AddonIsEnabled(inputstream.adaptive)" visible="![System.Platform.Android | String.StartsWith(System.BuildVersion, 17)]"/>
         <setting label="30911" help="30912" type="action" action="RunScript(script.module.inputstreamhelper, widevine_remove)" enable="String.StartsWith(System.BuildVersion,18) + System.HasAddon(inputstream.adaptive) | System.AddonIsEnabled(inputstream.adaptive)" visible="![System.Platform.Android | String.StartsWith(System.BuildVersion, 17)]"/>
         <setting label="30915" help="30916" type="action" action="RunScript(script.module.inputstreamhelper, rollback)" enable="String.StartsWith(System.BuildVersion,18) + System.HasAddon(inputstream.adaptive) | System.AddonIsEnabled(inputstream.adaptive)" visible="![System.Platform.Android | String.StartsWith(System.BuildVersion, 17)]"/>
+    </category>
+    <category label="30950">
+        <setting label="30903" help="30904" type="bool" id="disabled" default="false"/>
+        <setting label="30904" type="text" enable="false"/> <!-- disabled_warning -->
+        <setting label="30953" help="30954" type="text" id="image_url" option="urlencoded" default="https://dl.google.com/dl/edgedl/chromeos/recovery/chromeos_14092.77.0_veyron-fievel_recovery_stable-channel_fievel-mp.bin.zip"/>
+        <setting label="30955" help="30956" type="action" action="RunScript(script.module.inputstreamhelper, widevine_install_from)" enable="String.StartsWith(System.BuildVersion,18) + System.HasAddon(inputstream.adaptive) | System.AddonIsEnabled(inputstream.adaptive)" visible="![System.Platform.Android | String.StartsWith(System.BuildVersion, 17)]"/>
     </category>
 </settings>


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: InputStream Helper
  - Add-on ID: script.module.inputstreamhelper
  - Version number: 0.5.9
  - Kodi/repository version: krypton

- **Code location**
  - URL: https://github.com/emilsvennesson/script.module.inputstreamhelper
  
A simple Kodi module that makes life easier for add-on developers relying on InputStream based add-ons and DRM playback.

### Description of changes:


v0.5.9 (2022-03-22)
- Update Croatian translation
- Replace deprecated LooseVersion
- Fix http_get decode error
- Option to install Widevine from specified source

v0.5.8 (2021-09-09)
- Simplify Widevine CDM installation on ARM hardware
- Update Chrome OS ARM hardware id's
- Update Japanese and Korean translations

v0.5.7 (2021-07-02)
- Further improve Widevine CDM installation on ARM hardware

v0.5.6 (2021-06-24)
- Improve Widevine CDM installation on ARM hardware
- Postpone Widevine CDM updates when user rejects

v0.5.5 (2021-06-02)
- Improve Widevine CDM installation on ARM hardware

v0.5.4 (2021-05-27)
- Fix Widevine CDM installation on ARM hardware

v0.5.3 (2021-05-10)
- Temporary fix for Widevine CDM installation on ARM hardware
- Fix Widevine CDM installation on 32-bit Linux

v0.5.2 (2020-12-13)
- Update Chrome OS ARM hardware id's

v0.5.1 (2020-10-02)
- Fix incorrect ARM HWIDs: PHASER and PHASER360
- Added Hebrew translations
- Updated Dutch, Japanese and Korean translations

v0.5.0 (2020-06-25)
- Extract Widevine CDM directly from Chrome OS, minimizing disk space usage and eliminating the need for root access
- Improve progress dialog while extracting Widevine CDM on ARM devices
- Support resuming interrupted downloads on unreliable internet connections
- Reshape InputStream Helper information dialog
- Updated Dutch, English, French, German, Greek, Hungarian, Romanian, Russian, Spanish and Swedish translations
    

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
