### PR TITLE
[service.libraryautoupdate] 1.2.4

### DIFF
--- a/service.libraryautoupdate/addon.xml
+++ b/service.libraryautoupdate/addon.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="service.libraryautoupdate"
-    name="Library Auto Update" version="1.2.3" provider-name="robweber">
+    name="Library Auto Update" version="1.2.4" provider-name="robweber">
   <requires>
     <import addon="xbmc.python" version="3.0.0"/>
     <import addon="script.module.dateutil" version="2.7.3" />
@@ -78,7 +78,7 @@
 	<assets>
 		<icon>resources/media/icon.png</icon>
 	</assets>
-	<news>Version 1.2.3
-- fix for hourly timer settings not working </news>
+	<news>Version 1.2.4
+- use a connection check URL instead of google.com</news>
   </extension>
 </addon>

--- a/service.libraryautoupdate/resources/lib/service.py
+++ b/service.libraryautoupdate/resources/lib/service.py
@@ -337,7 +337,7 @@ class AutoUpdater:
 
     def _networkUp(self):
         try:
-            urlopen('http://www.google.com', timeout=1)
+            urlopen('http://connectivitycheck.gstatic.com/generate_204', timeout=1)
             return True
         except Exception:
             pass


### PR DESCRIPTION
### Description
The service.libraryautoupdate plugin performs a connectivity check before scanning the library. Previously, this check fetched `www.google.com`, which is inappropriate for a connection check.

This commit fixes the problem by fetching a static connectivity check page, which returns a 204 status code with an empty response.
### Checklist:
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [script.foo.bar] 1.0.0
