### PR TITLE
[script.service.hyperion-control@nexus] 20.0.1

### DIFF
--- a/script.service.hyperion-control/addon.xml
+++ b/script.service.hyperion-control/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<addon id="script.service.hyperion-control" name="Hyperion Control" version="20.0.0" provider-name="hyperion-project">
+<addon id="script.service.hyperion-control" name="Hyperion Control" version="20.0.1" provider-name="hyperion-project">
   <requires>
 	<import addon="xbmc.addon"  version="20.0.0"/>
     <import addon="xbmc.python" version="3.0.1"/>
@@ -17,6 +17,9 @@
     <website>https://hyperion-project.org/forum</website>
     <source>https://github.com/hyperion-project/hyperion.control</source>
     <news>
+      20.0.1
+      - Removed redundant debug setting
+
       20.0.0
       - Kodi 20 (Nexus) support
       - Multi instance handling

--- a/script.service.hyperion-control/resources/__init__.py
+++ b/script.service.hyperion-control/resources/__init__.py
@@ -1,0 +1,1 @@
+"""Hyperion control addon resources."""

--- a/script.service.hyperion-control/resources/language/resource.language.de_de/strings.po
+++ b/script.service.hyperion-control/resources/language/resource.language.de_de/strings.po
@@ -7,192 +7,188 @@ msgstr ""
 "Project-Id-Version: Hyperion Control\n"
 "Language: de\n"
 
-#:
+#: 
 msgctxt "#32000"
 msgid "General"
 msgstr "Allgemein"
 
-#:
+#: 
 msgctxt "#32001"
 msgid "Hyperion IP"
 msgstr "Hyperion IP"
 
-#:
+#: 
 msgctxt "#32002"
 msgid "Hyperion Webserver Port"
 msgstr "Hyperion Webserver Port"
 
-#:
+#: 
 msgctxt "#32003"
 msgid "Switch automatically between 2D/3D"
 msgstr "Automatisch auf 2D/3D umstellen"
 
-#:
+#: 
 msgctxt "#32004"
 msgid "Enable Hyperion on startup"
 msgstr "Aktiviere Hyperion beim Starten"
 
-#:
+#: 
 msgctxt "#32005"
 msgid "Disable Hyperion on shutdown"
 msgstr "Deaktiviere Hyperion beim Beenden"
 
-#:
-msgctxt "#32006"
-msgid "Enable Debug"
-msgstr "Aktiviere Debugging"
-
-#:
+#: 
 msgctxt "#32007"
 msgid "Show changelog after update"
 msgstr "Zeige Änderungen nach Update"
 
-#:
+#: 
 msgctxt "#32008"
 msgid "Authorization Token"
 msgstr "Autorisierungs-Token"
 
-#:
+#: 
 msgctxt "#32025"
 msgid "Component"
 msgstr "Komponente"
 
-#:
+#: 
 msgctxt "#32026"
 msgid "Enable the chosen component in these situations else disable it."
 msgstr "Aktiviere die Komponente in folgenden Situationen, sonst wird sie deaktiviert."
 
-#:
+#: 
 msgctxt "#32027"
 msgid "Hyperion component"
 msgstr "Hyperion Komponente"
 
-#:
+#: 
 msgctxt "#32028"
 msgid "Enable during video playback"
 msgstr "Aktiviere bei Videos"
 
-#:
+#: 
 msgctxt "#32029"
 msgid "Enable during music playback"
 msgstr "Aktiviere bei Musik"
 
-#:
+#: 
 msgctxt "#32030"
 msgid "Enable during player pause"
 msgstr "Aktiviere bei pausiertem Player"
 
-#:
+#: 
 msgctxt "#32031"
 msgid "Enable in Kodi menu"
 msgstr "Aktiviere im Kodi Menü"
 
-#:
+#: 
 msgctxt "#32032"
 msgid "Enable during active screensaver"
 msgstr "Aktiviere bei Bildschirmschoner"
 
-#:
+#: 
 msgctxt "#32041"
 msgid "USB Capture"
 msgstr "USB Aufnahme"
 
-#:
+#: 
 msgctxt "#32042"
 msgid "LED Hardware"
 msgstr "LED Hardware"
 
-#:
+#: 
 msgctxt "#32043"
 msgid "Smoothing"
 msgstr "Glättung"
 
-#:
+#: 
 msgctxt "#32045"
 msgid "Forwarder"
 msgstr "Weiterleitung"
 
-#:
-msgctxt "#32046"
-msgid "Boblight Server"
-msgstr "Boblight Server"
-
-#:
-msgctxt "#32047"
-msgid "Hyperion"
-msgstr "Hyperion"
-
-#:
-msgctxt "#32048"
-msgid "Audio Capture"
-msgstr "Audio Aufnahme"
-
-#:
+#: 
 msgctxt "#32101"
 msgid "Would you like to search for a Hyperion Server and adjust settings?"
 msgstr "Hyperion Server suchen und Einstellungen anpassen?"
 
-#:
+#: 
 msgctxt "#32102"
 msgid "Select a Hyperion Server, we found more than one"
 msgstr "Wähle einen Hyperion Server, es wurden mehrere gefunden"
 
-#:
+#: 
 msgctxt "#32104"
 msgid "We are sorry, no Hyperion Server has been found. You need to configure IP address and port by hand"
 msgstr "Leider wurde kein Hyperion Server gefunden, du musst IP-Adresse und Port selbst eintragen"
 
-#:
+#: 
 msgctxt "#32105"
 msgid "The Authorization Token isn't valid"
 msgstr "Das Autorisierungs-Token ist nicht gültig"
 
-#:
+#: 
 msgctxt "#32150"
 msgid "Execute"
 msgstr "Ausführen"
 
-#:
+#: 
 msgctxt "#32151"
 msgid "Execute a specific task you might need again.[CR]Select a task from the tasklist and press OK to close the settings dialog."
 msgstr "Führe eine spezifische Aufgabe nochmals aus.[CR]Wähle dazu aus der Liste eine Aufgabe und drücke den OK Button."
 
-#:
+#: 
 msgctxt "#32152"
 msgid "The addon will handle your request immediately.[CR]Be aware that the addon should be already enabled"
 msgstr "Die Einstellungen schließen sich.[CR]Das Addon wird sofort mit der Ausführung beginnen, sofern es aktiviert ist"
 
-#:
+#: 
 msgctxt "#32153"
 msgid "Tasklist"
 msgstr "Aufgabenliste"
 
-#:
+#: 
 msgctxt "#32154"
 msgid "No Task"
 msgstr "keine Aufgabe"
 
-#:
+#: 
 msgctxt "#32155"
 msgid "Search: Hyperion Server"
 msgstr "Suchen: Hyperion Server"
 
-#:
+#: 
 msgctxt "#32044"
 msgid "Blackbar detector"
 msgstr "Schwarze Balken Erkennung"
 
-#:
+#: 
 msgctxt "#32040"
 msgid "Screen Capture"
 msgstr "Bildschirm Aufnahme"
 
-#:
+#: 
 msgctxt "#32100"
 msgid "Welcome to Hyperion Control!"
 msgstr "Willkommen zu Hyperion Control!"
 
-#:
+#: 
 msgctxt "#32103"
 msgid "We found the following Hyperion Server for usage:"
 msgstr "Es wurde folgender Hyperion Server gefunden:"
+
+#: 
+msgctxt "#32046"
+msgid "Boblight Server"
+msgstr "Boblight Server"
+
+#: 
+msgctxt "#32047"
+msgid "Hyperion"
+msgstr "Hyperion"
+
+#: 
+msgctxt "#32048"
+msgid "Audio Capture"
+msgstr "Audio Aufnahme"
+

--- a/script.service.hyperion-control/resources/language/resource.language.en_gb/strings.po
+++ b/script.service.hyperion-control/resources/language/resource.language.en_gb/strings.po
@@ -7,192 +7,188 @@ msgstr ""
 "Project-Id-Version: Hyperion Control\n"
 "Language: en\n"
 
-#:
+#: 
 msgctxt "#32000"
 msgid "General"
 msgstr "General"
 
-#:
+#: 
 msgctxt "#32001"
 msgid "Hyperion IP"
 msgstr "Hyperion IP"
 
-#:
+#: 
 msgctxt "#32002"
 msgid "Hyperion Webserver Port"
 msgstr "Hyperion Webserver Port"
 
-#:
+#: 
 msgctxt "#32003"
 msgid "Switch automatically between 2D/3D"
 msgstr "Switch automatically between 2D/3D"
 
-#:
+#: 
 msgctxt "#32004"
 msgid "Enable Hyperion on startup"
 msgstr "Enable Hyperion on startup"
 
-#:
+#: 
 msgctxt "#32005"
 msgid "Disable Hyperion on shutdown"
 msgstr "Disable Hyperion on shutdown"
 
-#:
-msgctxt "#32006"
-msgid "Enable Debug"
-msgstr "Enable Debug"
-
-#:
+#: 
 msgctxt "#32007"
 msgid "Show changelog after update"
 msgstr "Show changelog after update"
 
-#:
+#: 
 msgctxt "#32008"
 msgid "Authorization Token"
 msgstr "Authorization Token"
 
-#:
+#: 
 msgctxt "#32025"
 msgid "Component"
 msgstr "Component"
 
-#:
+#: 
 msgctxt "#32026"
 msgid "Enable the chosen component in these situations else disable it."
 msgstr "Enable the chosen component in these situations else disable it."
 
-#:
+#: 
 msgctxt "#32027"
 msgid "Hyperion component"
 msgstr "Hyperion component"
 
-#:
+#: 
 msgctxt "#32028"
 msgid "Enable during video playback"
 msgstr "Enable during video playback"
 
-#:
+#: 
 msgctxt "#32029"
 msgid "Enable during music playback"
 msgstr "Enable during music playback"
 
-#:
+#: 
 msgctxt "#32030"
 msgid "Enable during player pause"
 msgstr "Enable during player pause"
 
-#:
+#: 
 msgctxt "#32031"
 msgid "Enable in Kodi menu"
 msgstr "Enable in Kodi menu"
 
-#:
+#: 
 msgctxt "#32032"
 msgid "Enable during active screensaver"
 msgstr "Enable during active screensaver"
 
-#:
+#: 
 msgctxt "#32041"
 msgid "USB Capture"
 msgstr "USB Capture"
 
-#:
+#: 
 msgctxt "#32042"
 msgid "LED Hardware"
 msgstr "LED Hardware"
 
-#:
+#: 
 msgctxt "#32043"
 msgid "Smoothing"
 msgstr "Smoothing"
 
-#:
+#: 
 msgctxt "#32045"
 msgid "Forwarder"
 msgstr "Forwarder"
 
-#:
-msgctxt "#32046"
-msgid "Boblight Server"
-msgstr "Boblight Server"
-
-#:
-msgctxt "#32047"
-msgid "Hyperion"
-msgstr "Hyperion"
-
-#:
-msgctxt "#32048"
-msgid "Audio Capture"
-msgstr "Audio Capture"
-
-#:
+#: 
 msgctxt "#32101"
 msgid "Would you like to search for a Hyperion Server and adjust settings?"
 msgstr "Would you like to search for a Hyperion Server and adjust settings?"
 
-#:
+#: 
 msgctxt "#32102"
 msgid "Select a Hyperion Server, we found more than one"
 msgstr "Select a Hyperion Server, we found more than one"
 
-#:
+#: 
 msgctxt "#32104"
 msgid "We are sorry, no Hyperion Server has been found. You need to configure IP address and port by hand"
 msgstr "We are sorry, no Hyperion Server has been found. You need to configure IP address and port by hand"
 
-#:
+#: 
 msgctxt "#32105"
 msgid "The Authorization Token isn't valid"
 msgstr "The Authorization Token isn't valid"
 
-#:
+#: 
 msgctxt "#32150"
 msgid "Execute"
-msgstr "Ausführen"
+msgstr "Execute"
 
-#:
+#: 
 msgctxt "#32151"
 msgid "Execute a specific task you might need again.[CR]Select a task from the tasklist and press OK to close the settings dialog."
 msgstr "Execute a specific task you might need again.[CR]Select a task from the tasklist and press OK to close the settings dialog."
 
-#:
+#: 
 msgctxt "#32152"
 msgid "The addon will handle your request immediately.[CR]Be aware that the addon should be already enabled"
 msgstr "The addon will handle your request immediately.[CR]Be aware that the addon should be already enabled"
 
-#:
+#: 
 msgctxt "#32153"
 msgid "Tasklist"
 msgstr "Tasklist"
 
-#:
+#: 
 msgctxt "#32154"
 msgid "No Task"
 msgstr "No Task"
 
-#:
+#: 
 msgctxt "#32155"
 msgid "Search: Hyperion Server"
 msgstr "Search: Hyperion Server"
 
-#:
+#: 
 msgctxt "#32044"
 msgid "Blackbar detector"
 msgstr "Blackbar detector"
 
-#:
+#: 
 msgctxt "#32040"
 msgid "Screen Capture"
 msgstr "Screen Capture"
 
-#:
+#: 
 msgctxt "#32100"
 msgid "Welcome to Hyperion Control!"
 msgstr "Welcome to Hyperion Control!"
 
-#:
+#: 
 msgctxt "#32103"
 msgid "We found the following Hyperion Server for usage:"
 msgstr "We found the following Hyperion Server for usage:"
+
+#: 
+msgctxt "#32046"
+msgid "Boblight Server"
+msgstr "Boblight Server"
+
+#: 
+msgctxt "#32047"
+msgid "Hyperion"
+msgstr "Hyperion"
+
+#: 
+msgctxt "#32048"
+msgid "Audio Capture"
+msgstr "Audio Capture"
+

--- a/script.service.hyperion-control/resources/language/resource.language.es_es/strings.po
+++ b/script.service.hyperion-control/resources/language/resource.language.es_es/strings.po
@@ -7,192 +7,188 @@ msgstr ""
 "Project-Id-Version: Hyperion Control\n"
 "Language: es\n"
 
-#:
+#: 
 msgctxt "#32000"
 msgid "General"
 msgstr "General"
 
-#:
+#: 
 msgctxt "#32001"
 msgid "Hyperion IP"
 msgstr "IP de Hyperion"
 
-#:
+#: 
 msgctxt "#32002"
 msgid "Hyperion Webserver Port"
 msgstr "Puerto del servidor web de Hyperion"
 
-#:
+#: 
 msgctxt "#32003"
 msgid "Switch automatically between 2D/3D"
 msgstr "Cambio automático entre 2D/3D"
 
-#:
+#: 
 msgctxt "#32004"
 msgid "Enable Hyperion on startup"
 msgstr "Habilitar Hyperion al inicio"
 
-#:
+#: 
 msgctxt "#32005"
 msgid "Disable Hyperion on shutdown"
 msgstr "Deshabilitar Hyperion al apagar"
 
-#:
-msgctxt "#32006"
-msgid "Enable Debug"
-msgstr "Habilitar la Depuración"
-
-#:
+#: 
 msgctxt "#32007"
 msgid "Show changelog after update"
 msgstr "Mostrar el registro de cambios tras la actualización"
 
-#:
+#: 
 msgctxt "#32008"
 msgid "Authorization Token"
 msgstr "Token de autorización"
 
-#:
+#: 
 msgctxt "#32025"
 msgid "Component"
 msgstr "Componente"
 
-#:
+#: 
 msgctxt "#32026"
 msgid "Enable the chosen component in these situations else disable it."
 msgstr "Habilitar el componente elegido en estas situaciones o deshabilitarlo."
 
-#:
+#: 
 msgctxt "#32027"
 msgid "Hyperion component"
 msgstr "Componente Hyperion"
 
-#:
+#: 
 msgctxt "#32028"
 msgid "Enable during video playback"
 msgstr "Activar durante la reproducción de vídeo"
 
-#:
+#: 
 msgctxt "#32029"
 msgid "Enable during music playback"
 msgstr "Activar durante la reproducción de música"
 
-#:
+#: 
 msgctxt "#32030"
 msgid "Enable during player pause"
 msgstr "Habilitar durante la pausa del reproductor"
 
-#:
+#: 
 msgctxt "#32031"
 msgid "Enable in Kodi menu"
 msgstr "Habilitar en el menú de Kodi"
 
-#:
+#: 
 msgctxt "#32032"
 msgid "Enable during active screensaver"
 msgstr "Habilitar durante el salvapantallas activo"
 
-#:
+#: 
 msgctxt "#32041"
 msgid "USB Capture"
 msgstr "Captura USB"
 
-#:
+#: 
 msgctxt "#32042"
 msgid "LED Hardware"
 msgstr "Hardware LED"
 
-#:
+#: 
 msgctxt "#32043"
 msgid "Smoothing"
 msgstr "Suavizado"
 
-#:
+#: 
 msgctxt "#32045"
 msgid "Forwarder"
 msgstr "Transmisor"
 
-#:
-msgctxt "#32046"
-msgid "Boblight Server"
-msgstr "Servidor Boblight"
-
-#:
-msgctxt "#32047"
-msgid "Hyperion"
-msgstr "Hyperion"
-
-#:
-msgctxt "#32048"
-msgid "Audio Capture"
-msgstr "Captura del Audio"
-
-#:
+#: 
 msgctxt "#32101"
 msgid "Would you like to search for a Hyperion Server and adjust settings?"
 msgstr "¿Desea buscar un Servidor Hyperion y ajustar la configuración?"
 
-#:
+#: 
 msgctxt "#32102"
 msgid "Select a Hyperion Server, we found more than one"
 msgstr "Seleccione un servidor Hyperion, encontramos más de uno"
 
-#:
+#: 
 msgctxt "#32104"
 msgid "We are sorry, no Hyperion Server has been found. You need to configure IP address and port by hand"
 msgstr "Lo sentimos, no se ha encontrado ningún Hyperion Server. Debe configurar la dirección IP y el puerto a mano"
 
-#:
+#: 
 msgctxt "#32105"
 msgid "The Authorization Token isn't valid"
 msgstr "Lo sentimos, no se ha encontrado ningún Servidor Hyperion. Es necesario configurar la dirección IP y el puerto a mano"
 
-#:
+#: 
 msgctxt "#32150"
 msgid "Execute"
 msgstr "Ejecutar"
 
-#:
+#: 
 msgctxt "#32151"
 msgid "Execute a specific task you might need again.[CR]Select a task from the tasklist and press OK to close the settings dialog."
 msgstr "Ejecutar una tarea específica que se pueda necesitar de nuevo.[CR]Seleccionar una tarea de la lista de tareas y pulsar OK para cerrar el diálogo de configuración."
 
-#:
+#: 
 msgctxt "#32152"
 msgid "The addon will handle your request immediately.[CR]Be aware that the addon should be already enabled"
 msgstr "El complemento se encargará de la solicitud inmediatamente.[CR]Ten en cuenta que el complemento debe estar ya activado"
 
-#:
+#: 
 msgctxt "#32153"
 msgid "Tasklist"
 msgstr "Lista de tareas"
 
-#:
+#: 
 msgctxt "#32154"
 msgid "No Task"
 msgstr "Sin Tareas"
 
-#:
+#: 
 msgctxt "#32155"
 msgid "Search: Hyperion Server"
 msgstr "Buscar: Servidor Hyperion"
 
-#:
+#: 
 msgctxt "#32044"
 msgid "Blackbar detector"
 msgstr "Detección de bordes negros"
 
-#:
+#: 
 msgctxt "#32040"
 msgid "Screen Capture"
 msgstr "Captura de Plataforma"
 
-#:
+#: 
 msgctxt "#32100"
 msgid "Welcome to Hyperion Control!"
 msgstr "Bienvenidol Control de Hyperion!"
 
-#:
+#: 
 msgctxt "#32103"
 msgid "We found the following Hyperion Server for usage:"
 msgstr "Encontramos los siguientes servidores Hyperion para su uso:"
+
+#: 
+msgctxt "#32046"
+msgid "Boblight Server"
+msgstr "Servidor Boblight"
+
+#: 
+msgctxt "#32047"
+msgid "Hyperion"
+msgstr "Hyperion"
+
+#: 
+msgctxt "#32048"
+msgid "Audio Capture"
+msgstr "Captura del Audio"
+

--- a/script.service.hyperion-control/resources/language/resource.language.fr_fr/strings.po
+++ b/script.service.hyperion-control/resources/language/resource.language.fr_fr/strings.po
@@ -7,194 +7,190 @@ msgstr ""
 "Project-Id-Version: Hyperion Control\n"
 "Language: fr\n"
 
-#:
+#: 
 msgctxt "#32000"
 msgid "General"
 msgstr "Général"
 
-#:
+#: 
 msgctxt "#32001"
 msgid "Hyperion IP"
 msgstr "Adresse IP Hyperion"
 
-#:
+#: 
 msgctxt "#32002"
 msgid "Hyperion Webserver Port"
 msgstr "Port Webserver Hyperion"
 
-#:
+#: 
 msgctxt "#32003"
 msgid "Switch automatically between 2D/3D"
 msgstr "Basculer automatiquement entre 2D/3D"
 
-#:
+#: 
 msgctxt "#32004"
 msgid "Enable Hyperion on startup"
 msgstr "Activer Hyperion au démarrage"
 
-#:
+#: 
 msgctxt "#32005"
 msgid "Disable Hyperion on shutdown"
 msgstr "Désactiver Hyperion à l'extinction"
 
-#:
-msgctxt "#32006"
-msgid "Enable Debug"
-msgstr "Activer le débogage"
-
-#:
+#: 
 msgctxt "#32007"
 msgid "Show changelog after update"
 msgstr "Afficher le changelog après la mise à jour"
 
-#:
+#: 
 msgctxt "#32008"
 msgid "Authorization Token"
 msgstr "Token d'autorisation"
 
-#:
+#: 
 msgctxt "#32025"
 msgid "Component"
 msgstr "Composant"
 
-#:
+#: 
 msgctxt "#32026"
 msgid "Enable the chosen component in these situations else disable it."
 msgstr "Activer le composant pour ces situations sinon le désactiver."
 
-#:
+#: 
 msgctxt "#32027"
 msgid "Hyperion component"
 msgstr "Composant Hyperion"
 
-#:
+#: 
 msgctxt "#32028"
 msgid "Enable during video playback"
 msgstr "Activer durant la lecture vidéo"
 
-#:
+#: 
 msgctxt "#32029"
 msgid "Enable during music playback"
 msgstr "Activer durant la lecture audio"
 
-#:
+#: 
 msgctxt "#32030"
 msgid "Enable during player pause"
 msgstr "Activer pendant la pause du lecteur"
 
-#:
+#: 
 msgctxt "#32031"
 msgid "Enable in Kodi menu"
 msgstr "Activer dans le menu de Kodi"
 
-#:
+#: 
 msgctxt "#32032"
 msgid "Enable during active screensaver"
 msgstr "Activer quand l'économiseur d'écran est actif"
 
-#:
+#: 
 msgctxt "#32041"
 msgid "USB Capture"
 msgstr "Capture USB"
 
-#:
+#: 
 msgctxt "#32042"
 msgid "LED Hardware"
 msgstr "LEDs"
 
-#:
+#: 
 msgctxt "#32043"
 msgid "Smoothing"
 msgstr "Lissage"
 
-#:
+#: 
 msgctxt "#32045"
 msgid "Forwarder"
 msgstr "Forwarder"
 
-#:
-msgctxt "#32046"
-msgid "Boblight Server"
-msgstr "Serveur Boblight"
-
-#:
-msgctxt "#32047"
-msgid "Hyperion"
-msgstr "Hyperion"
-
-#:
-msgctxt "#32048"
-msgid "Audio Capture"
-msgstr "Capture Audio"
-
-#:
+#: 
 msgctxt "#32101"
 msgid "Would you like to search for a Hyperion Server and adjust settings?"
 msgstr "Voulez vous chercher un serveur Hyperion et mettre à jour les paramètres ?"
 
-#:
+#: 
 msgctxt "#32102"
 msgid "Select a Hyperion Server, we found more than one"
 msgstr "Plusieurs serveurs Hyperion ont été trouvés, veuillez en sélectionner un"
 
-#:
+#: 
 msgctxt "#32104"
 msgid "We are sorry, no Hyperion Server has been found. You need to configure IP address and port by hand"
 msgstr "Désolé, aucun serveur Hyperion trouvé. Configurez l'adresse IP et le port manuellement."
 
-#:
+#: 
 msgctxt "#32105"
 msgid "The Authorization Token isn't valid"
 msgstr "Le token d'autorisation n'est pas valide"
 
-#:
+#: 
 msgctxt "#32150"
 msgid "Execute"
 msgstr "Exécuter"
 
-#:
+#: 
 msgctxt "#32151"
 msgid "Execute a specific task you might need again.[CR]Select a task from the tasklist and press OK to close the settings dialog."
 msgstr "Exécuter une tâche spécifique dont vous pourriez avoir besoin à nouveau.\n"
 "Choisir une tâche dans la liste et appuyer sur OK pour fermer la boite de dialogue."
 
-#:
+#: 
 msgctxt "#32152"
 msgid "The addon will handle your request immediately.[CR]Be aware that the addon should be already enabled"
 msgstr "L'addon va exécuter votre requête immédiatement.\n"
 "Attention : l'addon doit déjà être actif"
 
-#:
+#: 
 msgctxt "#32153"
 msgid "Tasklist"
 msgstr "Liste de tâches"
 
-#:
+#: 
 msgctxt "#32154"
 msgid "No Task"
 msgstr "Pas de tâche"
 
-#:
+#: 
 msgctxt "#32155"
 msgid "Search: Hyperion Server"
 msgstr "Recherche : serveur Hyperion"
 
-#:
+#: 
 msgctxt "#32044"
 msgid "Blackbar detector"
 msgstr "Détecteur de bandes noires"
 
-#:
+#: 
 msgctxt "#32040"
 msgid "Screen Capture"
 msgstr "Capture interne"
 
-#:
+#: 
 msgctxt "#32100"
 msgid "Welcome to Hyperion Control!"
 msgstr "Bienvenue dans l'addon Hyperion!"
 
-#:
+#: 
 msgctxt "#32103"
 msgid "We found the following Hyperion Server for usage:"
 msgstr "Le serveur Hyperion suivant a été trouvé pour utilisation:"
+
+#: 
+msgctxt "#32046"
+msgid "Boblight Server"
+msgstr "Serveur Boblight"
+
+#: 
+msgctxt "#32047"
+msgid "Hyperion"
+msgstr "Hyperion"
+
+#: 
+msgctxt "#32048"
+msgid "Audio Capture"
+msgstr "Capture Audio"
+

--- a/script.service.hyperion-control/resources/language/resource.language.hu_hu/strings.po
+++ b/script.service.hyperion-control/resources/language/resource.language.hu_hu/strings.po
@@ -7,192 +7,188 @@ msgstr ""
 "Project-Id-Version: Hyperion Control\n"
 "Language: hu\n"
 
-#:
+#: 
 msgctxt "#32000"
 msgid "General"
 msgstr "Általános"
 
-#:
+#: 
 msgctxt "#32001"
 msgid "Hyperion IP"
 msgstr "Hyperion IP"
 
-#:
+#: 
 msgctxt "#32002"
 msgid "Hyperion Webserver Port"
 msgstr "Hyperion Webserver Port"
 
-#:
+#: 
 msgctxt "#32003"
 msgid "Switch automatically between 2D/3D"
 msgstr "Automatikus átkapcsolás 2D/3D"
 
-#:
+#: 
 msgctxt "#32004"
 msgid "Enable Hyperion on startup"
 msgstr "Hyperion automatikus indítás"
 
-#:
+#: 
 msgctxt "#32005"
 msgid "Disable Hyperion on shutdown"
 msgstr "Hyperion kikapcsolása leállításkor"
 
-#:
-msgctxt "#32006"
-msgid "Enable Debug"
-msgstr "Hibakeresés engedélyezése"
-
-#:
+#: 
 msgctxt "#32007"
 msgid "Show changelog after update"
 msgstr "Változásnapló megjelenítése frissítés után"
 
-#:
+#: 
 msgctxt "#32008"
 msgid "Authorization Token"
 msgstr "Hozzáférési Token"
 
-#:
+#: 
 msgctxt "#32025"
 msgid "Component"
 msgstr "Komponens"
 
-#:
+#: 
 msgctxt "#32026"
 msgid "Enable the chosen component in these situations else disable it."
 msgstr "Engedélyezze a kiválasztott összetevőt, ellenkező esetben tiltsa le."
 
-#:
+#: 
 msgctxt "#32027"
 msgid "Hyperion component"
 msgstr "Hyperion komponens"
 
-#:
+#: 
 msgctxt "#32028"
 msgid "Enable during video playback"
 msgstr "Engedélyezés videólejátszás közben"
 
-#:
+#: 
 msgctxt "#32029"
 msgid "Enable during music playback"
 msgstr "Engedélyezés zenelejátszás közben"
 
-#:
+#: 
 msgctxt "#32030"
 msgid "Enable during player pause"
 msgstr "Engedélyezés lejátszási szünetben"
 
-#:
+#: 
 msgctxt "#32031"
 msgid "Enable in Kodi menu"
 msgstr "Engedélyezés a Kodi menüben"
 
-#:
+#: 
 msgctxt "#32032"
 msgid "Enable during active screensaver"
 msgstr "Engedélyezés aktív képernyővédő alatt"
 
-#:
+#: 
 msgctxt "#32041"
 msgid "USB Capture"
 msgstr "USB Capture"
 
-#:
+#: 
 msgctxt "#32042"
 msgid "LED Hardware"
 msgstr "LED Hardver"
 
-#:
+#: 
 msgctxt "#32043"
 msgid "Smoothing"
 msgstr "Símítás"
 
-#:
+#: 
 msgctxt "#32045"
 msgid "Forwarder"
 msgstr "Továbbító"
 
-#:
-msgctxt "#32046"
-msgid "Boblight Server"
-msgstr "Boblight Server"
-
-#:
-msgctxt "#32047"
-msgid "Hyperion"
-msgstr "Hyperion"
-
-#:
-msgctxt "#32048"
-msgid "Audio Capture"
-msgstr "Hangrögzítés"
-
-#:
+#: 
 msgctxt "#32101"
 msgid "Would you like to search for a Hyperion Server and adjust settings?"
 msgstr "Szeretne keresni egy Hyperion szervert és módosítani a beállításokat?"
 
-#:
+#: 
 msgctxt "#32102"
 msgid "Select a Hyperion Server, we found more than one"
 msgstr "Válasszon egy Hyperion kiszolgálót, többet is találtunk"
 
-#:
+#: 
 msgctxt "#32104"
 msgid "We are sorry, no Hyperion Server has been found. You need to configure IP address and port by hand"
 msgstr "Sajnáljuk, nem található Hyperion Server. Az IP-címet és a portot kézzel kell konfigurálnia!"
 
-#:
+#: 
 msgctxt "#32105"
 msgid "The Authorization Token isn't valid"
 msgstr "Az engedélyezési token nem érvényes"
 
-#:
+#: 
 msgctxt "#32150"
 msgid "Execute"
 msgstr "Végrehajtás"
 
-#:
+#: 
 msgctxt "#32151"
 msgid "Execute a specific task you might need again.[CR]Select a task from the tasklist and press OK to close the settings dialog."
 msgstr "Hajtsa végre újra az adott feladatot, amelyre szüksége lehet.[CR]Válasszon ki egy feladatot a feladatlistából, és nyomja meg az OK gombot a beállítások párbeszédpanel bezárásához."
 
-#:
+#: 
 msgctxt "#32152"
 msgid "The addon will handle your request immediately.[CR]Be aware that the addon should be already enabled"
 msgstr "A bővítmény azonnal kezeli a kérést.[CR]Ne feledje, hogy a kiegészítőnek már engedélyezve kell lennie"
 
-#:
+#: 
 msgctxt "#32153"
 msgid "Tasklist"
 msgstr "Feladat lista"
 
-#:
+#: 
 msgctxt "#32154"
 msgid "No Task"
 msgstr "Nincs feladat"
 
-#:
+#: 
 msgctxt "#32155"
 msgid "Search: Hyperion Server"
 msgstr "Keresés: Hyperion Server"
 
-#:
+#: 
 msgctxt "#32044"
 msgid "Blackbar detector"
 msgstr "Feketesáv detector"
 
-#:
+#: 
 msgctxt "#32040"
 msgid "Screen Capture"
 msgstr "Screen Capture"
 
-#:
+#: 
 msgctxt "#32100"
 msgid "Welcome to Hyperion Control!"
 msgstr "Üdvözli a Hyperion Control!"
 
-#:
+#: 
 msgctxt "#32103"
 msgid "We found the following Hyperion Server for usage:"
 msgstr "A következő Hyperion szervert találtuk használatra:"
+
+#: 
+msgctxt "#32046"
+msgid "Boblight Server"
+msgstr "Boblight Server"
+
+#: 
+msgctxt "#32047"
+msgid "Hyperion"
+msgstr "Hyperion"
+
+#: 
+msgctxt "#32048"
+msgid "Audio Capture"
+msgstr "Hangrögzítés"
+

--- a/script.service.hyperion-control/resources/language/resource.language.pl_pl/strings.po
+++ b/script.service.hyperion-control/resources/language/resource.language.pl_pl/strings.po
@@ -7,192 +7,188 @@ msgstr ""
 "Project-Id-Version: Hyperion Control\n"
 "Language: pl\n"
 
-#:
+#: 
 msgctxt "#32000"
 msgid "General"
 msgstr "Ogólne"
 
-#:
+#: 
 msgctxt "#32001"
 msgid "Hyperion IP"
 msgstr "Hyperion IP"
 
-#:
+#: 
 msgctxt "#32002"
 msgid "Hyperion Webserver Port"
 msgstr "Port Hyperion Webserver"
 
-#:
+#: 
 msgctxt "#32003"
 msgid "Switch automatically between 2D/3D"
 msgstr "Zmieniaj automatycznie 2D/3D"
 
-#:
+#: 
 msgctxt "#32004"
 msgid "Enable Hyperion on startup"
 msgstr "Uruchom Hyperion wraz ze startem systemu"
 
-#:
+#: 
 msgctxt "#32005"
 msgid "Disable Hyperion on shutdown"
 msgstr "Wyłącz Hyperion przy zamknięciu systemu"
 
-#:
-msgctxt "#32006"
-msgid "Enable Debug"
-msgstr "Włącz debugowanie"
-
-#:
+#: 
 msgctxt "#32007"
 msgid "Show changelog after update"
 msgstr "Pokaż dziennik zmian po aktualizacji"
 
-#:
+#: 
 msgctxt "#32008"
 msgid "Authorization Token"
 msgstr "Token autoryzacyjny"
 
-#:
+#: 
 msgctxt "#32025"
 msgid "Component"
 msgstr "Komponent"
 
-#:
+#: 
 msgctxt "#32026"
 msgid "Enable the chosen component in these situations else disable it."
 msgstr "Włącz wybrany komponent w wybranych sytuacjach - w przeciwnym wypadku wyłącz komponent."
 
-#:
+#: 
 msgctxt "#32027"
 msgid "Hyperion component"
 msgstr "Komponent Hyperion"
 
-#:
+#: 
 msgctxt "#32028"
 msgid "Enable during video playback"
 msgstr "Włącz podczas odtwarzania wideo"
 
-#:
+#: 
 msgctxt "#32029"
 msgid "Enable during music playback"
 msgstr "Włącz podczas odtwarzania muzyki"
 
-#:
+#: 
 msgctxt "#32030"
 msgid "Enable during player pause"
 msgstr "Włącz podczas zapauzowania odtwarzacza"
 
-#:
+#: 
 msgctxt "#32031"
 msgid "Enable in Kodi menu"
 msgstr "Włącz w menu Kodi"
 
-#:
+#: 
 msgctxt "#32032"
 msgid "Enable during active screensaver"
 msgstr "Włącz podczas aktywnego wygaszacza ekranu"
 
-#:
+#: 
 msgctxt "#32041"
 msgid "USB Capture"
 msgstr "Przechwytywanie USB"
 
-#:
+#: 
 msgctxt "#32042"
 msgid "LED Hardware"
 msgstr "Sprzęt LED"
 
-#:
+#: 
 msgctxt "#32043"
 msgid "Smoothing"
 msgstr "Wygładzanie"
 
-#:
+#: 
 msgctxt "#32045"
 msgid "Forwarder"
 msgstr "Przekierowywacz"
 
-#:
-msgctxt "#32046"
-msgid "Boblight Server"
-msgstr "Server Boblight"
-
-#:
-msgctxt "#32047"
-msgid "Hyperion"
-msgstr "Hyperion"
-
-#:
-msgctxt "#32048"
-msgid "Audio Capture"
-msgstr "Przechwytywanie Dźwięku"
-
-#:
+#: 
 msgctxt "#32101"
 msgid "Would you like to search for a Hyperion Server and adjust settings?"
 msgstr "Czy chcesz wyszukać serwer Hyperion i dostosować ustawienia?"
 
-#:
+#: 
 msgctxt "#32102"
 msgid "Select a Hyperion Server, we found more than one"
 msgstr "Wybierz serwer Hyperion, znaleziono więcej niż jeden"
 
-#:
+#: 
 msgctxt "#32104"
 msgid "We are sorry, no Hyperion Server has been found. You need to configure IP address and port by hand"
 msgstr "Niestety, nie znaleziono serwera Hyperion. Skonfiguruj adres IP oraz port manualnie"
 
-#:
+#: 
 msgctxt "#32105"
 msgid "The Authorization Token isn't valid"
 msgstr "Nieprawidłowy token autoryzacyjny"
 
-#:
+#: 
 msgctxt "#32150"
 msgid "Execute"
 msgstr "Wykonaj"
 
-#:
+#: 
 msgctxt "#32151"
 msgid "Execute a specific task you might need again.[CR]Select a task from the tasklist and press OK to close the settings dialog."
 msgstr "Wykonaj zadanie ponownie. Wybierz zadanie z listy zadań i wciśnij OK aby zamknąć okno ustawień."
 
-#:
+#: 
 msgctxt "#32152"
 msgid "The addon will handle your request immediately.[CR]Be aware that the addon should be already enabled"
 msgstr "Twoje zadanie zostanie wykonane natychmiastowo. Miej na uwadze, że addon powinien być wcześniej włączony"
 
-#:
+#: 
 msgctxt "#32153"
 msgid "Tasklist"
 msgstr "Lista zadań"
 
-#:
+#: 
 msgctxt "#32154"
 msgid "No Task"
 msgstr "Brak zadania"
 
-#:
+#: 
 msgctxt "#32155"
 msgid "Search: Hyperion Server"
 msgstr "Wyszukaj: Serwer Hyperion"
 
-#:
+#: 
 msgctxt "#32044"
 msgid "Blackbar detector"
 msgstr "Detekcja czarnych ramek"
 
-#:
+#: 
 msgctxt "#32040"
 msgid "Screen Capture"
 msgstr "Przechwytywanie platformy"
 
-#:
+#: 
 msgctxt "#32100"
 msgid "Welcome to Hyperion Control!"
 msgstr "Witaj w Hyperion Control!"
 
-#:
+#: 
 msgctxt "#32103"
 msgid "We found the following Hyperion Server for usage:"
 msgstr "Znaleziono następujący serwer Hyperion:"
+
+#: 
+msgctxt "#32046"
+msgid "Boblight Server"
+msgstr "Server Boblight"
+
+#: 
+msgctxt "#32047"
+msgid "Hyperion"
+msgstr "Hyperion"
+
+#: 
+msgctxt "#32048"
+msgid "Audio Capture"
+msgstr "Przechwytywanie Dźwięku"
+

--- a/script.service.hyperion-control/resources/lib/hyperion.py
+++ b/script.service.hyperion-control/resources/lib/hyperion.py
@@ -52,8 +52,7 @@ class Hyperion:
 
     def notify(self, command: str) -> None:
         """Process the commands sent by the observables."""
-        if self._settings.debug:
-            self._logger.log(f"received command: {command}")
+        self._logger.log(f"received command: {command}")
         if command == "updateSettings":
             self.update_settings()
         else:

--- a/script.service.hyperion-control/resources/lib/interfaces.py
+++ b/script.service.hyperion-control/resources/lib/interfaces.py
@@ -44,7 +44,6 @@ class SettingsManager(Protocol):
     menu_enabled: bool
     show_changelog_on_update: bool
     tasks: int
-    debug: bool
     first_run: bool
 
     @property

--- a/script.service.hyperion-control/resources/lib/settings_manager.py
+++ b/script.service.hyperion-control/resources/lib/settings_manager.py
@@ -49,7 +49,6 @@ class SettingsManager:
         self.menu_enabled: bool
         self.show_changelog_on_update: bool
         self.tasks: int
-        self.debug: bool
         self.first_run: bool
         self.read_settings()
 
@@ -108,7 +107,7 @@ class SettingsManager:
     def _log_set_outcome(self, name: str, value: Any, outcome: bool) -> None:
         if not outcome:
             self._logger.error(f"Error setting {name} to {value} (outcome={outcome})")
-        elif self.debug:
+        else:
             self._logger.log(f"Set {name} to {value}")
 
     def set_tasks(self, value: int) -> None:
@@ -140,7 +139,6 @@ class SettingsManager:
         self.enable_hyperion = get_bool("enableHyperion")
         self.disable_hyperion = get_bool("disableHyperion")
         self.show_changelog_on_update = get_bool("showChangelogOnUpdate")
-        self.debug = get_bool("debug")
         self.first_run = get_bool("firstRun")
         self.current_version = get_string("currAddonVersion")
 
@@ -155,8 +153,7 @@ class SettingsManager:
         self.tasks = get_int("tasks")
         self.rev += 1
 
-        if self.debug:
-            self._log_settings()
+        self._log_settings()
 
     def _log_settings(self) -> None:
         log = self._logger.log
@@ -172,7 +169,6 @@ class SettingsManager:
         log(f"Audio enabled:         {self.audio_enabled}")
         log(f"Pause enabled:         {self.pause_enabled}")
         log(f"Menu enabled:          {self.menu_enabled}")
-        log(f"Debug enabled:         {self.debug}")
         log(f"ChangelogOnUpdate:     {self.show_changelog_on_update}")
         log(f"tasks:                 {self.tasks}")
         log(f"first run:             {self.first_run}")

--- a/script.service.hyperion-control/resources/settings.xml
+++ b/script.service.hyperion-control/resources/settings.xml
@@ -8,7 +8,6 @@
         <setting id="enableHyperion" type="bool" label="32004" default="false" />
         <setting id="disableHyperion" type="bool" label="32005" default="false" />
         <setting id="showChangelogOnUpdate" type="bool" label="32007" default="true" visible="true" />
-        <setting id="debug" type="bool" label="32006" default="false" />
         <setting id="firstRun" type="bool" label="32000" default="true" visible="false" />
         <setting id="currAddonVersion" type="text" default="" visible="false" />
     </category>


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: Hyperion Control
  - Add-on ID: script.service.hyperion-control
  - Version number: 20.0.1
  - Kodi/repository version: nexus

- **Code location**
  - URL: https://github.com/hyperion-project/hyperion.control
  
Enable and disable components (like capture) of Hyperion automatically based on playing/screensaver state of Kodi[CR]-Supports auto detection of Hyperion Servers[CR]-Token authentication

### Description of changes:


      20.0.1
      - Removed redundant debug setting

      20.0.0
      - Kodi 20 (Nexus) support
      - Multi instance handling
      - New language: Hungarian

      19.0.2
      - New languages: Español, Français, Polski

      19.0.1
      - Kodi 19 support
      - minor cleanups and corrections

      1.0.1
      - Fixed a crash with 3d mode @b-jesch

      1.0.0
      - Added support for server search
      - Added support token authentication
      - Fixed issue where kodi api does not properly announce video playing states
    

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
