### PR TITLE
[script.module.libard] v6.0.2

### DIFF
--- a/script.module.libard/addon.xml
+++ b/script.module.libard/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.module.libard" name="libard" version="6.0.1" provider-name="sarbes">
+<addon id="script.module.libard" name="libard" version="6.0.2" provider-name="sarbes">
   <requires>
     <import addon="xbmc.python" version="3.0.0"/>
     <import addon="script.module.libmediathek4" version="1.0.0"/>

--- a/script.module.libard/lib/libardnewjsonparser.py
+++ b/script.module.libard/lib/libardnewjsonparser.py
@@ -144,7 +144,7 @@ class parser:
 				d['metadata']['art']['thumb'] = teaser['images']['aspect16x9']['src'].format(width='512')
 			if 'aspect3x4' in teaser['images']:
 				d['metadata']['art']['poster'] = teaser['images']['aspect3x4']['src'].format(width='512')
-		if 'show' in teaser and 'images' in teaser['show'] and '16x9' in teaser['show']['images']:
+		if 'show' in teaser and teaser['show'] and 'images' in teaser['show'] and teaser['show']['images'] and '16x9' in teaser['show']['images']:
 			d['metadata']['art']['fanart'] = teaser['show']['images']['16x9']['src'].format(width='512')
 		if client:
 			d['params']['client'] = client


### PR DESCRIPTION
### Description
prevent "TypeError: argument of type 'NoneType' is not iterable" on using the plugin "plugin.video.sportschau"

### Checklist:
- [X] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [X] Each add-on submission should be a single commit with using the following style: [script.foo.bar] 1.0.0

