### PR TITLE
[script.playrandomvideos@matrix] 2.1.1

### DIFF
--- a/script.playrandomvideos/addon.xml
+++ b/script.playrandomvideos/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.playrandomvideos" name="Play Random Videos" version="2.1.0" provider-name="rmrector">
+<addon id="script.playrandomvideos" name="Play Random Videos" version="2.1.1" provider-name="rmrector">
 	<requires>
 		<import addon="xbmc.python" version="3.0.0" />
 	</requires>
@@ -19,7 +19,10 @@
 	<extension point="xbmc.addon.metadata">
 		<summary lang="en_GB">Plays random videos from all sorts of lists.</summary>
 		<description lang="en_GB">This add-on can quickly play random episodes from TV shows, movies from genres/sets/years/tags, and videos from playlists, the filesystem, and just about anything else, other than plugins.</description>
-		<news>v2.1.0 (2022-02-20)
+		<news>v2.1.1 (2023-05-09)
+- Fix: recently played filter
+
+v2.1.0 (2022-02-20)
 - Feature: option to filter out recently played videos
 - Feature: add more metadata to playlist items
 

--- a/script.playrandomvideos/changelog.txt
+++ b/script.playrandomvideos/changelog.txt
@@ -1,3 +1,6 @@
+v2.1.1 (2023-05-09)
+- Fix: recently played filter
+
 v2.1.0 (2022-02-20)
 - Feature: option to filter out recently played videos
 - Feature: add more metadata to playlist items


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: Play Random Videos
  - Add-on ID: script.playrandomvideos
  - Version number: 2.1.1
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/rmrector/script.playrandomvideos
  
This add-on can quickly play random episodes from TV shows, movies from genres/sets/years/tags, and videos from playlists, the filesystem, and just about anything else, other than plugins.

### Description of changes:

v2.1.1 (2023-05-09)
- Fix: recently played filter

v2.1.0 (2022-02-20)
- Feature: option to filter out recently played videos
- Feature: add more metadata to playlist items

v2.0.0 (2021-01-29)
- Kodi 19 Matrix / Python 3 compatibility. Breaks compatibility with previous versions of Kodi.

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
