### PR TITLE
[service.upnext@matrix] 1.1.8+matrix.1

### DIFF
--- a/service.upnext/README.md
+++ b/service.upnext/README.md
@@ -20,9 +20,28 @@ The add-on has various settings to fine-tune the experience, however the default
 
 > NOTE: The add-on settings are found in the Kodi add-ons section, in the *Services* category.
 
-For [Addon Integration](https://github.com/im85288/service.upnext/wiki/Addon-Integration) and [Skinners](https://github.com/im85288/service.upnext/wiki/Skinners) see the [wiki](https://github.com/im85288/service.upnext/wiki)
+For [Addon Integration](https://github.com/im85288/service.upnext/wiki/Integration) and [Skinners](https://github.com/im85288/service.upnext/wiki/Skinners) see the [wiki](https://github.com/im85288/service.upnext/wiki)
 
 ## Releases
+
+### v1.1.8 (2022-09-13)
+- Never ask if Still Watching? if playedInARow is 0 (@MoojMidge)
+- Still Watching? checks number of plays not number+1 (@MoojMidge)
+
+### v1.1.7 (2022-09-03)
+- Update check for filename of multi-part episodes (@MoojMidge)
+- Check for physical disc or disc image being played (@MoojMidge)
+- Translation update to Russian (@ArtyIF)
+- Fix CI workflow (@MoojMidge)
+
+### v1.1.6 (2022-03-07)
+- Fix for missing mediatype video info with addon video content (@MoojMidge)
+- Translation updates to Croatian, Japanese, Korean, Swedish and Finnish (@dsardelic, @Thunderbird2086, @Sopor, @Dis90)
+- New translation for Taiwanese Mandarin (@JuenTingShie)
+- Use onAVStarted instead of onPlayBackStarted (@MoojMidge)
+- Fix for Kodi not using the video player/playlist to play videos (@MoojMidge)
+- Fixes misalignment of system.time and endtime (@jojobrogess)
+
 ### v1.1.5 (2021-02-21)
 - Fix playlists to work with non-library content (@MoojMidge)
 - Fix to prevent unwanted playback when using playlist queueing method (@MoojMidge)

--- a/service.upnext/addon.xml
+++ b/service.upnext/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="service.upnext" name="Up Next" version="1.1.5+matrix.1" provider-name="im85288">
+<addon id="service.upnext" name="Up Next" version="1.1.8+matrix.1" provider-name="im85288">
     <requires>
         <import addon="xbmc.python" version="3.0.0"/>
     </requires>
@@ -40,6 +40,24 @@ Många befintliga tillägg integreras redan med den här utanför lådan-tjänst
         <platform>all</platform>
         <license>GPL-2.0-only</license>
         <news>
+v1.1.8 (2022-09-13)
+- Never ask if Still Watching? if playedInARow is 0
+- Still Watching? checks number of plays not number+1
+
+v1.1.7 (2022-09-03)
+- Update check for filename of multi-part episodes
+- Check for physical disc or disc image being played
+- Translation update to Russian
+- Fix CI workflow
+
+v1.1.6 (2022-03-07)
+- Fix for missing mediatype video info with addon video content
+- Translation updates to Croatian, Japanese, Korean, Swedish and Finnish
+- New translation for Taiwanese Mandarin
+- Use onAVStarted instead of onPlayBackStarted
+- Fix for Kodi not using the video player/playlist to play videos
+- Fixes misalignment of system.time and endtime
+
 v1.1.5 (2021-02-21)
 - Fix playlists to work with non-library content
 - Fix to prevent unwanted playback when using playlist queueing method
@@ -56,28 +74,6 @@ v1.1.3 (2020-10-14)
 - Fix logging on Kodi v19 (Matrix) after recent breakage
 - Enqueue the next episode in the playlist
 - Translation updates to German
-
-v1.1.2 (2020-06-22)
-- Bug fix for change from sleep to waitForAbort using seconds and not ms
-- Translation updates to Japanese and Korean
-
-v1.1.1 (2020-06-21)
-- Avoid conflict with external players
-- Restore "Ignore Playlist" option
-- Fix a known Kodi bug related to displaying hours
-- Improvements to endtime visualization
-- New translations for Hindi and Romanian
-- Translation updates to Hungarian and Spanish
-
-v1.1.0 (2020-01-17)
-- Add notification_offset for Netflix add-on
-- Fix various runtime exceptions
-- Implement new settings
-- Implement new developer mode
-- Show current time and next endtime in notification
-- New translations for Brazilian, Czech, Greek, Japanese, Korean
-- New translations for Russian, Slovak, Spanish, Swedish
-- Translation updates to Croatian, French, German, Hungarian, Italian, Polish
         </news>
         <assets>
             <icon>resources/media/icon.png</icon>

--- a/service.upnext/resources/language/resource.language.hr_hr/strings.po
+++ b/service.upnext/resources/language/resource.language.hr_hr/strings.po
@@ -7,8 +7,8 @@ msgstr ""
 "Project-Id-Version: service.upnext\n"
 "Report-Msgid-Bugs-To: https://github.com/im85288/service.upnext\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"PO-Revision-Date: 2020-01-14 01:30+0100\n"
-"Last-Translator: arvvoid\n"
+"PO-Revision-Date: 2021-10-16 15:00+0200\n"
+"Last-Translator: dsardelic\n"
 "Language-Team: Croatian\n"
 "Language: hr\n"
 "MIME-Version: 1.0\n"
@@ -20,7 +20,7 @@ msgstr ""
 
 msgctxt "#30006"
 msgid "Watch Now"
-msgstr "Gledaj sada"
+msgstr "Gledaj sad"
 
 msgctxt "#30008"
 msgid "Up Next"
@@ -32,19 +32,19 @@ msgstr "Završava u: $INFO[Window.Property(endtime)]"
 
 msgctxt "#30010"
 msgid "Continue watching"
-msgstr "Nastavite gledati"
+msgstr "Nastavi gledati"
 
 msgctxt "#30024"
 msgid "Still there?"
-msgstr "Još uvijek si tu?"
+msgstr "Još uvijek ste tu?"
 
 msgctxt "#30032"
 msgid "Enable on playlists"
-msgstr "Omogući na popisima za reprodukciju"
+msgstr "Omogući na listama za reprodukciju"
 
 msgctxt "#30033"
 msgid "Stop"
-msgstr "Stop"
+msgstr "Zaustavi"
 
 msgctxt "#30034"
 msgid "Close"
@@ -52,15 +52,15 @@ msgstr "Zatvori"
 
 msgctxt "#30035"
 msgid "Continue watching in [COLOR FFFF4081]$INFO[Window.Property(remaining)][/COLOR] seconds"
-msgstr "Nastavite gledati u [COLOR FFFF4081]$INFO[Window.Property(remaining)][/COLOR] sekunde"
+msgstr "Nastavite gledati za [COLOR FFFF4081]$INFO[Window.Property(remaining)][/COLOR] sekundi"
 
 msgctxt "#30036"
 msgid "Up next in [COLOR FFFF4081]$INFO[Window.Property(remaining)][/COLOR] seconds"
-msgstr "Sljedeće u [COLOR FFFF4081]$INFO[Window.Property(remaining)][/COLOR] sekunde"
+msgstr "Sljedeće za [COLOR FFFF4081]$INFO[Window.Property(remaining)][/COLOR] sekundi"
 
 msgctxt "#30037"
 msgid "Next episode in [COLOR FFFF4081]$INFO[Window.Property(remaining)][/COLOR] seconds"
-msgstr "Sljedeća epizoda u [COLOR FFFF4081]$INFO[Window.Property(remaining)][/COLOR] sekunde"
+msgstr "Sljedeća epizoda za [COLOR FFFF4081]$INFO[Window.Property(remaining)][/COLOR] sekundi"
 
 msgctxt "#30038"
 msgid "Simple"
@@ -68,27 +68,27 @@ msgstr "Jednostavno"
 
 msgctxt "#30039"
 msgid "Fancy"
-msgstr "Složeno"
+msgstr "Otmjeno"
 
 msgctxt "#30040"
 msgid "Play next"
-msgstr "Reproduciraj"
+msgstr "Reproduciraj iduće"
 
 msgctxt "#30041"
 msgid "Stop playing"
-msgstr "Ne reproduciraj"
+msgstr "Zaustavi reprodukciju"
 
 msgctxt "#30042"
 msgid "None"
-msgstr "Nijedan"
+msgstr "Bez"
 
 msgctxt "#30043"
 msgid "Info"
-msgstr "Info"
+msgstr "Informativna"
 
 msgctxt "#30044"
 msgid "Debug"
-msgstr "Debug"
+msgstr "Debugiranje"
 
 msgctxt "#30049"
 msgid "Next Episode"
@@ -96,11 +96,11 @@ msgstr "Sljedeća epizoda"
 
 msgctxt "#30060"
 msgid "[B]UP NEXT DEMO MODE ENABLED[/B]"
-msgstr ""
+msgstr "[B]UKLJUČEN 'UP NEXT' DEMONSTRACIJSKI NAČIN RADA[/B]"
 
 msgctxt "#30061"
 msgid "[I]Episodes automatically skip to end.[/I]"
-msgstr ""
+msgstr "[I]Epizode automatski preskaču na kraj.[/I]"
 
 
 # ## SETTINGS
@@ -114,11 +114,11 @@ msgstr "Značajke"
 
 msgctxt "#30503"
 msgid "Set the display mode for the notifications"
-msgstr "Postavite način prikaza za obavijesti"
+msgstr "Postavite način prikaza obavijesti"
 
 msgctxt "#30505"
 msgid "Show a \"Stop\" button instead of a \"Close\" button"
-msgstr "Prikaži \"Zaustavi\" dugme umjesto \"Zatvori\" dugme"
+msgstr "Prikaži \"Zaustavi\" gumb umjesto \"Zatvori\" gumba"
 
 msgctxt "#30600"
 msgid "Behaviour"
@@ -134,19 +134,19 @@ msgstr "Zadana akcija kada ništa nije odabrano"
 
 msgctxt "#30605"
 msgid "Include already watched episodes"
-msgstr "Uključi gledane epizode"
+msgstr "Uključi već odgledane epizode"
 
 msgctxt "#30607"
 msgid "Number of episodes before \"Still there?\" query"
-msgstr "Broj epizoda prije upita dali još gledate"
+msgstr "Broj epizoda prije \"Jeste li još tu?\" upita"
 
 msgctxt "#30609"
 msgid "Duration in seconds for notification to be shown"
-msgstr "Broj sekundi prije kraja za prikaz obavijesti"
+msgstr "Trajanje u sekundama za prikaz obavijesti"
 
 msgctxt "#30611"
 msgid "Customize autoplay duration by episode length"
-msgstr "Prilagodba trajanja automatske reprodukcije po dužini epizode"
+msgstr "Prilagodi trajanje automatske reprodukcije duljini epizode"
 
 msgctxt "#30613"
 msgid "All episodes  [COLOR gray]any length[/COLOR]"
@@ -174,19 +174,19 @@ msgstr "Vrlo duge epizode  [COLOR gray]> 60 min[/COLOR]"
 
 msgctxt "#30700"
 msgid "Expert"
-msgstr "Stručnjak"
+msgstr "Stručne"
 
 msgctxt "#30703"
 msgid "Disable Up Next"
-msgstr "Onemogući Up Next"
+msgstr "Onemogući 'Up Next'"
 
 msgctxt "#30705"
 msgid "Log level"
-msgstr "Razina zapisnika"
+msgstr "Razina logiranja"
 
 msgctxt "#30800"
 msgid "Developer"
-msgstr "Developer"
+msgstr "Razvojne"
 
 msgctxt "#30801"
 msgid "Test how the user interface looks"
@@ -194,7 +194,7 @@ msgstr "Testirajte kako izgleda korisničko sučelje"
 
 msgctxt "#30803"
 msgid "Enable DEMO mode"
-msgstr ""
+msgstr "Omogući demonstracijski način rada"
 
 msgctxt "#30805"
 msgid "Show an UpNext pop-up…"

--- a/service.upnext/resources/language/resource.language.ja_jp/strings.po
+++ b/service.upnext/resources/language/resource.language.ja_jp/strings.po
@@ -96,11 +96,11 @@ msgstr "次のエピソード"
 
 msgctxt "#30060"
 msgid "[B]UP NEXT DEMO MODE ENABLED[/B]"
-msgstr ""
+msgstr "[B]UP NEXT デモモードが使用可能になりました。[/B]"
 
 msgctxt "#30061"
 msgid "[I]Episodes automatically skip to end.[/I]"
-msgstr ""
+msgstr "[I]自動で最後へスキップします。[/I]"
 
 
 ### SETTINGS
@@ -194,7 +194,7 @@ msgstr "テストしたい通知ウィンドウ"
 
 msgctxt "#30803"
 msgid "Enable DEMO mode"
-msgstr ""
+msgstr "デモモード使用"
 
 msgctxt "#30805"
 msgid "Show an UpNext pop-up…"

--- a/service.upnext/resources/language/resource.language.ko_kr/strings.po
+++ b/service.upnext/resources/language/resource.language.ko_kr/strings.po
@@ -96,11 +96,11 @@ msgstr "다음 에피소드"
 
 msgctxt "#30060"
 msgid "[B]UP NEXT DEMO MODE ENABLED[/B]"
-msgstr ""
+msgstr "[B]UP NEXT 데모모드 사용가능[/B]"
 
 msgctxt "#30061"
 msgid "[I]Episodes automatically skip to end.[/I]"
-msgstr ""
+msgstr "[I]자동으로 마지막으로 갑니다.[/I]"
 
 
 ### SETTINGS
@@ -194,7 +194,7 @@ msgstr "어떤 알림창을 테스트하시렵니까?"
 
 msgctxt "#30803"
 msgid "Enable DEMO mode"
-msgstr ""
+msgstr "데모모드 사용"
 
 msgctxt "#30805"
 msgid "Show an UpNext pop-up…"

--- a/service.upnext/resources/language/resource.language.ru_ru/strings.po
+++ b/service.upnext/resources/language/resource.language.ru_ru/strings.po
@@ -24,7 +24,7 @@ msgstr "Смотреть сейчас"
 
 msgctxt "#30008"
 msgid "Up Next"
-msgstr "Up Next"
+msgstr "Далее"
 
 msgctxt "#30009"
 msgid "Ends at: $INFO[Window.Property(endtime)]"

--- a/service.upnext/resources/language/resource.language.sv_se/strings.po
+++ b/service.upnext/resources/language/resource.language.sv_se/strings.po
@@ -8,8 +8,8 @@ msgstr ""
 "Report-Msgid-Bugs-To: https://github.com/im85288/service.upnext\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "PO-Revision-Date: 2018-02-26 13:31+0000\n"
-"Last-Translator: im85288\n"
-"Language-Team: English\n"
+"Last-Translator: Sopor\n"
+"Language-Team: Swedish\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -24,7 +24,7 @@ msgstr "Titta nu"
 
 msgctxt "#30008"
 msgid "Up Next"
-msgstr "Kommer strax"
+msgstr "Strax"
 
 msgctxt "#30009"
 msgid "Ends at: $INFO[Window.Property(endtime)]"
@@ -40,7 +40,7 @@ msgstr "Tittar du fortfarande?"
 
 msgctxt "#30032"
 msgid "Enable on playlists"
-msgstr "Aktiverad på spellistor"
+msgstr "Aktivera på spellistor"
 
 msgctxt "#30033"
 msgid "Stop"
@@ -52,11 +52,11 @@ msgstr "Stäng"
 
 msgctxt "#30035"
 msgid "Continue watching in [COLOR FFFF4081]$INFO[Window.Property(remaining)][/COLOR] seconds"
-msgstr "Fortsätt titta om [COLOR FFFF4081]$INFO[Window.Property(remaining)][/COLOR] sekunder"
+msgstr "Fortsätt titta i [COLOR FFFF4081]$INFO[Window.Property(remaining)][/COLOR] sekunder"
 
 msgctxt "#30036"
 msgid "Up next in [COLOR FFFF4081]$INFO[Window.Property(remaining)][/COLOR] seconds"
-msgstr "Kommer strax om [COLOR FFFF4081]$INFO[Window.Property(remaining)][/COLOR] sekunder"
+msgstr "Strax om [COLOR FFFF4081]$INFO[Window.Property(remaining)][/COLOR] sekunder"
 
 msgctxt "#30037"
 msgid "Next episode in [COLOR FFFF4081]$INFO[Window.Property(remaining)][/COLOR] seconds"
@@ -96,11 +96,11 @@ msgstr "Nästa avsnitt"
 
 msgctxt "#30060"
 msgid "[B]UP NEXT DEMO MODE ENABLED[/B]"
-msgstr ""
+msgstr "[B]UP NEXT DEMOLÄGE AKTIVERAT[/B]"
 
 msgctxt "#30061"
 msgid "[I]Episodes automatically skip to end.[/I]"
-msgstr ""
+msgstr "[I]Avsnitten hoppar automatiskt till slutet.[/I]"
 
 
 ### SETTINGS
@@ -178,7 +178,7 @@ msgstr "Expert"
 
 msgctxt "#30703"
 msgid "Disable Up Next"
-msgstr "Inaktivera kommer strax"
+msgstr "Inaktivera Up Next"
 
 msgctxt "#30705"
 msgid "Log level"
@@ -194,20 +194,20 @@ msgstr "Testa hur användargränssnittet ser ut"
 
 msgctxt "#30803"
 msgid "Enable DEMO mode"
-msgstr ""
+msgstr "Aktivera DEMO-läge"
 
 msgctxt "#30805"
 msgid "Show an UpNext pop-up…"
-msgstr "Visa en popup för \"kommer strax\""
+msgstr "Visa en popup för UpNext…"
 
 msgctxt "#30807"
 msgid "Show an UpNextSimple pop-up…"
-msgstr "Visa en enkel popup för \"kommer strax\""
+msgstr "Visa en enkel popup för UpNext…"
 
 msgctxt "#30809"
 msgid "Show a StillWatching pop-up…"
-msgstr "Visa en popup för \"fortfarande tittar\""
+msgstr "Visa en popup för \"tittar du fortfarande\"…"
 
 msgctxt "#30811"
 msgid "Show a StillWatchingSimple pop-up…"
-msgstr "Visa en enkel popup för \"fortfarande tittar\""
+msgstr "Visa en enkel popup för \"tittar du fortfarande\"…"

--- a/service.upnext/resources/language/resource.language.zh_tw/strings.po
+++ b/service.upnext/resources/language/resource.language.zh_tw/strings.po
@@ -8,206 +8,206 @@ msgstr ""
 "Report-Msgid-Bugs-To: https://github.com/im85288/service.upnext\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "PO-Revision-Date: 2018-02-26 13:31+0000\n"
-"Last-Translator: Dis90\n"
-"Language-Team: Finnish\n"
+"Last-Translator: JuenTingShie\n"
+"Language-Team: Traditional Chinese\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: en\n"
+"Language: zh\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 1.8.7\n"
 
 ### APPLICATION
 msgctxt "#30006"
 msgid "Watch Now"
-msgstr "Katso nyt"
+msgstr "立即播放"
 
 msgctxt "#30008"
 msgid "Up Next"
-msgstr "Seuraavaksi"
+msgstr "即將播放"
 
 msgctxt "#30009"
 msgid "Ends at: $INFO[Window.Property(endtime)]"
-msgstr "Päättyy: $INFO[Window.Property(endtime)]"
+msgstr "在 $INFO[Window.Property(endtime)] 結束"
 
 msgctxt "#30010"
 msgid "Continue watching"
-msgstr "Jatka katsomista"
+msgstr "繼續播放"
 
 msgctxt "#30024"
 msgid "Still there?"
-msgstr "Vielä paikalla?"
+msgstr "還在嗎？"
 
 msgctxt "#30032"
 msgid "Enable on playlists"
-msgstr "Ota käyttöön toistolistoissa"
+msgstr "在播放清單啟用"
 
 msgctxt "#30033"
 msgid "Stop"
-msgstr "Pysäytä"
+msgstr "停止"
 
 msgctxt "#30034"
 msgid "Close"
-msgstr "Sulje"
+msgstr "關閉"
 
 msgctxt "#30035"
 msgid "Continue watching in [COLOR FFFF4081]$INFO[Window.Property(remaining)][/COLOR] seconds"
-msgstr "Jatka katsomista [COLOR FFFF4081]$INFO[Window.Property(remaining)][/COLOR] sekunnin kuluttua"
+msgstr "在 [COLOR FFFF4081]$INFO[Window.Property(remaining)][/COLOR] 秒後繼續播放"
 
 msgctxt "#30036"
 msgid "Up next in [COLOR FFFF4081]$INFO[Window.Property(remaining)][/COLOR] seconds"
-msgstr "Seuraavaksi [COLOR FFFF4081]$INFO[Window.Property(remaining)][/COLOR] sekunnin kuluttua"
+msgstr "在 [COLOR FFFF4081]$INFO[Window.Property(remaining)][/COLOR] 秒後即將播放"
 
 msgctxt "#30037"
 msgid "Next episode in [COLOR FFFF4081]$INFO[Window.Property(remaining)][/COLOR] seconds"
-msgstr "Seuraava jakso [COLOR FFFF4081]$INFO[Window.Property(remaining)][/COLOR] sekunnin kuluttua"
+msgstr "在 [COLOR FFFF4081]$INFO[Window.Property(remaining)][/COLOR] 秒後播放下一集"
 
 msgctxt "#30038"
 msgid "Simple"
-msgstr "Yksinkertainen"
+msgstr "簡易"
 
 msgctxt "#30039"
 msgid "Fancy"
-msgstr "Hienostunut"
+msgstr "華麗"
 
 msgctxt "#30040"
 msgid "Play next"
-msgstr "Toista seuraava"
+msgstr "即將播放"
 
 msgctxt "#30041"
 msgid "Stop playing"
-msgstr "Pysäytä toisto"
+msgstr "停止播放"
 
 msgctxt "#30042"
 msgid "None"
-msgstr "Ei mitään"
+msgstr "無"
 
 msgctxt "#30043"
 msgid "Info"
-msgstr "Info"
+msgstr "資訊"
 
 msgctxt "#30044"
 msgid "Debug"
-msgstr "Debug"
+msgstr "偵錯"
 
 msgctxt "#30049"
 msgid "Next Episode"
-msgstr "Seuraava jakso"
+msgstr "下一集"
 
 msgctxt "#30060"
 msgid "[B]UP NEXT DEMO MODE ENABLED[/B]"
-msgstr "[B]UP NEXT DEMO-TILA KÄYTÖSSÄ[/B]"
+msgstr "[B]UP NEXT 演示模式開啟[/B]"
 
 msgctxt "#30061"
 msgid "[I]Episodes automatically skip to end.[/I]"
-msgstr "[I]Hyppää automaattisesti jaksojen loppuun.[/I]"
+msgstr "[I]影集自動略過至底[/I]"
 
 
 ### SETTINGS
 msgctxt "#30500"
 msgid "Interface"
-msgstr "Käyttöliittymä"
+msgstr "介面"
 
 msgctxt "#30501"
 msgid "Features"
-msgstr "Ominaisuudet"
+msgstr "功能"
 
 msgctxt "#30503"
 msgid "Set the display mode for the notifications"
-msgstr "Aseta ilmoitusten esitystila"
+msgstr "設定提醒的模式"
 
 msgctxt "#30505"
 msgid "Show a \"Stop\" button instead of a \"Close\" button"
-msgstr "Näytä \"Pysäytä\"-nappi \"Sulje\"-napin sijaan"
+msgstr "顯示 \"停止播放\" 按鈕而非 \"關閉\" 按鈕"
 
 msgctxt "#30600"
 msgid "Behaviour"
-msgstr "Käyttäytyminen"
+msgstr "風格"
 
 msgctxt "#30601"
 msgid "Features"
-msgstr "Ominaisuudet"
+msgstr "功能"
 
 msgctxt "#30603"
 msgid "Default action when nothing selected"
-msgstr "Oletustoiminto, kun mitään ei ole valittu"
+msgstr "無作為時的預設動作"
 
 msgctxt "#30605"
 msgid "Include already watched episodes"
-msgstr "Sisällytä katsotut jaksot"
+msgstr "包括已觀看的影集"
 
 msgctxt "#30607"
 msgid "Number of episodes before \"Still there?\" query"
-msgstr "Jaksojen määrä ennen \"Vielä paikalla?\" ilmoitusta"
+msgstr "在詢問 \"還在嗎？\" 之前的集數"
 
 msgctxt "#30609"
 msgid "Duration in seconds for notification to be shown"
-msgstr "Kesto sekunneissa, kuinka kauan ilmoitus näytetään"
+msgstr "顯示提醒的時間"
 
 msgctxt "#30611"
 msgid "Customize autoplay duration by episode length"
-msgstr "Mukauta automaattisen toiston kesto jakson pituuden mukaan"
+msgstr "依據影片長度制定自動播放的時間"
 
 msgctxt "#30613"
 msgid "All episodes  [COLOR gray]any length[/COLOR]"
-msgstr "Kaikki jaksot  [COLOR gray]kaikki pituudet[/COLOR]"
+msgstr "所有影集"
 
 msgctxt "#30615"
 msgid "Very short episodes  [COLOR gray]< 10 mins[/COLOR]"
-msgstr "Todella lyhyet jaksot  [COLOR gray]< 10 min[/COLOR]"
+msgstr "非常短的影集  [COLOR gray]< 10 分鐘[/COLOR]"
 
 msgctxt "#30617"
 msgid "Short episodes  [COLOR gray]> 10 mins[/COLOR]"
-msgstr "Lyhyet jaksot  [COLOR gray]> 10 min[/COLOR]"
+msgstr "短影集  [COLOR gray]> 10 分鐘[/COLOR]"
 
 msgctxt "#30619"
 msgid "Medium episodes  [COLOR gray]> 20 mins[/COLOR]"
-msgstr "Keskipituiset jaksot  [COLOR gray]> 20 min[/COLOR]"
+msgstr "一般影集  [COLOR gray]> 20 分鐘[/COLOR]"
 
 msgctxt "#30621"
 msgid "Long episodes  [COLOR gray]> 40 mins[/COLOR]"
-msgstr "Pitkät jaksot  [COLOR gray]> 40 min[/COLOR]"
+msgstr "長影集  [COLOR gray]> 40 分鐘[/COLOR]"
 
 msgctxt "#30623"
 msgid "Very long episodes  [COLOR gray]> 60 mins[/COLOR]"
-msgstr "Todella pitkät jaksot  [COLOR gray]> 60 min[/COLOR]"
+msgstr "非常長影集  [COLOR gray]> 60 分鐘[/COLOR]"
 
 msgctxt "#30700"
 msgid "Expert"
-msgstr "Asiantuntija"
+msgstr "專家"
 
 msgctxt "#30703"
 msgid "Disable Up Next"
-msgstr "Poista käytöstä Up Next"
+msgstr "停用 Up Next"
 
 msgctxt "#30705"
 msgid "Log level"
-msgstr "Lokitaso"
+msgstr "紀錄層級"
 
 msgctxt "#30800"
 msgid "Developer"
-msgstr "Kehittäjä"
+msgstr "開發者"
 
 msgctxt "#30801"
 msgid "Test how the user interface looks"
-msgstr "Kokeile miltä käyttöliittymä näyttää"
+msgstr "測試使用者介面外觀"
 
 msgctxt "#30803"
 msgid "Enable DEMO mode"
-msgstr "Ota käyttöön DEMO-tila"
+msgstr "啟用演示模式"
 
 msgctxt "#30805"
 msgid "Show an UpNext pop-up…"
-msgstr "Näytä UpNext ponnahdusikkuna"
+msgstr "顯示 即將播放 跳出"
 
 msgctxt "#30807"
 msgid "Show an UpNextSimple pop-up…"
-msgstr "Näytä UpNextSimple ponnahdusikkuna"
+msgstr "顯示 簡易即將播放 跳出"
 
 msgctxt "#30809"
 msgid "Show a StillWatching pop-up…"
-msgstr "Näytä StillWatching ponnahdusikkuna"
+msgstr "顯示 還在觀看 跳出"
 
 msgctxt "#30811"
 msgid "Show a StillWatchingSimple pop-up…"
-msgstr "Näytä StillWatchingSimple ponnahdusikkuna"
+msgstr "顯示 簡易還在觀看 跳出"

--- a/service.upnext/resources/lib/api.py
+++ b/service.upnext/resources/lib/api.py
@@ -2,13 +2,18 @@
 # GNU General Public License v2.0 (see COPYING or https://www.gnu.org/licenses/gpl-2.0.txt)
 
 from __future__ import absolute_import, division, unicode_literals
-from xbmc import sleep
+from xbmc import sleep, PLAYLIST_VIDEO, PLAYLIST_MUSIC
 from utils import event, get_int, get_setting_bool, get_setting_int, jsonrpc, log as ulog
 
 
 class Api:
     """Main API class"""
     _shared_state = {}
+
+    PLAYER_PLAYLIST = {
+        'video': PLAYLIST_VIDEO,  # 1
+        'audio': PLAYLIST_MUSIC   # 0
+    }
 
     def __init__(self):
         """Constructor for Api class"""
@@ -35,6 +40,51 @@ class Api:
     def play_kodi_item(episode):
         jsonrpc(method='Player.Open', id=0, params=dict(item=dict(episodeid=episode.get('episodeid'))))
 
+    @staticmethod
+    def _get_playerid(playerid_cache=[None]):  # pylint: disable=dangerous-default-value
+        """Function to get active player playerid"""
+
+        # We don't need to actually get playerid everytime, cache and reuse instead
+        if playerid_cache[0] is not None:
+            return playerid_cache[0]
+
+        # Sometimes Kodi gets confused and uses a music playlist for video content,
+        # so get the first active player instead, default to video player.
+        result = jsonrpc(method='Player.GetActivePlayers')
+        result = [
+            player for player in result.get('result', [{}])
+            if player.get('type', 'video') in Api.PLAYER_PLAYLIST
+        ]
+
+        playerid = get_int(result[0], 'playerid') if result else -1
+
+        if playerid == -1:
+            return None
+
+        playerid_cache[0] = playerid
+        return playerid
+
+    @staticmethod
+    def get_playlistid(playlistid_cache=[None]):  # pylint: disable=dangerous-default-value
+        """Function to get playlistid of active player"""
+
+        # We don't need to actually get playlistid everytime, cache and reuse instead
+        if playlistid_cache[0] is not None:
+            return playlistid_cache[0]
+
+        result = jsonrpc(
+            method='Player.GetProperties',
+            params={
+                'playerid': Api._get_playerid(playerid_cache=[None]),
+                'properties': ['playlistid'],
+            }
+        )
+        result = get_int(
+            result.get('result', {}), 'playlistid', Api.PLAYER_PLAYLIST['video']
+        )
+
+        return result
+
     def queue_next_item(self, episode):
         next_item = {}
         if not self.data:
@@ -43,24 +93,45 @@ class Api:
             next_item.update(file=self.data.get('play_url'))
 
         if next_item:
-            jsonrpc(method='Playlist.Add', id=0, params=dict(playlistid=1, item=next_item))
+            jsonrpc(
+                method='Playlist.Add',
+                id=0,
+                params=dict(
+                    playlistid=Api.get_playlistid(),
+                    item=next_item
+                )
+            )
 
         return bool(next_item)
 
     @staticmethod
     def dequeue_next_item():
         """Remove unplayed next item from video playlist"""
-        jsonrpc(method='Playlist.Remove', id=0, params=dict(playlistid=1, position=1))
+        jsonrpc(
+            method='Playlist.Remove',
+            id=0,
+            params=dict(
+                playlistid=Api.get_playlistid(),
+                position=1
+            )
+        )
         return False
 
     @staticmethod
     def reset_queue():
         """Remove previously played item from video playlist"""
-        jsonrpc(method='Playlist.Remove', id=0, params=dict(playlistid=1, position=0))
+        jsonrpc(
+            method='Playlist.Remove',
+            id=0,
+            params=dict(
+                playlistid=Api.get_playlistid(),
+                position=0
+            )
+        )
 
     def get_next_in_playlist(self, position):
         result = jsonrpc(method='Playlist.GetItems', params=dict(
-            playlistid=1,
+            playlistid=Api.get_playlistid(),
             # limits are zero indexed, position is one indexed
             limits=dict(start=position, end=position + 1),
             properties=['art', 'dateadded', 'episode', 'file', 'firstaired', 'lastplayed',
@@ -138,7 +209,7 @@ class Api:
 
     def get_now_playing(self):
         # Seems to work too fast loop whilst waiting for it to become active
-        result = dict()
+        result = {}
         while not result.get('result'):
             result = jsonrpc(method='Player.GetActivePlayers')
             self.log('Got active player %s' % result, 2)
@@ -229,14 +300,17 @@ class Api:
 
     def find_next_episode(self, result, current_file, include_watched, current_episode_id):
         found_match = False
+        current_library_file = current_file
         episodes = result.get('result', {}).get('episodes', [])
         for episode in episodes:
             # Find position of current episode
+            episode_library_file = episode.get('file')
             if current_episode_id == episode.get('episodeid'):
                 found_match = True
+                current_library_file = episode_library_file
                 continue
             # Check if it may be a multi-part episode
-            if episode.get('file') == current_file:
+            if episode_library_file in (current_file, current_library_file):
                 continue
             # Skip already watched episodes?
             if not include_watched and episode.get('playcount') > 0:

--- a/service.upnext/resources/lib/monitor.py
+++ b/service.upnext/resources/lib/monitor.py
@@ -24,7 +24,7 @@ class UpNextMonitor(Monitor):
         """Log wrapper"""
         ulog(msg, name=self.__class__.__name__, level=level)
 
-    def run(self):
+    def run(self):  # pylint: disable=too-many-branches
         """Main service loop"""
         self.log('Service started', 0)
 
@@ -60,6 +60,15 @@ class UpNextMonitor(Monitor):
                 current_file = self.player.getPlayingFile()
             except RuntimeError:
                 self.log('Up Next tracking stopped, failed player.getPlayingFile()', 2)
+                self.player.disable_tracking()
+                self.playback_manager.demo.hide()
+                continue
+
+            if (current_file.startswith((
+                    'bluray://', 'dvd://', 'udf://', 'iso9660://', 'cdda://'))
+                    or current_file.endswith((
+                        '.bdmv', '.iso', '.ifo'))):
+                self.log('Up Next tracking stopped, Blu-ray/DVD/CD playing', 2)
                 self.player.disable_tracking()
                 self.playback_manager.demo.hide()
                 continue
@@ -116,3 +125,5 @@ class UpNextMonitor(Monitor):
         self.playback_manager.handle_demo()
         decoded_data.update(id='%s_play_action' % sender.replace('.SIGNAL', ''))
         self.api.addon_data_received(decoded_data, encoding=encoding)
+        self.player.enable_tracking()
+        self.player.reset_queue()

--- a/service.upnext/resources/lib/playbackmanager.py
+++ b/service.upnext/resources/lib/playbackmanager.py
@@ -153,7 +153,7 @@ class PlaybackManager:
         self.log('played in a row %s' % self.state.played_in_a_row, 2)
         showing_next_up_page = False
         showing_still_watching_page = False
-        if int(self.state.played_in_a_row) <= int(played_in_a_row_number):
+        if not played_in_a_row_number or int(self.state.played_in_a_row) < int(played_in_a_row_number):
             self.log('showing next up page as played in a row is %s' % self.state.played_in_a_row, 2)
             next_up_page.show()
             set_property('service.upnext.dialog', 'true')

--- a/service.upnext/resources/lib/player.py
+++ b/service.upnext/resources/lib/player.py
@@ -30,18 +30,29 @@ class UpNextPlayer(Player):
     def disable_tracking(self):
         self.state.track = False
 
+    def enable_tracking(self):
+        self.state.track = True
+
     def reset_queue(self):
         if self.state.queued:
             self.api.reset_queue()
             self.state.queued = False
 
-    def onPlayBackStarted(self):  # pylint: disable=invalid-name
-        """Will be called when kodi starts playing a file"""
+    def _check_video(self):
         self.monitor.waitForAbort(5)
         if not getCondVisibility('videoplayer.content(episodes)'):
             return
         self.state.track = True
         self.reset_queue()
+
+    if callable(getattr(Player, 'onAVStarted', None)):
+        def onAVStarted(self):  # pylint: disable=invalid-name
+            """Will be called when Kodi has a video or audiostream"""
+            self._check_video()
+    else:
+        def onPlayBackStarted(self):  # pylint: disable=invalid-name
+            """Will be called when kodi starts playing a file"""
+            self._check_video()
 
     def onPlayBackPaused(self):  # pylint: disable=invalid-name
         self.state.pause = True

--- a/service.upnext/resources/lib/playitem.py
+++ b/service.upnext/resources/lib/playitem.py
@@ -2,7 +2,7 @@
 # GNU General Public License v2.0 (see COPYING or https://www.gnu.org/licenses/gpl-2.0.txt)
 
 from __future__ import absolute_import, division, unicode_literals
-from xbmc import PlayList, PLAYLIST_VIDEO
+from xbmc import PlayList
 from api import Api
 from player import Player
 from state import State
@@ -21,11 +21,10 @@ class PlayItem:
     def log(self, msg, level=2):
         ulog(msg, name=self.__class__.__name__, level=level)
 
-    @staticmethod
-    def get_playlist_position():
+    def get_playlist_position(self):
         """Function to get current playlist playback position"""
 
-        playlist = PlayList(PLAYLIST_VIDEO)
+        playlist = PlayList(self.api.get_playlistid(playlistid_cache=[None]))
         position = playlist.getposition()
         # A playlist with only one element has no next item and PlayList().getposition() starts counting from zero
         if playlist.size() > 1 and position < (playlist.size() - 1):

--- a/service.upnext/resources/skins/default/1080i/script-upnext-upnext.xml
+++ b/service.upnext/resources/skins/default/1080i/script-upnext-upnext.xml
@@ -213,7 +213,7 @@
                             <font>font_clock</font>
                             <shadowcolor>text_shadow</shadowcolor>
                             <top>0</top>
-                            <right>20</right>
+                            <right>24</right>
                             <height>200</height>
                             <width>600</width>
                             <align>right</align>


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: Up Next
  - Add-on ID: service.upnext
  - Version number: 1.1.8+matrix.1
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/im85288/service.upnext
  
A service add-on that shows a Netflix-style notification for watching the next episode. After a few automatic iterations it asks the user if he is still there watching.

A lot of existing add-ons already integrate with this service out-of-the-box.

### Description of changes:


v1.1.8 (2022-09-13)
- Never ask if Still Watching? if playedInARow is 0
- Still Watching? checks number of plays not number+1

v1.1.7 (2022-09-03)
- Update check for filename of multi-part episodes
- Check for physical disc or disc image being played
- Translation update to Russian
- Fix CI workflow

v1.1.6 (2022-03-07)
- Fix for missing mediatype video info with addon video content
- Translation updates to Croatian, Japanese, Korean, Swedish and Finnish
- New translation for Taiwanese Mandarin
- Use onAVStarted instead of onPlayBackStarted
- Fix for Kodi not using the video player/playlist to play videos
- Fixes misalignment of system.time and endtime

v1.1.5 (2021-02-21)
- Fix playlists to work with non-library content
- Fix to prevent unwanted playback when using playlist queueing method
- New translation for Finnish

v1.1.4 (2020-12-03)
- Fix problem causing pop-up to not appear
- Translation updates to Romanian, Russian and Spanish

v1.1.3 (2020-10-14)
- Enable customPlayTime by default
- Do not seek to the end before playing next episode
- Add Kodi v17 compatibility
- Fix logging on Kodi v19 (Matrix) after recent breakage
- Enqueue the next episode in the playlist
- Translation updates to German
        

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
