### PR TITLE
[script.metadata.editor] 3.0.1

### DIFF
--- a/script.metadata.editor/addon.xml
+++ b/script.metadata.editor/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.metadata.editor" name="Metadata Editor" version="3.0.1" provider-name="sualfred">
+<addon id="script.metadata.editor" name="Metadata Editor" version="3.0.2" provider-name="sualfred, update/fix by _BJ1">
 	<requires>
 		<import addon="xbmc.python" version="3.0.0"/>
 		<import addon="script.module.requests" version="2.9.1"/>

--- a/script.metadata.editor/resources/language/resource.language.de_DE/strings.po
+++ b/script.metadata.editor/resources/language/resource.language.de_DE/strings.po
@@ -125,7 +125,7 @@ msgstr "Als Standard setzen?"
 #: /resources/settings.xml
 msgctxt "#32021"
 msgid "Enable .nfo updating for movies, TV shows and music videos"
-msgstr "Aktiviere .nfo Updating für Filme, Serien und Musikvideos"
+msgstr "Aktiviere .nfo Aktualisierung für Filme, Serien und Musikvideos"
 
 #: /resources/lib/editor.py
 msgctxt "#32022"
@@ -155,7 +155,7 @@ msgstr "Hohe Serverlast. Bitte warten."
 #: /resources/settings.xml
 msgctxt "#32027"
 msgid "TV show library is based on informations of"
-msgstr "Serien-Datenbank ist basierend auf Informationen von"
+msgstr "Serien-Datenbank basiert auf Informationen von"
 
 #: /resources/settings.xml
 msgctxt "#32029"
@@ -170,7 +170,7 @@ msgstr "Bewertungs-Updater"
 #: /resources/settings.xml
 msgctxt "#32028"
 msgid "Run updating process in the background"
-msgstr "Führe das Updaten im Hintergrund aus"
+msgstr "Führe die Aktualisierung im Hintergrund aus"
 
 #: /resources/settings.xml
 msgctxt "#32031"
@@ -204,7 +204,7 @@ msgstr ""
 #: /default.py
 msgctxt "#32036"
 msgid "Update TV show ratings"
-msgstr "Aktutalisiere Serienbewertungen"
+msgstr "Aktualisiere Serienbewertungen"
 
 #: /resources/lib/rating_updater.py
 msgctxt "#32033"
@@ -223,7 +223,7 @@ msgstr "Erstelle .nfo Datei, falls diese fehlt"
 #: /default.py
 msgctxt "#32037"
 msgid "Update movie ratings"
-msgstr "Aktutalisiere Filmbewertungen"
+msgstr "Aktualisiere Filmbewertungen"
 
 #: /default.py
 msgctxt "#32038"
@@ -300,7 +300,7 @@ msgctxt "#32052"
 msgid "Fallback to US MPAA if configured country has no certification stored"
 msgstr ""
 "Nutze US MPAA als Fallback, falls keine Zertifizierung der konfigurierten "
-"Region gefunden wurde"
+"Region gefunden wird"
 
 #: /resources/settings.xml
 msgctxt "#32053"

--- a/script.metadata.editor/resources/lib/helper.py
+++ b/script.metadata.editor/resources/lib/helper.py
@@ -24,7 +24,7 @@ from contextlib import contextmanager
 
 ADDON = xbmcaddon.Addon()
 ADDON_ID = ADDON.getAddonInfo('id')
-ADDON_DATA_PATH = os.path.join(xbmc.translatePath("special://profile/addon_data/%s" % ADDON_ID))
+ADDON_DATA_PATH = os.path.join(xbmcvfs.translatePath("special://profile/addon_data/%s" % ADDON_ID))
 
 NOTICE = xbmc.LOGINFO
 WARNING = xbmc.LOGWARNING

--- a/script.metadata.editor/resources/lib/nfo_updater.py
+++ b/script.metadata.editor/resources/lib/nfo_updater.py
@@ -108,7 +108,7 @@ class UpdateNFO():
 
         xml_prettyprint(self.root)
 
-        content = ET.tostring(self.root, encoding='UTF-8', method='xml', xml_declaration=True).decode()
+        content = ET.tostring(self.root, encoding='UTF8', method='xml').decode()
 
         with xbmcvfs.File(self.targetfile, 'w') as f:
             result = f.write(content)


### PR DESCRIPTION
…mcvfs, correct spelling for german language, bump version.

### Description
Fix deprecated xbmc.translatePath to xbmcvfs.translatePath. This made the addon working in Nexus again. Additional fix some spelling in german language string and bump version from 3.0.1 to 3.0.2
### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [script.foo.bar] 1.0.0

Additional information :
- Submitting your add-on to this specific branch makes it available to any Kodi version equal or higher than the branch name with the applicable Kodi dependencies limits.
- [add-on development](http://kodi.wiki/view/Add-on_development) wiki page.
- Kodi [pydocs](http://kodi.wiki/view/PyDocs) provide information about the Python API
- [PEP8](https://www.python.org/dev/peps/pep-0008/) codingstyle which is considered best practise but not mandatory.
- This add-on repository has automated code guideline check which could help you improve your coding. You can find the results of these check at [Codacy](https://www.codacy.com/app/Kodi/repo-scripts/dashboard). You can create your own account as well to continuously monitor your python coding before submitting to repo.
- Development questions can be asked in the [add-on development](http://forum.kodi.tv/forumdisplay.php?fid=26) section on the Kodi forum.
