### PR TITLE
[service.autostop] 1.0.6

### DIFF
--- a/service.autostop/addon.xml
+++ b/service.autostop/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon  id="service.autostop" name="Autostop" version="1.0.5" provider-name="jbinkley60">
+<addon  id="service.autostop" name="Autostop" version="1.0.6" provider-name="jbinkley60">
   <requires>
     <import addon="xbmc.python" version="3.0.0"/>
   </requires>    

--- a/service.autostop/changelog.txt
+++ b/service.autostop/changelog.txt
@@ -1,3 +1,8 @@
+1.0.6
+
+- Added option setting to reset sleep timer back to 0 after sleep 
+  timer stops playback.
+
 1.0.5
 
 - Added 300 and 600 second options for playback stop notification.

--- a/service.autostop/common.py
+++ b/service.autostop/common.py
@@ -158,7 +158,7 @@ def stopPlayback(notifymsg, logmsg):                            # Function to st
             xbmc.executebuiltin('ActivateScreensaver')
         if settings('asreset') == 'true':                       #  Reset sleep timer if option selected
             settings('plstop', '0')
-            mgenlog = "Autosop sleep timer reset enabled.  Sleep timer reset to 0."
+            mgenlog = "Autostop sleep timer reset enabled.  Sleep timer reset to 0."
             xbmc.log(mgenlog, xbmc.LOGINFO)
         settings('notifyset', 'no')                             # Clear notification flag
         settings('varextnotify', 'no')                          # Clear notification flag

--- a/service.autostop/common.py
+++ b/service.autostop/common.py
@@ -156,6 +156,10 @@ def stopPlayback(notifymsg, logmsg):                            # Function to st
         dialog.notification(notifymsg, mgenlog, addon_icon, 5000)
         if settings('screensaver') == 'true':                   #  Active screensaver if option selected
             xbmc.executebuiltin('ActivateScreensaver')
+        if settings('asreset') == 'true':                       #  Reset sleep timer if option selected
+            settings('plstop', '0')
+            mgenlog = "Autosop sleep timer reset enabled.  Sleep timer reset to 0."
+            xbmc.log(mgenlog, xbmc.LOGINFO)
         settings('notifyset', 'no')                             # Clear notification flag
         settings('varextnotify', 'no')                          # Clear notification flag
     except:

--- a/service.autostop/resources/language/resource.language.en_gb/strings.po
+++ b/service.autostop/resources/language/resource.language.en_gb/strings.po
@@ -104,6 +104,10 @@ msgctxt "#30321"
 msgid "Autostop sleep timer and notification timer cannot be equal.  Notification timer set to 300 seconds. "
 msgstr ""
 
+msgctxt "#30322"
+msgid "Sleep Timer Reset"
+msgstr ""
+
 msgctxt "#30501"
 msgid "Automatically stop paused video or music in minutes.  0 = never automatically stop paused playback."
 msgstr ""
@@ -134,4 +138,8 @@ msgstr ""
 
 msgctxt "#30508"
 msgid "Adds option to stop playback when the sleep timer extension option is set to variable.  Default is disabled."
+msgstr ""
+
+msgctxt "#30509"
+msgid "Enabling resets sleep timer back to 0 after playback stopped by sleep timer.  Default is disabled."
 msgstr ""

--- a/service.autostop/resources/settings.xml
+++ b/service.autostop/resources/settings.xml
@@ -101,6 +101,11 @@
 					</constraints>
 					<control type="spinner" format="string"/>
 				</setting>
+				<setting id="asreset" type="boolean" label="30322" help="30509">
+					<level>0</level>
+					<default>false</default>
+					<control type="toggle"/>
+				</setting>
 				<setting id="screensaver" type="boolean" label="30302" help="30502">
 					<level>0</level>
 					<default>false</default>


### PR DESCRIPTION
### Description
v1.0.6 is a minor update to add a setting which allows the sleep timer to be reset after the addon stops playback. 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [ X] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [ X] Each add-on submission should be a single commit with using the following style: [script.foo.bar] 1.0.0

Additional information :
- Submitting your add-on to this specific branch makes it available to any Kodi version equal or higher than the branch name with the applicable Kodi dependencies limits.
- [add-on development](http://kodi.wiki/view/Add-on_development) wiki page.
- Kodi [pydocs](http://kodi.wiki/view/PyDocs) provide information about the Python API
- [PEP8](https://www.python.org/dev/peps/pep-0008/) codingstyle which is considered best practise but not mandatory.
- This add-on repository has automated code guideline check which could help you improve your coding. You can find the results of these check at [Codacy](https://www.codacy.com/app/Kodi/repo-scripts/dashboard). You can create your own account as well to continuously monitor your python coding before submitting to repo.
- Development questions can be asked in the [add-on development](http://forum.kodi.tv/forumdisplay.php?fid=26) section on the Kodi forum.
