### PR TITLE
[script.timers] 3.7.0

### DIFF
--- a/script.timers/addon.xml
+++ b/script.timers/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.timers" name="Timers" version="3.6.0" provider-name="Heckie">
+<addon id="script.timers" name="Timers" version="3.7.0" provider-name="Heckie">
   <requires>
     <import addon="xbmc.python" version="3.0.0" />
   </requires>
@@ -66,6 +66,10 @@
     <website>https://github.com/Heckie75/kodi-addon-timers</website>
     <source>https://github.com/Heckie75/kodi-addon-timers</source>
     <news>
+v3.7.0 (2023-06-30)
+- If you stop explicitly playback while a start-stop-timer is running there won't be another stop action anymore when this timer runs out.
+- Added workaround that streamed video (probably mpeg-dash) immediately stops after timer has started (only happened if 'seek to correct time if timer starts belatedly' is activated)
+
 v3.6.0 (2023-04-16)
 - Smart shuffle mode for slideshows (try randomly to find folder that fits into timeframe)
 - Fixed resuming slideshow at right position
@@ -87,10 +91,7 @@ v3.3.1 (2022-11-26)
 - Bugfix: scheduled timers stop working that are scheduled after Sunday (week change Sun -> Mon)
 - Refactoring
 
-v3.3.0 (2022-10-08)
-- Improved scheduler that enables scheduling to the second, reduces CPU load on idle and enables smoother fading
-- Added fields for start and end time in order to schedule to the second (expert only)
-- Fixed Zattoo PVR support and other audio/video addons
+Complete changelog see https://github.com/Heckie75/kodi-addon-timers
     </news>
     <assets>
       <icon>resources/assets/icon.png</icon>

--- a/script.timers/resources/language/resource.language.de_de/strings.po
+++ b/script.timers/resources/language/resource.language.de_de/strings.po
@@ -677,6 +677,10 @@ msgctxt "#32288"
 msgid "run addon"
 msgstr "führe Addon aus"
 
+msgctxt "#32289"
+msgid "interrupt running timers"
+msgstr "unterbreche laufende Timer"
+
 msgctxt "#32300"
 msgid "Opens a dialog where you can enter a duration for pause from now."
 msgstr "Öffnet einen Dialog zur Eingabe der Dauer von jetzt an."

--- a/script.timers/resources/language/resource.language.en_gb/strings.po
+++ b/script.timers/resources/language/resource.language.en_gb/strings.po
@@ -677,6 +677,10 @@ msgctxt "#32288"
 msgid "run addon"
 msgstr ""
 
+msgctxt "#32289"
+msgid "interrupt running timers"
+msgstr ""
+
 msgctxt "#32300"
 msgid "Opens a dialog where you can enter a duration for pause from now."
 msgstr ""

--- a/script.timers/resources/lib/timer/notification.py
+++ b/script.timers/resources/lib/timer/notification.py
@@ -1,0 +1,13 @@
+import xbmcaddon
+import xbmcgui
+from resources.lib.timer.timer import Timer
+from resources.lib.utils.vfs_utils import get_asset_path
+
+
+def showNotification(timer: Timer, msg_id: int, icon="icon_timers.png") -> None:
+
+    if timer.notify:
+        addon = xbmcaddon.Addon()
+        icon_path = get_asset_path(icon)
+        xbmcgui.Dialog().notification(
+            timer.label, addon.getLocalizedString(msg_id), icon_path)

--- a/script.timers/resources/lib/timer/scheduleraction.py
+++ b/script.timers/resources/lib/timer/scheduleraction.py
@@ -7,11 +7,11 @@ from resources.lib.player.mediatype import AUDIO, PICTURE, TYPES, VIDEO
 from resources.lib.player.player import Player
 from resources.lib.player.player_utils import (get_types_replaced_by_type,
                                                run_addon)
+from resources.lib.timer.notification import showNotification
 from resources.lib.timer.storage import Storage
-from resources.lib.timer.timer import (END_TYPE_NO, FADE_IN_FROM_MIN,
-                                       FADE_OUT_FROM_CURRENT, STATE_ENDING,
-                                       STATE_RUNNING, STATE_STARTING,
-                                       STATE_WAITING,
+from resources.lib.timer.timer import (FADE_IN_FROM_MIN, FADE_OUT_FROM_CURRENT,
+                                       STATE_ENDING, STATE_RUNNING,
+                                       STATE_STARTING, STATE_WAITING,
                                        SYSTEM_ACTION_CEC_STANDBY,
                                        SYSTEM_ACTION_HIBERNATE,
                                        SYSTEM_ACTION_POWEROFF,
@@ -20,7 +20,6 @@ from resources.lib.timer.timer import (END_TYPE_NO, FADE_IN_FROM_MIN,
                                        SYSTEM_ACTION_STANDBY, TIMER_WEEKLY,
                                        Timer)
 from resources.lib.utils.datetime_utils import DateTimeDelta, abs_time_diff
-from resources.lib.utils.vfs_utils import get_asset_path
 
 
 class SchedulerAction:
@@ -289,34 +288,34 @@ class SchedulerAction:
         def _performPlayerAction(_now: DateTimeDelta) -> None:
 
             if self.timerToPlayAV:
-                _showNotification(self.timerToPlayAV, msg_id=32280)
+                showNotification(self.timerToPlayAV, msg_id=32280)
                 self._player.playTimer(self.timerToPlayAV, _now)
 
             elif self.timerToStopAV:
-                _showNotification(self.timerToStopAV, msg_id=32281)
+                showNotification(self.timerToStopAV, msg_id=32281)
                 self._player.resumeFormerOrStop(self.timerToStopAV)
 
             elif self.timerToPauseAV and not self._player.isPaused():
-                _showNotification(self.timerToPauseAV, msg_id=32282)
+                showNotification(self.timerToPauseAV, msg_id=32282)
                 self._player.pause()
 
             elif self.timerToUnpauseAV and self._player.isPaused():
-                _showNotification(self.timerToUnpauseAV, msg_id=32283)
+                showNotification(self.timerToUnpauseAV, msg_id=32283)
                 self._player.pause()
 
             elif self.fader:
-                _showNotification(self.fader, msg_id=32284)
+                showNotification(self.fader, msg_id=32284)
 
             for type in set(self._forceResumeResetTypes):
                 self._player.resetResumeStatus(type)
 
             if not self.timerToPlayAV or self.timerToPlayAV.media_type != VIDEO:
                 if self.timerToPlaySlideshow:
-                    _showNotification(self.timerToPlaySlideshow, msg_id=32286)
+                    showNotification(self.timerToPlaySlideshow, msg_id=32286)
                     self._player.playTimer(self.timerToPlaySlideshow, _now)
 
                 elif self.timerToStopSlideshow:
-                    _showNotification(self.timerToStopSlideshow, msg_id=32287)
+                    showNotification(self.timerToStopSlideshow, msg_id=32287)
                     self._player.resumeFormerOrStop(self.timerToStopSlideshow)
 
         def _setVolume(dtd: DateTimeDelta) -> None:
@@ -333,14 +332,6 @@ class SchedulerAction:
             if ending_faders:
                 self._player.setVolume(
                     max(ending_faders, key=lambda t: t.return_vol).return_vol)
-
-        def _showNotification(timer: Timer, msg_id: int, icon="icon_timers.png") -> None:
-
-            if timer.notify:
-                addon = xbmcaddon.Addon()
-                icon_path = get_asset_path(icon)
-                xbmcgui.Dialog().notification(
-                    timer.label, addon.getLocalizedString(msg_id), icon_path)
 
         def _consumeSingleRunTimers() -> None:
 
@@ -363,7 +354,7 @@ class SchedulerAction:
         def _runScripts() -> None:
 
             for timer in self.timersToRunScript:
-                _showNotification(timer, msg_id=32288)
+                showNotification(timer, msg_id=32288)
                 run_addon(timer.path)
 
         def _performSystemAction() -> None:
@@ -372,27 +363,27 @@ class SchedulerAction:
                 pass
 
             elif self.timerWithSystemAction.system_action == SYSTEM_ACTION_SHUTDOWN_KODI:
-                _showNotification(self.timerWithSystemAction, msg_id=32082)
+                showNotification(self.timerWithSystemAction, msg_id=32082)
                 xbmc.shutdown()
 
             elif self.timerWithSystemAction.system_action == SYSTEM_ACTION_QUIT_KODI:
-                _showNotification(self.timerWithSystemAction, msg_id=32083)
+                showNotification(self.timerWithSystemAction, msg_id=32083)
                 xbmc.executebuiltin("Quit()")
 
             elif self.timerWithSystemAction.system_action == SYSTEM_ACTION_STANDBY:
-                _showNotification(self.timerWithSystemAction, msg_id=32084)
+                showNotification(self.timerWithSystemAction, msg_id=32084)
                 xbmc.executebuiltin("Suspend()")
 
             elif self.timerWithSystemAction.system_action == SYSTEM_ACTION_HIBERNATE:
-                _showNotification(self.timerWithSystemAction, msg_id=32085)
+                showNotification(self.timerWithSystemAction, msg_id=32085)
                 xbmc.executebuiltin("Hibernate()")
 
             elif self.timerWithSystemAction.system_action == SYSTEM_ACTION_POWEROFF:
-                _showNotification(self.timerWithSystemAction, msg_id=32086)
+                showNotification(self.timerWithSystemAction, msg_id=32086)
                 xbmc.executebuiltin("Powerdown()")
 
             elif self.timerWithSystemAction.system_action == SYSTEM_ACTION_CEC_STANDBY:
-                _showNotification(self.timerWithSystemAction, msg_id=32093)
+                showNotification(self.timerWithSystemAction, msg_id=32093)
                 xbmc.executebuiltin("CECStandby()")
 
         def _adjustState() -> None:


### PR DESCRIPTION
### Description
v3.7.0 (2023-06-30)
- If you stop explicitly playback while a start-stop-timer is running there won't be another stop action anymore when this timer runs out.
- Added workaround that streamed video (probably mpeg-dash) immediately stops after timer has started (only happened if 'seek to correct time if timer starts belatedly' is activated)

### Checklist:
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [script.foo.bar] 1.0.0