### PR TITLE
[weather.ozweather@matrix] 2.1.0

### DIFF
--- a/weather.ozweather/README.md
+++ b/weather.ozweather/README.md
@@ -7,13 +7,13 @@ Kodi Oz Weather
 
 Script for Kodi for high quality Australian weather data sourced directly from the BOM.  
 
-Available from the Kodi official repository (i.e. don't install from here - just go to Addons -> Get Addons -> Weather -> OzWeather)
+Available from the Kodi official repository (i.e. don't install from here - just go to Add-ons -> Get Add-ons -> Weather -> OzWeather)
 
 Retrieves BOM data including current conditions, 7-day forecast, and animated radar images.
 
-Script works fine standalone for standard high quality Australian weather data, but you need to make skin changes for the best bit, which is the animated BOM radar support.  See the Kodi [wiki page](http://wiki.xbmc.org/index.php?title=Add-on:Oz_Weather) for full details and links to the skin files.
+Script works fine stand-alone for standard high quality Australian weather data, but you need to make skin changes for the best bit, which is the animated BOM radar support.  See the Kodi [wiki page](http://wiki.xbmc.org/index.php?title=Add-on:Oz_Weather) for full details and links to a tool to make this very easy (or the actual modified skin files, if you wish to do this manually).
 
-Contributions of skin files for other skins gratefully accepted....just message me on the forums with your skin files (or even better jsut add them directly to the Wiki yourself!).
+Contributions of skin files for other skins gratefully accepted....just message me on the forums with your skin files.
 
 Support is via the [forum thread](<https://forum.kodi.tv/showthread.php?tid=116905>), or open an issue here.
 

--- a/weather.ozweather/addon.xml
+++ b/weather.ozweather/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="weather.ozweather" name="Oz Weather" version="2.0.9" provider-name="Bossanova808">
+<addon id="weather.ozweather" name="Oz Weather" version="2.1.0" provider-name="Bossanova808">
 	<requires>
 		<import addon="xbmc.python" version="3.0.0"/>
     	<import addon="script.module.requests" version="2.22.0+matrix.1"/>
@@ -22,8 +22,8 @@
        		<icon>icon.png</icon>
        		<fanart>fanart.jpg</fanart>
 		</assets>
-		<news>2.0.9
-			- Better fix for ABC weather video
+		<news>2.1.0
+			- Fix light_rain icon &amp; update BOM radar list
     	</news>
 	</extension>
 </addon>

--- a/weather.ozweather/changelog.txt
+++ b/weather.ozweather/changelog.txt
@@ -1,3 +1,6 @@
+2.1.0
+- Fix light_rain icon & update BOM radar list
+
 2.0.9
 - Better fix for ABC weather video
 

--- a/weather.ozweather/resources/lib/store.py
+++ b/weather.ozweather/resources/lib/store.py
@@ -98,7 +98,7 @@ class Store:
         # http://www.bom.gov.au/australia/radar/info/nt_info.shtml
         (-23.82, 133.90, "Alice Springs", "IDR253"),
         (-12.46, 130.93, "Darwin/Berrimah", "IDR633"),
-        (-12.28, 136.82, "Gove", "IDR093"),
+        (-12.27, 136.82, "Gove", "IDR1123"),
         (-14.51, 132.45, "Katherine/Tindal", "IDR423"),
         (-11.6494, 133.38, "Warruwi", "IDR773")
     ]
@@ -186,7 +186,7 @@ class Store:
                            'rain': '45',
                            'rain_and_snow': '46',
                            'rain_clearing': '45',
-                           'Light_rain': '12',
+                           'light_rain': '12',
                            'rain_developing': '45',
                            'rain_tending to_snow': '45',
                            'shower': '45',


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: Oz Weather
  - Add-on ID: weather.ozweather
  - Version number: 2.1.0
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/bossanova808/weather.ozweather
  
Weather forecasting and radar images for Australia using Bureau of Meteorology data.  For full features (animated radars & ABC weather videos) - make sure you install the replacement skin files - see information at the addon wiki (https://kodi.wiki/index.php?title=Add-on:Oz_Weather).

### Description of changes:

2.1.0
			- Fix light_rain icon & update BOM radar list
    	

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
