### PR TITLE
[script.video.nfl.gamepass] 2023.07.05

### DIFF
--- a/script.video.nfl.gamepass/README.md
+++ b/script.video.nfl.gamepass/README.md
@@ -1,3 +1,16 @@
+# All good things come to an end
+
+After retiring NFL Gamepass Domestic in 2022, the NFL decided to shutdown the international Gamepass service
+as well in 2023, rendering this add-on obsolete.
+
+Outside of the States, DAZN is the new home for the NFL Gamepass service. You can watch the games with a DAZN
+account and an NFL Gamepass subscription.
+
+The good news is that there is a DAZN add-on available for Kodi, so it is still possible to watch NFL games on our
+most favorite media center.
+
+---
+
 # NOTE #
 
 This addon supports NFL Game Pass, which is a merger of previous

--- a/script.video.nfl.gamepass/addon.xml
+++ b/script.video.nfl.gamepass/addon.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
   <addon id="script.video.nfl.gamepass"
     name="NFL Game Pass"
-    version="2022.05.14"
+    version="2023.07.05"
     provider-name="Alexqw,divingmule,BaumSchorle,eriksoderblom,kaileu,emilsvennesson,baardisk,Duke">
   <requires>
     <import addon="xbmc.python" version="3.0.0"/>
@@ -15,17 +15,17 @@
   <extension point="xbmc.addon.metadata">
     <summary lang="en_GB">NFL Game Pass</summary>
     <description lang="en_GB">Watch NFL Game Pass streams.</description>
+    <lifecyclestate type="broken" lang="en_GB">The NFL canceled the NFL Gamepass service, rendering this add-on obsolete.</lifecyclestate>
     <platform>all</platform>
     <language>en</language>
     <license>GPL-2.0-only</license>
     <source>https://github.com/pigskin/kodi-gamepass</source>
-    <disclaimer lang="en_GB">This addon requires you to have a subscription to NFL Game Pass.[CR]Please note that these subscriptions are region restricted by the NFL.[CR]This addon is completely unofficial and is /not/ endorsed by the NFL in any way.</disclaimer>
-    <news>2022.05.14
-    + Adapt to API changes implemented by Diva (jm-duke)
-    + Fix issue with LV Raiders logo (jm-duke)
-    + Fix display of 'None' for focused games in game week view (jm-duke)
-    + Implemented some improvements highlighted by Bas Rieter (jm-duke)
-    + Minor refactorings (jm-duke)
+    <disclaimer lang="en_GB">The NFL canceled the NFL Gamepass service, rendering this add-on obsolete.</disclaimer>
+    <news>2023.07.05
+      + Mark add-on as broken, NFL has canceled the Gamepass service (jm-duke)
+      + Show date (or weekday) of game (AleXSR700)
+      + Toggle display of current week's games (jm-duke)
+      + Implement workaround for failed content URL retrieval (jm-duke)
     </news>
     <assets>
       <icon>resources/art/icon.png</icon>

--- a/script.video.nfl.gamepass/changelog.txt
+++ b/script.video.nfl.gamepass/changelog.txt
@@ -1,3 +1,16 @@
+2023.07.05 -- Farewell Edition
++ Mark add-on as broken, NFL has canceled the Gamepass service (jm-duke)
++ Show date (or weekday) of game (AleXSR700)
++ Toggle display of current week's games (jm-duke)
++ Implement workaround for failed content URL retrieval (jm-duke)
+
+2022.11.14 -- Aaron Rodgers Edition
++ Fix open settings from app bug (ohhmyy)
++ Use updated team logos (ohhmyy)
++ Remove code for fixed bitrates - adaptive is default (jm-duke)
++ Add busy dialog to NFL Network (ohhmyy)
++ Fix issue with recent NFL API change (jm-duke)
+
 2022.05.14 -- Drew Brees Edition
 + Adapt to API changes implemented by Diva (jm-duke)
 + Fix issue with LV Raiders logo (jm-duke)

--- a/script.video.nfl.gamepass/default.py
+++ b/script.video.nfl.gamepass/default.py
@@ -271,6 +271,13 @@ class GamepassGUI(xbmcgui.WindowXML):
             listitem.setProperty('is_game', 'true')
             listitem.setProperty('is_show', 'false')
 
+            if addon.getSetting('time_notation') == '0':  # 12-hour clock
+                datetime_format = '%A, %b %d - %I:%M %p'
+            else:  # 24-hour clock
+                datetime_format = '%A, %b %d - %H:%M'
+
+            datetime_obj = self.gp.nfldate_to_datetime(game['gameDateTimeUtc'], True)
+
             if game['phase'] == 'FINAL' or game['phase'] == 'FINAL_OVERTIME':
                 # show game duration only if user wants to see it
                 if addon.getSetting('hide_game_length') == 'false' and game['video']:
@@ -280,16 +287,16 @@ class GamepassGUI(xbmcgui.WindowXML):
                         game['phase'],
                         str(timedelta(seconds=int(float(game['video']['videoDuration'].replace(',', '.'))))))
                 else:
-                    game_info = game['phase']
-                    if addon.getSetting('hide_game_length') == 'true' and game_info == 'FINAL_OVERTIME':
-                        game_info = 'FINAL'
+                    if addon.getSetting('display_datetime') == 'true':
+                        if addon.getSetting('hide_game_length') == 'true' and game['phase'] != 'FINAL':
+                            game_info = 'FINAL' + '\n' + '(' + datetime_obj.strftime(datetime_format) +')'
+                        else:
+                            game_info = game['phase'] + '\n' + '(' + datetime_obj.strftime(datetime_format) +')'
+                    else:
+                        game_info = game['phase']
+                        if addon.getSetting('hide_game_length') == 'true' and game['phase'] != 'FINAL':
+                            game_info = 'FINAL'
             else:
-                if addon.getSetting('time_notation') == '0':  # 12-hour clock
-                    datetime_format = '%A, %b %d - %I:%M %p'
-                else:  # 24-hour clock
-                    datetime_format = '%A, %b %d - %H:%M'
-
-                datetime_obj = self.gp.nfldate_to_datetime(game['gameDateTimeUtc'], True)
                 game_info = datetime_obj.strftime(datetime_format)
 
             if game['videoStatus'] == 'SCHEDULED':
@@ -490,11 +497,13 @@ class GamepassGUI(xbmcgui.WindowXML):
 
                     try:
                         self.display_seasons_weeks()
-                        self.display_weeks_games()
+                        if addon.getSetting('display_current_week') == 'true':
+                            self.display_weeks_games()
                     except Exception as e:
                         logger.debug('Error while reading seasons weeks and games')
                         logger.debug('Trace Message:\n{}'.format(format_exc()))
                 elif controlId == 130:
+                    xbmc.executebuiltin('ActivateWindow(busydialognocancel)')
                     self.main_selection = 'NFL Network'
                     self.window.setProperty('NW_clicked', 'true')
                     self.window.setProperty('GP_clicked', 'false')
@@ -509,7 +518,7 @@ class GamepassGUI(xbmcgui.WindowXML):
 
                     self.live_list.addItems(self.live_items)
                     self.display_nfln_seasons()
-
+                    xbmc.executebuiltin('Dialog.Close(busydialognocancel)')
                 return
 
             if self.main_selection == 'GamePass':

--- a/script.video.nfl.gamepass/resources/language/resource.language.de_de/strings.po
+++ b/script.video.nfl.gamepass/resources/language/resource.language.de_de/strings.po
@@ -85,6 +85,10 @@ msgctxt "#30030"
 msgid "Display/Video"
 msgstr "Anzeige"
 
+msgctxt "#30031"
+msgid "Load and display games of current week"
+msgstr "Zeige die Spiele der aktuellen Woche"
+
 msgctxt "#30032"
 msgid "Coaches Film"
 msgstr ""
@@ -152,3 +156,7 @@ msgstr "Bitte geben Sie Benutzernamen und Passwort für Ihr NFL Game Pass Abo ei
 msgctxt "#30051"
 msgid "Inputstream Adaptive is not installed or is disabled."
 msgstr "Inputstream Adaptive ist nicht installiert oder nicht aktiviert."
+
+msgctxt "#30052"
+msgid "Display date and time of kickoff"
+msgstr "Zeige das Datum und die Uhrzeit des Kickoffs an"

--- a/script.video.nfl.gamepass/resources/language/resource.language.en_gb/strings.po
+++ b/script.video.nfl.gamepass/resources/language/resource.language.en_gb/strings.po
@@ -85,6 +85,10 @@ msgctxt "#30030"
 msgid "Display/Video"
 msgstr ""
 
+msgctxt "#30031"
+msgid "Load and display games of current week"
+msgstr ""
+
 msgctxt "#30032"
 msgid "Coaches Film"
 msgstr ""
@@ -151,4 +155,8 @@ msgstr ""
 
 msgctxt "#30051"
 msgid "Inputstream Adaptive is not installed or is disabled."
+msgstr ""
+
+msgctxt "#30052"
+msgid "Display date and time of kickoff"
 msgstr ""

--- a/script.video.nfl.gamepass/resources/language/resource.language.ja_jp/strings.po
+++ b/script.video.nfl.gamepass/resources/language/resource.language.ja_jp/strings.po
@@ -86,6 +86,10 @@ msgctxt "#30030"
 msgid "Display/Video"
 msgstr "デイスプレイ・ビデオ"
 
+msgctxt "#30031"
+msgid "Load and display games of current week"
+msgstr ""
+
 msgctxt "#30032"
 msgid "Coaches Film"
 msgstr "監督フィルム集"
@@ -152,4 +156,8 @@ msgstr ""
 
 msgctxt "#30051"
 msgid "Inputstream Adaptive is not installed or is disabled."
+msgstr ""
+
+msgctxt "#30052"
+msgid "Display date and time of kickoff"
 msgstr ""

--- a/script.video.nfl.gamepass/resources/language/resource.language.nl_nl/strings.po
+++ b/script.video.nfl.gamepass/resources/language/resource.language.nl_nl/strings.po
@@ -85,6 +85,10 @@ msgctxt "#30030"
 msgid "Display/Video"
 msgstr "Weergave/Video"
 
+msgctxt "#30031"
+msgid "Load and display games of current week"
+msgstr ""
+
 msgctxt "#30032"
 msgid "Coaches Film"
 msgstr "Coaches Film"
@@ -151,4 +155,8 @@ msgstr "Vul de gebruikersnaam en wachtwoord in van uw NFL Game Pass abonnement."
 
 msgctxt "#30051"
 msgid "Inputstream Adaptive is not installed or is disabled."
+msgstr ""
+
+msgctxt "#30052"
+msgid "Display date and time of kickoff"
 msgstr ""

--- a/script.video.nfl.gamepass/resources/language/resource.language.ru_ru/strings.po
+++ b/script.video.nfl.gamepass/resources/language/resource.language.ru_ru/strings.po
@@ -86,8 +86,8 @@ msgid "Display/Video"
 msgstr "Воспроизведение/Видео"
 
 msgctxt "#30031"
-msgid "Advanced"
-msgstr "Продвинутые"
+msgid "Load and display games of current week"
+msgstr ""
 
 msgctxt "#30032"
 msgid "Coaches Film"
@@ -155,4 +155,8 @@ msgstr ""
 
 msgctxt "#30051"
 msgid "Inputstream Adaptive is not installed or is disabled."
+msgstr ""
+
+msgctxt "#30052"
+msgid "Display date and time of kickoff"
 msgstr ""

--- a/script.video.nfl.gamepass/resources/language/resource.language.uk_ua/strings.po
+++ b/script.video.nfl.gamepass/resources/language/resource.language.uk_ua/strings.po
@@ -86,8 +86,8 @@ msgid "Display/Video"
 msgstr "Відображення/Відео"
 
 msgctxt "#30031"
-msgid "Advanced"
-msgstr "Просунуті"
+msgid "Load and display games of current week"
+msgstr ""
 
 msgctxt "#30032"
 msgid "Coaches Film"
@@ -155,4 +155,8 @@ msgstr ""
 
 msgctxt "#30051"
 msgid "Inputstream Adaptive is not installed or is disabled."
+msgstr ""
+
+msgctxt "#30052"
+msgid "Display date and time of kickoff"
 msgstr ""

--- a/script.video.nfl.gamepass/resources/lib/pigskin/pigskin.py
+++ b/script.video.nfl.gamepass/resources/lib/pigskin/pigskin.py
@@ -933,7 +933,10 @@ class pigskin(object):
             except Exception as e:
                 raise e
 
-            streams[vs_format] = data['ContentUrl'] + '|' + urlencode(m3u8_header)
+            if isinstance(data, dict) and 'ContentUrl' in data:
+                streams[vs_format] = data['ContentUrl'] + '|' + urlencode(m3u8_header)
+            else:
+                continue
 
         return streams
 

--- a/script.video.nfl.gamepass/resources/settings.xml
+++ b/script.video.nfl.gamepass/resources/settings.xml
@@ -66,6 +66,22 @@
           <level>0</level>
           <default>false</default>
           <control type="toggle"/>
+          <dependencies>
+            <dependency type="enable" operator="!is" setting="display_datetime">true</dependency>
+          </dependencies>
+        </setting>
+        <setting help="" id="display_datetime" label="30052" type="boolean">
+          <level>0</level>
+          <default>false</default>
+          <control type="toggle"/>
+          <dependencies>
+            <dependency type="enable" operator="is" setting="hide_game_length">true</dependency>
+          </dependencies>
+        </setting>
+        <setting help="" id="display_current_week" label="30031" type="boolean">
+          <level>0</level>
+          <default>true</default>
+          <control type="toggle"/>
         </setting>
       </group>
     </category>


### PR DESCRIPTION
### Description
**Addon**

Name: NFL Game Pass
ID: script.video.nfl.gamepass
Version: n/a
Source: https://github.com/pigskin/kodi-gamepass

**Info**

NFL has canceled the NFL Gamepass service, making this add-on obsolete. This PR updates the add-on to the latest code base and marks it as broken.

### Checklist:
- [X] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [X] Each add-on submission should be a single commit with using the following style: [script.foo.bar] 1.0.0
