### PR TITLE
[script.service.hue@matrix] 1.2.3

### DIFF
--- a/script.service.hue/addon.xml
+++ b/script.service.hue/addon.xml
@@ -1,4 +1,4 @@
-<addon id="script.service.hue" name="Hue Service" provider-name="zim514" version="1.2.1">
+<addon id="script.service.hue" name="Hue Service" provider-name="zim514" version="1.2.3">
 	<requires>
 		<import addon="xbmc.python" version="3.0.0"/>
 		<import addon="script.module.requests" version="2.25.1"/>

--- a/script.service.hue/resources/lib/ambigroup.py
+++ b/script.service.hue/resources/lib/ambigroup.py
@@ -61,7 +61,7 @@ class AmbiGroup(lightgroup.LightGroup):
             light_ids = ADDON.getSetting(f"group{self.light_group_id}_Lights").split(",")
             index = 0
 
-            if len(light_ids) <= 0:
+            if len(light_ids) > 0:
                 for L in light_ids:
                     gamut = self._get_light_gamut(self.bridge, L)
                     light = {L: {'gamut': gamut, 'prev_xy': (0, 0), "index": index}}
@@ -165,7 +165,7 @@ class AmbiGroup(lightgroup.LightGroup):
                 cap_image = cap.getImage()  # timeout to wait for OS in ms, default 1000
 
                 if cap_image is None or len(cap_image) < expected_capture_size:
-                    # xbmc.log("[script.service.hue] capImage is none or < expected. captured: {}, expected: {}".format(len(capImage), expected_capture_size))
+                    xbmc.log("[script.service.hue] capImage is none or < expected. captured: {}, expected: {}".format(len(capImage), expected_capture_size))
                     xbmc.sleep(250)  # pause before trying again
                     continue  # no image captured, try again next iteration
                 image = Image.frombytes("RGBA", (self.capture_size_x, self.capture_size_y), bytes(cap_image), "raw", "BGRA", 0, 1)  # Kodi always returns a BGRA image.


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: Hue Service
  - Add-on ID: script.service.hue
  - Version number: 1.2.3
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/zim514/script.service.hue
  
Automate your Hue lights with Kodi. Create multi-room scenes that run when you Play, Pause or Stop media playback. Create and delete multi-room scenes from add-on settings then select which to apply for different Playback events. Can use Hue's sunrise and sunset times to automatically disable the service during daytime and turn on the lights at sunset during playback. Includes Ambilight support.

### Description of changes:

v1.2.3
Fix Ambilight not initializing properly


### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
