### PR TITLE
[script.module.inputstreamhelper@matrix] 0.6.1+matrix.1

### DIFF
--- a/script.module.inputstreamhelper/README.md
+++ b/script.module.inputstreamhelper/README.md
@@ -91,6 +91,10 @@ Please report any issues or bug reports on the [GitHub Issues](https://github.co
 This module is licensed under the **The MIT License**. Please see the [LICENSE.txt](LICENSE.txt) file for details.
 
 ## Releases
+### v0.6.1 (2023-05-30)
+- Performance improvements on Linux ARM (@horstle)
+- This will be the last release for Python 2 i.e. Kodi 18 (Leia) and below. The next release will require Python 3 and Kodi 19 (Matrix) or higher.
+
 ### v0.6.0 (2023-05-03)
 - Initial support for AARCH64 Linux (@horstle)
 - Initial support for AARCH64 Macs (@mediaminister)

--- a/script.module.inputstreamhelper/addon.xml
+++ b/script.module.inputstreamhelper/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.module.inputstreamhelper" name="InputStream Helper" version="0.6.0+matrix.1" provider-name="emilsvennesson, dagwieers, mediaminister, horstle">
+<addon id="script.module.inputstreamhelper" name="InputStream Helper" version="0.6.1+matrix.1" provider-name="emilsvennesson, dagwieers, mediaminister, horstle">
   <requires>
     <!--py3 compliant-->
     <import addon="xbmc.python" version="3.0.0"/>
@@ -25,10 +25,14 @@
     <description lang="hr_HR">Jednostavan Kodi modul koji olakšava razvijanje dodataka koji se temelje na InputStream dodatku i reprodukciji DRM zaštićenog sadržaja.</description>
     <description lang="ru_RU">Простой модуль для Kodi, который облегчает жизнь разработчикам дополнений, с использованием InputStream дополнений и воспроизведения DRM контента.</description>
     <news>
+v0.6.1 (2023-05-30)
+- Performance improvements on Linux ARM
+- This will be the last release for Python 2 i.e. Kodi 18 (Leia) and below. The next release will require Python 3 and Kodi 19 (Matrix) or higher.
+
 v0.6.0 (2023-05-03)
-- Initial support for AARCH64 Linux (@horstle)
-- Initial support for AARCH64 Macs (@mediaminister)
-- New option to install a specific version on most platforms (@horstle)
+- Initial support for AARCH64 Linux
+- Initial support for AARCH64 Macs
+- New option to install a specific version on most platforms
 
 v0.5.10 (2022-04-18)
 - Fix automatic submission of release

--- a/script.module.inputstreamhelper/lib/inputstreamhelper/config.py
+++ b/script.module.inputstreamhelper/lib/inputstreamhelper/config.py
@@ -84,53 +84,22 @@ CHROMEOS_RECOVERY_URL = 'https://dl.google.com/dl/edgedl/chromeos/recovery/recov
 # https://www.chromium.org/chromium-os/developer-information-for-chrome-os-devices
 # https://chromiumdash.appspot.com/serving-builds?deviceCategory=Chrome%20OS
 # Last updated: 2023-03-24
-CHROMEOS_RECOVERY_ARM_HWIDS = [
-    'BOB',
-    'BURNET',
-    'COACHZ',
-    'COZMO',
-    'DAMU',
-    'DOJO-EJPG',
-    'DRUWL',
-    'DUMO',
-    'ELM',
-    'ESCHE',
-    'FENNEL',
-    'FENNEL14',
-    'HANA',
-    'HAYATO-YLRO',
-    'HOMESTAR-MBLE',
-    'JUNIPER-HVPU',
-    'KAKADU-WFIQ',
-    'KAPPA',
-    'KAPPA-EWFK',
-    'KATSU',
-    'KENZO-IGRW',
-    'KEVIN',
-    'KODAMA',
-    'KRANE-ZDKS',
-    'MAKOMO-UTTX',
-    'PICO-EXEM',
-    'QUACKINGSTICK',
-    'SCARLET',
-    'SPHERION',
-    'TOMATO-LYVN',
-    'WILLOW-TFIY',
-    'WORMDINGLER-JQAO',
+CHROMEOS_RECOVERY_ARM_BNAMES = [
+    'asurada',
+    'bob',
+    'cherry',
+    'elm',
+    'hana',
+    'jacuzzi',
+    'kevin',
+    'kukui',
+    'scarlet',
+    'strongbad',
 ]
 
-CHROMEOS_RECOVERY_ARM64_HWIDS = [
-    'KINGOFTOWN-KDDA',
-    'LAZOR',
-    'LIMOZEEN',
-    'MAGNETON-LCKC',
-    'PAZQUEL-HGNV',
-    'PAZQUEL-OPNA',
-    'POMPOM-MZVS',
-    'RUSTY-ZNCE',
-    'STEELIX-VZSZ',
-    'TENTACOOL-ZLJE',
-    'TENTACRUEL-VAFH',
+CHROMEOS_RECOVERY_ARM64_BNAMES = [
+    'corsola',
+    'trogdor',
 ]
 
 MINIMUM_INPUTSTREAM_VERSION_ARM64 = {

--- a/script.module.inputstreamhelper/resources/language/resource.language.en_gb/strings.po
+++ b/script.module.inputstreamhelper/resources/language/resource.language.en_gb/strings.po
@@ -21,6 +21,10 @@ msgctxt "#30002"
 msgid "This add-on relies on the proprietary decryption module [B]Widevine CDM[/B] for playback."
 msgstr ""
 
+msgctxt "#30003"
+msgid "Warning"
+msgstr ""
+
 msgctxt "#30004"
 msgid "Error"
 msgstr ""
@@ -267,6 +271,14 @@ msgstr ""
 
 msgctxt "#30069"
 msgid "Choose which version to install"
+msgstr ""
+
+msgctxt "#30070"
+msgid "Something seems wrong with the downloaded {filename}. Shall we try to continue anyway?"
+msgstr ""
+
+msgctxt "#30071"
+msgid "Could not find the Widevine CDM by a quick scan. Now doing a proper search, but this might take very long..."
 msgstr ""
 
 


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: InputStream Helper
  - Add-on ID: script.module.inputstreamhelper
  - Version number: 0.6.1+matrix.1
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/emilsvennesson/script.module.inputstreamhelper
  
A simple Kodi module that makes life easier for add-on developers relying on InputStream based add-ons and DRM playback.

### Description of changes:


v0.6.1 (2023-05-30)
- Performance improvements on Linux ARM
- This will be the last release for Python 2 i.e. Kodi 18 (Leia) and below. The next release will require Python 3 and Kodi 19 (Matrix) or higher.

v0.6.0 (2023-05-03)
- Initial support for AARCH64 Linux
- Initial support for AARCH64 Macs
- New option to install a specific version on most platforms

v0.5.10 (2022-04-18)
- Fix automatic submission of release
- Update German translation
- Fix update_frequency setting
- Fix install_from
- Improve/Fix Widevine extraction from Chrome OS images

v0.5.9 (2022-03-22)
- Update Croatian translation
- Replace deprecated LooseVersion
- Fix http_get decode error
- Option to install Widevine from specified source
    

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
