### PR TITLE
[script.module.codequick@matrix] 1.0.3+matrix.1

### DIFF
--- a/script.module.codequick/addon.xml
+++ b/script.module.codequick/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.module.codequick" name="CodeQuick" provider-name="willforde" version="1.0.2+matrix.1">
+<addon id="script.module.codequick" name="CodeQuick" provider-name="willforde" version="1.0.3+matrix.1">
     <requires>
         <import addon="xbmc.python" version="3.0.0"/>
         <import addon="script.module.youtube.dl" version="19.912.1"/>

--- a/script.module.codequick/lib/urlquick.py
+++ b/script.module.codequick/lib/urlquick.py
@@ -60,7 +60,6 @@ except ImportError:
 # Third Party
 from htmlement import HTMLement
 from requests.structures import CaseInsensitiveDict
-from requests.adapters import HTTPResponse
 from requests import adapters
 from requests import *
 import requests


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: CodeQuick
  - Add-on ID: script.module.codequick
  - Version number: 1.0.3+matrix.1
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/willforde/script.module.codequick
  
Codequick is a framework for kodi add-on's. The goal of this framework is to simplify add-on development. This is achieved by reducing the amount of boilerplate code to a minimum, automating tasks like route dispatching and sort method selection. Ultimately allowing the developer to focus primarily on scraping content from websites and passing it to kodi.

### Description of changes:

Removed HTTPResponse from urlquick as it did not work with requests 2.31. It was only used for type annotations anyway.

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
