### PR TITLE
[script.service.hyperion-control@nexus] 20.0.0

### DIFF
--- a/script.service.hyperion-control/addon.xml
+++ b/script.service.hyperion-control/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon id="script.service.hyperion-control" name="Hyperion Control" version="20.0.0" provider-name="hyperion-project">
   <requires>
-	<import addon="xbmc.addon"  version="20.0.0"/>
+	<import addon="xbmc.addon"  version="20.0.1"/>
     <import addon="xbmc.python" version="3.0.1"/>
     <import addon="script.module.requests" version="2.3.0"/>
   </requires>
@@ -17,6 +17,9 @@
     <website>https://hyperion-project.org/forum</website>
     <source>https://github.com/hyperion-project/hyperion.control</source>
     <news>
+      20.0.1
+      - Removed redundant debug setting
+
       20.0.0
       - Kodi 20 (Nexus) support
       - Multi instance handling

--- a/script.service.hyperion-control/resources/__init__.py
+++ b/script.service.hyperion-control/resources/__init__.py
@@ -1,0 +1,1 @@
+"""Hyperion control addon resources."""

--- a/script.service.hyperion-control/resources/language/resource.language.de_de/strings.po
+++ b/script.service.hyperion-control/resources/language/resource.language.de_de/strings.po
@@ -38,11 +38,6 @@ msgid "Disable Hyperion on shutdown"
 msgstr "Deaktiviere Hyperion beim Beenden"
 
 #:
-msgctxt "#32006"
-msgid "Enable Debug"
-msgstr "Aktiviere Debugging"
-
-#:
 msgctxt "#32007"
 msgid "Show changelog after update"
 msgstr "Zeige Änderungen nach Update"

--- a/script.service.hyperion-control/resources/language/resource.language.en_gb/strings.po
+++ b/script.service.hyperion-control/resources/language/resource.language.en_gb/strings.po
@@ -38,11 +38,6 @@ msgid "Disable Hyperion on shutdown"
 msgstr "Disable Hyperion on shutdown"
 
 #:
-msgctxt "#32006"
-msgid "Enable Debug"
-msgstr "Enable Debug"
-
-#:
 msgctxt "#32007"
 msgid "Show changelog after update"
 msgstr "Show changelog after update"

--- a/script.service.hyperion-control/resources/language/resource.language.es_es/strings.po
+++ b/script.service.hyperion-control/resources/language/resource.language.es_es/strings.po
@@ -38,11 +38,6 @@ msgid "Disable Hyperion on shutdown"
 msgstr "Deshabilitar Hyperion al apagar"
 
 #:
-msgctxt "#32006"
-msgid "Enable Debug"
-msgstr "Habilitar la Depuración"
-
-#:
 msgctxt "#32007"
 msgid "Show changelog after update"
 msgstr "Mostrar el registro de cambios tras la actualización"

--- a/script.service.hyperion-control/resources/language/resource.language.fr_fr/strings.po
+++ b/script.service.hyperion-control/resources/language/resource.language.fr_fr/strings.po
@@ -38,11 +38,6 @@ msgid "Disable Hyperion on shutdown"
 msgstr "Désactiver Hyperion à l'extinction"
 
 #:
-msgctxt "#32006"
-msgid "Enable Debug"
-msgstr "Activer le débogage"
-
-#:
 msgctxt "#32007"
 msgid "Show changelog after update"
 msgstr "Afficher le changelog après la mise à jour"

--- a/script.service.hyperion-control/resources/language/resource.language.hu_hu/strings.po
+++ b/script.service.hyperion-control/resources/language/resource.language.hu_hu/strings.po
@@ -38,11 +38,6 @@ msgid "Disable Hyperion on shutdown"
 msgstr "Hyperion kikapcsolása leállításkor"
 
 #:
-msgctxt "#32006"
-msgid "Enable Debug"
-msgstr "Hibakeresés engedélyezése"
-
-#:
 msgctxt "#32007"
 msgid "Show changelog after update"
 msgstr "Változásnapló megjelenítése frissítés után"

--- a/script.service.hyperion-control/resources/language/resource.language.pl_pl/strings.po
+++ b/script.service.hyperion-control/resources/language/resource.language.pl_pl/strings.po
@@ -38,11 +38,6 @@ msgid "Disable Hyperion on shutdown"
 msgstr "Wyłącz Hyperion przy zamknięciu systemu"
 
 #:
-msgctxt "#32006"
-msgid "Enable Debug"
-msgstr "Włącz debugowanie"
-
-#:
 msgctxt "#32007"
 msgid "Show changelog after update"
 msgstr "Pokaż dziennik zmian po aktualizacji"

--- a/script.service.hyperion-control/resources/lib/hyperion.py
+++ b/script.service.hyperion-control/resources/lib/hyperion.py
@@ -52,8 +52,7 @@ class Hyperion:
 
     def notify(self, command: str) -> None:
         """Process the commands sent by the observables."""
-        if self._settings.debug:
-            self._logger.log(f"received command: {command}")
+        self._logger.log(f"received command: {command}")
         if command == "updateSettings":
             self.update_settings()
         else:

--- a/script.service.hyperion-control/resources/lib/interfaces.py
+++ b/script.service.hyperion-control/resources/lib/interfaces.py
@@ -44,7 +44,6 @@ class SettingsManager(Protocol):
     menu_enabled: bool
     show_changelog_on_update: bool
     tasks: int
-    debug: bool
     first_run: bool
 
     @property

--- a/script.service.hyperion-control/resources/lib/settings_manager.py
+++ b/script.service.hyperion-control/resources/lib/settings_manager.py
@@ -49,7 +49,6 @@ class SettingsManager:
         self.menu_enabled: bool
         self.show_changelog_on_update: bool
         self.tasks: int
-        self.debug: bool
         self.first_run: bool
         self.read_settings()
 
@@ -108,7 +107,7 @@ class SettingsManager:
     def _log_set_outcome(self, name: str, value: Any, outcome: bool) -> None:
         if not outcome:
             self._logger.error(f"Error setting {name} to {value} (outcome={outcome})")
-        elif self.debug:
+        else:
             self._logger.log(f"Set {name} to {value}")
 
     def set_tasks(self, value: int) -> None:
@@ -140,7 +139,6 @@ class SettingsManager:
         self.enable_hyperion = get_bool("enableHyperion")
         self.disable_hyperion = get_bool("disableHyperion")
         self.show_changelog_on_update = get_bool("showChangelogOnUpdate")
-        self.debug = get_bool("debug")
         self.first_run = get_bool("firstRun")
         self.current_version = get_string("currAddonVersion")
 
@@ -155,8 +153,7 @@ class SettingsManager:
         self.tasks = get_int("tasks")
         self.rev += 1
 
-        if self.debug:
-            self._log_settings()
+        self._log_settings()
 
     def _log_settings(self) -> None:
         log = self._logger.log
@@ -172,7 +169,6 @@ class SettingsManager:
         log(f"Audio enabled:         {self.audio_enabled}")
         log(f"Pause enabled:         {self.pause_enabled}")
         log(f"Menu enabled:          {self.menu_enabled}")
-        log(f"Debug enabled:         {self.debug}")
         log(f"ChangelogOnUpdate:     {self.show_changelog_on_update}")
         log(f"tasks:                 {self.tasks}")
         log(f"first run:             {self.first_run}")

--- a/script.service.hyperion-control/resources/settings.xml
+++ b/script.service.hyperion-control/resources/settings.xml
@@ -8,7 +8,6 @@
         <setting id="enableHyperion" type="bool" label="32004" default="false" />
         <setting id="disableHyperion" type="bool" label="32005" default="false" />
         <setting id="showChangelogOnUpdate" type="bool" label="32007" default="true" visible="true" />
-        <setting id="debug" type="bool" label="32006" default="false" />
         <setting id="firstRun" type="bool" label="32000" default="true" visible="false" />
         <setting id="currAddonVersion" type="text" default="" visible="false" />
     </category>


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: Hyperion Control
  - Add-on ID: script.service.hyperion-control
  - Version number: 20.0.0
  - Kodi/repository version: nexus

- **Code location**
  - URL: https://github.com/hyperion-project/hyperion.control
  
Enable and disable components (like capture) of Hyperion automatically based on playing/screensaver state of Kodi[CR]-Supports auto detection of Hyperion Servers[CR]-Token authentication

### Description of changes:


      20.0.1
      - Removed redundant debug setting

      20.0.0
      - Kodi 20 (Nexus) support
      - Multi instance handling
      - New language: Hungarian

      19.0.2
      - New languages: Español, Français, Polski

      19.0.1
      - Kodi 19 support
      - minor cleanups and corrections

      1.0.1
      - Fixed a crash with 3d mode @b-jesch

      1.0.0
      - Added support for server search
      - Added support token authentication
      - Fixed issue where kodi api does not properly announce video playing states
    

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
