### PR TITLE
[weather.ozweather@matrix] 2.1.1

### DIFF
--- a/weather.ozweather/addon.xml
+++ b/weather.ozweather/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="weather.ozweather" name="Oz Weather" version="2.1.0" provider-name="Bossanova808">
+<addon id="weather.ozweather" name="Oz Weather" version="2.1.1" provider-name="Bossanova808">
 	<requires>
 		<import addon="xbmc.python" version="3.0.0"/>
     	<import addon="script.module.requests" version="2.22.0+matrix.1"/>
@@ -22,8 +22,8 @@
        		<icon>icon.png</icon>
        		<fanart>fanart.jpg</fanart>
 		</assets>
-		<news>2.1.0
-			- Fix light_rain icon &amp; update BOM radar list
+		<news>2.1.1
+			- Add Latitude and Longitude to Window data for skins that display 'season' using (arguably dubious) logic
     	</news>
 	</extension>
 </addon>

--- a/weather.ozweather/changelog.txt
+++ b/weather.ozweather/changelog.txt
@@ -1,3 +1,6 @@
+2.1.1
+- Add Latitude and Longitude to Window data for skins that display 'season' using (arguably dubious) logic
+
 2.1.0
 - Fix light_rain icon & update BOM radar list
 

--- a/weather.ozweather/resources/lib/forecast.py
+++ b/weather.ozweather/resources/lib/forecast.py
@@ -27,6 +27,8 @@ def clear_properties():
 
         set_property(WEATHER_WINDOW, 'Forecast.City')
         set_property(WEATHER_WINDOW, 'Forecast.Country')
+        set_property(WEATHER_WINDOW, 'Forecast.Latitude')
+        set_property(WEATHER_WINDOW, 'Forecast.Longitude')
         set_property(WEATHER_WINDOW, 'Forecast.Updated')
 
         set_property(WEATHER_WINDOW, 'ForecastUpdated')
@@ -248,6 +250,8 @@ def get_weather():
 
     # Set the location we updated
     location_in_use = ADDON.getSetting(f'Location{sys.argv[1]}BOM')
+    latitude = ADDON.getSetting(f'Location{sys.argv[1]}Lat')
+    longitude = ADDON.getSetting(f'Location{sys.argv[1]}Lon')
     try:
         location_in_use = location_in_use[0:location_in_use.index(' (')]
     except ValueError:
@@ -258,5 +262,7 @@ def get_weather():
     set_property(WEATHER_WINDOW, 'Current.Location', location_in_use)
     set_property(WEATHER_WINDOW, 'Forecast.City', location_in_use)
     set_property(WEATHER_WINDOW, 'Forecast.Country', "Australia")
+    set_property(WEATHER_WINDOW, 'Forecast.Latitude', latitude)
+    set_property(WEATHER_WINDOW, 'Forecast.Longitude', longitude)
     set_property(WEATHER_WINDOW, 'Forecast.Updated', time.strftime("%d/%m @ %H:%M").lower())
 


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: Oz Weather
  - Add-on ID: weather.ozweather
  - Version number: 2.1.1
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/bossanova808/weather.ozweather
  
Weather forecasting and radar images for Australia using Bureau of Meteorology data.  For full features (animated radars & ABC weather videos) - make sure you install the replacement skin files - see information at the addon wiki (https://kodi.wiki/index.php?title=Add-on:Oz_Weather).

### Description of changes:

2.1.1
			- Add Latitude and Longitude to Window data for skins that display 'season' using (arguably dubious) logic
    	

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
