### PR TITLE
[script.xbmc.lcdproc] 4.0.0

### DIFF
--- a/script.xbmc.lcdproc/addon.xml
+++ b/script.xbmc.lcdproc/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.xbmc.lcdproc" name="XBMC LCDproc" version="3.90.2" provider-name="Team Kodi: Memphiz, Daniel 'herrnst' Scheller">
+<addon id="script.xbmc.lcdproc" name="XBMC LCDproc" version="4.0.0" provider-name="Team Kodi: Memphiz, Daniel 'herrnst' Scheller">
   <requires>
     <import addon="xbmc.python" version="3.0.0"/>
   </requires>
@@ -24,8 +24,8 @@
     <assets>
       <icon>resources/icon.png</icon>
     </assets>
-    <news>3.90.2
-- fix compatibility with Python 3.9+
+    <news>4.0.0
+- fix Python exception when using the HD44780 character encodings/translation maps
 </news>
   </extension>
 </addon>

--- a/script.xbmc.lcdproc/changelog.txt
+++ b/script.xbmc.lcdproc/changelog.txt
@@ -1,3 +1,5 @@
+4.0.0
+- fix Python exception when using the HD44780 character encodings/translation maps
 3.90.2
 - fix compatibility with Python 3.9
 3.90.1

--- a/script.xbmc.lcdproc/resources/lib/charset_hd44780.py
+++ b/script.xbmc.lcdproc/resources/lib/charset_hd44780.py
@@ -52,10 +52,10 @@ class HD44780_StreamWriter(HD44780_Codec,codecs.StreamWriter):
 class HD44780_StreamReader(HD44780_Codec,codecs.StreamReader):
   pass
 
-def charset_hd44780(name):
-  if name == "hd44780-a00":
+def charset_hd44780(mapname):
+  if mapname == "hd44780_a00":
     return codecs.CodecInfo(
-      name               = "hd44780-a00",
+      name               = mapname,
       encode             = HD44780_Codec().encode_a00,
       decode             = HD44780_Codec().decode,
       incrementalencoder = HD44780_IncrementalEncoder_a00,
@@ -63,9 +63,9 @@ def charset_hd44780(name):
       streamreader       = HD44780_StreamReader,
       streamwriter       = HD44780_StreamWriter,
     )
-  elif name == "hd44780-a02":
+  elif mapname == "hd44780_a02":
     return codecs.CodecInfo(
-      name               = "hd44780-a02",
+      name               = mapname,
       encode             = HD44780_Codec().encode_a02,
       decode             = HD44780_Codec().decode,
       incrementalencoder = HD44780_IncrementalEncoder_a02,

--- a/script.xbmc.lcdproc/resources/lib/lcdbase.py
+++ b/script.xbmc.lcdproc/resources/lib/lcdbase.py
@@ -220,7 +220,7 @@ class LcdBase():
   def UpdateGUISettings(self):
     str_charset = self.m_Settings.getCharset()
     if str_charset != self.m_strLCDEncoding:
-      if (str_charset == "hd44780-a00" or str_charset == "hd44780-a02") and not self.m_bHaveHD44780Charmap:
+      if (str_charset == "hd44780_a00" or str_charset == "hd44780_a02") and not self.m_bHaveHD44780Charmap:
         str_charset = "iso8859-1"
 
       self.m_strLCDEncoding = str_charset

--- a/script.xbmc.lcdproc/resources/lib/settings.py
+++ b/script.xbmc.lcdproc/resources/lib/settings.py
@@ -129,9 +129,9 @@ class Settings():
             elif self._charset == "4":
                 ret = "iso-8859-5"
             elif self._charset == "5":
-                ret = "hd44780-a00"
+                ret = "hd44780_a00"
             elif self._charset == "6":
-                ret = "hd44780-a02"
+                ret = "hd44780_a02"
             else:
                 ret = "iso-8859-1"
 


### PR DESCRIPTION
### Description

From the changelog:

Fix Python exception when using the HD44780 character encodings/translation maps (Python 3.9+ converts hyphens et al to underscore in custom codec names, while we register the HD44780 translation maps with names containing such hyphens)

Also, as the addon itself seems quite mature for/since the Kodi Matrix release, finally get rid of the "beta" versioning and call this 4.0.0.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [script.foo.bar] 1.0.0
