### PR TITLE
[service.autostop] 1.0.5

### DIFF
--- a/service.autostop/addon.xml
+++ b/service.autostop/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon  id="service.autostop" name="Autostop" version="1.0.4" provider-name="jbinkley60">
+<addon  id="service.autostop" name="Autostop" version="1.0.5" provider-name="jbinkley60">
   <requires>
     <import addon="xbmc.python" version="3.0.0"/>
   </requires>    

--- a/service.autostop/changelog.txt
+++ b/service.autostop/changelog.txt
@@ -1,3 +1,12 @@
+1.0.5
+
+- Added 300 and 600 second options for playback stop notification.
+- Added check to ensure both playback stop and notification timers 
+  aren't set to 10 minutes creating a logic loop and instant 
+  notification on playback start. 
+- Added Autostop addon icon to notification messages for easier
+  identification.
+
 1.0.4
 
 - Fixed a bug where the sleep timer could execute prematurely

--- a/service.autostop/common.py
+++ b/service.autostop/common.py
@@ -6,6 +6,8 @@ import time
 
 msgdialogprogress = xbmcgui.DialogProgress()
 addon = xbmcaddon.Addon()
+addon_path = addon.getAddonInfo("path")
+addon_icon = addon_path + '/resources/icon.png'
 notifycount = 0
 
 def translate(text):
@@ -92,8 +94,7 @@ def sleepNotify(plcount, plstoptime, plflag, plnotify, plextend, asevlog, paflag
                 dialog = xbmcgui.Dialog()
                 mgenlog = translate(30309) + extmins + translate(30313)
                 xbmc.log(mgenlog, xbmc.LOGINFO)
-                dialog.notification(translate(30310), mgenlog, \
-                xbmcgui.NOTIFICATION_INFO, 3000)
+                dialog.notification(translate(30310), mgenlog, addon_icon, 3000)
                 settings('notifyset', 'no')                     # Clear notification flag
     elif notifyset == 'yes' and plflag == 0 and paflag == 0:                    
         msgdialogprogress.close()   
@@ -152,7 +153,7 @@ def stopPlayback(notifymsg, logmsg):                            # Function to st
         time.gmtime(pos))
         xbmc.log(mgenlog, xbmc.LOGINFO)
         dialog = xbmcgui.Dialog()
-        dialog.notification(notifymsg, mgenlog, xbmcgui.NOTIFICATION_INFO, 5000)
+        dialog.notification(notifymsg, mgenlog, addon_icon, 5000)
         if settings('screensaver') == 'true':                   #  Active screensaver if option selected
             xbmc.executebuiltin('ActivateScreensaver')
         settings('notifyset', 'no')                             # Clear notification flag
@@ -182,5 +183,20 @@ def checkTime(plstoptime, plcount, asevlog):                    # Calculate rema
         return '-1'
 
     
+def checkNotify():                                              # Verify plstop and plnotify are both 10 minutes
+
+    try:
+        plnotify = int(settings('plnotify'))
+        plstoptime = int(settings('plstop')) 
+
+        if plnotify == plstoptime * 60:
+            settings('plnotify', '300')                         # Stop timer and notification timer cannot be the same
+            notifymsg = translate(30310)
+            mgenlog = translate(30321)
+            xbmc.log(mgenlog, xbmc.LOGINFO)
+            dialog = xbmcgui.Dialog()
+            dialog.notification(notifymsg, mgenlog, addon_icon, 5000)
+    except:
+        xbmc.log('Autostop error processing checkNotify comparison.', xbmc.LOGINFO)                            
 
 

--- a/service.autostop/resources/language/resource.language.en_gb/strings.po
+++ b/service.autostop/resources/language/resource.language.en_gb/strings.po
@@ -37,7 +37,7 @@ msgid "Sleep Timer Pause Adjustment"
 msgstr ""
 
 msgctxt "#30305"
-msgid "Sleep Timer Notification 0-180 (seconds)"
+msgid "Sleep Timer Notification 0-600 (seconds)"
 msgstr ""
 
 msgctxt "#30306"
@@ -98,6 +98,10 @@ msgstr ""
 
 msgctxt "#30320"
 msgid "Autostop stopped current playback: "
+msgstr ""
+
+msgctxt "#30321"
+msgid "Autostop sleep timer and notification timer cannot be equal.  Notification timer set to 300 seconds. "
 msgstr ""
 
 msgctxt "#30501"

--- a/service.autostop/resources/settings.xml
+++ b/service.autostop/resources/settings.xml
@@ -54,6 +54,8 @@
 							<option>60</option>
 							<option>120</option>
 							<option>180</option>
+							<option>300</option>
+							<option>600</option>
 						</options>
 					</constraints>
 					<control type="spinner" format="string"/>

--- a/service.autostop/service.py
+++ b/service.autostop/service.py
@@ -2,7 +2,7 @@ import xbmc
 import xbmcaddon
 import xbmcgui
 import xbmcplugin
-from common import settings, playCount, sleepNotify, stopPlayback, translate
+from common import settings, playCount, sleepNotify, stopPlayback, translate, checkNotify
 
 pos = 0
 count = 0 
@@ -17,6 +17,7 @@ settings('extime', '0')
 asevlog = settings('asevlog')
 settings('notifyset', 'no')
 settings('varextnotify', 'no')
+checkNotify()
 
 xbmc.log("Autostop addon service started." , xbmc.LOGINFO)
   

--- a/service.autostop/utilities.py
+++ b/service.autostop/utilities.py
@@ -4,6 +4,9 @@ import xbmcplugin
 import xbmcaddon
 from common import settings
 
+addon = xbmcaddon.Addon()
+addon_path = addon.getAddonInfo("path")
+addon_icon = addon_path + '/resources/icon.png'
 
 def sleepTimer():
 
@@ -21,7 +24,7 @@ def sleepTimer():
     xbmc.log(mgenlog, xbmc.LOGINFO)
 
     dialog = xbmcgui.Dialog()
-    dialog.notification('Autostop Sleep Timer', mgenlog, xbmcgui.NOTIFICATION_INFO, 3000)
+    dialog.notification('Autostop Sleep Timer', mgenlog, addon_icon, 3000)
 
 
 sleepTimer()


### PR DESCRIPTION
### Description

Autostop v1.0.5 update.  Includes the following changes:

- Added 300 and 600 second options for playback stop notification.
- Added check to ensure both playback stop and notification timers 
  aren't set to 10 minutes creating a logic loop and instant 
  notification on playback start. 
- Added Autostop addon icon to notification messages for easier
  identification.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [X] Each add-on submission should be a single commit with using the following style: [script.foo.bar] 1.0.0

Additional information :
- Submitting your add-on to this specific branch makes it available to any Kodi version equal or higher than the branch name with the applicable Kodi dependencies limits.
- [add-on development](http://kodi.wiki/view/Add-on_development) wiki page.
- Kodi [pydocs](http://kodi.wiki/view/PyDocs) provide information about the Python API
- [PEP8](https://www.python.org/dev/peps/pep-0008/) codingstyle which is considered best practise but not mandatory.
- This add-on repository has automated code guideline check which could help you improve your coding. You can find the results of these check at [Codacy](https://www.codacy.com/app/Kodi/repo-scripts/dashboard). You can create your own account as well to continuously monitor your python coding before submitting to repo.
- Development questions can be asked in the [add-on development](http://forum.kodi.tv/forumdisplay.php?fid=26) section on the Kodi forum.
