### PR TITLE
script.copacetic.helper 1.0.12

### DIFF
--- a/script.copacetic.helper/README.md
+++ b/script.copacetic.helper/README.md
@@ -13,6 +13,20 @@ All code contained in this project is licensed under GPL 3.0.
 * __jurialmunkey__ for all the best-practice code examples from [plugin.video.themoviedb.helper](https://github.com/jurialmunkey/plugin.video.themoviedb.helper) and forum support.
 
 ### Changelog
+**1.0.11**
+- Removed visualisation waveform setting from list of settings changed by SettingsMonitor
+
+**1.0.11**
+- Reordered addon.xml back to how it was before 1.0.9 due to removal of script.copacetic.helper as a plugin source selectable for widgets.
+- Enhanced Slideshow_Monitor class so that it can now fetch fanarts from containers with plugin sources when they are available then use these fanarts in the custom background slideshow. In this way, you can use a custom path to populate a global custom fanart slideshow even without any content in your local library
+
+**1.0.10**
+- read_fanart() method added in 1.0.10 now triggers on services monitor initialise rather than the first time that the SlideShow monitor is run so it should display backgrounds slightly quicker
+
+**1.0.10**
+- Custom path for Global slideshows can now be refreshed on first entry or on change of path without needing Kodi to restart https://github.com/realcopacetic/script.copacetic.helper/issues/6
+- Added new methods to SlideShow monitor class enabling the service monitor to save current global slideshow fanarts to XML on exit, then make these available during initialisation. The aim of this is to serve the last fanart URL from the previous session while new fanarts are being fetched by the slideshow monitor, which should minimise the black-screen delay on starting up Kodi on slower hardware while fanarts are fetched for the first time https://github.com/realcopacetic/script.copacetic.helper/issues/4
+
 **1.0.9**
 - Background slideshows from custom paths/playlists are now generated via the background fanart fetching service and available globally throughout the skin, via a window property. Previously this was done in-skin using a container so would not be available persistently across windows.
 - Removed glitch in background slideshows causing them to fetch new fanarts too often
@@ -20,9 +34,6 @@ All code contained in this project is licensed under GPL 3.0.
 - Added toggle_addon action to script.
 - Switched incorrect labels Enabled/Disabled for script enabler toggle function
 - Reordered addon.xml extension points to update how addon is categorised in Kodi repository
-
-TO DO
-- Add check of json repsonse before notifying of addon status toggle success
 
 **1.0.8**
 - Push dbid of corresponding cropped clearlogo to window prop for comparison so cropped clearlogos only show on correct listitems.

--- a/script.copacetic.helper/addon.xml
+++ b/script.copacetic.helper/addon.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
-<addon id="script.copacetic.helper" name="Copacetic Helper" version="1.0.9" provider-name="realcopacetic">
+<addon id="script.copacetic.helper" name="Copacetic Helper" version="1.0.12" provider-name="realcopacetic">
   <requires>
     <import addon="xbmc.python" version="3.0.1" />
     <import addon="script.module.pil" version="5.1.0" />
   </requires>
-  <extension point="xbmc.service" library="service.py" />
   <extension point="xbmc.python.pluginsource" library="plugin.py">
     <provides>video</provides>
   </extension>
+  <extension point="xbmc.service" library="service.py" />
   <extension point="xbmc.python.script" library="script.py">
     <provides>executable</provides>
   </extension>

--- a/script.copacetic.helper/resources/lib/service/monitor.py
+++ b/script.copacetic.helper/resources/lib/service/monitor.py
@@ -16,6 +16,7 @@ from resources.lib.utilities import (CROPPED_FOLDERPATH, LOOKUP_XML,
 
 XMLSTR = '''<?xml version="1.0" encoding="utf-8"?>
 <data>
+    <backgrounds />
     <clearlogos />
 </data>
 '''
@@ -56,6 +57,7 @@ class Monitor(xbmc.Monitor):
             log('Monitor started', force=True)
             self.start = False
             self.player_monitor = PlayerMonitor()
+            self.art_monitor.read_fanart()
         else:
             log('Monitor resumed', force=True) if self._conditions_met() else None
         while not self.abortRequested() and self._conditions_met():
@@ -64,11 +66,7 @@ class Monitor(xbmc.Monitor):
 
     def _conditions_met(self):
         return (
-            self._get_skindir() and not self.idle and
-            (
-                condition('!Skin.HasSetting(Background_Disabled)') or
-                condition('Skin.HasSetting(Crop_Clearlogos)')
-            )
+            self._get_skindir() and not self.idle
         )
 
     def _get_skindir(self):
@@ -148,8 +146,7 @@ class Monitor(xbmc.Monitor):
 
         # slideshow window is visible run SlideshowMonitor()
         elif condition(
-            '!Skin.HasSetting(Background_Disabled) + ['
-            'Window.IsVisible(home) | '
+            '[Window.IsVisible(home) | '
             'Window.IsVisible(skinsettings) | '
             'Window.IsVisible(appearancesettings) | '
             'Window.IsVisible(mediasettings) | '
@@ -231,6 +228,7 @@ class Monitor(xbmc.Monitor):
         if not self.abortRequested():
             self._on_start()
         else:
+            self.art_monitor.write_art()
             del self.player_monitor
             del self.settings_monitor
             del self.art_monitor

--- a/script.copacetic.helper/resources/lib/service/player.py
+++ b/script.copacetic.helper/resources/lib/service/player.py
@@ -4,7 +4,7 @@ from xbmc import Player
 
 from resources.lib.script.actions import clean_filename
 from resources.lib.service.art import ImageEditor
-from resources.lib.utilities import condition, window_property
+from resources.lib.utilities import condition, json_call, log, window_property
 
 
 class PlayerMonitor(Player):

--- a/script.copacetic.helper/resources/lib/service/settings.py
+++ b/script.copacetic.helper/resources/lib/service/settings.py
@@ -19,8 +19,7 @@ class SettingsMonitor:
             'videolibrary.tvshowartwhitelist': ['keyart', 'square', 'clearlogo', 'clearlogo-alt', 'clearlogo-billboard'],
             'musiclibrary.showallitems': False,
             'musiclibrary.showcompilationartists': False,
-            'pictures.generatethumbs': True,
-            'musicplayer.visualisation': 'visualization.waveform'
+            'pictures.generatethumbs': True
         }
         self.settings_to_change = {}
 


### PR DESCRIPTION
### Description
<!--- Provide a short summary of submitted add-on in case it's a new addition. -->
<!--- If it's plugin update only highlight biggest changes if needed. -->
<!--- Make sure you follow the checklist below before finalising your pull-request. -->
**1.0.11**
- Removed visualisation waveform setting from list of settings changed by SettingsMonitor

**1.0.11**
- Reordered addon.xml back to how it was before 1.0.9 due to removal of script.copacetic.helper as a plugin source selectable for widgets.
- Enhanced Slideshow_Monitor class so that it can now fetch fanarts from containers with plugin sources when they are available then use these fanarts in the custom background slideshow. In this way, you can use a custom path to populate a global custom fanart slideshow even without any content in your local library

**1.0.10**
- read_fanart() method added in 1.0.10 now triggers on services monitor initialise rather than the first time that the SlideShow monitor is run so it should display backgrounds slightly quicker

**1.0.10**
- Custom path for Global slideshows can now be refreshed on first entry or on change of path without needing Kodi to restart https://github.com/realcopacetic/script.copacetic.helper/issues/6
- Added new methods to SlideShow monitor class enabling the service monitor to save current global slideshow fanarts to XML on exit, then make these available during initialisation. The aim of this is to serve the last fanart URL from the previous session while new fanarts are being fetched by the slideshow monitor, which should minimise the black-screen delay on starting up Kodi on slower hardware while fanarts are fetched for the first time https://github.com/realcopacetic/script.copacetic.helper/issues/4

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [X] Each add-on submission should be a single commit with using the following style: [script.foo.bar] 1.0.0

Additional information :
- Submitting your add-on to this specific branch makes it available to any Kodi version equal or higher than the branch name with the applicable Kodi dependencies limits.
- [add-on development](http://kodi.wiki/view/Add-on_development) wiki page.
- Kodi [pydocs](http://kodi.wiki/view/PyDocs) provide information about the Python API
- [PEP8](https://www.python.org/dev/peps/pep-0008/) codingstyle which is considered best practise but not mandatory.
- This add-on repository has automated code guideline check which could help you improve your coding. You can find the results of these check at [Codacy](https://www.codacy.com/app/Kodi/repo-scripts/dashboard). You can create your own account as well to continuously monitor your python coding before submitting to repo.
- Development questions can be asked in the [add-on development](http://forum.kodi.tv/forumdisplay.php?fid=26) section on the Kodi forum.
