### PR TITLE
[service.cronxbmc] 0.1.7

### DIFF
--- a/service.cronxbmc/addon.xml
+++ b/service.cronxbmc/addon.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="service.cronxbmc"
-    name="Cron For Kodi" version="0.1.6" provider-name="robweber">
+    name="Cron For Kodi" version="0.1.7" provider-name="robweber">
   <requires>
     <import addon="xbmc.python" version="3.0.0"/>
     <import addon="script.module.dateutil" version="2.8.1+matrix.1" />
@@ -20,6 +20,9 @@
     <assets>
     	<icon>resources/images/icon.png</icon>
     </assets>
+    <news>Version 0.1.7
+- fixed bug of deprecated API in Nexus
+    </news>
     <news>Version 0.1.6
 - fixed so it addon imports work properly
 - updated settings to new Kodi format

--- a/service.cronxbmc/resources/lib/cron/main.py
+++ b/service.cronxbmc/resources/lib/cron/main.py
@@ -137,8 +137,7 @@ class CronManager:
 
     def _readCronFile(self):
         if(not xbmcvfs.exists(xbmcvfs.translatePath('special://profile/addon_data/service.cronxbmc/'))):
-            xbmcvfs.mkdir(xbmc.translatePath('special://profile/addon_data/service.cronxbmc/'))
-
+            xbmcvfs.mkdir(xbmcvfs.translatePath('special://profile/addon_data/service.cronxbmc/'))
         adv_jobs = {}
         try:
             doc = xml.dom.minidom.parse(xbmcvfs.translatePath(self.CRONFILE))


### PR DESCRIPTION
### Description
Fixes issue with deprecated `xbmc.translatePath`. It works in Matrix but not Nexus, this will work for both. 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [script.foo.bar] 1.0.0

Additional information :
- Submitting your add-on to this specific branch makes it available to any Kodi version equal or higher than the branch name with the applicable Kodi dependencies limits.
- [add-on development](http://kodi.wiki/view/Add-on_development) wiki page.
- Kodi [pydocs](http://kodi.wiki/view/PyDocs) provide information about the Python API
- [PEP8](https://www.python.org/dev/peps/pep-0008/) codingstyle which is considered best practise but not mandatory.
- This add-on repository has automated code guideline check which could help you improve your coding. You can find the results of these check at [Codacy](https://www.codacy.com/app/Kodi/repo-scripts/dashboard). You can create your own account as well to continuously monitor your python coding before submitting to repo.
- Development questions can be asked in the [add-on development](http://forum.kodi.tv/forumdisplay.php?fid=26) section on the Kodi forum.
