### PR TITLE
Matrix - script.module.libmediathek4 : Handle Timestamps Containing Millseconds Correctly

### DIFF
--- a/script.module.libmediathek4/addon.xml
+++ b/script.module.libmediathek4/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.module.libmediathek4" name="libmediathek4" version="1.0.0" provider-name="sarbes">
+<addon id="script.module.libmediathek4" name="libmediathek4" version="1.0.1" provider-name="sarbes">
   <requires>
     <import addon="xbmc.python" version="3.0.0" />
   </requires>

--- a/script.module.libmediathek4/lib/libmediathek4.py
+++ b/script.module.libmediathek4/lib/libmediathek4.py
@@ -69,7 +69,7 @@ class lm4:
 					if 'aired' in metadata:
 						if 'ISO8601' in metadata['aired']:
 							if metadata['aired']['ISO8601'].endswith('Z'):
-								t = time.strptime(metadata['aired']['ISO8601'],'%Y-%m-%dT%H:%M:%SZ')
+								t = time.strptime(metadata['aired']['ISO8601'][:19],'%Y-%m-%dT%H:%M:%S')
 							else:
 								t = time.strptime(metadata['aired']['ISO8601'],'%Y-%m-%dT%H:%M:%S%z')
 							ilabels['aired'] = time.strftime('%Y-%m-%d',t)


### PR DESCRIPTION
### Description
Handle timestamps containing millseconds correctly.
Mainly in German channel "ARD/Das Erste" list creation A-Z stopped with error.
This does not happen anymore because the milliseconds are "cut off" with new code.
Of course also channels without milliseconds still work.
### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [X] Each add-on submission should be a single commit with using the following style: [script.foo.bar] 1.0.0

Additional information :
- Submitting your add-on to this specific branch makes it available to any Kodi version equal or higher than the branch name with the applicable Kodi dependencies limits.
- [add-on development](http://kodi.wiki/view/Add-on_development) wiki page.
- Kodi [pydocs](http://kodi.wiki/view/PyDocs) provide information about the Python API
- [PEP8](https://www.python.org/dev/peps/pep-0008/) codingstyle which is considered best practise but not mandatory.
- This add-on repository has automated code guideline check which could help you improve your coding. You can find the results of these check at [Codacy](https://www.codacy.com/app/Kodi/repo-scripts/dashboard). You can create your own account as well to continuously monitor your python coding before submitting to repo.
- Development questions can be asked in the [add-on development](http://forum.kodi.tv/forumdisplay.php?fid=26) section on the Kodi forum.
