### PR TITLE
[script.service.next-episode@matrix] 1.2.6

### DIFF
--- a/script.service.next-episode/addon.xml
+++ b/script.service.next-episode/addon.xml
@@ -1,14 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon id="script.service.next-episode"
    name="Next Episode (next-episode.net)"
-   version="1.2.5+matrix.1"
-   provider-name="next-episode.net">
+   version="1.2.6"
+   provider-name="Roman V.M.">
   <requires>
     <import addon="xbmc.python" version="3.0.0" />
     <import addon="script.module.pyxbmct" />
-    <import addon="script.module.requests" />
-    <import addon="script.module.future" />
-    <import addon="script.module.kodi-six" />
   </requires>
   <extension point="xbmc.service" library="service.py" />
   <extension point="xbmc.python.script" library="main.py">
@@ -25,14 +22,14 @@
     <license>GPL-3.0-or-later</license>
     <website>http://next-episode.net</website>
     <email>roman1972@gmail.com</email>
-    <source>https://github.com/santah/next-episode-kodi</source>
+    <source>https://github.com/romanvm/next-episode-kodi</source>
     <assets>
       <icon>icon.png</icon>
     </assets>
-    <news>1.2.5:
-- Fixed crashes when movies do not have IMDB ID.
+    <news>1.2.6:
+- Removed Python 2 compatibility
 
-1.2.4:
-- Fixed compatibility with Kodi 20 "Nexus".</news>
+1.2.5:
+- Fixed crashes when movies do not have IMDB ID.</news>
   </extension>
 </addon>

--- a/script.service.next-episode/libs/__init__.py
+++ b/script.service.next-episode/libs/__init__.py
@@ -1,4 +1,14 @@
-# coding: utf-8
-# Created on: 15.03.2016
-# Author: Roman Miroshnychenko aka Roman V.M. (romanvm@yandex.ua)
-# License: GPL v. 3 <http://www.gnu.org/licenses/gpl-3.0.en.html>
+# (c) Roman Miroshnychenko, 2023
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.

--- a/script.service.next-episode/libs/addon.py
+++ b/script.service.next-episode/libs/addon.py
@@ -1,20 +1,24 @@
-# coding: utf-8
-# (c) 2018, Roman Miroshnychenko <roman1972@gmail.com>
-# License: GPL v. 3 <http://www.gnu.org/licenses/gpl-3.0.en.html>
-
-from __future__ import unicode_literals
+# (c) Roman Miroshnychenko, 2023
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import os
 
-from kodi_six.xbmc import getInfoLabel
-from kodi_six.xbmcaddon import Addon
+from xbmc import getInfoLabel
+from xbmcaddon import Addon
+from xbmcvfs import translatePath
 
-try:
-    from kodi_six.xbmcvfs import translatePath
-except (ImportError, AttributeError):
-    from kodi_six.xbmc import translatePath
-
-__all__ = ['ADDON', 'ADDON_ID', 'ADDON_VERSION', 'ADDON_PATH', 'ICON']
 
 ADDON = Addon()
 ADDON_ID = ADDON.getAddonInfo('id')

--- a/script.service.next-episode/libs/exception_logger.py
+++ b/script.service.next-episode/libs/exception_logger.py
@@ -1,5 +1,4 @@
-# coding: utf-8
-# (c) Roman Miroshnychenko <roman1972@gmail.com> 2020
+# (c) Roman Miroshnychenko <roman1972@gmail.com> 2023
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -20,44 +19,39 @@ import sys
 from contextlib import contextmanager
 from platform import uname
 from pprint import pformat
+from typing import Any, Dict, Callable, Generator, Iterable, Optional
 
-import six
-from kodi_six import xbmc
-
-from .logger import log_error
-
-try:
-    from typing import Text, Dict, Callable, Generator  # pylint: disable=unused-import
-except ImportError:
-    pass
+import xbmc
 
 
-def _format_vars(variables):
-    # type: (dict) -> Text
+def _log_error(message: str) -> None:
+    xbmc.log(message, level=xbmc.LOGERROR)
+
+
+def _format_vars(variables: Dict[str, Any]) -> str:
     """
     Format variables dictionary
 
     :param variables: variables dict
     :return: formatted string with sorted ``var = val`` pairs
     """
-    var_list = [(var, val) for var, val in six.iteritems(variables)
+    var_list = [(var, val) for var, val in variables.items()
                 if not (var.startswith('__') or var.endswith('__'))]
     var_list.sort(key=lambda i: i[0])
     lines = []
     for var, val in var_list:
-        lines.append('{} = {}'.format(var, pformat(val)))
+        lines.append(f'{var} = {pformat(val)}')
     return '\n'.join(lines)
 
 
-def _format_code_context(frame_info):
-    # type: (tuple) -> Text
+def _format_code_context(frame_info: inspect.FrameInfo) -> str:
     context = ''
-    if frame_info[4] is not None:
-        for i, line in enumerate(frame_info[4], frame_info[2] - frame_info[5]):
-            if i == frame_info[2]:
-                context += '{}:>{}'.format(six.text_type(i).rjust(5), line)
+    if frame_info.code_context is not None:
+        for i, line in enumerate(frame_info.code_context, frame_info.lineno - frame_info.index):
+            if i == frame_info.lineno:
+                context += f'{str(i).rjust(5)}:>{line}'
             else:
-                context += '{}: {}'.format(six.text_type(i).rjust(5), line)
+                context += f'{str(i).rjust(5)}: {line}'
     return context
 
 
@@ -73,30 +67,16 @@ Local variables:
 """
 
 
-def _format_frame_info(frame_info):
-    # type: (tuple) -> Text
+def _format_frame_info(frame_info: inspect.FrameInfo) -> str:
     return FRAME_INFO_TEMPLATE.format(
-        file_path=frame_info[1],
-        lineno=frame_info[2],
+        file_path=frame_info.filename,
+        lineno=frame_info.lineno,
         code_context=_format_code_context(frame_info),
-        local_vars=_format_vars(frame_info[0].f_locals)
+        local_vars=_format_vars(frame_info.frame.f_locals)
     )
 
 
-EXCEPTION_TEMPLATE = """
-*********************************** Unhandled exception detected ***********************************
-####################################################################################################
-                                           Diagnostic info
-----------------------------------------------------------------------------------------------------
-Exception type  : {exc_type}
-Exception value : {exc}
-System info     : {system_info}
-Python version  : {python_version}
-Kodi version    : {kodi_version}
-sys.argv        : {sys_argv}
-----------------------------------------------------------------------------------------------------
-sys.path:
-{sys_path}
+STACK_TRACE_TEMPLATE = """
 ####################################################################################################
                                             Stack Trace
 ====================================================================================================
@@ -105,9 +85,78 @@ sys.path:
 """
 
 
+def _format_stack_trace(frames: Iterable[inspect.FrameInfo]) -> str:
+    stack_trace = ''
+    for frame_info in frames:
+        stack_trace += _format_frame_info(frame_info)
+    return STACK_TRACE_TEMPLATE.format(stack_trace=stack_trace)
+
+
+EXCEPTION_TEMPLATE = """
+####################################################################################################
+                                     Exception Diagnostic Info
+----------------------------------------------------------------------------------------------------
+Exception type    : {exc_type}
+Exception message : {exc}
+System info       : {system_info}
+Python version    : {python_version}
+Kodi version      : {kodi_version}
+sys.argv          : {sys_argv}
+----------------------------------------------------------------------------------------------------
+sys.path:
+{sys_path}
+{stack_trace_info}
+"""
+
+
+def format_trace(frames_to_exclude: int = 1) -> str:
+    """
+    Returns a pretty stack trace with code context and local variables
+
+    Stack trace info includes the following:
+
+    * File path and line number
+    * Code fragment
+    * Local variables
+
+    It allows to inspect execution state at the point of this function call
+
+    :param frames_to_exclude: How many top frames are excluded from the trace
+        to skip unnecessary info. Since each function call creates a stack frame
+        you need to exclude at least this function frame.
+    """
+    frames = inspect.stack(5)[frames_to_exclude:]
+    return _format_stack_trace(reversed(frames))
+
+
+def format_exception(exc_obj: Optional[Exception] = None) -> str:
+    """
+    Returns a pretty exception stack trace with code context and local variables
+
+    :param exc_obj: exception object (optional)
+    :raises ValueError: if no exception is being handled
+    """
+    if exc_obj is None:
+        _, exc_obj, _ = sys.exc_info()
+    if exc_obj is None:
+        raise ValueError('No exception is currently being handled')
+    stack_trace = inspect.getinnerframes(exc_obj.__traceback__, context=5)
+    stack_trace_info = _format_stack_trace(stack_trace)
+    message = EXCEPTION_TEMPLATE.format(
+        exc_type=exc_obj.__class__.__name__,
+        exc=exc_obj,
+        system_info=uname(),
+        python_version=sys.version.replace('\n', ' '),
+        kodi_version=xbmc.getInfoLabel('System.BuildVersion'),
+        sys_argv=pformat(sys.argv),
+        sys_path=pformat(sys.path),
+        stack_trace_info=stack_trace_info
+    )
+    return message
+
+
 @contextmanager
-def log_exception(logger_func=log_error):
-    # type: (Callable[[Text], None]) -> Generator[None, None, None]
+def catch_exception(logger_func: Callable[[str], None] = _log_error) -> Generator[None, None, None]:
     """
     Diagnostic helper context manager
 
@@ -128,7 +177,7 @@ def log_exception(logger_func=log_error):
 
     Example::
 
-        with debug_exception():
+        with catch_exception():
             # Some risky code
             raise RuntimeError('Fatal error!')
 
@@ -138,18 +187,8 @@ def log_exception(logger_func=log_error):
     try:
         yield
     except Exception as exc:
-        stack_trace = ''
-        for frame_info in inspect.trace(5):
-            stack_trace += _format_frame_info(frame_info)
-        message = EXCEPTION_TEMPLATE.format(
-            exc_type=exc.__class__.__name__,
-            exc=exc,
-            system_info=uname(),
-            python_version=sys.version.replace('\n', ' '),
-            kodi_version=xbmc.getInfoLabel('System.BuildVersion'),
-            sys_argv=pformat(sys.argv),
-            sys_path=pformat(sys.path),
-            stack_trace=stack_trace
-        )
-        logger_func(message)
-        raise exc
+        message = format_exception(exc)
+        # pylint: disable=line-too-long
+        logger_func('\n*********************************** Unhandled exception detected ***********************************\n'
+                    + message)
+        raise

--- a/script.service.next-episode/libs/gui.py
+++ b/script.service.next-episode/libs/gui.py
@@ -1,16 +1,24 @@
-# coding: utf-8
-# Created on: 15.03.2016
-# Author: Roman Miroshnychenko aka Roman V.M. (romanvm@yandex.ua)
-# License: GPL v. 3 <http://www.gnu.org/licenses/gpl-3.0.en.html>
+# (c) Roman Miroshnychenko, 2023
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-from __future__ import absolute_import, unicode_literals
-
-from abc import ABCMeta, abstractmethod
+from abc import ABC, abstractmethod
 from contextlib import contextmanager
 
 import pyxbmct
-from future.utils import with_metaclass
-from kodi_six.xbmc import executebuiltin
+
+from xbmc import executebuiltin
 from xbmcgui import ACTION_NAV_BACK
 
 from .addon import ADDON
@@ -45,7 +53,7 @@ def busy_spinner():
         executebuiltin('Dialog.Close(10138)')  # Busy spinner off
 
 
-class NextEpDialog(with_metaclass(ABCMeta, pyxbmct.AddonDialogWindow)):
+class NextEpDialog(ABC, pyxbmct.AddonDialogWindow):
     """
     Base class for addon dialogs
     """

--- a/script.service.next-episode/libs/logger.py
+++ b/script.service.next-episode/libs/logger.py
@@ -1,44 +1,61 @@
-# coding: utf-8
-# Author: Roman Miroshnychenko aka Roman V.M.
-# E-mail: roman1972@gmail.com
-# License: GPL v. 3 <http://www.gnu.org/licenses/gpl-3.0.en.html>
+# (c) Roman Miroshnychenko, 2023
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-from __future__ import absolute_import, unicode_literals
-import os
-from inspect import currentframe
-from kodi_six import xbmc
-from .addon import ADDON_ID, ADDON_VERSION
+import logging
 
-__all__ = ['log_debug', 'log_error', 'log_info', 'log_warning']
+import xbmc
 
-FORMAT = '{id} [v.{version}] - {filename}:{lineno} - {message}'
+from libs.addon import ADDON_ID, ADDON_VERSION
+
+LOG_FORMAT = '[{addon_id} v.{addon_version}] {filename}:{lineno} - {message}'
 
 
-def log_message(msg, level=xbmc.LOGDEBUG):
-    curr_frame = currentframe()
-    xbmc.log(
-        FORMAT.format(
-            id=ADDON_ID,
-            version=ADDON_VERSION,
-            filename=os.path.basename(curr_frame.f_back.f_back.f_code.co_filename),
-            lineno=curr_frame.f_back.f_back.f_lineno,
-            message=msg
-        ),
-        level
+class KodiLogHandler(logging.Handler):
+    """
+    Logging handler that writes to the Kodi log with correct levels
+
+    It also adds {addon_id} and {addon_version} variables available to log format.
+    """
+    LEVEL_MAP = {
+        logging.NOTSET: xbmc.LOGNONE,
+        logging.DEBUG: xbmc.LOGDEBUG,
+        logging.INFO: xbmc.LOGINFO,
+        logging.WARN: xbmc.LOGWARNING,
+        logging.WARNING: xbmc.LOGWARNING,
+        logging.ERROR: xbmc.LOGERROR,
+        logging.CRITICAL: xbmc.LOGFATAL,
+    }
+
+    def emit(self, record):
+        record.addon_id = ADDON_ID
+        record.addon_version = ADDON_VERSION
+        message = self.format(record)
+        kodi_log_level = self.LEVEL_MAP.get(record.levelno, xbmc.LOGDEBUG)
+        xbmc.log(message, level=kodi_log_level)
+
+
+def initialize_logging():
+    """
+    Initialize the root logger that writes to the Kodi log
+
+    After initialization, you can use Python logging facilities as usual.
+    """
+    logging.basicConfig(
+        format=LOG_FORMAT,
+        style='{',
+        level=logging.DEBUG,
+        handlers=[KodiLogHandler()],
+        force=True
     )
-
-
-def log_info(msg):
-    log_message(msg, xbmc.LOGINFO)
-
-
-def log_warning(msg):
-    log_message(msg, xbmc.LOGWARNING)
-
-
-def log_error(msg):
-    log_message(msg, xbmc.LOGERROR)
-
-
-def log_debug(msg):
-    log_message(msg, xbmc.LOGDEBUG)

--- a/script.service.next-episode/libs/monitoring.py
+++ b/script.service.next-episode/libs/monitoring.py
@@ -1,17 +1,28 @@
-# coding: utf-8
-# Created on: 17.03.2016
-# Author: Roman Miroshnychenko aka Roman V.M. (romanvm@yandex.ua)
-# License: GPL v. 3 <http://www.gnu.org/licenses/gpl-3.0.en.html>
+# (c) Roman Miroshnychenko, 2023
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-from __future__ import absolute_import, unicode_literals
 import json
-from kodi_six import xbmc
-from kodi_six.xbmcgui import Dialog
-from . import logger
-from .addon import ADDON
-from .utils import sync_library, sync_new_items, login, update_single_item
-from .medialibrary import get_item_details
-from .gui import ui_string
+import logging
+
+import xbmc
+from xbmcgui import Dialog
+
+from libs.addon import ADDON
+from libs.gui import ui_string
+from libs.medialibrary import get_item_details
+from libs.utils import sync_library, sync_new_items, login, update_single_item
 
 # Here ``addon`` is imported from another module to prevent a bug
 # when username and hash are not stored in the addon settings.
@@ -29,7 +40,7 @@ class UpdateMonitor(xbmc.Monitor):
     def onScanFinished(self, library):
         if library == 'video':
             sync_new_items()
-            logger.log_debug('New items updated')
+            logging.debug('New items updated')
 
     def onNotification(self, sender, method, data):
         """

--- a/script.service.next-episode/libs/nextepisode.py
+++ b/script.service.next-episode/libs/nextepisode.py
@@ -1,21 +1,25 @@
-# coding: utf-8
-# Created on: 15.03.2016
-# Author: Roman Miroshnychenko aka Roman V.M. (romanvm@yandex.ua)
-# License: GPL v. 3 <http://www.gnu.org/licenses/gpl-3.0.en.html>
-
-from __future__ import absolute_import, unicode_literals
+# (c) Roman Miroshnychenko, 2023
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import json
+import logging
 from copy import deepcopy
 from pprint import pformat
 
-from future.utils import python_2_unicode_compatible
-from requests import post
-
-from . import logger
-from .medialibrary import get_tvdb_id
-
-__all__ = ['prepare_movies_list', 'prepare_episodes_list', 'update_data']
+from libs import simple_requests as requests
+from libs.medialibrary import get_tvdb_id
 
 UPDATE_DATA = 'https://next-episode.net/api/kodi/v1/update_data'
 LOGIN = 'https://next-episode.net/api/kodi/v1/login'
@@ -25,7 +29,6 @@ class LoginError(Exception):
     pass
 
 
-@python_2_unicode_compatible
 class DataUpdateError(Exception):
     """
     Exception that carries information about movies and/or TV shows
@@ -59,9 +62,7 @@ class DataUpdateError(Exception):
     def __str__(self):
         return (
             'Data update error! '
-            'Failed movies: {0}. Failed TV shows: {1}'.format(
-                self.failed_movies,
-                self.failed_shows)
+            f'Failed movies: {self.failed_movies}. Failed TV shows: {self.failed_shows}'
         )
 
 
@@ -76,12 +77,12 @@ def web_client(url, data=None):
     :return. website JSON response
     :rtype: dict
     """
-    reply = post(url, json=data, verify=False)
+    reply = requests.post(url, json=data, verify=False)
     result = json.loads(reply.text)
     logged_data = deepcopy(result)
     if 'hash' in logged_data:
         logged_data['hash'] = '*****'
-    logger.log_debug('next-episode reply:\n{0}'.format(pformat(logged_data)))
+    logging.debug('next-episode reply:\n%s', pformat(logged_data))
     return result
 
 

--- a/script.service.next-episode/libs/simple_requests.py
+++ b/script.service.next-episode/libs/simple_requests.py
@@ -1,0 +1,235 @@
+# Copyright (C) 2019, Roman Miroshnychenko aka Roman V.M. <roman1972@gmail.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""
+A simple library for making HTTP requests with API similar to the popular "requests" library
+
+It depends only on the Python standard library.
+
+Supported:
+* HTTP methods: GET, POST
+* HTTP and HTTPS.
+* Disabling SSL certificates validation.
+* Request payload as form data and JSON.
+* Custom headers.
+* Basic authentication.
+* Gzipped response content.
+Not supported:
+* Cookies.
+* File upload.
+"""
+# pylint: skip-file
+import gzip
+import io
+import json as _json
+import ssl
+from base64 import b64encode
+from email.message import Message
+from typing import Optional, Dict, Any, Tuple, Union, List
+from urllib import request as url_request
+from urllib.error import HTTPError as _HTTPError
+from urllib.parse import urlparse, urlencode
+
+__all__ = [
+    'RequestException',
+    'ConnectionError',
+    'HTTPError',
+    'get',
+    'post',
+]
+
+
+class RequestException(IOError):
+
+    def __repr__(self) -> str:
+        return self.__str__()
+
+
+class ConnectionError(RequestException):
+
+    def __init__(self, message: str, url: str):
+        super().__init__(message)
+        self.message = message
+        self.url = url
+
+    def __str__(self) -> str:
+        return f'ConnectionError for url {self.url}: {self.message}'
+
+
+class HTTPError(RequestException):
+
+    def __init__(self, response: 'Response'):
+        self.response = response
+
+    def __str__(self) -> str:
+        return f'HTTPError: {self.response.status_code} for url: {self.response.url}'
+
+
+class HTTPMessage(Message):
+
+    def update(self, dct: Dict[str, str]) -> None:
+        for key, value in dct.items():
+            self[key] = value
+
+
+class Response:
+    NULL = object()
+
+    def __init__(self):
+        self.encoding: str = 'utf-8'
+        self.status_code: int = -1
+        self.headers: Dict[str, str] = {}
+        self.url: str = ''
+        self.content: bytes = b''
+        self._text = None
+        self._json = self.NULL
+
+    def __str__(self) -> str:
+        return f'<Response [{self.status_code}]>'
+
+    def __repr__(self) -> str:
+        return self.__str__()
+
+    @property
+    def ok(self) -> bool:
+        return self.status_code < 400
+
+    @property
+    def text(self) -> str:
+        """
+        :return: Response payload as decoded text
+        """
+        if self._text is None:
+            self._text = self.content.decode(self.encoding)
+        return self._text
+
+    def json(self) -> Optional[Union[Dict[str, Any], List[Any]]]:
+        try:
+            if self._json is self.NULL:
+                self._json = _json.loads(self.content)
+            return self._json
+        except ValueError as exc:
+            raise ValueError('Response content is not a valid JSON') from exc
+
+    def raise_for_status(self) -> None:
+        if not self.ok:
+            raise HTTPError(self)
+
+
+def _create_request(url_structure, params=None, data=None, headers=None, auth=None, json=None):
+    query = url_structure.query
+    if params is not None:
+        separator = '&' if query else ''
+        query += separator + urlencode(params, doseq=True)
+    full_url = url_structure.scheme + '://' + url_structure.netloc + url_structure.path
+    if query:
+        full_url += '?' + query
+    prepared_headers = HTTPMessage()
+    if headers is not None:
+        prepared_headers.update(headers)
+    body = None
+    if json is not None:
+        body = _json.dumps(json).encode('utf-8')
+        prepared_headers['Content-Type'] = 'application/json'
+    if body is None and data is not None:
+        body = urlencode(data, doseq=True).encode('ascii')
+        prepared_headers['Content-Type'] = 'application/x-www-form-urlencoded'
+    if auth is not None:
+        encoded_credentials = b64encode((auth[0] + ':' + auth[1]).encode('utf-8')).decode('ascii')
+        prepared_headers['Authorization'] = f'Basic {encoded_credentials}'
+    if 'Accept-Encoding' not in prepared_headers:
+        prepared_headers['Accept-Encoding'] = 'gzip'
+    return url_request.Request(full_url, body, prepared_headers)
+
+
+def post(url: str,
+         params: Optional[Dict[str, Any]] = None,
+         data: Optional[Dict[str, Any]] = None,
+         headers: Optional[Dict[str, str]] = None,
+         auth: Optional[Tuple[str, str]] = None,
+         timeout: Optional[float] = None,
+         verify: bool = True,
+         json: Optional[Dict[str, Any]] = None) -> Response:
+    """
+    POST request
+
+    This function assumes that a request body should be encoded with UTF-8
+    and by default sends Accept-Encoding: gzip header to receive response content compressed.
+
+    :param url: URL
+    :param params: URL query params
+    :param data: request payload as form data. If "data" or "json" are passed
+        then a POST request is sent
+    :param headers: additional headers
+    :param auth: a tuple of (login, password) for Basic authentication
+    :param timeout: request timeout in seconds
+    :param verify: verify SSL certificates
+    :param json: request payload as JSON. This parameter has precedence over "data", that is,
+        if it's present then "data" is ignored.
+    :return: Response object
+    """
+    url_structure = urlparse(url)
+    request = _create_request(url_structure, params, data, headers, auth, json)
+    context = None
+    if url_structure.scheme == 'https':
+        context = ssl.SSLContext()
+        if not verify:
+            context.verify_mode = ssl.CERT_NONE
+            context.check_hostname = False
+    fp = None
+    try:
+        r = fp = url_request.urlopen(request, timeout=timeout, context=context)
+        content = fp.read()
+    except _HTTPError as exc:
+        r = exc
+        fp = exc.fp
+        content = fp.read()
+    except Exception as exc:
+        raise ConnectionError(str(exc), request.full_url) from exc
+    finally:
+        if fp is not None:
+            fp.close()
+    response = Response()
+    response.status_code = r.status if hasattr(r, 'status') else r.getstatus()
+    response.headers = r.headers
+    response.url = r.url if hasattr(r, 'url') else r.geturl()
+    if r.headers.get('Content-Encoding') == 'gzip':
+        temp_fo = io.BytesIO(content)
+        gzip_file = gzip.GzipFile(fileobj=temp_fo)
+        content = gzip_file.read()
+    response.content = content
+    return response
+
+
+def get(url: str,
+        params: Optional[Dict[str, Any]] = None,
+        headers: Optional[Dict[str, str]] = None,
+        auth: Optional[Tuple[str, str]] = None,
+        timeout: Optional[float] = None,
+        verify: bool = True) -> Response:
+    """
+    GET request
+
+    This function by default sends Accept-Encoding: gzip header
+    to receive response content compressed.
+
+    :param url: URL
+    :param params: URL query params
+    :param headers: additional headers
+    :param auth: a tuple of (login, password) for Basic authentication
+    :param timeout: request timeout in seconds
+    :param verify: verify SSL certificates
+    :return: Response object
+    """
+    return post(url=url, params=params, headers=headers, auth=auth, timeout=timeout, verify=verify)

--- a/script.service.next-episode/libs/utils.py
+++ b/script.service.next-episode/libs/utils.py
@@ -1,28 +1,32 @@
-# coding: utf-8
-# Created on: 17.03.2016
-# Author: Roman Miroshnychenko aka Roman V.M. (romanvm@yandex.ua)
-# License: GPL v. 3 <http://www.gnu.org/licenses/gpl-3.0.en.html>
+# (c) Roman Miroshnychenko, 2023
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-from __future__ import absolute_import, unicode_literals
-
+import logging
 from copy import deepcopy
 from pprint import pformat
 
+from xbmcgui import Dialog
+
 import pyxbmct
-from future.builtins import str
-from kodi_six.xbmcgui import Dialog
-
-from . import logger
-from .addon import ADDON, ICON, KODI_VERSION
-from .gui import NextEpDialog, ui_string, busy_spinner
-from .medialibrary import (get_movies, get_tvshows, get_episodes,
-                           get_recent_movies, get_recent_episodes, get_tvdb_id,
-                           NoDataError)
-from .nextepisode import (prepare_movies_list, prepare_episodes_list, update_data,
-                          get_password_hash, LoginError, DataUpdateError)
-
-__all__ = ['LoginDialog', 'sync_library', 'sync_new_items', 'login',
-           'update_single_item']
+from libs.addon import ADDON, ICON, KODI_VERSION
+from libs.gui import NextEpDialog, ui_string, busy_spinner
+from libs.medialibrary import (get_movies, get_tvshows, get_episodes,
+                               get_recent_movies, get_recent_episodes, get_tvdb_id,
+                               NoDataError)
+from libs.nextepisode import (prepare_movies_list, prepare_episodes_list, update_data,
+                              get_password_hash, LoginError, DataUpdateError)
 
 DIALOG = Dialog()
 
@@ -98,10 +102,10 @@ def send_data(data):
     try:
         update_data(data)
     except LoginError:
-        logger.log_error('Login failed! Re-enter your username and password.')
+        logging.error('Login failed! Re-enter your username and password.')
         DIALOG.notification('next-episode.net', ui_string(32007), icon='error')
     except DataUpdateError as ex:
-        logger.log_error(str(ex))
+        logging.exception(str(ex))
         if ADDON.getSetting('disable_error_dialogs') != 'true':
             DIALOG.ok('next-epsisode.net',
                       '[CR]'.join((
@@ -126,7 +130,7 @@ def log_data_sent(data):
     """
     logged_data = deepcopy(data)
     logged_data['user']['username'] = logged_data['user']['hash'] = '*****'
-    logger.log_debug('Data sent:\n{0}'.format(pformat(logged_data)))
+    logging.debug('Data sent:\n%s', pformat(logged_data))
 
 
 def sync_library():
@@ -162,7 +166,7 @@ def sync_library():
             log_data_sent(data)
             send_data(data)
         else:
-            logger.log_warning(
+            logging.warning(
                 'Kodi video library has no movies and TV episodes.'
             )
 
@@ -188,7 +192,7 @@ def sync_new_items():
         log_data_sent(data)
         send_data(data)
     else:
-        logger.log_warning(
+        logging.warning(
             'Kodi video library has no recent movies and episodes.'
         )
 
@@ -254,11 +258,11 @@ def login():
                               ui_string(32007),
                               ui_string(32010)
                           )))
-                logger.log_error('Login failed!')
+                logging.error('Login failed!')
             else:
                 ADDON.setSetting('username', username)
                 ADDON.setSetting('hash', hash_)
-                logger.log_debug('Successful login')
+                logging.debug('Successful login')
                 DIALOG.notification('next-episode.net', ui_string(32011),
                                     time=3000, sound=False)
                 result = True

--- a/script.service.next-episode/main.py
+++ b/script.service.next-episode/main.py
@@ -1,13 +1,26 @@
-# coding: utf-8
-# Author: Roman Miroshnychenko aka Roman V.M.
-# E-mail: romanvm@yandex.ua
-# License: GPL v. 3 <http://www.gnu.org/licenses/gpl-3.0.en.html>
+# (c) Roman Miroshnychenko, 2023
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-from __future__ import unicode_literals
+import logging
 import sys
+
 import pyxbmct
-from libs.exception_logger import log_exception
+
+from libs.exception_logger import catch_exception
 from libs.gui import NextEpDialog, ui_string
+from libs.logger import initialize_logging
 from libs.utils import sync_library, login
 
 
@@ -40,7 +53,8 @@ class MainDialog(NextEpDialog):
 
 
 if __name__ == '__main__':
-    with log_exception():
+    initialize_logging()
+    with catch_exception(logging.error):
         if 'sync_library' in sys.argv:
             sync_library()
         elif 'login' in sys.argv:

--- a/script.service.next-episode/resources/settings.xml
+++ b/script.service.next-episode/resources/settings.xml
@@ -1,15 +1,47 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<settings>
-  <category label="32000">
-    <setting label="32019" type="bool" id="disable_error_dialogs" default="false" />
-    <setting type="action"
-             label="32001"
-             action="RunScript(script.service.next-episode,login)" />
-    <setting type="action"
-             label="32002"
-             action="RunScript(script.service.next-episode,sync_library)" />
-    <setting label="Prompt" type="bool" id="prompt_shown" default="false" visible="false" />
-    <setting label="Username" type="text" id="username" default="" visible="false"/>
-    <setting label="Hash" type="text" id="hash" default="" visible="false"/>
-  </category>
+<settings version="1">
+  <section id="script.service.next-episode">
+    <category id="general" label="32000" help="">
+      <group id="1">
+        <setting id="disable_error_dialogs" type="boolean" label="32019" help="">
+          <level>0</level>
+          <default>false</default>
+          <control type="toggle"/>
+        </setting>
+        <setting id="run_login" type="action" label="32001" help="">
+          <level>0</level>
+          <data>RunScript(script.service.next-episode,login)</data>
+          <control type="button" format="action">
+            <close>true</close>
+          </control>
+        </setting>
+        <setting id="run_sync_library" type="action" label="32002" help="">
+          <level>0</level>
+          <data>RunScript(script.service.next-episode,sync_library)</data>
+          <control type="button" format="action">
+            <close>true</close>
+          </control>
+        </setting>
+        <setting id="prompt_shown" type="boolean" label="" help="">
+          <default>false</default>
+          <control type="toggle"/>
+          <visible>false</visible>
+        </setting>
+        <setting id="username" type="string" label="" help="">
+          <default/>
+          <constraints>
+            <allowempty>true</allowempty>
+          </constraints>
+          <visible>false</visible>
+        </setting>
+        <setting id="hash" type="string" label="" help="">
+          <default/>
+          <constraints>
+            <allowempty>true</allowempty>
+          </constraints>
+          <visible>false</visible>
+        </setting>
+      </group>
+    </category>
+  </section>
 </settings>

--- a/script.service.next-episode/service.py
+++ b/script.service.next-episode/service.py
@@ -1,17 +1,28 @@
-# coding: utf-8
-# Created on: 15.03.2016
-# Author: Roman Miroshnychenko aka Roman V.M. (romanvm@yandex.ua)
-# License: GPL v. 3 <http://www.gnu.org/licenses/gpl-3.0.en.html>
+# (c) Roman Miroshnychenko, 2023
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-from __future__ import unicode_literals
+import logging
 
-from libs.exception_logger import log_exception
-from libs.logger import log_info
+from libs.exception_logger import catch_exception
+from libs.logger import initialize_logging
 from libs.monitoring import UpdateMonitor, initial_prompt
 
-with log_exception():
+initialize_logging()
+with catch_exception(logging.error):
     initial_prompt()
     update_monitor = UpdateMonitor()
-    log_info('Service started')
+    logging.debug('Service started')
     update_monitor.waitForAbort()
-    log_info('Service stopped')
+    logging.debug('Service stopped')


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: Next Episode (next-episode.net)
  - Add-on ID: script.service.next-episode
  - Version number: 1.2.6
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/romanvm/next-episode-kodi
  
The next-episode.net service for Kodi allows to add your movies and TV episodes from media library to your inventory on next-episode.net. The service also monitors video playback and updates 'watched' status of your movies and episodes on next-episode.net.[CR][B]Note:[/B] The addon works only with Kodi medialibrary!

### Description of changes:

1.2.6:
- Removed Python 2 compatibility

1.2.5:
- Fixed crashes when movies do not have IMDB ID.

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
