### PR TITLE
[script.module.phate89@jarvis] 1.2.2

### DIFF
--- a/script.module.phate89/addon.xml
+++ b/script.module.phate89/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.module.phate89" name="phate89 helper module" version="1.2.1" provider-name="phate89">
+<addon id="script.module.phate89" name="phate89 helper module" version="1.2.2" provider-name="phate89">
 	<requires>
 		<import addon="xbmc.python" version="2.24.0"/>
 		<import addon="script.module.requests" version="2.9.1"/>

--- a/script.module.phate89/changelog.txt
+++ b/script.module.phate89/changelog.txt
@@ -1,3 +1,6 @@
+1.2.2
+- fixed crashes after nexus changes (thx to nixxo and ChristianSumma)
+
 1.2.1
 - added function to get formatted date
 - code cleanup and improvements

--- a/script.module.phate89/lib/phate89lib/kodiutils.py
+++ b/script.module.phate89/lib/phate89lib/kodiutils.py
@@ -94,13 +94,13 @@ def showOkDialog(heading, line):
     xbmcgui.Dialog().ok(heading, line)
 
 
-def addListItem(label="", params=None, label2=None, thumb=None, fanart=None, poster=None, arts=None,
-                videoInfo=None, properties=None, isFolder=True):
+def createListItem(label="", params=None, label2=None, thumb=None, fanart=None, poster=None, arts=None,
+                videoInfo=None, properties=None, isFolder=True, path=None, subs=None):
     if arts is None:
         arts = {}
     if properties is None:
         properties = {}
-    item = xbmcgui.ListItem(label, label2)
+    item = xbmcgui.ListItem(label, label2, path)
     if thumb:
         arts['thumb'] = thumb
     if fanart:
@@ -109,22 +109,33 @@ def addListItem(label="", params=None, label2=None, thumb=None, fanart=None, pos
         arts['poster'] = poster
     item.setArt(arts)
     item.setInfo('video', videoInfo)
+    if subs is not None:
+        item.setSubtitles(subs)
     if not isFolder:
         properties['IsPlayable'] = 'true'
+    for key, value in list(properties.items()):
+        item.setProperty(key, value)
+    return item
+
+
+def addListItem(label="", params=None, label2=None, thumb=None, fanart=None, poster=None, arts=None,
+                videoInfo=None, properties=None, isFolder=True, path=None, subs=None):
     if isinstance(params, dict):
         url = staticutils.parameters(params)
     else:
         url = params
-    for key, value in list(properties.items()):
-        item.setProperty(key, value)
+    item = createListItem(label=label, params=params, label2=label2,
+                          thumb=thumb, fanart=fanart, poster=poster,
+                          arts=arts, videoInfo=videoInfo, properties=properties,
+                          subs=subs, isFolder=isFolder)
     return xbmcplugin.addDirectoryItem(handle=HANDLE, url=url, listitem=item, isFolder=isFolder)
 
 
-def setResolvedUrl(url="", solved=True, subs=None, headers=None, ins=None, insdata=None):
+def setResolvedUrl(url="", solved=True, subs=None, headers=None, ins=None, insdata=None, item=None, exit=True):
     headerUrl = ""
     if headers:
         headerUrl = urlencode(headers)
-    item = xbmcgui.ListItem(path=url + "|" + headerUrl)
+    item = xbmcgui.ListItem(path=url + "|" + headerUrl) if item is None else item
     if subs is not None:
         item.setSubtitles(subs)
     if ins:
@@ -134,7 +145,8 @@ def setResolvedUrl(url="", solved=True, subs=None, headers=None, ins=None, insda
             for key, value in list(insdata.items()):
                 item.setProperty(ins + '.' + key, value)
     xbmcplugin.setResolvedUrl(HANDLE, solved, item)
-    sys.exit()
+    if exit:
+        sys.exit()
 
 
 def append_subtitle(sUrl, subtitlename, sync=False, provider=None):


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: phate89 helper module
  - Add-on ID: script.module.phate89
  - Version number: 1.2.2
  - Kodi/repository version: jarvis

- **Code location**
  - URL: https://github.com/phate89/script.module.phate89
  
Helper module for addons

### Description of changes:



### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
