### PR TITLE
[script.skipit] 1.0.3

### DIFF
--- a/script.skipit/addon.xml
+++ b/script.skipit/addon.xml
@@ -1,11 +1,12 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.skipit" name="SkipIt" version="1.0.2" provider-name="shartrec">
+<addon id="script.skipit" name="SkipIt" version="1.0.3" provider-name="shartrec">
 	<requires>
 		<import addon="xbmc.python" version="3.0.0"/>
 	</requires>
 	<extension point="xbmc.python.script" library="addon.py">
 		<provides>executable</provides>
 	</extension>
+	<extension point="xbmc.service" library="autoexec.py"/>
 	<extension point="xbmc.addon.metadata">
 		<platform>all</platform>
 		<summary lang="en_GB">Skip It</summary>

--- a/script.skipit/autoexec.py
+++ b/script.skipit/autoexec.py
@@ -1,0 +1,2 @@
+import sys
+from resources.lib import buildkeymap

--- a/script.skipit/changelog.txt
+++ b/script.skipit/changelog.txt
@@ -1,3 +1,4 @@
+1.0.3 Added a service to automatically setup  the keymapping to invoke the addon
 
 1.0.2 Fixed a race condition when skip is incomplete before querying current position.
       Fixed a race condition when skip button is pressed multip[le times in quick succession.

--- a/script.skipit/readme.txt
+++ b/script.skipit/readme.txt
@@ -14,18 +14,11 @@ Installation
 
 1/ Launch Kodi >> Add-ons >> Get More >> .. >> Install from repository
 
-2/ This addon needs to be bound to a key to launch its functionality while watching a video. Typically this is the "Right Arrow" key 
-   on your keyboard or remote control.
-   * Use the Keymap Editor plugin to bind the "Right Arrow" key to this addon in Fullscreen Video and Fullscreen Live TV Windows
-   --->  Addon 
-      ---> Keymap Editor
-         ---> Edit
-            ---> Window - Fullscreen Video   (repeat for Fullscreen Live TV)
-               ---> Category - Add-ons
-                  ---> Action - Launch SkipIt
-                     ---> Edit 
-                        ---> Press the 'Right Arrow' key when prompted or the right arrow on the remote control
-    --- Cancel your way back through the screens, remembering to save as the final step.
+2/ When installed, this addon binds the 'Right Arrow' key to load the addon when watching a video.
+   If you wish to use a different key you can either modify the file .kodi/userdata/keymaps/skipit.xml 
+   or
+   Remove the content from .kodi/userdata/keymaps/skipit.xml (do not delete the file) 
+   and use the keymap editor plugin to define the new key to use. 
     
 =============
 Configuration

--- a/script.skipit/resources/lib/buildkeymap.py
+++ b/script.skipit/resources/lib/buildkeymap.py
@@ -1,0 +1,35 @@
+import os
+import xbmcvfs
+import xbmc
+
+
+def setup_keymap_folder():
+    if not os.path.exists(userdata):
+        os.makedirs(userdata)
+
+def write_keymap(file):
+    
+    setup_keymap_folder()
+    # if the skipit keymapfile already exists do nothing
+    if os.path.exists(file):
+        exit
+
+    keymapxml = open(file,"w")
+    keymapxml.write("<keymap><fullscreenvideo><keyboard>")
+    keymapxml.write("<key id=\"61571\">runaddon(script.skipit)</key>")
+    keymapxml.write("</keyboard></fullscreenvideo></keymap>")
+    
+    keymapxml.close()
+    
+monitor = xbmc.Monitor()
+
+if monitor.abortRequested():
+    exit
+
+userdata = xbmcvfs.translatePath("special://userdata/keymaps")
+skipit_keymap_file = os.path.join(userdata, "skipit.xml")
+
+xbmc.log('Write keymap: ' + skipit_keymap_file, xbmc.LOGDEBUG)
+write_keymap(skipit_keymap_file)
+
+xbmc.executebuiltin("action(reloadkeymaps)")


### PR DESCRIPTION
### Description
Added a service to add a keymap file to bind "Right Arrow" to the plugin when in full screen video mode.
### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [ x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [ x] Each add-on submission should be a single commit with using the following style: [script.foo.bar] 1.0.0

Additional information :
- Submitting your add-on to this specific branch makes it available to any Kodi version equal or higher than the branch name with the applicable Kodi dependencies limits.
- [add-on development](http://kodi.wiki/view/Add-on_development) wiki page.
- Kodi [pydocs](http://kodi.wiki/view/PyDocs) provide information about the Python API
- [PEP8](https://www.python.org/dev/peps/pep-0008/) codingstyle which is considered best practise but not mandatory.
- This add-on repository has automated code guideline check which could help you improve your coding. You can find the results of these check at [Codacy](https://www.codacy.com/app/Kodi/repo-scripts/dashboard). You can create your own account as well to continuously monitor your python coding before submitting to repo.
- Development questions can be asked in the [add-on development](http://forum.kodi.tv/forumdisplay.php?fid=26) section on the Kodi forum.
