### PR TITLE
[script.service.hue@matrix] 1.1.9

### DIFF
--- a/script.service.hue/addon.xml
+++ b/script.service.hue/addon.xml
@@ -1,4 +1,4 @@
-<addon id="script.service.hue" name="Hue Service" provider-name="zim514" version="1.1.3">
+<addon id="script.service.hue" name="Hue Service" provider-name="zim514" version="1.1.9">
 	<requires>
 		<import addon="xbmc.python" version="3.0.0"/>
 		<import addon="script.module.requests" version="2.25.1"/>
@@ -6,7 +6,6 @@
 		<import addon="script.module.simplecache" version="2.0.2"/>
 		<import addon="script.module.pyrollbar" version="0.15.2"/>
 		<import addon="script.module.qhue" version="2.0.1"/>
-		<!-- <import addon="script.module.web-pdb" version="1.5.6"/>  -->
 	</requires>
 	<extension point="xbmc.service" name="service.hue" library="service.py"/>
 	<extension point="xbmc.python.pluginsource" library="plugin.py">
@@ -22,24 +21,13 @@
 		</assets>
 		<source>https://github.com/zim514/script.service.hue</source>
 		<forum>https://forum.kodi.tv/showthread.php?tid=344886</forum>
-		<news>
-v1.1.3
-Update localisation
-Make Qhue an external dependency
-v1.1.2
-Update localisations
+		<news>v1.1.9
+Fix Ambilight attempting to initialize when disabled.
 Crash fixes
-Error handling fixes
-Remove SSDP discovery as recommended by Hue
-v1.1
-Add toggle to disable Hue Labs when Ambilight is activated (Thanks @toupeira!)
-Refactoring
-Bug and crash fixes
-Update Qhue lib
-Improve exception handling
-Add localisations
-Refactor logging and settings
-Update to new settings system</news>
+Error reporting improvements
+v1.1.4
+Fix error reporting
+</news>
 		<summary lang="cs_CZ">Automatizace Hue světel s přehráváním Kodi</summary>
 		<summary lang="da_DK">Automatiser Hue-lys sammen med afspilning i Kodi</summary>
 		<summary lang="de_DE">Automatisiere Hue-Lichter mit der Kodi-Wiedergabe</summary>

--- a/script.service.hue/plugin.py
+++ b/script.service.hue/plugin.py
@@ -1,4 +1,4 @@
-#      Copyright (C) 2019-2021 Kodi Hue Service (script.service.hue)
+#      Copyright (C) 2019 Kodi Hue Service (script.service.hue)
 #      This file is part of script.service.hue
 #      SPDX-License-Identifier: MIT
 #      See LICENSE.TXT for more information.

--- a/script.service.hue/resources/lib/__init__.py
+++ b/script.service.hue/resources/lib/__init__.py
@@ -1,4 +1,4 @@
-#      Copyright (C) 2019-2021 Kodi Hue Service (script.service.hue)
+#      Copyright (C) 2019 Kodi Hue Service (script.service.hue)
 #      This file is part of script.service.hue
 #      SPDX-License-Identifier: MIT
 #      See LICENSE.TXT for more information.

--- a/script.service.hue/resources/lib/ambigroup.py
+++ b/script.service.hue/resources/lib/ambigroup.py
@@ -1,4 +1,4 @@
-#      Copyright (C) 2019-2022 Kodi Hue Service (script.service.hue)
+#      Copyright (C) 2019 Kodi Hue Service (script.service.hue)
 #      This file is part of script.service.hue
 #      SPDX-License-Identifier: MIT
 #      See LICENSE.TXT for more information.
@@ -56,17 +56,19 @@ class AmbiGroup(lightgroup.LightGroup):
         if self.update_interval == 0:
             self.update_interval = 0.1
 
-        self.ambi_lights = {}
-        light_ids = ADDON.getSetting(f"group{self.light_group_id}_Lights").split(",")
-        index = 0
+        if self.enabled:
+            self.ambi_lights = {}
+            light_ids = ADDON.getSetting(f"group{self.light_group_id}_Lights").split(",")
+            index = 0
 
-        for L in light_ids:
-            gamut = self._get_light_gamut(self.bridge, L)
-            light = {L: {'gamut': gamut, 'prev_xy': (0, 0), "index": index}}
-            self.ambi_lights.update(light)
-            index = index + 1
+            if len(light_ids) <= 0:
+                for L in light_ids:
+                    gamut = self._get_light_gamut(self.bridge, L)
+                    light = {L: {'gamut': gamut, 'prev_xy': (0, 0), "index": index}}
+                    self.ambi_lights.update(light)
+                    index = index + 1
 
-        super(xbmc.Player).__init__()
+                super(xbmc.Player).__init__()
 
     @staticmethod
     def _force_on(ambi_lights, bridge, saved_light_states):
@@ -231,8 +233,8 @@ class AmbiGroup(lightgroup.LightGroup):
     def _bridge_error500(self):
         self.bridge_error500 = self.bridge_error500 + 1  # increment counter
         if self.bridge_error500 > 50 and ADDON.getSettingBool("show500Error"):
-            stop_showing_error = xbmcgui.Dialog().yesno(_("Hue Bridge over capacity"), _("The Hue Bridge is over capacity. Increase refresh rate or reduce the number of Ambilights."), yeslabel=_("Do not show again"), nolabel=_("Ok"))
             AMBI_RUNNING.clear()  # shut it down
+            stop_showing_error = xbmcgui.Dialog().yesno(_("Hue Bridge over capacity"), _("The Hue Bridge is over capacity. Increase refresh rate or reduce the number of Ambilights."), yeslabel=_("Do not show again"), nolabel=_("Ok"))
             if stop_showing_error:
                 ADDON.setSettingBool("show500Error", False)
             self.bridge_error500 = 0

--- a/script.service.hue/resources/lib/core.py
+++ b/script.service.hue/resources/lib/core.py
@@ -1,4 +1,4 @@
-#      Copyright (C) 2019-2022 Kodi Hue Service (script.service.hue)
+#      Copyright (C) 2019 Kodi Hue Service (script.service.hue)
 #      This file is part of script.service.hue
 #      SPDX-License-Identifier: MIT
 #      See LICENSE.TXT for more information.

--- a/script.service.hue/resources/lib/imageprocess.py
+++ b/script.service.hue/resources/lib/imageprocess.py
@@ -1,4 +1,4 @@
-#      Copyright (C) 2019-2021 Kodi Hue Service (script.service.hue)
+#      Copyright (C) 2019 Kodi Hue Service (script.service.hue)
 #      This file is part of script.service.hue
 #      SPDX-License-Identifier: MIT
 #      See LICENSE.TXT for more information.

--- a/script.service.hue/resources/lib/language.py
+++ b/script.service.hue/resources/lib/language.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 
-#      Copyright (C) 2019-2021 Kodi Hue Service (script.service.hue)
+#      Copyright (C) 2019 Kodi Hue Service (script.service.hue)
 #      This file is part of script.service.hue
 #      SPDX-License-Identifier: MIT
 #      See LICENSE.TXT for more information.
@@ -123,7 +123,6 @@ _strings['[b][i]warning: not supported on all hardware[/b][/i]'] = 30521
 _strings['cpu & hue performance'] = 30522
 _strings['ambilight'] = 30523
 _strings['advanced'] = 32101
-_strings['separate debug log'] = 32105
 _strings['video activation'] = 32106
 _strings['select lights'] = 6101
 _strings['enabled'] = 30520

--- a/script.service.hue/resources/lib/lightgroup.py
+++ b/script.service.hue/resources/lib/lightgroup.py
@@ -1,4 +1,4 @@
-#      Copyright (C) 2019-2021 Kodi Hue Service (script.service.hue)
+#      Copyright (C) 2019 Kodi Hue Service (script.service.hue)
 #      This file is part of script.service.hue
 #      SPDX-License-Identifier: MIT
 #      See LICENSE.TXT for more information.
@@ -45,7 +45,8 @@ class LightGroup(xbmc.Player):
         self.lights = self.bridge.lights
         self.group0 = self.bridge.groups[0]
 
-        super().__init__()
+        if self.enabled:
+            super().__init__()
 
     def __repr__(self):
         return f"light_group_id: {self.light_group_id}, enabled: {self.enabled}, state: {self.state}"
@@ -126,7 +127,7 @@ class LightGroup(xbmc.Player):
             self.group0.action(scene=scene)
         except QhueException as exc:
             xbmc.log(f"[script.service.hue] run_action: Hue call fail: {exc.type_id}: {exc.message} {traceback.format_exc()}")
-            if "7" in exc.type_id:
+            if ["7", "3"] in exc.type_id:
                 xbmc.log("[script.service.hue] Scene not found")
                 hue.notification(_("Hue Service"), _("ERROR: Scene not found"), icon=xbmcgui.NOTIFICATION_ERROR)
             else:
@@ -164,8 +165,8 @@ class LightGroup(xbmc.Player):
 
         if service_enabled:
             if ADDON.getSettingBool("enableSchedule"):
-                start = convert_time(ADDON.getSettingBool("startTime"))
-                end = convert_time(ADDON.getSettingBool("endTime"))
+                start = convert_time(ADDON.getSettingString("startTime"))
+                end = convert_time(ADDON.getSettingString("endTime"))
                 now = datetime.datetime.now().time()
                 if (now > start) and (now < end):
                     # xbmc.log("[script.service.hue] Enabled by schedule")
@@ -224,8 +225,12 @@ class LightGroup(xbmc.Player):
                         return True
                 # xbmc.log("[script.service.hue] Check if scene light already active: False")
             except QhueException as exc:
-                xbmc.log(f"[script.service.hue] checkAlreadyActive: Hue call fail: {exc.type_id}: {exc.message} {traceback.format_exc()}")
-                reporting.process_exception(exc)
+                if ["7", "3"] in exc.type_id:
+                    xbmc.log("[script.service.hue] Scene not found")
+                    hue.notification(_("Hue Service"), _("ERROR: Scene not found"), icon=xbmcgui.NOTIFICATION_ERROR)
+                else:
+                    xbmc.log(f"[script.service.hue] checkAlreadyActive: Hue call fail: {exc.type_id}: {exc.message} {traceback.format_exc()}")
+                    reporting.process_exception(exc)
             except requests.RequestException as exc:
                 xbmc.log(f"[script.service.hue] Requests exception: {exc}")
                 hue.notification(header=_("Hue Service"), message=_(f"Connection Error"), icon=xbmcgui.NOTIFICATION_ERROR)

--- a/script.service.hue/resources/lib/menu.py
+++ b/script.service.hue/resources/lib/menu.py
@@ -1,4 +1,4 @@
-#      Copyright (C) 2019-2021 Kodi Hue Service (script.service.hue)
+#      Copyright (C) 2019 Kodi Hue Service (script.service.hue)
 #      This file is part of script.service.hue
 #      SPDX-License-Identifier: MIT
 #      See LICENSE.TXT for more information.

--- a/script.service.hue/resources/lib/reporting.py
+++ b/script.service.hue/resources/lib/reporting.py
@@ -1,4 +1,4 @@
-#      Copyright (C) 2019-2021 Kodi Hue Service (script.service.hue)
+#      Copyright (C) 2019 Kodi Hue Service (script.service.hue)
 #      This file is part of script.service.hue
 #      SPDX-License-Identifier: MIT
 #      See LICENSE.TXT for more information.
@@ -14,10 +14,10 @@ from resources.lib import ADDONVERSION, ROLLBAR_API_KEY, KODIVERSION, ADDONPATH,
 from resources.lib.language import get_string as _
 
 
-def process_exception(exc, level="critical"):
+def process_exception(exc, level="critical", error=""):
     if ADDON.getSettingBool("error_reporting"):
         if _error_report_dialog(exc):
-            _report_error(level)
+            _report_error(level, error)
 
 
 def _error_report_dialog(exc):
@@ -29,7 +29,7 @@ def _error_report_dialog(exc):
     return response
 
 
-def _report_error(level="critical"):
+def _report_error(level="critical", error=""):
     if "dev" in ADDONVERSION:
         env = "dev"
     else:
@@ -39,6 +39,7 @@ def _report_error(level="critical"):
         'machine': platform.machine(),
         'platform': platform.system(),
         'kodi': KODIVERSION,
+        'error': error
     }
-    rollbar.init(ROLLBAR_API_KEY, capture_ip=False, code_version=ADDONVERSION, root=ADDONPATH, scrub_fields='bridgeUser, bridgeIP', environment=env)
+    rollbar.init(ROLLBAR_API_KEY, capture_ip=False, code_version="v" + ADDONVERSION, root=ADDONPATH, scrub_fields='bridgeUser, bridgeIP', environment=env)
     rollbar.report_exc_info(sys.exc_info(), extra_data=data, level=level)

--- a/script.service.hue/resources/lib/settings.py
+++ b/script.service.hue/resources/lib/settings.py
@@ -1,4 +1,4 @@
-#      Copyright (C) 2019-2021 Kodi Hue Service (script.service.hue)
+#      Copyright (C) 2019 Kodi Hue Service (script.service.hue)
 #      This file is part of script.service.hue
 #      SPDX-License-Identifier: MIT
 #      See LICENSE.TXT for more information.
@@ -24,20 +24,19 @@ def _validate_ambilight():
         if light_ids == "-1":
             xbmc.log("[script.service.hue] No ambilights selected")
             hue.notification(_("Hue Service"), _("No lights selected for Ambilight."), icon=xbmcgui.NOTIFICATION_ERROR)
-            ADDON.setSettingBool("group3_enabled", False)
 
 
 def _validate_schedule():
     xbmc.log(f"[script.service.hue] Validate schedule. Schedule Enabled: {ADDON.getSettingBool('enableSchedule')}")
     if ADDON.getSettingBool("enableSchedule"):
         try:
-            convert_time(ADDON.getSettingBool("startTime"))
-            convert_time(ADDON.getSettingBool("endTime"))
+            convert_time(ADDON.getSettingString("startTime"))
+            convert_time(ADDON.getSettingString("endTime"))
             # xbmc.log("[script.service.hue] Time looks valid")
         except ValueError as e:
+            ADDON.setSettingBool("EnableSchedule", False)
             xbmc.log(f"[script.service.hue] Invalid time settings: {e}")
             hue.notification(_("Hue Service"), _("Invalid start or end time, schedule disabled"), icon=xbmcgui.NOTIFICATION_ERROR)
-            ADDON.setSettingBool("EnableSchedule", False)
 
 
 def convert_time(time):

--- a/script.service.hue/service.py
+++ b/script.service.hue/service.py
@@ -1,4 +1,4 @@
-#      Copyright (C) 2019-2021 Kodi Hue Service (script.service.hue)
+#      Copyright (C) 2019 Kodi Hue Service (script.service.hue)
 #      This file is part of script.service.hue
 #      SPDX-License-Identifier: MIT
 #      See LICENSE.TXT for more information.


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: Hue Service
  - Add-on ID: script.service.hue
  - Version number: 1.1.9
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/zim514/script.service.hue
  
Automate your Hue lights with Kodi. Create multi-room scenes that run when you Play, Pause or Stop media playback. Create and delete multi-room scenes from add-on settings then select which to apply for different Playback events. Can use Hue's sunrise and sunset times to automatically disable the service during daytime and turn on the lights at sunset during playback. Includes Ambilight support.

### Description of changes:

v1.1.9
Fix Ambilight attempting to initialize when disabled
Fix copyright notice
Fix frequently occurring crash
Error reporting improvements



### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
