### PR TITLE
script.module.infotagger 0.0.5

### DIFF
--- a/script.module.infotagger/addon.xml
+++ b/script.module.infotagger/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.module.infotagger" name="InfoTagger" provider-name="jurialmunkey" version="0.0.4">
+<addon id="script.module.infotagger" name="InfoTagger" provider-name="jurialmunkey" version="0.0.5">
   <requires>
     <import addon="xbmc.python" version="3.0.1"/>
   </requires>

--- a/script.module.infotagger/resources/modules/infotagger/listitem.py
+++ b/script.module.infotagger/resources/modules/infotagger/listitem.py
@@ -157,6 +157,17 @@ class ListItemInfoTag():
             except TypeError:
                 func(_tag_attr['convert'](v))  # Attempt to force conversion to correct type
 
+    def set_resume_point(self, infoproperties: dict, resume_key='ResumeTime', total_key='TotalTime', pop_keys=True):
+        """ Wrapper to get/pop resumetime and totaltime properties for InfoTagVideo.setResumePoint() """
+        getter_func = infoproperties.pop if pop_keys else infoproperties.get
+        resume_time = getter_func(resume_key, None)
+        total_time = getter_func(total_key, None)
+        if resume_time and total_time:
+            self._info_tag.setResumePoint(resume_time, total_time)
+        elif resume_time:
+            self._info_tag.setResumePoint(resume_time)
+        return infoproperties
+
     def set_info_music_dbid(self, dbid: int, infolabels: dict, *args, **kwargs):
         """ Wrapper for InfoTagMusic.setDbId to retrieve mediatype """
         try:


### PR DESCRIPTION
### Description
<!--- Provide a short summary of submitted add-on in case it's a new addition. -->
<!--- If it's plugin update only highlight biggest changes if needed. -->
<!--- Make sure you follow the checklist below before finalising your pull-request. -->
Adds a setter function for setResumePoint() to use infoproperties dictionary with backwards compatibility for depreciated ResumeTime and TotalTime properties

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [script.foo.bar] 1.0.0

Additional information :
- Submitting your add-on to this specific branch makes it available to any Kodi version equal or higher than the branch name with the applicable Kodi dependencies limits.
- [add-on development](http://kodi.wiki/view/Add-on_development) wiki page.
- Kodi [pydocs](http://kodi.wiki/view/PyDocs) provide information about the Python API
- [PEP8](https://www.python.org/dev/peps/pep-0008/) codingstyle which is considered best practise but not mandatory.
- This add-on repository has automated code guideline check which could help you improve your coding. You can find the results of these check at [Codacy](https://www.codacy.com/app/Kodi/repo-scripts/dashboard). You can create your own account as well to continuously monitor your python coding before submitting to repo.
- Development questions can be asked in the [add-on development](http://forum.kodi.tv/forumdisplay.php?fid=26) section on the Kodi forum.
