### PR TITLE
[script.service.playbackresumer@matrix] 2.0.5

### DIFF
--- a/script.service.playbackresumer/addon.xml
+++ b/script.service.playbackresumer/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.service.playbackresumer" name="Kodi Playback Resumer" version="2.0.4" provider-name="bossanova808, bradvido88">
+<addon id="script.service.playbackresumer" name="Kodi Playback Resumer" version="2.0.5" provider-name="bossanova808, bradvido88">
   <requires>
     <import addon="xbmc.python" version="3.0.0"/>
   </requires>
@@ -15,8 +15,8 @@
     <source>https://github.com/bossanova808/script.service.playbackresumer</source>
     <forum>https://forum.kodi.tv/showthread.php?tid=355383</forum>
     <email>bossanova808@gmail.com</email>
-    <news>v2.0.4
-      - Handle unicode characters in video names
+    <news>v2.0.5
+      - Fix odd reported bug with resume points
     </news>
     <assets>
       <icon>icon.png</icon>

--- a/script.service.playbackresumer/changelog.txt
+++ b/script.service.playbackresumer/changelog.txt
@@ -1,3 +1,6 @@
+v2.0.5
+- Fix wierd bug with resume points: https://forum.kodi.tv/showthread.php?tid=355383&pid=3163480#pid3163480
+
 v2.0.4
 - Handle unicode characters in video names
 

--- a/script.service.playbackresumer/resources/lib/player.py
+++ b/script.service.playbackresumer/resources/lib/player.py
@@ -179,11 +179,11 @@ class KodiPlayer(xbmc.Player):
                 id_name: Store.library_id,
                 "resume": {
                     "position": seconds,
-                    # "total": 0 # Not needed: https://forum.kodi.tv/showthread.php?tid=161912&pid=1596436#pid1596436
+                    "total": Store.length_of_currently_playing_file
                 }
             }
         })
-        send_kodi_json(f'Set resume point to {seconds}', query)
+        send_kodi_json(f'Set resume point to {seconds}, total to {Store.length_of_currently_playing_file}', query)
 
         # For debugging - let's retrieve and log the current resume point...
         query = json.dumps({
@@ -195,7 +195,7 @@ class KodiPlayer(xbmc.Player):
                 "properties": ["resume"],
             }
         })
-        send_kodi_json(f'Get resume point for id {Store.library_id}', query)
+        send_kodi_json(f'Check new resume point & total for id {Store.library_id}', query)
 
     def resume_if_was_playing(self):
         """


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: Kodi Playback Resumer
  - Add-on ID: script.service.playbackresumer
  - Version number: 2.0.5
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/bossanova808/script.service.playbackresumer
  

        Runs as a service and will periodically update the resume point while videos are playing, so you can re-start from where you were in the event of a crash.  It can also automatically resume a video if Kodi was shutdown while playing it. See setting to configure how often the resume point is set, and whether to automatically resume.
    

### Description of changes:

v2.0.5
      - Fix odd reported bug with resume points (https://forum.kodi.tv/showthread.php?tid=355383&pid=3163480#pid3163480)
    

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
