### PR TITLE
[service.subtitles.shooter] 2.0.1

### DIFF
--- a/service.subtitles.shooter/addon.xml
+++ b/service.subtitles.shooter/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="service.subtitles.shooter"
        name="Shooter"
-       version="2.0.0"
+       version="2.0.1"
        provider-name="taxigps">
     <requires>
         <import addon="xbmc.python" version="3.0.0"/>
@@ -30,6 +30,9 @@
             <screenshot>resources/media/screenshot_3.jpg</screenshot>
         </assets>
         <news>
+V2.0.1 (2023-05-14)
+- fixed: function was removed in Kodi 20
+
 V2.0.0 (2020-04-18)
 - Ported to python 3.0 for Kodi 19
 

--- a/service.subtitles.shooter/service.py
+++ b/service.subtitles.shooter/service.py
@@ -26,10 +26,10 @@ __scriptname__ = __addon__.getAddonInfo('name')
 __version__    = __addon__.getAddonInfo('version')
 __language__   = __addon__.getLocalizedString
 
-__cwd__        = xbmc.translatePath( __addon__.getAddonInfo('path') )
-__profile__    = xbmc.translatePath( __addon__.getAddonInfo('profile') )
-__resource__   = xbmc.translatePath( os.path.join( __cwd__, 'resources', 'lib' ) )
-__temp__       = xbmc.translatePath( os.path.join( __profile__, 'temp') )
+__cwd__        = xbmcvfs.translatePath( __addon__.getAddonInfo('path') )
+__profile__    = xbmcvfs.translatePath( __addon__.getAddonInfo('profile') )
+__resource__   = xbmcvfs.translatePath( os.path.join( __cwd__, 'resources', 'lib' ) )
+__temp__       = xbmcvfs.translatePath( os.path.join( __profile__, 'temp') )
 
 sys.path.append (__resource__)
 from langconv import *


### PR DESCRIPTION
### Description
fixed: function xbmc.translatePath was removed in Kodi 20
<!--- Provide a short summary of submitted add-on in case it's a new addition. -->
<!--- If it's plugin update only highlight biggest changes if needed. -->
<!--- Make sure you follow the checklist below before finalising your pull-request. -->
### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [X] Each add-on submission should be a single commit with using the following style: [script.foo.bar] 1.0.0
