### PR TITLE
script.copacetic.helper 1.0.5

### DIFF
--- a/script.copacetic.helper/README.md
+++ b/script.copacetic.helper/README.md
@@ -14,14 +14,21 @@ All code contained in this project is licensed under GPL 3.0.
 
 ### Changelog
 
+**1.0.5**
+- Added script for easily re-ordering widgets in Copacetic settings screen
+
+**1.0.4**
+- Return dominant colour for home widgets when clearlogo cropper is active
+- Added fanart multiart to backgtround slideshows
+
 **1.0.3**
- - Updated fanart.
+- Updated fanart.
 
 **1.0.2**
- - Fixes for errors flagged by Kodi Addon Checker workflow during submission process.
+- Fixes for errors flagged by Kodi Addon Checker workflow during submission process.
 
 **1.0.1**
- - Fix for an error when the label passessd to the function clean_filename() was not escaped properly. Now to avoid the issue, by default, if no label is provided, the function will pull the listitem label directly using xbmc.getInfoLabel('ListItem.Label')
+- Fix for an error when the label passessd to the function clean_filename() was not escaped properly. Now to avoid the issue, by default, if no label is provided, the function will pull the listitem label directly using xbmc.getInfoLabel('ListItem.Label')
 
 **1.0.0** 
- - Initial release.
+- Initial release.

--- a/script.copacetic.helper/addon.xml
+++ b/script.copacetic.helper/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
-<addon id="script.copacetic.helper" name="Copacetic Helper" version="1.0.3" provider-name="realcopacetic">
+<addon id="script.copacetic.helper" name="Copacetic Helper" version="1.0.5" provider-name="realcopacetic">
   <requires>
     <import addon="xbmc.python" version="3.0.1" />
     <import addon="script.module.pil" version="5.1.0" />

--- a/script.copacetic.helper/resources/lib/script/actions.py
+++ b/script.copacetic.helper/resources/lib/script/actions.py
@@ -3,8 +3,8 @@
 import urllib.parse as urllib
 
 from resources.lib.service.art import ImageEditor
-from resources.lib.utilities import (DIALOG, clear_playlists, infolabel,
-                                     json_call, log_and_execute,
+from resources.lib.utilities import (DIALOG, clear_playlists, condition, infolabel,
+                                     json_call, log, log_and_execute, skin_string,
                                      window_property, xbmc)
 
 
@@ -266,3 +266,119 @@ def split_random_return(string, **kwargs):
 
     window_property(name, set=random)
     return random
+
+def widget_move(posa, posb, **kwargs):
+    tempa_name = ''
+    tempa_target = ''
+    tempa_sortmethod = ''
+    tempa_sortorder = ''
+    tempa_path = ''
+    tempa_limit = ''
+    tempa_thumb = False,
+    tempb_name = ''
+    tempb_target = ''
+    tempb_sortmethod = ''
+    tempb_sortorder = ''
+    tempb_path = ''
+    tempb_limit = ''
+    tempb_thumb = False
+
+    tempa_view = infolabel(f'Skin.String(Widget{posa}_View)')
+    tempa_display = infolabel(f'Skin.String(Widget{posa}_Display)')
+    tempb_view = infolabel(f'Skin.String(Widget{posb}_View)')
+    tempb_display = infolabel(f'Skin.String(Widget{posb}_Display)')
+
+    if condition(f'Skin.HasSetting(Widget{posa}_Content_Disabled)'):
+        tempa_content = 'Disabled'
+    elif condition(f'Skin.HasSetting(Widget{posa}_Content_InProgress)'):
+        tempa_content = 'InProgress'
+    elif condition(f'Skin.HasSetting(Widget{posa}_Content_NextUp)'):
+        tempa_content = 'NextUp'
+    elif condition(f'Skin.HasSetting(Widget{posa}_Content_LatestMovies)'):
+        tempa_content = 'LatestMovies'
+    elif condition(f'Skin.HasSetting(Widget{posa}_Content_LatestTVShows)'):
+        tempa_content = 'LatestTVShows'
+    elif condition(f'Skin.HasSetting(Widget{posa}_Content_RandomMovies)'):
+        tempa_content = 'RandomMovies'
+    elif condition(f'Skin.HasSetting(Widget{posa}_Content_RandomTVShows)'):
+        tempa_content = 'RandomTVShows'
+    elif condition(f'Skin.HasSetting(Widget{posa}_Content_LatestAlbums)'):
+        tempa_content = 'LatestAlbums'
+    elif condition(f'Skin.HasSetting(Widget{posa}_Content_RecentAlbums)'):
+        tempa_content = 'RecentAlbums'
+    elif condition(f'Skin.HasSetting(Widget{posa}_Content_RandomAlbums)'):
+        tempa_content = 'RandomAlbums'
+    elif condition(f'Skin.HasSetting(Widget{posa}_Content_LikedSongs)'):
+        tempa_content = 'LikedSongs'
+    elif condition(f'Skin.HasSetting(Widget{posa}_Content_Favourites)'):
+        tempa_content = 'Favourites'
+    elif condition(f'Skin.HasSetting(Widget{posa}_Content_Custom)'):
+        tempa_content = 'Custom'
+        tempa_name = infolabel(f'Skin.String(Widget{posa}_Custom_Name)')
+        tempa_target = infolabel(f'Skin.String(Widget{posa}_Custom_Target)')
+        tempa_sortmethod = infolabel(f'Skin.String(Widget{posa}_Custom_SortMethod)')
+        tempa_sortorder = infolabel(f'Skin.String(Widget{posa}_Custom_SortOrder)')
+        tempa_path = infolabel(f'Skin.String(Widget{posa}_Custom_Path)')
+        tempa_limit = infolabel(f'Skin.String(Widget{posa}_Custom_Limit)')
+        tempa_thumb = True if condition(f'Skin.HasSetting(Widget{posa}_Episode_Thumbs)') else False
+
+    if condition(f'Skin.HasSetting(Widget{posb}_Content_Disabled)'):
+        tempb_content = 'Disabled'
+    elif condition(f'Skin.HasSetting(Widget{posb}_Content_InProgress)'):
+        tempb_content = 'InProgress'
+    elif condition(f'Skin.HasSetting(Widget{posb}_Content_NextUp)'):
+        tempb_content = 'NextUp'
+    elif condition(f'Skin.HasSetting(Widget{posb}_Content_LatestMovies)'):
+        tempb_content = 'LatestMovies'
+    elif condition(f'Skin.HasSetting(Widget{posb}_Content_LatestTVShows)'):
+        tempb_content = 'LatestTVShows'
+    elif condition(f'Skin.HasSetting(Widget{posb}_Content_RandomMovies)'):
+        tempb_content = 'RandomMovies'
+    elif condition(f'Skin.HasSetting(Widget{posb}_Content_RandomTVShows)'):
+        tempb_content = 'RandomTVShows'
+    elif condition(f'Skin.HasSetting(Widget{posb}_Content_LatestAlbums)'):
+        tempb_content = 'LatestAlbums'
+    elif condition(f'Skin.HasSetting(Widget{posb}_Content_RecentAlbums)'):
+        tempb_content = 'RecentAlbums'
+    elif condition(f'Skin.HasSetting(Widget{posb}_Content_RandomAlbums)'):
+        tempb_content = 'RandomAlbums'
+    elif condition(f'Skin.HasSetting(Widget{posb}_Content_LikedSongs)'):
+        tempb_content = 'LikedSongs'
+    elif condition(f'Skin.HasSetting(Widget{posb}_Content_Favourites)'):
+        tempb_content = 'Favourites'
+    elif condition(f'Skin.HasSetting(Widget{posb}_Content_Custom)'):
+        tempb_content = 'Custom'
+        tempb_name = infolabel(f'Skin.String(Widget{posb}_Custom_Name)')
+        tempb_target = infolabel(f'Skin.String(Widget{posb}_Custom_Target)')
+        tempb_sortmethod = infolabel(f'Skin.String(Widget{posb}_Custom_SortMethod)')
+        tempb_sortorder = infolabel(f'Skin.String(Widget{posb}_Custom_SortOrder)')
+        tempb_path = infolabel(f'Skin.String(Widget{posb}_Custom_Path)')
+        tempb_limit = infolabel(f'Skin.String(Widget{posb}_Custom_Limit)')
+        tempb_thumb = True if condition(f'Skin.HasSetting(Widget{posb}_Episode_Thumbs)') else False
+    
+    xbmc.executebuiltin(f'Skin.ToggleSetting(Widget{posa}_Content_{tempa_content})')
+    xbmc.executebuiltin(f'Skin.SetBool(Widget{posa}_Content_{tempb_content})')
+    xbmc.executebuiltin(f'Skin.ToggleSetting(Widget{posb}_Content_{tempb_content})')
+    xbmc.executebuiltin(f'Skin.SetBool(Widget{posb}_Content_{tempa_content})')
+    skin_string(f'Widget{posb}_View', set=tempa_view)
+    skin_string(f'Widget{posa}_View', set=tempb_view)
+    skin_string(f'Widget{posb}_Display', set=tempa_display)
+    skin_string(f'Widget{posa}_Display', set=tempb_display)
+    skin_string(f'Widget{posb}_Custom_Name', set=tempa_name)
+    skin_string(f'Widget{posa}_Custom_Name', set=tempb_name)
+    skin_string(f'Widget{posb}_Custom_Target', set=tempa_target)
+    skin_string(f'Widget{posa}_Custom_Target', set=tempb_target)
+    skin_string(f'Widget{posb}_Custom_SortMethod', set=tempa_sortmethod)
+    skin_string(f'Widget{posa}_Custom_SortMethod', set=tempb_sortmethod)
+    skin_string(f'Widget{posb}_Custom_SortOrder', set=tempa_sortorder)
+    skin_string(f'Widget{posa}_Custom_SortOrder', set=tempb_sortorder)
+    skin_string(f'Widget{posb}_Custom_Path', set=tempa_path)
+    skin_string(f'Widget{posa}_Custom_Path', set=tempb_path)
+    skin_string(f'Widget{posb}_Custom_Limit', set=tempa_limit)
+    skin_string(f'Widget{posa}_Custom_Limit', set=tempb_limit)
+    if tempa_thumb and not tempb_thumb:
+        xbmc.executebuiltin(f'Skin.ToggleSetting(Widget{posa}_Episode_Thumbs)')
+        xbmc.executebuiltin(f'Skin.SetBool(Widget{posb}_Episode_Thumbs)')
+    elif tempb_thumb and not tempa_thumb:
+        xbmc.executebuiltin(f'Skin.ToggleSetting(Widget{posb}_Episode_Thumbs)')
+        xbmc.executebuiltin(f'Skin.SetBool(Widget{posa}_Episode_Thumbs)')

--- a/script.copacetic.helper/resources/lib/service/art.py
+++ b/script.copacetic.helper/resources/lib/service/art.py
@@ -280,7 +280,10 @@ class SlideshowMonitor:
 
     def _set_art(self, key, items):
         art = random.choice(items)
-        fanart = self._url_decode_path(art.get('fanart', ''))
+        # fanart = self._url_decode_path(art.get('fanart'))
+        fanarts = {key: value for (key, value) in art.items() if 'fanart' in key}
+        fanart = random.choice(list(fanarts.values()))
+        fanart = self._url_decode_path(fanart)
         window_property(f'{key}_Fanart', set=fanart)
         # clearlogo if present otherwise clear
         clearlogo = art.get('clearlogo', False)

--- a/script.copacetic.helper/resources/lib/service/monitor.py
+++ b/script.copacetic.helper/resources/lib/service/monitor.py
@@ -117,7 +117,7 @@ class Monitor(xbmc.Monitor):
             'Control.HasFocus(3209)]'
         ):
             widget = infolabel('System.CurrentControlID')
-            self._on_scroll(key=widget, return_color=False)
+            self._on_scroll(key=widget)
             self.waitForAbort(0.2)
 
         # slideshow window is visible run SlideshowMonitor()


### PR DESCRIPTION
### Description
**1.0.5**
- Added script for easily re-ordering widgets in Copacetic settings screen

**1.0.4**
- Return dominant colour for home widgets when clearlogo cropper is active
- Added fanart multiart to backgtround slideshows

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [X] Each add-on submission should be a single commit with using the following style: [script.foo.bar] 1.0.0

Additional information :
- Submitting your add-on to this specific branch makes it available to any Kodi version equal or higher than the branch name with the applicable Kodi dependencies limits.
- [add-on development](http://kodi.wiki/view/Add-on_development) wiki page.
- Kodi [pydocs](http://kodi.wiki/view/PyDocs) provide information about the Python API
- [PEP8](https://www.python.org/dev/peps/pep-0008/) codingstyle which is considered best practise but not mandatory.
- This add-on repository has automated code guideline check which could help you improve your coding. You can find the results of these check at [Codacy](https://www.codacy.com/app/Kodi/repo-scripts/dashboard). You can create your own account as well to continuously monitor your python coding before submitting to repo.
- Development questions can be asked in the [add-on development](http://forum.kodi.tv/forumdisplay.php?fid=26) section on the Kodi forum.
