### PR TITLE
[script.service.checkpreviousepisode@matrix] 0.4.6

### DIFF
--- a/script.service.checkpreviousepisode/addon.xml
+++ b/script.service.checkpreviousepisode/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.service.checkpreviousepisode" version="0.4.5" name="Kodi Check Previous Episode" provider-name="bossanova808, Razzeee, Lucleonhart" >
+<addon id="script.service.checkpreviousepisode" version="0.4.6" name="Kodi Check Previous Episode" provider-name="bossanova808, Razzeee, Lucleonhart" >
   <requires>
     <import addon="xbmc.python" version="3.0.0" />
     <import addon="script.module.yaml" version="3.11.0" />
@@ -16,8 +16,8 @@
     <forum>https://forum.kodi.tv/showthread.php?tid=355464</forum>
     <website>https://kodi.wiki/view/Add-on:XBMC_Check_Previous_Episode</website>
     <source>https://github.com/bossanova808/script.service.checkpreviousepisode</source>
-    <news>v0.4.5
-    - Fix logic of ignore if previous episode not actually in library 
+    <news>v0.4.6
+    - Ignore shows that have already been decided on (i.e. those with a non-zero resume point)
     </news>
   <assets>
      <icon>icon.png</icon>

--- a/script.service.checkpreviousepisode/changelog.txt
+++ b/script.service.checkpreviousepisode/changelog.txt
@@ -1,3 +1,6 @@
+v0.4.6
+- Ignore shows that have already been decided on (i.e. those with a non-zero resume point)
+
 v0.4.5
 - Fix logic of ignore if previous episode not actually in library 
     

--- a/script.service.checkpreviousepisode/resources/lib/player.py
+++ b/script.service.checkpreviousepisode/resources/lib/player.py
@@ -58,7 +58,7 @@ class KodiPlayer(xbmc.Player):
                     "method": "VideoLibrary.GetEpisodeDetails",
                     "params": {
                         "episodeid": json_object['result']['item']['id'],
-                        "properties": ["tvshowid", "showtitle", "season", "episode"]
+                        "properties": ["tvshowid", "showtitle", "season", "episode", "resume"]
                     }
                 })
                 json_object = send_kodi_json("Get episode details", command)
@@ -70,11 +70,18 @@ class KodiPlayer(xbmc.Player):
                     playing_tvshow_title = json_object['result']['episodedetails']['showtitle']
                     playing_season = json_object['result']['episodedetails']['season']
                     playing_episode = json_object['result']['episodedetails']['episode']
-                    log(f'Playing - title: {playing_tvshow_title} , id: {playing_tvshowid} , season: {playing_season}, episode: {playing_episode}')
+                    resume_point = json_object['result']['episodedetails']['resume']['position']
+
+                    log(f'Playing - title: {playing_tvshow_title} , id: {playing_tvshowid} , season: {playing_season}, episode: {playing_episode}, resume: {resume_point}')
 
                     # Is show set to be ignored?
                     if Store.ignored_shows and playing_tvshowid in Store.ignored_shows:
-                        log(f'Show {playing_tvshow_title} set to ignore, carry on...')
+                        log(f'Show {playing_tvshow_title} set to ignore, so allowing.')
+                        return
+
+                    # Is the resume point is non-zero - then we've previously made a decision about playing this episode, so don't make the user make it again
+                    if resume_point > 0.0:
+                        log(f"Show {playing_tvshow_title} Season {playing_season} Episode {playing_episode} has a non-zero resume point, so decision has been previously made to play this episode, so allowing.")
                         return
 
                     # We ignore first episodes...
@@ -106,7 +113,7 @@ class KodiPlayer(xbmc.Player):
                             # If we couldn't find the previous episode in the library
                             # AND the user has asked us to ignore this, we're done.
                             if not found and Store.ignore_if_episode_absent_from_library:
-                                log("Previous episode was not found, and ignore if absent from library is true")
+                                log("Previous episode was not found in library, and setting ignore if absent from library is true, so allowing.")
                                 return
 
                             # If we couldn't find the previous episode in the library,


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: Kodi Check Previous Episode
  - Add-on ID: script.service.checkpreviousepisode
  - Version number: 0.4.6
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/bossanova808/script.service.checkpreviousepisode
  
This service helps prevent spoilers by checking if the previous episode in a series has been watched. If not, it will pause playback and warn you.  Specific shows can be marked to be ignored if episode order does not matter.

### Description of changes:

v0.4.6
    - Ignore shows that have already been decided on (i.e. those with a non-zero resume point)
    

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
