### PR TITLE
[script.module.phate89@matrix] 1.2.2+matrix.1

### DIFF
--- a/script.module.phate89/addon.xml
+++ b/script.module.phate89/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.module.phate89" name="phate89 helper module" version="1.2.1+matrix.1" provider-name="phate89">
+<addon id="script.module.phate89" name="phate89 helper module" version="1.2.2+matrix.1" provider-name="phate89">
 	<requires>
 		<import addon="xbmc.python" version="3.0.0"/>
 		<import addon="script.module.requests" version="2.9.1"/>

--- a/script.module.phate89/changelog.txt
+++ b/script.module.phate89/changelog.txt
@@ -1,3 +1,6 @@
+1.2.2
+- fixed crashes after nexus changes (thx to nixxo and ChristianSumma)
+
 1.2.1
 - added function to get formatted date
 - code cleanup and improvements


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: phate89 helper module
  - Add-on ID: script.module.phate89
  - Version number: 1.2.2+matrix.1
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/phate89/script.module.phate89
  
Helper module for addons

### Description of changes:



### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
