### PR TITLE
[script.timers] 3.9.0

### DIFF
--- a/script.timers/addon.xml
+++ b/script.timers/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.timers" name="Timers" version="3.8.0" provider-name="Heckie">
+<addon id="script.timers" name="Timers" version="3.9.0" provider-name="Heckie">
   <requires>
     <import addon="xbmc.python" version="3.0.0" />
   </requires>
@@ -66,6 +66,11 @@
     <website>https://github.com/Heckie75/kodi-addon-timers</website>
     <source>https://github.com/Heckie75/kodi-addon-timers</source>
     <news>
+v3.9.0 (2023-11-11)
+- Add new system action 'restart Kodi'
+- Add new extra feature to prevent display off when audio is playing
+- Bugfix: Prevent exception in fader context
+
 v3.8.0 (2023-08-06)
 - Context menu quicktimer: Added dialog if item is already scheduled and ask to replace or delete
 
@@ -83,16 +88,6 @@ v3.5.0 (2023-02-07)
 - New feature: priority of timers and competitive behavior
 - New feature: System action to put playing device on standby via a CEC peripheral
 - Fixed issue so that favourites can be scheduled again
-
-v3.4.0 (2023-01-10)
-- New feature: Media action in order to pause audio or video, feature request #21
-- Refactoring: moved state to timer object
-- Reorganized setting levels (simple, standard, advanced, expert)
-- Introduced logging (see kodi.log)
-
-v3.3.1 (2022-11-26)
-- Bugfix: scheduled timers stop working that are scheduled after Sunday (week change Sun -> Mon)
-- Refactoring
 
 Complete changelog see https://github.com/Heckie75/kodi-addon-timers
     </news>

--- a/script.timers/resources/language/resource.language.de_de/strings.po
+++ b/script.timers/resources/language/resource.language.de_de/strings.po
@@ -77,6 +77,10 @@ msgctxt "#32030"
 msgid "Presets"
 msgstr "Voreinstellungen"
 
+msgctxt "#32031"
+msgid "Don't put display to sleep on audio playback"
+msgstr "Ruhezustand des Bildschirms bei Audiowiedergabe vermeiden"
+
 msgctxt "#32032"
 msgid "Prevent lock screen"
 msgstr "Verhindere Bildschirmsperre"
@@ -104,6 +108,10 @@ msgstr "Tage"
 msgctxt "#32038"
 msgid "Presets for snooze timer"
 msgstr "Voreinstellungen für Schlummern"
+
+msgctxt "#32039"
+msgid "Deactivate sleep display on audio playback"
+msgstr "Deaktiviere Ruhezustand des Bildschirms während der Audiowiedergabe"
 
 msgctxt "#32040"
 msgid "and"
@@ -273,6 +281,10 @@ msgctxt "#32093"
 msgid "Standby TV via CEC"
 msgstr "Standby TV via CEC"
 
+msgctxt "#32094"
+msgid "Restart Kodi"
+msgstr "Kodi neu starten"
+
 msgctxt "#32095"
 msgid "Low volume"
 msgstr "Niedrige Lautstärke"
@@ -288,6 +300,10 @@ msgstr "Benachrichtigungen"
 msgctxt "#32098"
 msgid "Timer Notifications"
 msgstr "Benachrichtigungen anzeigen"
+
+msgctxt "#32099"
+msgid "Reboot system"
+msgstr "System neu starten"
 
 msgctxt "#32100"
 msgid "Timer starts"

--- a/script.timers/resources/language/resource.language.en_gb/strings.po
+++ b/script.timers/resources/language/resource.language.en_gb/strings.po
@@ -77,6 +77,10 @@ msgctxt "#32030"
 msgid "Presets"
 msgstr ""
 
+msgctxt "#32031"
+msgid "Don't put display to sleep on audio playback"
+msgstr ""
+
 msgctxt "#32032"
 msgid "Prevent lock screen"
 msgstr ""
@@ -103,6 +107,10 @@ msgstr ""
 
 msgctxt "#32038"
 msgid "Presets for snooze timer"
+msgstr ""
+
+msgctxt "#32039"
+msgid "Deactivate sleep display on audio playback"
 msgstr ""
 
 msgctxt "#32040"
@@ -273,6 +281,10 @@ msgctxt "#32093"
 msgid "Standby TV via CEC"
 msgstr ""
 
+msgctxt "#32094"
+msgid "Restart Kodi"
+msgstr ""
+
 msgctxt "#32095"
 msgid "Low volume"
 msgstr ""
@@ -287,6 +299,10 @@ msgstr ""
 
 msgctxt "#32098"
 msgid "Timer Notifications"
+msgstr ""
+
+msgctxt "#32099"
+msgid "Reboot system"
 msgstr ""
 
 msgctxt "#32100"

--- a/script.timers/resources/lib/timer/scheduleraction.py
+++ b/script.timers/resources/lib/timer/scheduleraction.py
@@ -16,6 +16,8 @@ from resources.lib.timer.timer import (FADE_IN_FROM_MIN, FADE_OUT_FROM_CURRENT,
                                        SYSTEM_ACTION_HIBERNATE,
                                        SYSTEM_ACTION_POWEROFF,
                                        SYSTEM_ACTION_QUIT_KODI,
+                                       SYSTEM_ACTION_RESTART_KODI,
+                                       SYSTEM_ACTION_REBOOT_SYSTEM,
                                        SYSTEM_ACTION_SHUTDOWN_KODI,
                                        SYSTEM_ACTION_STANDBY, TIMER_WEEKLY,
                                        Timer)
@@ -166,8 +168,7 @@ class SchedulerAction:
             addon = xbmcaddon.Addon()
             lines = list()
             lines.append(addon.getLocalizedString(32270))
-            lines.append(addon.getLocalizedString(
-                32081 + self.timerWithSystemAction.system_action))
+            lines.append(self.timerWithSystemAction.format("$P"))
             lines.append(addon.getLocalizedString(32271))
             abort = xbmcgui.Dialog().yesno(heading="%s: %s" % (addon.getLocalizedString(32256), self.timerWithSystemAction.label),
                                            message="\n".join(lines),
@@ -248,7 +249,7 @@ class SchedulerAction:
         vol_max = self.fader.return_vol if self.fader.fade == FADE_OUT_FROM_CURRENT else self.fader.vol_max
         vol_diff = vol_max - self.fader.vol_min
 
-        return delta_end_start/vol_diff
+        return delta_end_start / vol_diff if vol_diff != 0 else None
 
     def _setTimerToPlayAny(self, timer: Timer) -> None:
 
@@ -370,6 +371,10 @@ class SchedulerAction:
                 showNotification(self.timerWithSystemAction, msg_id=32083)
                 xbmc.executebuiltin("Quit()")
 
+            elif self.timerWithSystemAction.system_action == SYSTEM_ACTION_RESTART_KODI:
+                showNotification(self.timerWithSystemAction, msg_id=32094)
+                xbmc.executebuiltin("RestartApp()")
+
             elif self.timerWithSystemAction.system_action == SYSTEM_ACTION_STANDBY:
                 showNotification(self.timerWithSystemAction, msg_id=32084)
                 xbmc.executebuiltin("Suspend()")
@@ -381,6 +386,10 @@ class SchedulerAction:
             elif self.timerWithSystemAction.system_action == SYSTEM_ACTION_POWEROFF:
                 showNotification(self.timerWithSystemAction, msg_id=32086)
                 xbmc.executebuiltin("Powerdown()")
+
+            elif self.timerWithSystemAction.system_action == SYSTEM_ACTION_REBOOT_SYSTEM:
+                showNotification(self.timerWithSystemAction, msg_id=32099)
+                xbmc.executebuiltin("Reboot()")
 
             elif self.timerWithSystemAction.system_action == SYSTEM_ACTION_CEC_STANDBY:
                 showNotification(self.timerWithSystemAction, msg_id=32093)

--- a/script.timers/resources/lib/timer/timer.py
+++ b/script.timers/resources/lib/timer/timer.py
@@ -23,6 +23,8 @@ SYSTEM_ACTION_STANDBY = 3
 SYSTEM_ACTION_HIBERNATE = 4
 SYSTEM_ACTION_POWEROFF = 5
 SYSTEM_ACTION_CEC_STANDBY = 6
+SYSTEM_ACTION_RESTART_KODI = 7
+SYSTEM_ACTION_REBOOT_SYSTEM = 8
 
 MEDIA_ACTION_NONE = 0
 MEDIA_ACTION_START_STOP = 1
@@ -231,6 +233,12 @@ class Timer():
 
         elif self.system_action == SYSTEM_ACTION_CEC_STANDBY:
             return self._addon.getLocalizedString(32093)
+
+        elif self.system_action == SYSTEM_ACTION_RESTART_KODI:
+            return self._addon.getLocalizedString(32094)
+
+        elif self.system_action == SYSTEM_ACTION_REBOOT_SYSTEM:
+            return self._addon.getLocalizedString(32099)
 
         else:
             return self._addon.getLocalizedString(32071)

--- a/script.timers/resources/settings.xml
+++ b/script.timers/resources/settings.xml
@@ -490,9 +490,11 @@
               <option label="32071">0</option>
               <option label="32082">1</option>
               <option label="32083">2</option>
+              <option label="32094">7</option>
               <option label="32084">3</option>
               <option label="32085">4</option>
               <option label="32086">5</option>
+              <option label="32099">8</option>
               <option label="32093">6</option>
             </options>
           </constraints>
@@ -738,6 +740,11 @@
           <dependencies>
             <dependency type="visible" on="property" operator="!is" name="infobool">system.isstandalone</dependency>
           </dependencies>
+        </setting>
+        <setting id="audio_displaysoff" type="boolean" label="32031" help="32039">
+          <level>3</level>
+          <default>false</default>
+          <control type="toggle" />
         </setting>
         <setting id="windows_unlock" type="boolean" label="32032" help="32384">
           <level>3</level>


### PR DESCRIPTION
### Description
v3.9.0 (2023-11-11)
- Add new system action 'restart Kodi'
- Add new extra feature to prevent display off when audio is playing
- Bugfix: Prevent exception in fader context

### Checklist:
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [script.foo.bar] 1.0.0
