### PR TITLE
[script.video.nfl.gamepass] 2022.11.14

### DIFF
--- a/script.video.nfl.gamepass/addon.xml
+++ b/script.video.nfl.gamepass/addon.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
   <addon id="script.video.nfl.gamepass"
     name="NFL Game Pass"
-    version="2022.05.14"
+    version="2022.11.14"
     provider-name="Alexqw,divingmule,BaumSchorle,eriksoderblom,kaileu,emilsvennesson,baardisk,Duke">
   <requires>
     <import addon="xbmc.python" version="3.0.0"/>
@@ -20,12 +20,12 @@
     <license>GPL-2.0-only</license>
     <source>https://github.com/pigskin/kodi-gamepass</source>
     <disclaimer lang="en_GB">This addon requires you to have a subscription to NFL Game Pass.[CR]Please note that these subscriptions are region restricted by the NFL.[CR]This addon is completely unofficial and is /not/ endorsed by the NFL in any way.</disclaimer>
-    <news>2022.05.14
-    + Adapt to API changes implemented by Diva (jm-duke)
-    + Fix issue with LV Raiders logo (jm-duke)
-    + Fix display of 'None' for focused games in game week view (jm-duke)
-    + Implemented some improvements highlighted by Bas Rieter (jm-duke)
-    + Minor refactorings (jm-duke)
+    <news>2022.11.14
+    + Fix open settings from app bug (ohhmyy)
+    + Use updated team logos (ohhmyy)
+    + Remove code for fixed bitrates - adaptive is default (jm-duke)
+    + Add busy dialog to NFL Network (ohhmyy)
+    + Fix issue with recent NFL API change (jm-duke)
     </news>
     <assets>
       <icon>resources/art/icon.png</icon>

--- a/script.video.nfl.gamepass/changelog.txt
+++ b/script.video.nfl.gamepass/changelog.txt
@@ -1,3 +1,10 @@
+2022.11.14 -- Aaron Rodgers Edition
++ Fix open settings from app bug (ohhmyy)
++ Use updated team logos (ohhmyy)
++ Remove code for fixed bitrates - adaptive is default (jm-duke)
++ Add busy dialog to NFL Network (ohhmyy)
++ Fix issue with recent NFL API change (jm-duke)
+
 2022.05.14 -- Drew Brees Edition
 + Adapt to API changes implemented by Diva (jm-duke)
 + Fix issue with LV Raiders logo (jm-duke)

--- a/script.video.nfl.gamepass/default.py
+++ b/script.video.nfl.gamepass/default.py
@@ -495,6 +495,7 @@ class GamepassGUI(xbmcgui.WindowXML):
                         logger.debug('Error while reading seasons weeks and games')
                         logger.debug('Trace Message:\n{}'.format(format_exc()))
                 elif controlId == 130:
+                    xbmc.executebuiltin('ActivateWindow(busydialognocancel)')
                     self.main_selection = 'NFL Network'
                     self.window.setProperty('NW_clicked', 'true')
                     self.window.setProperty('GP_clicked', 'false')
@@ -509,7 +510,7 @@ class GamepassGUI(xbmcgui.WindowXML):
 
                     self.live_list.addItems(self.live_items)
                     self.display_nfln_seasons()
-
+                    xbmc.executebuiltin('Dialog.Close(busydialognocancel)')
                 return
 
             if self.main_selection == 'GamePass':

--- a/script.video.nfl.gamepass/resources/lib/pigskin/pigskin.py
+++ b/script.video.nfl.gamepass/resources/lib/pigskin/pigskin.py
@@ -933,7 +933,10 @@ class pigskin(object):
             except Exception as e:
                 raise e
 
-            streams[vs_format] = data['ContentUrl'] + '|' + urlencode(m3u8_header)
+            if isinstance(data, dict) and 'ContentUrl' in data:
+                streams[vs_format] = data['ContentUrl'] + '|' + urlencode(m3u8_header)
+            else:
+                continue
 
         return streams
 


### PR DESCRIPTION
### Description
**Addon**

Name: NFL Game Pass
ID: script.video.nfl.gamepass
Version: 2022.11.14
Source: https://github.com/pigskin/kodi-gamepass

**Info**

NFL Game Pass is a service that allows those with subscriptions to watch NFL games. This add-on allows watching of live and past games via NFL's Game Pass service.

**Updates**

Adds a busy dialog when retrieving NFL Network content and fixes an issue introduced by a recent API change.

### Checklist:
- [X] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [X] Each add-on submission should be a single commit with using the following style: [script.foo.bar] 1.0.0
