### PR TITLE
[service.xbmc.versioncheck@leia] 0.5.30

### DIFF
--- a/service.xbmc.versioncheck/addon.xml
+++ b/service.xbmc.versioncheck/addon.xml
@@ -1,12 +1,15 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="service.xbmc.versioncheck" name="Version Check" version="0.5.28" provider-name="Team Kodi">
+<addon id="service.xbmc.versioncheck" name="Version Check" version="0.5.30" provider-name="Team Kodi">
     <requires>
         <import addon="xbmc.python" version="2.26.0"/>
     </requires>
     <extension point="xbmc.service" library="resources/lib/runner.py"/>
     <extension point="xbmc.addon.metadata">
         <news>
-- add Kodi 20.1 release
+- add Kodi 21.0 release
+- add Kodi 20.5 release
+- add webOS indentification
+- upgrade and exception fixes |contrib: clement-dufour|
 - Update translations from Weblate
         </news>
         <assets>

--- a/service.xbmc.versioncheck/resources/language/resource.language.af_za/strings.po
+++ b/service.xbmc.versioncheck/resources/language/resource.language.af_za/strings.po
@@ -89,17 +89,6 @@ msgctxt "#32024"
 msgid "Linux: Upgrade using apt"
 msgstr ""
 
-# empty strings from id 32025 to 32029
-#. Used in OK dialog
-msgctxt "#32030"
-msgid "A new stable version of Kodi is available."
-msgstr ""
-
-#. Direct people to the website. Used in OK dialog
-msgctxt "#32031"
-msgid "Visit http://kodi.tv for more information."
-msgstr ""
-
 #. Used in OK dialog
 msgctxt "#32032"
 msgid "A new stable version of Kodi is available."

--- a/service.xbmc.versioncheck/resources/language/resource.language.am_et/strings.po
+++ b/service.xbmc.versioncheck/resources/language/resource.language.am_et/strings.po
@@ -89,17 +89,6 @@ msgctxt "#32024"
 msgid "Linux: Upgrade using apt"
 msgstr ""
 
-# empty strings from id 32025 to 32029
-#. Used in OK dialog
-msgctxt "#32030"
-msgid "A new stable version of Kodi is available."
-msgstr ""
-
-#. Direct people to the website. Used in OK dialog
-msgctxt "#32031"
-msgid "Visit http://kodi.tv for more information."
-msgstr ""
-
 #. Used in OK dialog
 msgctxt "#32032"
 msgid "A new stable version of Kodi is available."

--- a/service.xbmc.versioncheck/resources/language/resource.language.ar_sa/strings.po
+++ b/service.xbmc.versioncheck/resources/language/resource.language.ar_sa/strings.po
@@ -89,17 +89,6 @@ msgctxt "#32024"
 msgid "Linux: Upgrade using apt"
 msgstr ""
 
-# empty strings from id 32025 to 32029
-#. Used in OK dialog
-msgctxt "#32030"
-msgid "A new stable version of Kodi is available."
-msgstr ""
-
-#. Direct people to the website. Used in OK dialog
-msgctxt "#32031"
-msgid "Visit http://kodi.tv for more information."
-msgstr ""
-
 #. Used in OK dialog
 msgctxt "#32032"
 msgid "A new stable version of Kodi is available."

--- a/service.xbmc.versioncheck/resources/language/resource.language.ast_es/strings.po
+++ b/service.xbmc.versioncheck/resources/language/resource.language.ast_es/strings.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: XBMC Addons\n"
-"Report-Msgid-Bugs-To: translations@kodi.tv\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "PO-Revision-Date: 2022-11-16 20:15+0000\n"
 "Last-Translator: Enol P. <enolp@softastur.org>\n"
@@ -90,17 +90,6 @@ msgstr ""
 msgctxt "#32024"
 msgid "Linux: Upgrade using apt"
 msgstr "Linux: Anueva con apt"
-
-# empty strings from id 32025 to 32029
-#. Used in OK dialog
-msgctxt "#32030"
-msgid "A new stable version of Kodi is available."
-msgstr ""
-
-#. Direct people to the website. Used in OK dialog
-msgctxt "#32031"
-msgid "Visit http://kodi.tv for more information."
-msgstr ""
 
 #. Used in OK dialog
 msgctxt "#32032"

--- a/service.xbmc.versioncheck/resources/language/resource.language.az_az/strings.po
+++ b/service.xbmc.versioncheck/resources/language/resource.language.az_az/strings.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: XBMC Addons\n"
-"Report-Msgid-Bugs-To: translations@kodi.tv\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "PO-Revision-Date: 2022-02-25 18:13+0000\n"
 "Last-Translator: Christian Gade <gade@kodi.tv>\n"
@@ -89,17 +89,6 @@ msgstr ""
 
 msgctxt "#32024"
 msgid "Linux: Upgrade using apt"
-msgstr ""
-
-# empty strings from id 32025 to 32029
-#. Used in OK dialog
-msgctxt "#32030"
-msgid "A new stable version of Kodi is available."
-msgstr ""
-
-#. Direct people to the website. Used in OK dialog
-msgctxt "#32031"
-msgid "Visit http://kodi.tv for more information."
 msgstr ""
 
 #. Used in OK dialog

--- a/service.xbmc.versioncheck/resources/language/resource.language.be_by/strings.po
+++ b/service.xbmc.versioncheck/resources/language/resource.language.be_by/strings.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: XBMC Addons\n"
-"Report-Msgid-Bugs-To: translations@kodi.tv\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "PO-Revision-Date: 2022-09-05 17:37+0000\n"
 "Last-Translator: Antikruk <zmicerturok@gmail.com>\n"
@@ -89,17 +89,6 @@ msgctxt "#32024"
 msgid "Linux: Upgrade using apt"
 msgstr "Linux: абнаўленне з дапамогай apt"
 
-# empty strings from id 32025 to 32029
-#. Used in OK dialog
-msgctxt "#32030"
-msgid "A new stable version of Kodi is available."
-msgstr "Даступна новая стабільная версія Kodi."
-
-#. Direct people to the website. Used in OK dialog
-msgctxt "#32031"
-msgid "Visit http://kodi.tv for more information."
-msgstr "Каб даведацца больш падрабязна, наведайце http://kodi.tv."
-
 #. Used in OK dialog
 msgctxt "#32032"
 msgid "A new stable version of Kodi is available."
@@ -132,3 +121,12 @@ msgstr "Калі ласка, абнавіце аперацыйную сістэ�
 msgctxt "#32042"
 msgid "For more information, see https://kodi.wiki/view/Linux"
 msgstr "Каб даведацца больш падрабязна, наведайце https://kodi.wiki/view/Linux"
+
+# empty strings from id 32025 to 32029
+#~ msgctxt "#32030"
+#~ msgid "A new stable version of Kodi is available."
+#~ msgstr "Даступна новая стабільная версія Kodi."
+
+#~ msgctxt "#32031"
+#~ msgid "Visit http://kodi.tv for more information."
+#~ msgstr "Каб даведацца больш падрабязна, наведайце http://kodi.tv."

--- a/service.xbmc.versioncheck/resources/language/resource.language.bg_bg/strings.po
+++ b/service.xbmc.versioncheck/resources/language/resource.language.bg_bg/strings.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: XBMC Addons\n"
-"Report-Msgid-Bugs-To: translations@kodi.tv\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "PO-Revision-Date: 2022-01-07 15:13+0000\n"
 "Last-Translator: Christian Gade <gade@kodi.tv>\n"
@@ -90,16 +90,6 @@ msgid "Linux: Upgrade using apt"
 msgstr "Линукс: Актуализиране чрез apt"
 
 #. Used in OK dialog
-msgctxt "#32030"
-msgid "A new stable version of Kodi is available."
-msgstr "Налична е нова стабилна версия на Kodi."
-
-#. Direct people to the website. Used in OK dialog
-msgctxt "#32031"
-msgid "Visit http://kodi.tv for more information."
-msgstr "За повече информация посетете www.kodi.tv"
-
-#. Used in OK dialog
 msgctxt "#32032"
 msgid "A new stable version of Kodi is available."
 msgstr "Налична е нова стабилна версия на Kodi."
@@ -131,6 +121,14 @@ msgstr "Моля подновете Вашата операционна сист
 msgctxt "#32042"
 msgid "For more information, see https://kodi.wiki/view/Linux"
 msgstr "За повече информация, посететеше https://kodi.wiki/view/Linux."
+
+#~ msgctxt "#32030"
+#~ msgid "A new stable version of Kodi is available."
+#~ msgstr "Налична е нова стабилна версия на Kodi."
+
+#~ msgctxt "#32031"
+#~ msgid "Visit http://kodi.tv for more information."
+#~ msgstr "За повече информация посетете www.kodi.tv"
 
 #~ msgctxt "#32035"
 #~ msgid "It is recommended that you to upgrade to a newer version."

--- a/service.xbmc.versioncheck/resources/language/resource.language.bs_ba/strings.po
+++ b/service.xbmc.versioncheck/resources/language/resource.language.bs_ba/strings.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: XBMC Addons\n"
-"Report-Msgid-Bugs-To: translations@kodi.tv\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "PO-Revision-Date: 2022-07-01 07:24+0000\n"
 "Last-Translator: SecularSteve <fairfull.playing@gmail.com>\n"
@@ -90,17 +90,6 @@ msgctxt "#32024"
 msgid "Linux: Upgrade using apt"
 msgstr "Linux: Nadogradite pomoću apt-a"
 
-# empty strings from id 32025 to 32029
-#. Used in OK dialog
-msgctxt "#32030"
-msgid "A new stable version of Kodi is available."
-msgstr "Nova stabilna verzija Kodija je dostupna."
-
-#. Direct people to the website. Used in OK dialog
-msgctxt "#32031"
-msgid "Visit http://kodi.tv for more information."
-msgstr "Za više informacija posjetite http://kodi.tv."
-
 #. Used in OK dialog
 msgctxt "#32032"
 msgid "A new stable version of Kodi is available."
@@ -133,3 +122,12 @@ msgstr "Molim vas da nadogradite vaš operativni sistem."
 msgctxt "#32042"
 msgid "For more information, see https://kodi.wiki/view/Linux"
 msgstr "Za više informacija, posjetite https://kodi.wiki/view/Linux"
+
+# empty strings from id 32025 to 32029
+#~ msgctxt "#32030"
+#~ msgid "A new stable version of Kodi is available."
+#~ msgstr "Nova stabilna verzija Kodija je dostupna."
+
+#~ msgctxt "#32031"
+#~ msgid "Visit http://kodi.tv for more information."
+#~ msgstr "Za više informacija posjetite http://kodi.tv."

--- a/service.xbmc.versioncheck/resources/language/resource.language.ca_es/strings.po
+++ b/service.xbmc.versioncheck/resources/language/resource.language.ca_es/strings.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: XBMC Addons\n"
-"Report-Msgid-Bugs-To: translations@kodi.tv\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "PO-Revision-Date: 2021-10-25 10:08+0000\n"
 "Last-Translator: Christian Gade <gade@kodi.tv>\n"
@@ -89,17 +89,6 @@ msgctxt "#32024"
 msgid "Linux: Upgrade using apt"
 msgstr "Linux: actualitzeu amb apt"
 
-# empty strings from id 32025 to 32029
-#. Used in OK dialog
-msgctxt "#32030"
-msgid "A new stable version of Kodi is available."
-msgstr "Hi ha disponible una nova versió estable de Kodi."
-
-#. Direct people to the website. Used in OK dialog
-msgctxt "#32031"
-msgid "Visit http://kodi.tv for more information."
-msgstr "Visiteu http://kodi.tv per obtenir més informació."
-
 #. Used in OK dialog
 msgctxt "#32032"
 msgid "A new stable version of Kodi is available."
@@ -132,6 +121,15 @@ msgstr "Si us plau, actualitzeu el vostre sistema operatiu."
 msgctxt "#32042"
 msgid "For more information, see https://kodi.wiki/view/Linux"
 msgstr "Per obtenir més informació, consulteu https://kodi.wiki/view/Linux"
+
+# empty strings from id 32025 to 32029
+#~ msgctxt "#32030"
+#~ msgid "A new stable version of Kodi is available."
+#~ msgstr "Hi ha disponible una nova versió estable de Kodi."
+
+#~ msgctxt "#32031"
+#~ msgid "Visit http://kodi.tv for more information."
+#~ msgstr "Visiteu http://kodi.tv per obtenir més informació."
 
 #~ msgctxt "#32035"
 #~ msgid "It is recommended that you to upgrade to a newer version."

--- a/service.xbmc.versioncheck/resources/language/resource.language.cs_cz/strings.po
+++ b/service.xbmc.versioncheck/resources/language/resource.language.cs_cz/strings.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: XBMC Addons\n"
-"Report-Msgid-Bugs-To: translations@kodi.tv\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "PO-Revision-Date: 2023-01-08 13:15+0000\n"
 "Last-Translator: HansCR <h.vanek@gmail.com>\n"
@@ -90,16 +90,6 @@ msgid "Linux: Upgrade using apt"
 msgstr "Linux: Aktualizace za použití apt"
 
 #. Used in OK dialog
-msgctxt "#32030"
-msgid "A new stable version of Kodi is available."
-msgstr "Je k dispozici nová stabilní verze Kodi."
-
-#. Direct people to the website. Used in OK dialog
-msgctxt "#32031"
-msgid "Visit http://kodi.tv for more information."
-msgstr "Navštivte http://kodi.tv pro více informací."
-
-#. Used in OK dialog
 msgctxt "#32032"
 msgid "A new stable version of Kodi is available."
 msgstr "Je k dispozici nová stabilní verze Kodi."
@@ -131,6 +121,14 @@ msgstr "Prosím aktualizujte váš operační systém."
 msgctxt "#32042"
 msgid "For more information, see https://kodi.wiki/view/Linux"
 msgstr "Pro více informací navštivte https://kodi.wiki/view/Linux"
+
+#~ msgctxt "#32030"
+#~ msgid "A new stable version of Kodi is available."
+#~ msgstr "Je k dispozici nová stabilní verze Kodi."
+
+#~ msgctxt "#32031"
+#~ msgid "Visit http://kodi.tv for more information."
+#~ msgstr "Navštivte http://kodi.tv pro více informací."
 
 #~ msgctxt "#32035"
 #~ msgid "It is recommended that you to upgrade to a newer version."

--- a/service.xbmc.versioncheck/resources/language/resource.language.cy_gb/strings.po
+++ b/service.xbmc.versioncheck/resources/language/resource.language.cy_gb/strings.po
@@ -89,17 +89,6 @@ msgctxt "#32024"
 msgid "Linux: Upgrade using apt"
 msgstr ""
 
-# empty strings from id 32025 to 32029
-#. Used in OK dialog
-msgctxt "#32030"
-msgid "A new stable version of Kodi is available."
-msgstr ""
-
-#. Direct people to the website. Used in OK dialog
-msgctxt "#32031"
-msgid "Visit http://kodi.tv for more information."
-msgstr ""
-
 #. Used in OK dialog
 msgctxt "#32032"
 msgid "A new stable version of Kodi is available."

--- a/service.xbmc.versioncheck/resources/language/resource.language.da_dk/strings.po
+++ b/service.xbmc.versioncheck/resources/language/resource.language.da_dk/strings.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: XBMC Addons\n"
-"Report-Msgid-Bugs-To: translations@kodi.tv\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "PO-Revision-Date: 2021-10-25 10:08+0000\n"
 "Last-Translator: Christian Gade <gade@kodi.tv>\n"
@@ -90,16 +90,6 @@ msgid "Linux: Upgrade using apt"
 msgstr "Linux: opgrader ved brug af apt"
 
 #. Used in OK dialog
-msgctxt "#32030"
-msgid "A new stable version of Kodi is available."
-msgstr "Der er en ny stabil version af Kodi tilgængelig."
-
-#. Direct people to the website. Used in OK dialog
-msgctxt "#32031"
-msgid "Visit http://kodi.tv for more information."
-msgstr "Besøg http://kodi.tv for mere information."
-
-#. Used in OK dialog
 msgctxt "#32032"
 msgid "A new stable version of Kodi is available."
 msgstr "Der er en ny stabil version af Kodi tilgængelig."
@@ -131,6 +121,14 @@ msgstr "Opgrader venligst dit operativsystem."
 msgctxt "#32042"
 msgid "For more information, see https://kodi.wiki/view/Linux"
 msgstr "For yderligere information, se https://kodi.wiki/view/Linux"
+
+#~ msgctxt "#32030"
+#~ msgid "A new stable version of Kodi is available."
+#~ msgstr "Der er en ny stabil version af Kodi tilgængelig."
+
+#~ msgctxt "#32031"
+#~ msgid "Visit http://kodi.tv for more information."
+#~ msgstr "Besøg http://kodi.tv for mere information."
 
 #~ msgctxt "#32035"
 #~ msgid "It is recommended that you to upgrade to a newer version."

--- a/service.xbmc.versioncheck/resources/language/resource.language.de_de/strings.po
+++ b/service.xbmc.versioncheck/resources/language/resource.language.de_de/strings.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: XBMC Addons\n"
-"Report-Msgid-Bugs-To: translations@kodi.tv\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "PO-Revision-Date: 2023-02-05 23:15+0000\n"
 "Last-Translator: Kai Sommerfeld <kai.sommerfeld@gmx.com>\n"
@@ -90,16 +90,6 @@ msgid "Linux: Upgrade using apt"
 msgstr "Linux: Aktualisierung durch apt"
 
 #. Used in OK dialog
-msgctxt "#32030"
-msgid "A new stable version of Kodi is available."
-msgstr "Eine neue stabile Kodi-Version ist verfügbar."
-
-#. Direct people to the website. Used in OK dialog
-msgctxt "#32031"
-msgid "Visit http://kodi.tv for more information."
-msgstr "Mehr Informationen gibt es auf http://kodi.tv."
-
-#. Used in OK dialog
 msgctxt "#32032"
 msgid "A new stable version of Kodi is available."
 msgstr "Eine neue stabile Kodi-Version ist verfügbar."
@@ -131,6 +121,14 @@ msgstr "Bitte das Betriebssystem aktualisieren."
 msgctxt "#32042"
 msgid "For more information, see https://kodi.wiki/view/Linux"
 msgstr "Mehr Informationen dazu gibt es unter https://kodi.wiki/view/Linux"
+
+#~ msgctxt "#32030"
+#~ msgid "A new stable version of Kodi is available."
+#~ msgstr "Eine neue stabile Kodi-Version ist verfügbar."
+
+#~ msgctxt "#32031"
+#~ msgid "Visit http://kodi.tv for more information."
+#~ msgstr "Mehr Informationen gibt es auf http://kodi.tv."
 
 #~ msgctxt "#32035"
 #~ msgid "It is recommended that you to upgrade to a newer version."

--- a/service.xbmc.versioncheck/resources/language/resource.language.el_gr/strings.po
+++ b/service.xbmc.versioncheck/resources/language/resource.language.el_gr/strings.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: XBMC Addons\n"
-"Report-Msgid-Bugs-To: translations@kodi.tv\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "PO-Revision-Date: 2021-10-25 10:08+0000\n"
 "Last-Translator: Christian Gade <gade@kodi.tv>\n"
@@ -90,16 +90,6 @@ msgid "Linux: Upgrade using apt"
 msgstr "Linux: Αναβάθμιση με χρήση apt"
 
 #. Used in OK dialog
-msgctxt "#32030"
-msgid "A new stable version of Kodi is available."
-msgstr "Είναι διαθέσιμη νεώτερη σταθερή έκδοση του Kodi."
-
-#. Direct people to the website. Used in OK dialog
-msgctxt "#32031"
-msgid "Visit http://kodi.tv for more information."
-msgstr "Επισκεφθείτε το http://kodi.tv για περισσότερες πληροφορίες."
-
-#. Used in OK dialog
 msgctxt "#32032"
 msgid "A new stable version of Kodi is available."
 msgstr "Είναι διαθέσιμη νεώτερη σταθερή έκδοση του Kodi."
@@ -131,6 +121,14 @@ msgstr ""
 msgctxt "#32042"
 msgid "For more information, see https://kodi.wiki/view/Linux"
 msgstr ""
+
+#~ msgctxt "#32030"
+#~ msgid "A new stable version of Kodi is available."
+#~ msgstr "Είναι διαθέσιμη νεώτερη σταθερή έκδοση του Kodi."
+
+#~ msgctxt "#32031"
+#~ msgid "Visit http://kodi.tv for more information."
+#~ msgstr "Επισκεφθείτε το http://kodi.tv για περισσότερες πληροφορίες."
 
 #~ msgctxt "#32035"
 #~ msgid "It is recommended that you to upgrade to a newer version."

--- a/service.xbmc.versioncheck/resources/language/resource.language.en_au/strings.po
+++ b/service.xbmc.versioncheck/resources/language/resource.language.en_au/strings.po
@@ -89,17 +89,6 @@ msgctxt "#32024"
 msgid "Linux: Upgrade using apt"
 msgstr ""
 
-# empty strings from id 32025 to 32029
-#. Used in OK dialog
-msgctxt "#32030"
-msgid "A new stable version of Kodi is available."
-msgstr ""
-
-#. Direct people to the website. Used in OK dialog
-msgctxt "#32031"
-msgid "Visit http://kodi.tv for more information."
-msgstr ""
-
 #. Used in OK dialog
 msgctxt "#32032"
 msgid "A new stable version of Kodi is available."

--- a/service.xbmc.versioncheck/resources/language/resource.language.en_gb/strings.po
+++ b/service.xbmc.versioncheck/resources/language/resource.language.en_gb/strings.po
@@ -92,17 +92,7 @@ msgctxt "#32024"
 msgid "Linux: Upgrade using apt"
 msgstr ""
 
-# empty strings from id 32025 to 32029
-
-#. Used in OK dialog
-msgctxt "#32030"
-msgid "A new stable version of Kodi is available."
-msgstr ""
-
-#. Direct people to the website. Used in OK dialog
-msgctxt "#32031"
-msgid "Visit http://kodi.tv for more information."
-msgstr ""
+# empty strings from id 32025 to 32031
 
 #. Used in OK dialog
 msgctxt "#32032"

--- a/service.xbmc.versioncheck/resources/language/resource.language.en_nz/strings.po
+++ b/service.xbmc.versioncheck/resources/language/resource.language.en_nz/strings.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: XBMC Addons\n"
-"Report-Msgid-Bugs-To: translations@kodi.tv\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "PO-Revision-Date: 2021-10-25 10:08+0000\n"
 "Last-Translator: Christian Gade <gade@kodi.tv>\n"
@@ -90,16 +90,6 @@ msgid "Linux: Upgrade using apt"
 msgstr "Linux: Upgrade using apt"
 
 #. Used in OK dialog
-msgctxt "#32030"
-msgid "A new stable version of Kodi is available."
-msgstr "A new stable version of Kodi is available."
-
-#. Direct people to the website. Used in OK dialog
-msgctxt "#32031"
-msgid "Visit http://kodi.tv for more information."
-msgstr "Visit http://kodi.tv for more information."
-
-#. Used in OK dialog
 msgctxt "#32032"
 msgid "A new stable version of Kodi is available."
 msgstr "A new stable version of Kodi is available."
@@ -131,6 +121,14 @@ msgstr ""
 msgctxt "#32042"
 msgid "For more information, see https://kodi.wiki/view/Linux"
 msgstr ""
+
+#~ msgctxt "#32030"
+#~ msgid "A new stable version of Kodi is available."
+#~ msgstr "A new stable version of Kodi is available."
+
+#~ msgctxt "#32031"
+#~ msgid "Visit http://kodi.tv for more information."
+#~ msgstr "Visit http://kodi.tv for more information."
 
 #~ msgctxt "#32035"
 #~ msgid "It is recommended that you to upgrade to a newer version."

--- a/service.xbmc.versioncheck/resources/language/resource.language.en_us/strings.po
+++ b/service.xbmc.versioncheck/resources/language/resource.language.en_us/strings.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: XBMC Addons\n"
-"Report-Msgid-Bugs-To: translations@kodi.tv\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "PO-Revision-Date: 2021-10-25 10:08+0000\n"
 "Last-Translator: Christian Gade <gade@kodi.tv>\n"
@@ -90,16 +90,6 @@ msgid "Linux: Upgrade using apt"
 msgstr "Linux: Upgrade using apt"
 
 #. Used in OK dialog
-msgctxt "#32030"
-msgid "A new stable version of Kodi is available."
-msgstr "A new stable version of Kodi is available."
-
-#. Direct people to the website. Used in OK dialog
-msgctxt "#32031"
-msgid "Visit http://kodi.tv for more information."
-msgstr "Visit http://kodi.tv for more information."
-
-#. Used in OK dialog
 msgctxt "#32032"
 msgid "A new stable version of Kodi is available."
 msgstr "A new stable version of Kodi is available."
@@ -131,6 +121,14 @@ msgstr ""
 msgctxt "#32042"
 msgid "For more information, see https://kodi.wiki/view/Linux"
 msgstr ""
+
+#~ msgctxt "#32030"
+#~ msgid "A new stable version of Kodi is available."
+#~ msgstr "A new stable version of Kodi is available."
+
+#~ msgctxt "#32031"
+#~ msgid "Visit http://kodi.tv for more information."
+#~ msgstr "Visit http://kodi.tv for more information."
 
 #~ msgctxt "#32035"
 #~ msgid "It is recommended that you to upgrade to a newer version."

--- a/service.xbmc.versioncheck/resources/language/resource.language.eo/strings.po
+++ b/service.xbmc.versioncheck/resources/language/resource.language.eo/strings.po
@@ -90,17 +90,6 @@ msgctxt "#32024"
 msgid "Linux: Upgrade using apt"
 msgstr ""
 
-# empty strings from id 32025 to 32029
-#. Used in OK dialog
-msgctxt "#32030"
-msgid "A new stable version of Kodi is available."
-msgstr "Nova, stabila versio de Kodi disponeblas."
-
-#. Direct people to the website. Used in OK dialog
-msgctxt "#32031"
-msgid "Visit http://kodi.tv for more information."
-msgstr "Vizitu http://kodi.tv por pli informoj."
-
 #. Used in OK dialog
 msgctxt "#32032"
 msgid "A new stable version of Kodi is available."
@@ -133,3 +122,12 @@ msgstr "Bonvolu ĝisdatigi vian operaciumon."
 msgctxt "#32042"
 msgid "For more information, see https://kodi.wiki/view/Linux"
 msgstr "Por pli informoj, viziti https://kodi.wiki/view/Linux"
+
+# empty strings from id 32025 to 32029
+#~ msgctxt "#32030"
+#~ msgid "A new stable version of Kodi is available."
+#~ msgstr "Nova, stabila versio de Kodi disponeblas."
+
+#~ msgctxt "#32031"
+#~ msgid "Visit http://kodi.tv for more information."
+#~ msgstr "Vizitu http://kodi.tv por pli informoj."

--- a/service.xbmc.versioncheck/resources/language/resource.language.es_ar/strings.po
+++ b/service.xbmc.versioncheck/resources/language/resource.language.es_ar/strings.po
@@ -89,17 +89,6 @@ msgctxt "#32024"
 msgid "Linux: Upgrade using apt"
 msgstr ""
 
-# empty strings from id 32025 to 32029
-#. Used in OK dialog
-msgctxt "#32030"
-msgid "A new stable version of Kodi is available."
-msgstr ""
-
-#. Direct people to the website. Used in OK dialog
-msgctxt "#32031"
-msgid "Visit http://kodi.tv for more information."
-msgstr ""
-
 #. Used in OK dialog
 msgctxt "#32032"
 msgid "A new stable version of Kodi is available."

--- a/service.xbmc.versioncheck/resources/language/resource.language.es_es/strings.po
+++ b/service.xbmc.versioncheck/resources/language/resource.language.es_es/strings.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: XBMC Addons\n"
-"Report-Msgid-Bugs-To: translations@kodi.tv\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "PO-Revision-Date: 2021-10-25 10:08+0000\n"
 "Last-Translator: Christian Gade <gade@kodi.tv>\n"
@@ -90,16 +90,6 @@ msgid "Linux: Upgrade using apt"
 msgstr "Linux: Actualizar usado apt"
 
 #. Used in OK dialog
-msgctxt "#32030"
-msgid "A new stable version of Kodi is available."
-msgstr "Una nueva versión estable de Kodi está disponible."
-
-#. Direct people to the website. Used in OK dialog
-msgctxt "#32031"
-msgid "Visit http://kodi.tv for more information."
-msgstr "Visite http://kodi.tv para más información."
-
-#. Used in OK dialog
 msgctxt "#32032"
 msgid "A new stable version of Kodi is available."
 msgstr "Una nueva versión estable de Kodi está disponible."
@@ -131,6 +121,14 @@ msgstr "Por favor, actualice el sistema operativo."
 msgctxt "#32042"
 msgid "For more information, see https://kodi.wiki/view/Linux"
 msgstr "Para más información visite https://kodi.wiki/view/Linux"
+
+#~ msgctxt "#32030"
+#~ msgid "A new stable version of Kodi is available."
+#~ msgstr "Una nueva versión estable de Kodi está disponible."
+
+#~ msgctxt "#32031"
+#~ msgid "Visit http://kodi.tv for more information."
+#~ msgstr "Visite http://kodi.tv para más información."
 
 #~ msgctxt "#32035"
 #~ msgid "It is recommended that you to upgrade to a newer version."

--- a/service.xbmc.versioncheck/resources/language/resource.language.es_mx/strings.po
+++ b/service.xbmc.versioncheck/resources/language/resource.language.es_mx/strings.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: XBMC Addons\n"
-"Report-Msgid-Bugs-To: translations@kodi.tv\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "PO-Revision-Date: 2021-12-14 15:13+0000\n"
 "Last-Translator: Edson Armando <edsonarmando78@outlook.com>\n"
@@ -89,17 +89,6 @@ msgctxt "#32024"
 msgid "Linux: Upgrade using apt"
 msgstr "Linux: Actualizar utilizando apt"
 
-# empty strings from id 32025 to 32029
-#. Used in OK dialog
-msgctxt "#32030"
-msgid "A new stable version of Kodi is available."
-msgstr "Una nueva versión estable de Kodi está disponible."
-
-#. Direct people to the website. Used in OK dialog
-msgctxt "#32031"
-msgid "Visit http://kodi.tv for more information."
-msgstr "Visita http://kodi.tv para más información."
-
 #. Used in OK dialog
 msgctxt "#32032"
 msgid "A new stable version of Kodi is available."
@@ -132,6 +121,15 @@ msgstr "Por favor actualiza tu sistema operativo."
 msgctxt "#32042"
 msgid "For more information, see https://kodi.wiki/view/Linux"
 msgstr "Para más información, visita https://kodi.wiki/view/Linux"
+
+# empty strings from id 32025 to 32029
+#~ msgctxt "#32030"
+#~ msgid "A new stable version of Kodi is available."
+#~ msgstr "Una nueva versión estable de Kodi está disponible."
+
+#~ msgctxt "#32031"
+#~ msgid "Visit http://kodi.tv for more information."
+#~ msgstr "Visita http://kodi.tv para más información."
 
 #~ msgctxt "#32035"
 #~ msgid "It is recommended that you to upgrade to a newer version."

--- a/service.xbmc.versioncheck/resources/language/resource.language.et_ee/strings.po
+++ b/service.xbmc.versioncheck/resources/language/resource.language.et_ee/strings.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: XBMC Addons\n"
-"Report-Msgid-Bugs-To: translations@kodi.tv\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "PO-Revision-Date: 2021-10-25 10:08+0000\n"
 "Last-Translator: Christian Gade <gade@kodi.tv>\n"
@@ -90,17 +90,6 @@ msgctxt "#32024"
 msgid "Linux: Upgrade using apt"
 msgstr "Linux: uuenda paketihalduri abil"
 
-# empty strings from id 32025 to 32029
-#. Used in OK dialog
-msgctxt "#32030"
-msgid "A new stable version of Kodi is available."
-msgstr "Saadaval on uus stabiilne Kodi versioon."
-
-#. Direct people to the website. Used in OK dialog
-msgctxt "#32031"
-msgid "Visit http://kodi.tv for more information."
-msgstr "Lisateavet leiab aadressilt kodi.tv."
-
 #. Used in OK dialog
 msgctxt "#32032"
 msgid "A new stable version of Kodi is available."
@@ -133,6 +122,15 @@ msgstr "Uuenda oma operatsioonisüsteemi."
 msgctxt "#32042"
 msgid "For more information, see https://kodi.wiki/view/Linux"
 msgstr "Lisateavet leiab aadressilt https://kodi.wiki/view/Linux"
+
+# empty strings from id 32025 to 32029
+#~ msgctxt "#32030"
+#~ msgid "A new stable version of Kodi is available."
+#~ msgstr "Saadaval on uus stabiilne Kodi versioon."
+
+#~ msgctxt "#32031"
+#~ msgid "Visit http://kodi.tv for more information."
+#~ msgstr "Lisateavet leiab aadressilt kodi.tv."
 
 #~ msgctxt "#32035"
 #~ msgid "It is recommended that you to upgrade to a newer version."

--- a/service.xbmc.versioncheck/resources/language/resource.language.eu_es/strings.po
+++ b/service.xbmc.versioncheck/resources/language/resource.language.eu_es/strings.po
@@ -89,17 +89,6 @@ msgctxt "#32024"
 msgid "Linux: Upgrade using apt"
 msgstr ""
 
-# empty strings from id 32025 to 32029
-#. Used in OK dialog
-msgctxt "#32030"
-msgid "A new stable version of Kodi is available."
-msgstr ""
-
-#. Direct people to the website. Used in OK dialog
-msgctxt "#32031"
-msgid "Visit http://kodi.tv for more information."
-msgstr ""
-
 #. Used in OK dialog
 msgctxt "#32032"
 msgid "A new stable version of Kodi is available."

--- a/service.xbmc.versioncheck/resources/language/resource.language.fa_af/strings.po
+++ b/service.xbmc.versioncheck/resources/language/resource.language.fa_af/strings.po
@@ -89,17 +89,6 @@ msgctxt "#32024"
 msgid "Linux: Upgrade using apt"
 msgstr ""
 
-# empty strings from id 32025 to 32029
-#. Used in OK dialog
-msgctxt "#32030"
-msgid "A new stable version of Kodi is available."
-msgstr ""
-
-#. Direct people to the website. Used in OK dialog
-msgctxt "#32031"
-msgid "Visit http://kodi.tv for more information."
-msgstr ""
-
 #. Used in OK dialog
 msgctxt "#32032"
 msgid "A new stable version of Kodi is available."

--- a/service.xbmc.versioncheck/resources/language/resource.language.fa_ir/strings.po
+++ b/service.xbmc.versioncheck/resources/language/resource.language.fa_ir/strings.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: XBMC Addons\n"
-"Report-Msgid-Bugs-To: translations@kodi.tv\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "PO-Revision-Date: 2021-10-25 10:08+0000\n"
 "Last-Translator: Christian Gade <gade@kodi.tv>\n"
@@ -90,17 +90,6 @@ msgctxt "#32024"
 msgid "Linux: Upgrade using apt"
 msgstr "گنو/لینوکس: ارتقا با استفاده از apt"
 
-# empty strings from id 32025 to 32029
-#. Used in OK dialog
-msgctxt "#32030"
-msgid "A new stable version of Kodi is available."
-msgstr "نگارش پایدار جدیدی از کودی موجود است."
-
-#. Direct people to the website. Used in OK dialog
-msgctxt "#32031"
-msgid "Visit http://kodi.tv for more information."
-msgstr "برای اطّلاعات بیش‌ترhttp://kodi.tv را ببنید."
-
 #. Used in OK dialog
 msgctxt "#32032"
 msgid "A new stable version of Kodi is available."
@@ -133,6 +122,15 @@ msgstr "لطفاً سیستم‌عاملتان را ارتقا دهید."
 msgctxt "#32042"
 msgid "For more information, see https://kodi.wiki/view/Linux"
 msgstr "برای اطّلاعات بیش‌تر https://kodi.wiki/view/Linux را ببینید"
+
+# empty strings from id 32025 to 32029
+#~ msgctxt "#32030"
+#~ msgid "A new stable version of Kodi is available."
+#~ msgstr "نگارش پایدار جدیدی از کودی موجود است."
+
+#~ msgctxt "#32031"
+#~ msgid "Visit http://kodi.tv for more information."
+#~ msgstr "برای اطّلاعات بیش‌ترhttp://kodi.tv را ببنید."
 
 #~ msgctxt "#32035"
 #~ msgid "It is recommended that you to upgrade to a newer version."

--- a/service.xbmc.versioncheck/resources/language/resource.language.fi_fi/strings.po
+++ b/service.xbmc.versioncheck/resources/language/resource.language.fi_fi/strings.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: XBMC Addons\n"
-"Report-Msgid-Bugs-To: translations@kodi.tv\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "PO-Revision-Date: 2022-03-09 16:11+0000\n"
 "Last-Translator: Oskari Lavinto <olavinto@protonmail.com>\n"
@@ -91,16 +91,6 @@ msgid "Linux: Upgrade using apt"
 msgstr "Linux: päivitä käyttäen APT-pakettienhallintaa"
 
 #. Used in OK dialog
-msgctxt "#32030"
-msgid "A new stable version of Kodi is available."
-msgstr "Uusi, vakaa Kodi-versio on saatavilla."
-
-#. Direct people to the website. Used in OK dialog
-msgctxt "#32031"
-msgid "Visit http://kodi.tv for more information."
-msgstr "Lue lisää kodi.tv-sivustolta."
-
-#. Used in OK dialog
 msgctxt "#32032"
 msgid "A new stable version of Kodi is available."
 msgstr "Uusi, vakaa Kodi-versio on saatavilla."
@@ -132,6 +122,14 @@ msgstr "Päivitä käyttöjärjestelmäsi."
 msgctxt "#32042"
 msgid "For more information, see https://kodi.wiki/view/Linux"
 msgstr "Lue lisää osoitteesta https://kodi.wiki/view/Linux"
+
+#~ msgctxt "#32030"
+#~ msgid "A new stable version of Kodi is available."
+#~ msgstr "Uusi, vakaa Kodi-versio on saatavilla."
+
+#~ msgctxt "#32031"
+#~ msgid "Visit http://kodi.tv for more information."
+#~ msgstr "Lue lisää kodi.tv-sivustolta."
 
 #~ msgctxt "#32035"
 #~ msgid "It is recommended that you to upgrade to a newer version."

--- a/service.xbmc.versioncheck/resources/language/resource.language.fil/strings.po
+++ b/service.xbmc.versioncheck/resources/language/resource.language.fil/strings.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: XBMC Addons\n"
-"Report-Msgid-Bugs-To: translations@kodi.tv\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "PO-Revision-Date: 2022-06-12 12:14+0000\n"
 "Last-Translator: Christian Gade <gade@kodi.tv>\n"
@@ -89,17 +89,6 @@ msgstr ""
 
 msgctxt "#32024"
 msgid "Linux: Upgrade using apt"
-msgstr ""
-
-# empty strings from id 32025 to 32029
-#. Used in OK dialog
-msgctxt "#32030"
-msgid "A new stable version of Kodi is available."
-msgstr ""
-
-#. Direct people to the website. Used in OK dialog
-msgctxt "#32031"
-msgid "Visit http://kodi.tv for more information."
 msgstr ""
 
 #. Used in OK dialog

--- a/service.xbmc.versioncheck/resources/language/resource.language.fo_fo/strings.po
+++ b/service.xbmc.versioncheck/resources/language/resource.language.fo_fo/strings.po
@@ -89,17 +89,6 @@ msgctxt "#32024"
 msgid "Linux: Upgrade using apt"
 msgstr ""
 
-# empty strings from id 32025 to 32029
-#. Used in OK dialog
-msgctxt "#32030"
-msgid "A new stable version of Kodi is available."
-msgstr ""
-
-#. Direct people to the website. Used in OK dialog
-msgctxt "#32031"
-msgid "Visit http://kodi.tv for more information."
-msgstr ""
-
 #. Used in OK dialog
 msgctxt "#32032"
 msgid "A new stable version of Kodi is available."

--- a/service.xbmc.versioncheck/resources/language/resource.language.fr_ca/strings.po
+++ b/service.xbmc.versioncheck/resources/language/resource.language.fr_ca/strings.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: XBMC Addons\n"
-"Report-Msgid-Bugs-To: translations@kodi.tv\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "PO-Revision-Date: 2021-10-25 10:08+0000\n"
 "Last-Translator: Christian Gade <gade@kodi.tv>\n"
@@ -90,16 +90,6 @@ msgid "Linux: Upgrade using apt"
 msgstr "Linux : mettre à niveau en utilisant apt"
 
 #. Used in OK dialog
-msgctxt "#32030"
-msgid "A new stable version of Kodi is available."
-msgstr "Une nouvelle version stable de Kodi est proposée."
-
-#. Direct people to the website. Used in OK dialog
-msgctxt "#32031"
-msgid "Visit http://kodi.tv for more information."
-msgstr "Visitez http://kodi.tv pour plus d'informations."
-
-#. Used in OK dialog
 msgctxt "#32032"
 msgid "A new stable version of Kodi is available."
 msgstr "Une nouvelle version de Kodi est proposée."
@@ -131,6 +121,14 @@ msgstr ""
 msgctxt "#32042"
 msgid "For more information, see https://kodi.wiki/view/Linux"
 msgstr ""
+
+#~ msgctxt "#32030"
+#~ msgid "A new stable version of Kodi is available."
+#~ msgstr "Une nouvelle version stable de Kodi est proposée."
+
+#~ msgctxt "#32031"
+#~ msgid "Visit http://kodi.tv for more information."
+#~ msgstr "Visitez http://kodi.tv pour plus d'informations."
 
 #~ msgctxt "#32035"
 #~ msgid "It is recommended that you to upgrade to a newer version."

--- a/service.xbmc.versioncheck/resources/language/resource.language.fr_fr/strings.po
+++ b/service.xbmc.versioncheck/resources/language/resource.language.fr_fr/strings.po
@@ -5,9 +5,9 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: XBMC Addons\n"
-"Report-Msgid-Bugs-To: translations@kodi.tv\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"PO-Revision-Date: 2022-12-25 11:15+0000\n"
+"PO-Revision-Date: 2023-04-05 16:16+0000\n"
 "Last-Translator: skypichat <skypichat@hotmail.fr>\n"
 "Language-Team: French (France) <https://kodi.weblate.cloud/projects/kodi-core/service-xbmc-versioncheck/fr_fr/>\n"
 "Language: fr_fr\n"
@@ -15,7 +15,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
-"X-Generator: Weblate 4.15\n"
+"X-Generator: Weblate 4.15.2\n"
 
 msgctxt "Addon Summary"
 msgid "Kodi Version Check checks if you are running latest released version."
@@ -90,16 +90,6 @@ msgid "Linux: Upgrade using apt"
 msgstr "Linux: mettre à niveau en utilisant apt"
 
 #. Used in OK dialog
-msgctxt "#32030"
-msgid "A new stable version of Kodi is available."
-msgstr "Une nouvelle version stable de Kodi est disponible."
-
-#. Direct people to the website. Used in OK dialog
-msgctxt "#32031"
-msgid "Visit http://kodi.tv for more information."
-msgstr "Consulter http://kodi.tv pour plus d'informations."
-
-#. Used in OK dialog
 msgctxt "#32032"
 msgid "A new stable version of Kodi is available."
 msgstr "Une nouvelle version stable de Kodi est disponible."
@@ -126,11 +116,19 @@ msgstr "Votre version %s du module Python de cryptographie est trop vieille. Vou
 
 msgctxt "#32041"
 msgid "Please upgrade your operating system."
-msgstr "Veuillez mettre à jour votre système d’exploitation."
+msgstr "Mettez a jour votre système d'exploitation."
 
 msgctxt "#32042"
 msgid "For more information, see https://kodi.wiki/view/Linux"
-msgstr "Plus d’informations disponibles sur https://kodi.wiki/view/Linux"
+msgstr "Pour plus d'information, voir https://kodi.wiki/view/Linux"
+
+#~ msgctxt "#32030"
+#~ msgid "A new stable version of Kodi is available."
+#~ msgstr "Une nouvelle version stable de Kodi est disponible."
+
+#~ msgctxt "#32031"
+#~ msgid "Visit http://kodi.tv for more information."
+#~ msgstr "Consulter http://kodi.tv pour plus d'informations."
 
 #~ msgctxt "#32035"
 #~ msgid "It is recommended that you to upgrade to a newer version."

--- a/service.xbmc.versioncheck/resources/language/resource.language.gl_es/strings.po
+++ b/service.xbmc.versioncheck/resources/language/resource.language.gl_es/strings.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: XBMC Addons\n"
-"Report-Msgid-Bugs-To: translations@kodi.tv\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "PO-Revision-Date: 2021-10-25 10:08+0000\n"
 "Last-Translator: Christian Gade <gade@kodi.tv>\n"
@@ -90,16 +90,6 @@ msgid "Linux: Upgrade using apt"
 msgstr "Linux: Actualizar empregando apt"
 
 #. Used in OK dialog
-msgctxt "#32030"
-msgid "A new stable version of Kodi is available."
-msgstr "Está dispoñible unha versión estable nova de Kodi."
-
-#. Direct people to the website. Used in OK dialog
-msgctxt "#32031"
-msgid "Visit http://kodi.tv for more information."
-msgstr "Ir a http://kodi.tv para máis información."
-
-#. Used in OK dialog
 msgctxt "#32032"
 msgid "A new stable version of Kodi is available."
 msgstr "Está dispoñíbel unha nova versión estábel de Kodi."
@@ -131,6 +121,14 @@ msgstr ""
 msgctxt "#32042"
 msgid "For more information, see https://kodi.wiki/view/Linux"
 msgstr ""
+
+#~ msgctxt "#32030"
+#~ msgid "A new stable version of Kodi is available."
+#~ msgstr "Está dispoñible unha versión estable nova de Kodi."
+
+#~ msgctxt "#32031"
+#~ msgid "Visit http://kodi.tv for more information."
+#~ msgstr "Ir a http://kodi.tv para máis información."
 
 #~ msgctxt "#32035"
 #~ msgid "It is recommended that you to upgrade to a newer version."

--- a/service.xbmc.versioncheck/resources/language/resource.language.he_il/strings.po
+++ b/service.xbmc.versioncheck/resources/language/resource.language.he_il/strings.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: XBMC Addons\n"
-"Report-Msgid-Bugs-To: translations@kodi.tv\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "PO-Revision-Date: 2021-10-25 10:08+0000\n"
 "Last-Translator: Christian Gade <gade@kodi.tv>\n"
@@ -90,16 +90,6 @@ msgid "Linux: Upgrade using apt"
 msgstr "לינוקס: שדרוג באמצעות apt"
 
 #. Used in OK dialog
-msgctxt "#32030"
-msgid "A new stable version of Kodi is available."
-msgstr "גרסה יציבה חדשה של קודי זמינה."
-
-#. Direct people to the website. Used in OK dialog
-msgctxt "#32031"
-msgid "Visit http://kodi.tv for more information."
-msgstr "בקר ב-http://kodi.tv למידע נוסף."
-
-#. Used in OK dialog
 msgctxt "#32032"
 msgid "A new stable version of Kodi is available."
 msgstr "גרסה יציבה חדשה של קודי זמינה."
@@ -131,6 +121,14 @@ msgstr "נא לשדרג את מערכת ההפעלה שלך."
 msgctxt "#32042"
 msgid "For more information, see https://kodi.wiki/view/Linux"
 msgstr "למידע נוסף, כדאי לגשת אל https://kodi.wiki/view/Linux"
+
+#~ msgctxt "#32030"
+#~ msgid "A new stable version of Kodi is available."
+#~ msgstr "גרסה יציבה חדשה של קודי זמינה."
+
+#~ msgctxt "#32031"
+#~ msgid "Visit http://kodi.tv for more information."
+#~ msgstr "בקר ב-http://kodi.tv למידע נוסף."
 
 #~ msgctxt "#32035"
 #~ msgid "It is recommended that you to upgrade to a newer version."

--- a/service.xbmc.versioncheck/resources/language/resource.language.hi_in/strings.po
+++ b/service.xbmc.versioncheck/resources/language/resource.language.hi_in/strings.po
@@ -89,17 +89,6 @@ msgctxt "#32024"
 msgid "Linux: Upgrade using apt"
 msgstr ""
 
-# empty strings from id 32025 to 32029
-#. Used in OK dialog
-msgctxt "#32030"
-msgid "A new stable version of Kodi is available."
-msgstr ""
-
-#. Direct people to the website. Used in OK dialog
-msgctxt "#32031"
-msgid "Visit http://kodi.tv for more information."
-msgstr ""
-
 #. Used in OK dialog
 msgctxt "#32032"
 msgid "A new stable version of Kodi is available."

--- a/service.xbmc.versioncheck/resources/language/resource.language.hr_hr/strings.po
+++ b/service.xbmc.versioncheck/resources/language/resource.language.hr_hr/strings.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: XBMC Addons\n"
-"Report-Msgid-Bugs-To: translations@kodi.tv\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "PO-Revision-Date: 2022-02-10 11:38+0000\n"
 "Last-Translator: gogogogi <trebelnik2@gmail.com>\n"
@@ -90,16 +90,6 @@ msgid "Linux: Upgrade using apt"
 msgstr "Linux: Nadogradi putem apt upravitelja paketa"
 
 #. Used in OK dialog
-msgctxt "#32030"
-msgid "A new stable version of Kodi is available."
-msgstr "Dostupna je nova stabilna inačica Kodija."
-
-#. Direct people to the website. Used in OK dialog
-msgctxt "#32031"
-msgid "Visit http://kodi.tv for more information."
-msgstr "Za više informacija posjetite http://kodi.tv."
-
-#. Used in OK dialog
 msgctxt "#32032"
 msgid "A new stable version of Kodi is available."
 msgstr "Dostupna je nova stabilna inačica Kodija."
@@ -131,6 +121,14 @@ msgstr "Nadogradite svoj operativni sustav."
 msgctxt "#32042"
 msgid "For more information, see https://kodi.wiki/view/Linux"
 msgstr "Za više informacija, posjetite https://kodi.wiki/view/Linux"
+
+#~ msgctxt "#32030"
+#~ msgid "A new stable version of Kodi is available."
+#~ msgstr "Dostupna je nova stabilna inačica Kodija."
+
+#~ msgctxt "#32031"
+#~ msgid "Visit http://kodi.tv for more information."
+#~ msgstr "Za više informacija posjetite http://kodi.tv."
 
 #~ msgctxt "#32035"
 #~ msgid "It is recommended that you to upgrade to a newer version."

--- a/service.xbmc.versioncheck/resources/language/resource.language.hu_hu/strings.po
+++ b/service.xbmc.versioncheck/resources/language/resource.language.hu_hu/strings.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: XBMC Addons\n"
-"Report-Msgid-Bugs-To: translations@kodi.tv\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "PO-Revision-Date: 2021-10-25 10:08+0000\n"
 "Last-Translator: Christian Gade <gade@kodi.tv>\n"
@@ -90,16 +90,6 @@ msgid "Linux: Upgrade using apt"
 msgstr "Linux: Frissítés apt segítségével"
 
 #. Used in OK dialog
-msgctxt "#32030"
-msgid "A new stable version of Kodi is available."
-msgstr "Újabb stabil Kodi kiadás elérhető."
-
-#. Direct people to the website. Used in OK dialog
-msgctxt "#32031"
-msgid "Visit http://kodi.tv for more information."
-msgstr "További információkért keresse fel az http://kodi.tv oldalt!"
-
-#. Used in OK dialog
 msgctxt "#32032"
 msgid "A new stable version of Kodi is available."
 msgstr "Újabb stabil Kodi kiadás elérhető."
@@ -131,6 +121,14 @@ msgstr "Kérjük, frissítse az operációs rendszert."
 msgctxt "#32042"
 msgid "For more information, see https://kodi.wiki/view/Linux"
 msgstr "További információ: https://kodi.wiki/view/Linux"
+
+#~ msgctxt "#32030"
+#~ msgid "A new stable version of Kodi is available."
+#~ msgstr "Újabb stabil Kodi kiadás elérhető."
+
+#~ msgctxt "#32031"
+#~ msgid "Visit http://kodi.tv for more information."
+#~ msgstr "További információkért keresse fel az http://kodi.tv oldalt!"
 
 #~ msgctxt "#32035"
 #~ msgid "It is recommended that you to upgrade to a newer version."

--- a/service.xbmc.versioncheck/resources/language/resource.language.hy_am/strings.po
+++ b/service.xbmc.versioncheck/resources/language/resource.language.hy_am/strings.po
@@ -89,17 +89,6 @@ msgctxt "#32024"
 msgid "Linux: Upgrade using apt"
 msgstr ""
 
-# empty strings from id 32025 to 32029
-#. Used in OK dialog
-msgctxt "#32030"
-msgid "A new stable version of Kodi is available."
-msgstr ""
-
-#. Direct people to the website. Used in OK dialog
-msgctxt "#32031"
-msgid "Visit http://kodi.tv for more information."
-msgstr ""
-
 #. Used in OK dialog
 msgctxt "#32032"
 msgid "A new stable version of Kodi is available."

--- a/service.xbmc.versioncheck/resources/language/resource.language.id_id/strings.po
+++ b/service.xbmc.versioncheck/resources/language/resource.language.id_id/strings.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: XBMC Addons\n"
-"Report-Msgid-Bugs-To: translations@kodi.tv\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "PO-Revision-Date: 2021-11-18 07:13+0000\n"
 "Last-Translator: Nao3Line Prez <n.yazawa6932@gmail.com>\n"
@@ -89,17 +89,6 @@ msgctxt "#32024"
 msgid "Linux: Upgrade using apt"
 msgstr "Linux: Perbarui menggunakan apt"
 
-# empty strings from id 32025 to 32029
-#. Used in OK dialog
-msgctxt "#32030"
-msgid "A new stable version of Kodi is available."
-msgstr "Versi stabil baru dari Kodi tersedia."
-
-#. Direct people to the website. Used in OK dialog
-msgctxt "#32031"
-msgid "Visit http://kodi.tv for more information."
-msgstr "Kunjungi http://kodi.tv untuk informasi lebih lanjut."
-
 #. Used in OK dialog
 msgctxt "#32032"
 msgid "A new stable version of Kodi is available."
@@ -132,3 +121,12 @@ msgstr "Harap tingkatkan sistem operasi Anda."
 msgctxt "#32042"
 msgid "For more information, see https://kodi.wiki/view/Linux"
 msgstr "Untuk informasi lebih lanjut, lihat https://kodi.wiki/view/Linux"
+
+# empty strings from id 32025 to 32029
+#~ msgctxt "#32030"
+#~ msgid "A new stable version of Kodi is available."
+#~ msgstr "Versi stabil baru dari Kodi tersedia."
+
+#~ msgctxt "#32031"
+#~ msgid "Visit http://kodi.tv for more information."
+#~ msgstr "Kunjungi http://kodi.tv untuk informasi lebih lanjut."

--- a/service.xbmc.versioncheck/resources/language/resource.language.is_is/strings.po
+++ b/service.xbmc.versioncheck/resources/language/resource.language.is_is/strings.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: XBMC Addons\n"
-"Report-Msgid-Bugs-To: translations@kodi.tv\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "PO-Revision-Date: 2022-02-25 18:13+0000\n"
 "Last-Translator: Sveinn í Felli <sv1@fellsnet.is>\n"
@@ -89,17 +89,6 @@ msgctxt "#32024"
 msgid "Linux: Upgrade using apt"
 msgstr "Linux: Uppfærðu með apt"
 
-# empty strings from id 32025 to 32029
-#. Used in OK dialog
-msgctxt "#32030"
-msgid "A new stable version of Kodi is available."
-msgstr "Ný stöðug útgáfa af Kodi er tiltæk."
-
-#. Direct people to the website. Used in OK dialog
-msgctxt "#32031"
-msgid "Visit http://kodi.tv for more information."
-msgstr "Farðu inn á Kodi.tv til að fá nánari upplýsingar."
-
 #. Used in OK dialog
 msgctxt "#32032"
 msgid "A new stable version of Kodi is available."
@@ -132,3 +121,12 @@ msgstr "Endilega uppfærðu stýrikerfið þitt."
 msgctxt "#32042"
 msgid "For more information, see https://kodi.wiki/view/Linux"
 msgstr "Skoðaðu https://kodi.wiki/view/Linux til að fá frekari upplýsingar"
+
+# empty strings from id 32025 to 32029
+#~ msgctxt "#32030"
+#~ msgid "A new stable version of Kodi is available."
+#~ msgstr "Ný stöðug útgáfa af Kodi er tiltæk."
+
+#~ msgctxt "#32031"
+#~ msgid "Visit http://kodi.tv for more information."
+#~ msgstr "Farðu inn á Kodi.tv til að fá nánari upplýsingar."

--- a/service.xbmc.versioncheck/resources/language/resource.language.it_it/strings.po
+++ b/service.xbmc.versioncheck/resources/language/resource.language.it_it/strings.po
@@ -5,9 +5,9 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: XBMC Addons\n"
-"Report-Msgid-Bugs-To: translations@kodi.tv\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"PO-Revision-Date: 2023-01-01 06:37+0000\n"
+"PO-Revision-Date: 2023-03-16 20:38+0000\n"
 "Last-Translator: Massimo Pissarello <mapi68@gmail.com>\n"
 "Language-Team: Italian <https://kodi.weblate.cloud/projects/kodi-core/service-xbmc-versioncheck/it_it/>\n"
 "Language: it_it\n"
@@ -15,7 +15,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 4.15\n"
+"X-Generator: Weblate 4.15.2\n"
 
 msgctxt "Addon Summary"
 msgid "Kodi Version Check checks if you are running latest released version."
@@ -90,16 +90,6 @@ msgid "Linux: Upgrade using apt"
 msgstr "Linux: aggiorna usando apt"
 
 #. Used in OK dialog
-msgctxt "#32030"
-msgid "A new stable version of Kodi is available."
-msgstr "È disponibile una nuova versione stabile di Kodi."
-
-#. Direct people to the website. Used in OK dialog
-msgctxt "#32031"
-msgid "Visit http://kodi.tv for more information."
-msgstr "Visita http://kodi.tv per ulteriori informazioni."
-
-#. Used in OK dialog
 msgctxt "#32032"
 msgid "A new stable version of Kodi is available."
 msgstr "È disponibile una nuova versione stabile di Kodi."
@@ -112,7 +102,7 @@ msgstr "Visita http://kodi.tv per ulteriori informazioni."
 #. For example: "You are using 13.1 prealpha while 13.2 stable is available"
 msgctxt "#32034"
 msgid "Using %s while %s is available."
-msgstr "Utilizzo %s mentre %s è disponibile."
+msgstr "Sto usando %s mentre %s è disponibile."
 
 #. Used in OK dialog
 msgctxt "#32035"
@@ -131,6 +121,14 @@ msgstr "Si prega di aggiornare il sistema operativo."
 msgctxt "#32042"
 msgid "For more information, see https://kodi.wiki/view/Linux"
 msgstr "Per ulteriori informazioni, vedi https://kodi.wiki/view/Linux"
+
+#~ msgctxt "#32030"
+#~ msgid "A new stable version of Kodi is available."
+#~ msgstr "È disponibile una nuova versione stabile di Kodi."
+
+#~ msgctxt "#32031"
+#~ msgid "Visit http://kodi.tv for more information."
+#~ msgstr "Visita http://kodi.tv per ulteriori informazioni."
 
 #~ msgctxt "#32035"
 #~ msgid "It is recommended that you to upgrade to a newer version."

--- a/service.xbmc.versioncheck/resources/language/resource.language.ja_jp/strings.po
+++ b/service.xbmc.versioncheck/resources/language/resource.language.ja_jp/strings.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: XBMC Addons\n"
-"Report-Msgid-Bugs-To: translations@kodi.tv\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "PO-Revision-Date: 2021-10-25 10:08+0000\n"
 "Last-Translator: Christian Gade <gade@kodi.tv>\n"
@@ -90,17 +90,6 @@ msgctxt "#32024"
 msgid "Linux: Upgrade using apt"
 msgstr ""
 
-# empty strings from id 32025 to 32029
-#. Used in OK dialog
-msgctxt "#32030"
-msgid "A new stable version of Kodi is available."
-msgstr "Kodi の新しい安定バージョンがあります。"
-
-#. Direct people to the website. Used in OK dialog
-msgctxt "#32031"
-msgid "Visit http://kodi.tv for more information."
-msgstr "詳しくは http://kodi.tv を参照してください。"
-
 #. Used in OK dialog
 msgctxt "#32032"
 msgid "A new stable version of Kodi is available."
@@ -133,6 +122,15 @@ msgstr "お使いの OS をアップグレードしてください。"
 msgctxt "#32042"
 msgid "For more information, see https://kodi.wiki/view/Linux"
 msgstr "詳しくは https://kodi.wiki/view/Linux を参照してください"
+
+# empty strings from id 32025 to 32029
+#~ msgctxt "#32030"
+#~ msgid "A new stable version of Kodi is available."
+#~ msgstr "Kodi の新しい安定バージョンがあります。"
+
+#~ msgctxt "#32031"
+#~ msgid "Visit http://kodi.tv for more information."
+#~ msgstr "詳しくは http://kodi.tv を参照してください。"
 
 #~ msgctxt "#32035"
 #~ msgid "It is recommended that you to upgrade to a newer version."

--- a/service.xbmc.versioncheck/resources/language/resource.language.kn_in/strings.po
+++ b/service.xbmc.versioncheck/resources/language/resource.language.kn_in/strings.po
@@ -90,17 +90,6 @@ msgctxt "#32024"
 msgid "Linux: Upgrade using apt"
 msgstr ""
 
-# empty strings from id 32025 to 32029
-#. Used in OK dialog
-msgctxt "#32030"
-msgid "A new stable version of Kodi is available."
-msgstr ""
-
-#. Direct people to the website. Used in OK dialog
-msgctxt "#32031"
-msgid "Visit http://kodi.tv for more information."
-msgstr ""
-
 #. Used in OK dialog
 msgctxt "#32032"
 msgid "A new stable version of Kodi is available."

--- a/service.xbmc.versioncheck/resources/language/resource.language.ko_kr/strings.po
+++ b/service.xbmc.versioncheck/resources/language/resource.language.ko_kr/strings.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: XBMC Addons\n"
-"Report-Msgid-Bugs-To: translations@kodi.tv\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "PO-Revision-Date: 2021-10-25 10:08+0000\n"
 "Last-Translator: Christian Gade <gade@kodi.tv>\n"
@@ -90,16 +90,6 @@ msgid "Linux: Upgrade using apt"
 msgstr "리눅스: apt를 사용하여 업그레이드"
 
 #. Used in OK dialog
-msgctxt "#32030"
-msgid "A new stable version of Kodi is available."
-msgstr "안정적인 Kodi 새 버전을 사용할 수 있습니다."
-
-#. Direct people to the website. Used in OK dialog
-msgctxt "#32031"
-msgid "Visit http://kodi.tv for more information."
-msgstr "자세한 정보는 http://kodi.tv를 방문하세요."
-
-#. Used in OK dialog
 msgctxt "#32032"
 msgid "A new stable version of Kodi is available."
 msgstr "안정적인 Kodi 새 버전을 사용할 수 있습니다."
@@ -131,6 +121,14 @@ msgstr "운영 체제를 업그레이드하십시오."
 msgctxt "#32042"
 msgid "For more information, see https://kodi.wiki/view/Linux"
 msgstr "자세한 내용은 https://kodi.wiki/view/Linux를 참조하십시오"
+
+#~ msgctxt "#32030"
+#~ msgid "A new stable version of Kodi is available."
+#~ msgstr "안정적인 Kodi 새 버전을 사용할 수 있습니다."
+
+#~ msgctxt "#32031"
+#~ msgid "Visit http://kodi.tv for more information."
+#~ msgstr "자세한 정보는 http://kodi.tv를 방문하세요."
 
 #~ msgctxt "#32035"
 #~ msgid "It is recommended that you to upgrade to a newer version."

--- a/service.xbmc.versioncheck/resources/language/resource.language.lt_lt/strings.po
+++ b/service.xbmc.versioncheck/resources/language/resource.language.lt_lt/strings.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: XBMC Addons\n"
-"Report-Msgid-Bugs-To: translations@kodi.tv\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "PO-Revision-Date: 2021-10-25 10:08+0000\n"
 "Last-Translator: Christian Gade <gade@kodi.tv>\n"
@@ -90,16 +90,6 @@ msgid "Linux: Upgrade using apt"
 msgstr "Linux: atnaujinti naudojant apt"
 
 #. Used in OK dialog
-msgctxt "#32030"
-msgid "A new stable version of Kodi is available."
-msgstr "Galima nauja Kodi versija."
-
-#. Direct people to the website. Used in OK dialog
-msgctxt "#32031"
-msgid "Visit http://kodi.tv for more information."
-msgstr "Apsilankykite http://kodi.tv, norėdami gauti daugiau informacijos."
-
-#. Used in OK dialog
 msgctxt "#32032"
 msgid "A new stable version of Kodi is available."
 msgstr "Galima nauja stabili Kodi versija."
@@ -131,6 +121,14 @@ msgstr "Atnaujinkite savo operacinę sistemą."
 msgctxt "#32042"
 msgid "For more information, see https://kodi.wiki/view/Linux"
 msgstr "Norėdami gauti daugiau informacijos, žr. https://kodi.wiki/view/Linux"
+
+#~ msgctxt "#32030"
+#~ msgid "A new stable version of Kodi is available."
+#~ msgstr "Galima nauja Kodi versija."
+
+#~ msgctxt "#32031"
+#~ msgid "Visit http://kodi.tv for more information."
+#~ msgstr "Apsilankykite http://kodi.tv, norėdami gauti daugiau informacijos."
 
 #~ msgctxt "#32035"
 #~ msgid "It is recommended that you to upgrade to a newer version."

--- a/service.xbmc.versioncheck/resources/language/resource.language.lv_lv/strings.po
+++ b/service.xbmc.versioncheck/resources/language/resource.language.lv_lv/strings.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: XBMC Addons\n"
-"Report-Msgid-Bugs-To: translations@kodi.tv\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "PO-Revision-Date: 2023-02-24 00:15+0000\n"
 "Last-Translator: Coool (github.com/Coool) <coool@mail.lv>\n"
@@ -90,17 +90,6 @@ msgctxt "#32024"
 msgid "Linux: Upgrade using apt"
 msgstr "Linux: Atjaunināt, izmantojot apt"
 
-# empty strings from id 32025 to 32029
-#. Used in OK dialog
-msgctxt "#32030"
-msgid "A new stable version of Kodi is available."
-msgstr "Ir pieejama jauna stabila Kodi versija."
-
-#. Direct people to the website. Used in OK dialog
-msgctxt "#32031"
-msgid "Visit http://kodi.tv for more information."
-msgstr "Lai iegūtu vairāk informācijas, apmeklējiet http://kodi.tv vietni."
-
 #. Used in OK dialog
 msgctxt "#32032"
 msgid "A new stable version of Kodi is available."
@@ -133,3 +122,12 @@ msgstr "Lūdzu, atjauniniet savu operētājsistēmu."
 msgctxt "#32042"
 msgid "For more information, see https://kodi.wiki/view/Linux"
 msgstr "Lai iegūtu vairāk informācijas, skatiet https://kodi.wiki/view/Linux vietni"
+
+# empty strings from id 32025 to 32029
+#~ msgctxt "#32030"
+#~ msgid "A new stable version of Kodi is available."
+#~ msgstr "Ir pieejama jauna stabila Kodi versija."
+
+#~ msgctxt "#32031"
+#~ msgid "Visit http://kodi.tv for more information."
+#~ msgstr "Lai iegūtu vairāk informācijas, apmeklējiet http://kodi.tv vietni."

--- a/service.xbmc.versioncheck/resources/language/resource.language.mi/strings.po
+++ b/service.xbmc.versioncheck/resources/language/resource.language.mi/strings.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: XBMC Addons\n"
-"Report-Msgid-Bugs-To: translations@kodi.tv\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "PO-Revision-Date: 2022-03-09 16:11+0000\n"
 "Last-Translator: Christian Gade <gade@kodi.tv>\n"
@@ -89,17 +89,6 @@ msgstr ""
 
 msgctxt "#32024"
 msgid "Linux: Upgrade using apt"
-msgstr ""
-
-# empty strings from id 32025 to 32029
-#. Used in OK dialog
-msgctxt "#32030"
-msgid "A new stable version of Kodi is available."
-msgstr ""
-
-#. Direct people to the website. Used in OK dialog
-msgctxt "#32031"
-msgid "Visit http://kodi.tv for more information."
 msgstr ""
 
 #. Used in OK dialog

--- a/service.xbmc.versioncheck/resources/language/resource.language.mk_mk/strings.po
+++ b/service.xbmc.versioncheck/resources/language/resource.language.mk_mk/strings.po
@@ -89,17 +89,6 @@ msgctxt "#32024"
 msgid "Linux: Upgrade using apt"
 msgstr ""
 
-# empty strings from id 32025 to 32029
-#. Used in OK dialog
-msgctxt "#32030"
-msgid "A new stable version of Kodi is available."
-msgstr ""
-
-#. Direct people to the website. Used in OK dialog
-msgctxt "#32031"
-msgid "Visit http://kodi.tv for more information."
-msgstr ""
-
 #. Used in OK dialog
 msgctxt "#32032"
 msgid "A new stable version of Kodi is available."

--- a/service.xbmc.versioncheck/resources/language/resource.language.ml_in/strings.po
+++ b/service.xbmc.versioncheck/resources/language/resource.language.ml_in/strings.po
@@ -89,17 +89,6 @@ msgctxt "#32024"
 msgid "Linux: Upgrade using apt"
 msgstr ""
 
-# empty strings from id 32025 to 32029
-#. Used in OK dialog
-msgctxt "#32030"
-msgid "A new stable version of Kodi is available."
-msgstr ""
-
-#. Direct people to the website. Used in OK dialog
-msgctxt "#32031"
-msgid "Visit http://kodi.tv for more information."
-msgstr ""
-
 #. Used in OK dialog
 msgctxt "#32032"
 msgid "A new stable version of Kodi is available."

--- a/service.xbmc.versioncheck/resources/language/resource.language.mn_mn/strings.po
+++ b/service.xbmc.versioncheck/resources/language/resource.language.mn_mn/strings.po
@@ -89,17 +89,6 @@ msgctxt "#32024"
 msgid "Linux: Upgrade using apt"
 msgstr ""
 
-# empty strings from id 32025 to 32029
-#. Used in OK dialog
-msgctxt "#32030"
-msgid "A new stable version of Kodi is available."
-msgstr ""
-
-#. Direct people to the website. Used in OK dialog
-msgctxt "#32031"
-msgid "Visit http://kodi.tv for more information."
-msgstr ""
-
 #. Used in OK dialog
 msgctxt "#32032"
 msgid "A new stable version of Kodi is available."

--- a/service.xbmc.versioncheck/resources/language/resource.language.ms_my/strings.po
+++ b/service.xbmc.versioncheck/resources/language/resource.language.ms_my/strings.po
@@ -89,17 +89,6 @@ msgctxt "#32024"
 msgid "Linux: Upgrade using apt"
 msgstr ""
 
-# empty strings from id 32025 to 32029
-#. Used in OK dialog
-msgctxt "#32030"
-msgid "A new stable version of Kodi is available."
-msgstr ""
-
-#. Direct people to the website. Used in OK dialog
-msgctxt "#32031"
-msgid "Visit http://kodi.tv for more information."
-msgstr ""
-
 #. Used in OK dialog
 msgctxt "#32032"
 msgid "A new stable version of Kodi is available."

--- a/service.xbmc.versioncheck/resources/language/resource.language.mt_mt/strings.po
+++ b/service.xbmc.versioncheck/resources/language/resource.language.mt_mt/strings.po
@@ -89,17 +89,6 @@ msgctxt "#32024"
 msgid "Linux: Upgrade using apt"
 msgstr ""
 
-# empty strings from id 32025 to 32029
-#. Used in OK dialog
-msgctxt "#32030"
-msgid "A new stable version of Kodi is available."
-msgstr ""
-
-#. Direct people to the website. Used in OK dialog
-msgctxt "#32031"
-msgid "Visit http://kodi.tv for more information."
-msgstr ""
-
 #. Used in OK dialog
 msgctxt "#32032"
 msgid "A new stable version of Kodi is available."

--- a/service.xbmc.versioncheck/resources/language/resource.language.my_mm/strings.po
+++ b/service.xbmc.versioncheck/resources/language/resource.language.my_mm/strings.po
@@ -89,17 +89,6 @@ msgctxt "#32024"
 msgid "Linux: Upgrade using apt"
 msgstr ""
 
-# empty strings from id 32025 to 32029
-#. Used in OK dialog
-msgctxt "#32030"
-msgid "A new stable version of Kodi is available."
-msgstr ""
-
-#. Direct people to the website. Used in OK dialog
-msgctxt "#32031"
-msgid "Visit http://kodi.tv for more information."
-msgstr ""
-
 #. Used in OK dialog
 msgctxt "#32032"
 msgid "A new stable version of Kodi is available."

--- a/service.xbmc.versioncheck/resources/language/resource.language.nb_no/strings.po
+++ b/service.xbmc.versioncheck/resources/language/resource.language.nb_no/strings.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: XBMC Addons\n"
-"Report-Msgid-Bugs-To: translations@kodi.tv\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "PO-Revision-Date: 2021-10-25 10:08+0000\n"
 "Last-Translator: Christian Gade <gade@kodi.tv>\n"
@@ -90,16 +90,6 @@ msgid "Linux: Upgrade using apt"
 msgstr "Linux: Oppgrader med apt"
 
 #. Used in OK dialog
-msgctxt "#32030"
-msgid "A new stable version of Kodi is available."
-msgstr "En ny stabil versjon av Kodi er tilgjengelig."
-
-#. Direct people to the website. Used in OK dialog
-msgctxt "#32031"
-msgid "Visit http://kodi.tv for more information."
-msgstr "Se http://kodi.tv for mer informasjon."
-
-#. Used in OK dialog
 msgctxt "#32032"
 msgid "A new stable version of Kodi is available."
 msgstr "En ny stabil versjon av Kodi er tilgjengelig."
@@ -131,6 +121,14 @@ msgstr ""
 msgctxt "#32042"
 msgid "For more information, see https://kodi.wiki/view/Linux"
 msgstr ""
+
+#~ msgctxt "#32030"
+#~ msgid "A new stable version of Kodi is available."
+#~ msgstr "En ny stabil versjon av Kodi er tilgjengelig."
+
+#~ msgctxt "#32031"
+#~ msgid "Visit http://kodi.tv for more information."
+#~ msgstr "Se http://kodi.tv for mer informasjon."
 
 #~ msgctxt "#32035"
 #~ msgid "It is recommended that you to upgrade to a newer version."

--- a/service.xbmc.versioncheck/resources/language/resource.language.nl_nl/strings.po
+++ b/service.xbmc.versioncheck/resources/language/resource.language.nl_nl/strings.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: XBMC Addons\n"
-"Report-Msgid-Bugs-To: translations@kodi.tv\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "PO-Revision-Date: 2021-12-14 15:13+0000\n"
 "Last-Translator: Deleted User <noreply+158@weblate.org>\n"
@@ -90,16 +90,6 @@ msgid "Linux: Upgrade using apt"
 msgstr "Linux: Upgrade gebruikt apt"
 
 #. Used in OK dialog
-msgctxt "#32030"
-msgid "A new stable version of Kodi is available."
-msgstr "Een nieuwe stabiele versie van Kodi is beschikbaar."
-
-#. Direct people to the website. Used in OK dialog
-msgctxt "#32031"
-msgid "Visit http://kodi.tv for more information."
-msgstr "Bezoek http://kodi.tv voor meer informatie."
-
-#. Used in OK dialog
 msgctxt "#32032"
 msgid "A new stable version of Kodi is available."
 msgstr "Een nieuwe stabiele versie van Kodi is beschikbaar."
@@ -131,6 +121,14 @@ msgstr "Update uw besturingssysteem."
 msgctxt "#32042"
 msgid "For more information, see https://kodi.wiki/view/Linux"
 msgstr "Voor meer informatie, kijk op https://kodi.wiki/view/Linux"
+
+#~ msgctxt "#32030"
+#~ msgid "A new stable version of Kodi is available."
+#~ msgstr "Een nieuwe stabiele versie van Kodi is beschikbaar."
+
+#~ msgctxt "#32031"
+#~ msgid "Visit http://kodi.tv for more information."
+#~ msgstr "Bezoek http://kodi.tv voor meer informatie."
 
 #~ msgctxt "#32035"
 #~ msgid "It is recommended that you to upgrade to a newer version."

--- a/service.xbmc.versioncheck/resources/language/resource.language.oc_fr/strings.po
+++ b/service.xbmc.versioncheck/resources/language/resource.language.oc_fr/strings.po
@@ -91,17 +91,6 @@ msgctxt "#32024"
 msgid "Linux: Upgrade using apt"
 msgstr ""
 
-# empty strings from id 32025 to 32029
-#. Used in OK dialog
-msgctxt "#32030"
-msgid "A new stable version of Kodi is available."
-msgstr ""
-
-#. Direct people to the website. Used in OK dialog
-msgctxt "#32031"
-msgid "Visit http://kodi.tv for more information."
-msgstr ""
-
 #. Used in OK dialog
 msgctxt "#32032"
 msgid "A new stable version of Kodi is available."

--- a/service.xbmc.versioncheck/resources/language/resource.language.os_os/strings.po
+++ b/service.xbmc.versioncheck/resources/language/resource.language.os_os/strings.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: XBMC Addons\n"
-"Report-Msgid-Bugs-To: translations@kodi.tv\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "PO-Revision-Date: 2022-03-09 16:11+0000\n"
 "Last-Translator: Christian Gade <gade@kodi.tv>\n"
@@ -89,17 +89,6 @@ msgstr ""
 
 msgctxt "#32024"
 msgid "Linux: Upgrade using apt"
-msgstr ""
-
-# empty strings from id 32025 to 32029
-#. Used in OK dialog
-msgctxt "#32030"
-msgid "A new stable version of Kodi is available."
-msgstr ""
-
-#. Direct people to the website. Used in OK dialog
-msgctxt "#32031"
-msgid "Visit http://kodi.tv for more information."
 msgstr ""
 
 #. Used in OK dialog

--- a/service.xbmc.versioncheck/resources/language/resource.language.pl_pl/strings.po
+++ b/service.xbmc.versioncheck/resources/language/resource.language.pl_pl/strings.po
@@ -5,9 +5,9 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: XBMC Addons\n"
-"Report-Msgid-Bugs-To: translations@kodi.tv\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"PO-Revision-Date: 2021-10-25 09:12+0000\n"
+"PO-Revision-Date: 2024-04-05 21:54+0000\n"
 "Last-Translator: Marek Adamski <fevbew@wp.pl>\n"
 "Language-Team: Polish <https://kodi.weblate.cloud/projects/kodi-core/service-xbmc-versioncheck/pl_pl/>\n"
 "Language: pl_pl\n"
@@ -15,7 +15,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
-"X-Generator: Weblate 4.8\n"
+"X-Generator: Weblate 5.4\n"
 
 msgctxt "Addon Summary"
 msgid "Kodi Version Check checks if you are running latest released version."
@@ -90,16 +90,6 @@ msgid "Linux: Upgrade using apt"
 msgstr "Linux: aktualizuj za pomocą menedżera pakietów (apt)"
 
 #. Used in OK dialog
-msgctxt "#32030"
-msgid "A new stable version of Kodi is available."
-msgstr "Dostępna jest nowa stabilna wersja Kodi."
-
-#. Direct people to the website. Used in OK dialog
-msgctxt "#32031"
-msgid "Visit http://kodi.tv for more information."
-msgstr "Odwiedź stronę http://kodi.tv po więcej informacji."
-
-#. Used in OK dialog
 msgctxt "#32032"
 msgid "A new stable version of Kodi is available."
 msgstr "Dostępna jest nowa stabilna wersja Kodi."
@@ -131,6 +121,18 @@ msgstr "Dokonaj uaktualnienia systemu operacyjnego."
 msgctxt "#32042"
 msgid "For more information, see https://kodi.wiki/view/Linux"
 msgstr "Aby znaleźć więcej informacji, odwiedź https://kodi.wiki/view/Linux"
+
+#~ msgctxt "#32043"
+#~ msgid "How can I help make Kodi better?"
+#~ msgstr "Jak mogę pomóc ulepszyć Kodi?"
+
+#~ msgctxt "#32030"
+#~ msgid "A new stable version of Kodi is available."
+#~ msgstr "Dostępna jest nowa stabilna wersja Kodi."
+
+#~ msgctxt "#32031"
+#~ msgid "Visit http://kodi.tv for more information."
+#~ msgstr "Odwiedź stronę http://kodi.tv po więcej informacji."
 
 #~ msgctxt "#32035"
 #~ msgid "It is recommended that you to upgrade to a newer version."

--- a/service.xbmc.versioncheck/resources/language/resource.language.pt_br/strings.po
+++ b/service.xbmc.versioncheck/resources/language/resource.language.pt_br/strings.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: XBMC Addons\n"
-"Report-Msgid-Bugs-To: translations@kodi.tv\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "PO-Revision-Date: 2021-10-25 10:08+0000\n"
 "Last-Translator: Christian Gade <gade@kodi.tv>\n"
@@ -90,16 +90,6 @@ msgid "Linux: Upgrade using apt"
 msgstr "Linux: Atualizar usando apt"
 
 #. Used in OK dialog
-msgctxt "#32030"
-msgid "A new stable version of Kodi is available."
-msgstr "Uma nova versão estável do Kodi se encontra disponível."
-
-#. Direct people to the website. Used in OK dialog
-msgctxt "#32031"
-msgid "Visit http://kodi.tv for more information."
-msgstr "visite http://kodi.tv para maiores informações."
-
-#. Used in OK dialog
 msgctxt "#32032"
 msgid "A new stable version of Kodi is available."
 msgstr "Uma nova versão estável do Kodi se encontra disponível."
@@ -131,6 +121,14 @@ msgstr "Atualize seu sistema operacional."
 msgctxt "#32042"
 msgid "For more information, see https://kodi.wiki/view/Linux"
 msgstr "Para mais informações, veja https://kodi.wiki/view/Linux"
+
+#~ msgctxt "#32030"
+#~ msgid "A new stable version of Kodi is available."
+#~ msgstr "Uma nova versão estável do Kodi se encontra disponível."
+
+#~ msgctxt "#32031"
+#~ msgid "Visit http://kodi.tv for more information."
+#~ msgstr "visite http://kodi.tv para maiores informações."
 
 #~ msgctxt "#32035"
 #~ msgid "It is recommended that you to upgrade to a newer version."

--- a/service.xbmc.versioncheck/resources/language/resource.language.pt_pt/strings.po
+++ b/service.xbmc.versioncheck/resources/language/resource.language.pt_pt/strings.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: XBMC Addons\n"
-"Report-Msgid-Bugs-To: translations@kodi.tv\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "PO-Revision-Date: 2021-10-25 10:08+0000\n"
 "Last-Translator: Christian Gade <gade@kodi.tv>\n"
@@ -90,16 +90,6 @@ msgid "Linux: Upgrade using apt"
 msgstr "Linux: Actualizar com apt"
 
 #. Used in OK dialog
-msgctxt "#32030"
-msgid "A new stable version of Kodi is available."
-msgstr "Está disponível uma nova versão do Kodi."
-
-#. Direct people to the website. Used in OK dialog
-msgctxt "#32031"
-msgid "Visit http://kodi.tv for more information."
-msgstr "Visite http://kodi.tv para mais informação."
-
-#. Used in OK dialog
 msgctxt "#32032"
 msgid "A new stable version of Kodi is available."
 msgstr "Está disponível uma nova versão do Kodi."
@@ -131,6 +121,14 @@ msgstr ""
 msgctxt "#32042"
 msgid "For more information, see https://kodi.wiki/view/Linux"
 msgstr ""
+
+#~ msgctxt "#32030"
+#~ msgid "A new stable version of Kodi is available."
+#~ msgstr "Está disponível uma nova versão do Kodi."
+
+#~ msgctxt "#32031"
+#~ msgid "Visit http://kodi.tv for more information."
+#~ msgstr "Visite http://kodi.tv para mais informação."
 
 #~ msgctxt "#32035"
 #~ msgid "It is recommended that you to upgrade to a newer version."

--- a/service.xbmc.versioncheck/resources/language/resource.language.ro_ro/strings.po
+++ b/service.xbmc.versioncheck/resources/language/resource.language.ro_ro/strings.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: XBMC Addons\n"
-"Report-Msgid-Bugs-To: translations@kodi.tv\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "PO-Revision-Date: 2021-10-25 10:08+0000\n"
 "Last-Translator: Christian Gade <gade@kodi.tv>\n"
@@ -91,16 +91,6 @@ msgid "Linux: Upgrade using apt"
 msgstr "Linux: Actualizare folosind apt"
 
 #. Used in OK dialog
-msgctxt "#32030"
-msgid "A new stable version of Kodi is available."
-msgstr "Este disponibilă o versiune stabilă mai nouă pentru Kodi."
-
-#. Direct people to the website. Used in OK dialog
-msgctxt "#32031"
-msgid "Visit http://kodi.tv for more information."
-msgstr "Vizitați http://kodi.tv pentru mai multe informații."
-
-#. Used in OK dialog
 msgctxt "#32032"
 msgid "A new stable version of Kodi is available."
 msgstr "Este disponibilă o versiune stabilă mai nouă pentru Kodi."
@@ -132,6 +122,14 @@ msgstr ""
 msgctxt "#32042"
 msgid "For more information, see https://kodi.wiki/view/Linux"
 msgstr ""
+
+#~ msgctxt "#32030"
+#~ msgid "A new stable version of Kodi is available."
+#~ msgstr "Este disponibilă o versiune stabilă mai nouă pentru Kodi."
+
+#~ msgctxt "#32031"
+#~ msgid "Visit http://kodi.tv for more information."
+#~ msgstr "Vizitați http://kodi.tv pentru mai multe informații."
 
 #~ msgctxt "#32035"
 #~ msgid "It is recommended that you to upgrade to a newer version."

--- a/service.xbmc.versioncheck/resources/language/resource.language.ru_ru/strings.po
+++ b/service.xbmc.versioncheck/resources/language/resource.language.ru_ru/strings.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: XBMC Addons\n"
-"Report-Msgid-Bugs-To: translations@kodi.tv\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "PO-Revision-Date: 2021-10-25 10:08+0000\n"
 "Last-Translator: Christian Gade <gade@kodi.tv>\n"
@@ -90,16 +90,6 @@ msgid "Linux: Upgrade using apt"
 msgstr "Linux: Обновление с помощью apt"
 
 #. Used in OK dialog
-msgctxt "#32030"
-msgid "A new stable version of Kodi is available."
-msgstr "Доступна новая стабильная версия Kodi."
-
-#. Direct people to the website. Used in OK dialog
-msgctxt "#32031"
-msgid "Visit http://kodi.tv for more information."
-msgstr "Для более полной информации посетите http://kodi.tv."
-
-#. Used in OK dialog
 msgctxt "#32032"
 msgid "A new stable version of Kodi is available."
 msgstr "Доступна новая стабильная версия Kodi."
@@ -131,6 +121,14 @@ msgstr "Пожалуйста, обновите операционную сист
 msgctxt "#32042"
 msgid "For more information, see https://kodi.wiki/view/Linux"
 msgstr "Для подробной информации, смотрите https://kodi.wiki/view/Linux"
+
+#~ msgctxt "#32030"
+#~ msgid "A new stable version of Kodi is available."
+#~ msgstr "Доступна новая стабильная версия Kodi."
+
+#~ msgctxt "#32031"
+#~ msgid "Visit http://kodi.tv for more information."
+#~ msgstr "Для более полной информации посетите http://kodi.tv."
 
 #~ msgctxt "#32035"
 #~ msgid "It is recommended that you to upgrade to a newer version."

--- a/service.xbmc.versioncheck/resources/language/resource.language.si_lk/strings.po
+++ b/service.xbmc.versioncheck/resources/language/resource.language.si_lk/strings.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: XBMC Addons\n"
-"Report-Msgid-Bugs-To: translations@kodi.tv\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "PO-Revision-Date: 2022-03-09 16:11+0000\n"
 "Last-Translator: Christian Gade <gade@kodi.tv>\n"
@@ -89,17 +89,6 @@ msgstr ""
 
 msgctxt "#32024"
 msgid "Linux: Upgrade using apt"
-msgstr ""
-
-# empty strings from id 32025 to 32029
-#. Used in OK dialog
-msgctxt "#32030"
-msgid "A new stable version of Kodi is available."
-msgstr ""
-
-#. Direct people to the website. Used in OK dialog
-msgctxt "#32031"
-msgid "Visit http://kodi.tv for more information."
 msgstr ""
 
 #. Used in OK dialog

--- a/service.xbmc.versioncheck/resources/language/resource.language.sk_sk/strings.po
+++ b/service.xbmc.versioncheck/resources/language/resource.language.sk_sk/strings.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: XBMC Addons\n"
-"Report-Msgid-Bugs-To: translations@kodi.tv\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "PO-Revision-Date: 2022-02-04 19:13+0000\n"
 "Last-Translator: Patrik Špaňo <patrik.spano@gmail.com>\n"
@@ -90,16 +90,6 @@ msgid "Linux: Upgrade using apt"
 msgstr "Linux: Aktualizovať pomocou apt"
 
 #. Used in OK dialog
-msgctxt "#32030"
-msgid "A new stable version of Kodi is available."
-msgstr "Nová stabilná verzia Kodi je k dipozícii."
-
-#. Direct people to the website. Used in OK dialog
-msgctxt "#32031"
-msgid "Visit http://kodi.tv for more information."
-msgstr "Pre viac informácií navštívte http://kodi.tv."
-
-#. Used in OK dialog
 msgctxt "#32032"
 msgid "A new stable version of Kodi is available."
 msgstr "Nová stabilná verzia Kodi je k dipozícii."
@@ -131,3 +121,11 @@ msgstr "Prosím aktualizujte váš operačný systém."
 msgctxt "#32042"
 msgid "For more information, see https://kodi.wiki/view/Linux"
 msgstr "Pre viac informácií navštívte https://kodi.wiki/view/Linux"
+
+#~ msgctxt "#32030"
+#~ msgid "A new stable version of Kodi is available."
+#~ msgstr "Nová stabilná verzia Kodi je k dipozícii."
+
+#~ msgctxt "#32031"
+#~ msgid "Visit http://kodi.tv for more information."
+#~ msgstr "Pre viac informácií navštívte http://kodi.tv."

--- a/service.xbmc.versioncheck/resources/language/resource.language.sl_si/strings.po
+++ b/service.xbmc.versioncheck/resources/language/resource.language.sl_si/strings.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: XBMC Addons\n"
-"Report-Msgid-Bugs-To: translations@kodi.tv\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "PO-Revision-Date: 2022-08-29 13:14+0000\n"
 "Last-Translator: Matej <mateju@src.gnome.org>\n"
@@ -90,16 +90,6 @@ msgid "Linux: Upgrade using apt"
 msgstr "GNU/Linux: nadgradite z apt"
 
 #. Used in OK dialog
-msgctxt "#32030"
-msgid "A new stable version of Kodi is available."
-msgstr "Na voljo je nova stabilna različica Kodija."
-
-#. Direct people to the website. Used in OK dialog
-msgctxt "#32031"
-msgid "Visit http://kodi.tv for more information."
-msgstr "Za dodatne informacije obiščite http://kodi.tv"
-
-#. Used in OK dialog
 msgctxt "#32032"
 msgid "A new stable version of Kodi is available."
 msgstr "Na voljo je nova stabilna različica Kodija."
@@ -131,6 +121,14 @@ msgstr ""
 msgctxt "#32042"
 msgid "For more information, see https://kodi.wiki/view/Linux"
 msgstr ""
+
+#~ msgctxt "#32030"
+#~ msgid "A new stable version of Kodi is available."
+#~ msgstr "Na voljo je nova stabilna različica Kodija."
+
+#~ msgctxt "#32031"
+#~ msgid "Visit http://kodi.tv for more information."
+#~ msgstr "Za dodatne informacije obiščite http://kodi.tv"
 
 #~ msgctxt "#32035"
 #~ msgid "It is recommended that you to upgrade to a newer version."

--- a/service.xbmc.versioncheck/resources/language/resource.language.sq_al/strings.po
+++ b/service.xbmc.versioncheck/resources/language/resource.language.sq_al/strings.po
@@ -89,17 +89,6 @@ msgctxt "#32024"
 msgid "Linux: Upgrade using apt"
 msgstr ""
 
-# empty strings from id 32025 to 32029
-#. Used in OK dialog
-msgctxt "#32030"
-msgid "A new stable version of Kodi is available."
-msgstr ""
-
-#. Direct people to the website. Used in OK dialog
-msgctxt "#32031"
-msgid "Visit http://kodi.tv for more information."
-msgstr ""
-
 #. Used in OK dialog
 msgctxt "#32032"
 msgid "A new stable version of Kodi is available."

--- a/service.xbmc.versioncheck/resources/language/resource.language.sr_rs/strings.po
+++ b/service.xbmc.versioncheck/resources/language/resource.language.sr_rs/strings.po
@@ -89,17 +89,6 @@ msgctxt "#32024"
 msgid "Linux: Upgrade using apt"
 msgstr ""
 
-# empty strings from id 32025 to 32029
-#. Used in OK dialog
-msgctxt "#32030"
-msgid "A new stable version of Kodi is available."
-msgstr ""
-
-#. Direct people to the website. Used in OK dialog
-msgctxt "#32031"
-msgid "Visit http://kodi.tv for more information."
-msgstr ""
-
 #. Used in OK dialog
 msgctxt "#32032"
 msgid "A new stable version of Kodi is available."

--- a/service.xbmc.versioncheck/resources/language/resource.language.sr_rs@latin/strings.po
+++ b/service.xbmc.versioncheck/resources/language/resource.language.sr_rs@latin/strings.po
@@ -89,17 +89,6 @@ msgctxt "#32024"
 msgid "Linux: Upgrade using apt"
 msgstr ""
 
-# empty strings from id 32025 to 32029
-#. Used in OK dialog
-msgctxt "#32030"
-msgid "A new stable version of Kodi is available."
-msgstr ""
-
-#. Direct people to the website. Used in OK dialog
-msgctxt "#32031"
-msgid "Visit http://kodi.tv for more information."
-msgstr ""
-
 #. Used in OK dialog
 msgctxt "#32032"
 msgid "A new stable version of Kodi is available."

--- a/service.xbmc.versioncheck/resources/language/resource.language.sv_se/strings.po
+++ b/service.xbmc.versioncheck/resources/language/resource.language.sv_se/strings.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: XBMC Addons\n"
-"Report-Msgid-Bugs-To: translations@kodi.tv\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "PO-Revision-Date: 2021-10-25 10:08+0000\n"
 "Last-Translator: Christian Gade <gade@kodi.tv>\n"
@@ -90,16 +90,6 @@ msgid "Linux: Upgrade using apt"
 msgstr "Linux: Uppgradera med apt"
 
 #. Used in OK dialog
-msgctxt "#32030"
-msgid "A new stable version of Kodi is available."
-msgstr "En ny stabil Kodi-version finns tillgänglig."
-
-#. Direct people to the website. Used in OK dialog
-msgctxt "#32031"
-msgid "Visit http://kodi.tv for more information."
-msgstr "Besök Kodi.tv för mer information."
-
-#. Used in OK dialog
 msgctxt "#32032"
 msgid "A new stable version of Kodi is available."
 msgstr "En ny stabil Kodi-version finns tillgänglig."
@@ -131,6 +121,14 @@ msgstr "Vänligen uppgradera ditt operativsystem."
 msgctxt "#32042"
 msgid "For more information, see https://kodi.wiki/view/Linux"
 msgstr "För mer information, se https://kodi.wiki/view/Linux"
+
+#~ msgctxt "#32030"
+#~ msgid "A new stable version of Kodi is available."
+#~ msgstr "En ny stabil Kodi-version finns tillgänglig."
+
+#~ msgctxt "#32031"
+#~ msgid "Visit http://kodi.tv for more information."
+#~ msgstr "Besök Kodi.tv för mer information."
 
 #~ msgctxt "#32035"
 #~ msgid "It is recommended that you to upgrade to a newer version."

--- a/service.xbmc.versioncheck/resources/language/resource.language.szl/strings.po
+++ b/service.xbmc.versioncheck/resources/language/resource.language.szl/strings.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: XBMC Addons\n"
-"Report-Msgid-Bugs-To: translations@kodi.tv\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "PO-Revision-Date: 2022-04-03 13:41+0000\n"
 "Last-Translator: Christian Gade <gade@kodi.tv>\n"
@@ -89,17 +89,6 @@ msgstr ""
 
 msgctxt "#32024"
 msgid "Linux: Upgrade using apt"
-msgstr ""
-
-# empty strings from id 32025 to 32029
-#. Used in OK dialog
-msgctxt "#32030"
-msgid "A new stable version of Kodi is available."
-msgstr ""
-
-#. Direct people to the website. Used in OK dialog
-msgctxt "#32031"
-msgid "Visit http://kodi.tv for more information."
 msgstr ""
 
 #. Used in OK dialog

--- a/service.xbmc.versioncheck/resources/language/resource.language.ta_in/strings.po
+++ b/service.xbmc.versioncheck/resources/language/resource.language.ta_in/strings.po
@@ -89,17 +89,6 @@ msgctxt "#32024"
 msgid "Linux: Upgrade using apt"
 msgstr ""
 
-# empty strings from id 32025 to 32029
-#. Used in OK dialog
-msgctxt "#32030"
-msgid "A new stable version of Kodi is available."
-msgstr ""
-
-#. Direct people to the website. Used in OK dialog
-msgctxt "#32031"
-msgid "Visit http://kodi.tv for more information."
-msgstr ""
-
 #. Used in OK dialog
 msgctxt "#32032"
 msgid "A new stable version of Kodi is available."

--- a/service.xbmc.versioncheck/resources/language/resource.language.te_in/strings.po
+++ b/service.xbmc.versioncheck/resources/language/resource.language.te_in/strings.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: XBMC Addons\n"
-"Report-Msgid-Bugs-To: translations@kodi.tv\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "PO-Revision-Date: 2022-03-09 16:11+0000\n"
 "Last-Translator: Christian Gade <gade@kodi.tv>\n"
@@ -89,17 +89,6 @@ msgstr ""
 
 msgctxt "#32024"
 msgid "Linux: Upgrade using apt"
-msgstr ""
-
-# empty strings from id 32025 to 32029
-#. Used in OK dialog
-msgctxt "#32030"
-msgid "A new stable version of Kodi is available."
-msgstr ""
-
-#. Direct people to the website. Used in OK dialog
-msgctxt "#32031"
-msgid "Visit http://kodi.tv for more information."
 msgstr ""
 
 #. Used in OK dialog

--- a/service.xbmc.versioncheck/resources/language/resource.language.tg_tj/strings.po
+++ b/service.xbmc.versioncheck/resources/language/resource.language.tg_tj/strings.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: XBMC Addons\n"
-"Report-Msgid-Bugs-To: translations@kodi.tv\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "PO-Revision-Date: 2022-04-03 13:41+0000\n"
 "Last-Translator: Christian Gade <gade@kodi.tv>\n"
@@ -89,17 +89,6 @@ msgstr ""
 
 msgctxt "#32024"
 msgid "Linux: Upgrade using apt"
-msgstr ""
-
-# empty strings from id 32025 to 32029
-#. Used in OK dialog
-msgctxt "#32030"
-msgid "A new stable version of Kodi is available."
-msgstr ""
-
-#. Direct people to the website. Used in OK dialog
-msgctxt "#32031"
-msgid "Visit http://kodi.tv for more information."
 msgstr ""
 
 #. Used in OK dialog

--- a/service.xbmc.versioncheck/resources/language/resource.language.th_th/strings.po
+++ b/service.xbmc.versioncheck/resources/language/resource.language.th_th/strings.po
@@ -89,17 +89,6 @@ msgctxt "#32024"
 msgid "Linux: Upgrade using apt"
 msgstr ""
 
-# empty strings from id 32025 to 32029
-#. Used in OK dialog
-msgctxt "#32030"
-msgid "A new stable version of Kodi is available."
-msgstr ""
-
-#. Direct people to the website. Used in OK dialog
-msgctxt "#32031"
-msgid "Visit http://kodi.tv for more information."
-msgstr ""
-
 #. Used in OK dialog
 msgctxt "#32032"
 msgid "A new stable version of Kodi is available."

--- a/service.xbmc.versioncheck/resources/language/resource.language.tr_tr/strings.po
+++ b/service.xbmc.versioncheck/resources/language/resource.language.tr_tr/strings.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: XBMC Addons\n"
-"Report-Msgid-Bugs-To: translations@kodi.tv\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "PO-Revision-Date: 2021-10-25 10:08+0000\n"
 "Last-Translator: Christian Gade <gade@kodi.tv>\n"
@@ -90,16 +90,6 @@ msgid "Linux: Upgrade using apt"
 msgstr "Linux: apt kullanarak güncelle"
 
 #. Used in OK dialog
-msgctxt "#32030"
-msgid "A new stable version of Kodi is available."
-msgstr "Yeni kararlı bir Kodi sürümü mevcut."
-
-#. Direct people to the website. Used in OK dialog
-msgctxt "#32031"
-msgid "Visit http://kodi.tv for more information."
-msgstr "Daha fazla bilgi için http://kodi.tv adresini ziyaret edin."
-
-#. Used in OK dialog
 msgctxt "#32032"
 msgid "A new stable version of Kodi is available."
 msgstr "Yeni kararlı bir Kodi sürümü mevcut."
@@ -131,6 +121,14 @@ msgstr "Lütfen işletim sisteminizi yükseltin."
 msgctxt "#32042"
 msgid "For more information, see https://kodi.wiki/view/Linux"
 msgstr "Daha fazla bilgi için, https://kodi.wiki/view/Linux sayfasına bakınız"
+
+#~ msgctxt "#32030"
+#~ msgid "A new stable version of Kodi is available."
+#~ msgstr "Yeni kararlı bir Kodi sürümü mevcut."
+
+#~ msgctxt "#32031"
+#~ msgid "Visit http://kodi.tv for more information."
+#~ msgstr "Daha fazla bilgi için http://kodi.tv adresini ziyaret edin."
 
 #~ msgctxt "#32035"
 #~ msgid "It is recommended that you to upgrade to a newer version."

--- a/service.xbmc.versioncheck/resources/language/resource.language.uk_ua/strings.po
+++ b/service.xbmc.versioncheck/resources/language/resource.language.uk_ua/strings.po
@@ -89,17 +89,6 @@ msgctxt "#32024"
 msgid "Linux: Upgrade using apt"
 msgstr ""
 
-# empty strings from id 32025 to 32029
-#. Used in OK dialog
-msgctxt "#32030"
-msgid "A new stable version of Kodi is available."
-msgstr ""
-
-#. Direct people to the website. Used in OK dialog
-msgctxt "#32031"
-msgid "Visit http://kodi.tv for more information."
-msgstr ""
-
 #. Used in OK dialog
 msgctxt "#32032"
 msgid "A new stable version of Kodi is available."

--- a/service.xbmc.versioncheck/resources/language/resource.language.uz_uz/strings.po
+++ b/service.xbmc.versioncheck/resources/language/resource.language.uz_uz/strings.po
@@ -89,17 +89,6 @@ msgctxt "#32024"
 msgid "Linux: Upgrade using apt"
 msgstr ""
 
-# empty strings from id 32025 to 32029
-#. Used in OK dialog
-msgctxt "#32030"
-msgid "A new stable version of Kodi is available."
-msgstr ""
-
-#. Direct people to the website. Used in OK dialog
-msgctxt "#32031"
-msgid "Visit http://kodi.tv for more information."
-msgstr ""
-
 #. Used in OK dialog
 msgctxt "#32032"
 msgid "A new stable version of Kodi is available."

--- a/service.xbmc.versioncheck/resources/language/resource.language.vi_vn/strings.po
+++ b/service.xbmc.versioncheck/resources/language/resource.language.vi_vn/strings.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: XBMC Addons\n"
-"Report-Msgid-Bugs-To: translations@kodi.tv\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "PO-Revision-Date: 2021-10-25 10:08+0000\n"
 "Last-Translator: Christian Gade <gade@kodi.tv>\n"
@@ -90,17 +90,6 @@ msgctxt "#32024"
 msgid "Linux: Upgrade using apt"
 msgstr "Linux: Nâng cấp bằng apt"
 
-# empty strings from id 32025 to 32029
-#. Used in OK dialog
-msgctxt "#32030"
-msgid "A new stable version of Kodi is available."
-msgstr "Đã có phiên bản ổn định mới của Kodi."
-
-#. Direct people to the website. Used in OK dialog
-msgctxt "#32031"
-msgid "Visit http://kodi.tv for more information."
-msgstr "Truy cập http://kodi.tv để biết thêm thông tin."
-
 #. Used in OK dialog
 msgctxt "#32032"
 msgid "A new stable version of Kodi is available."
@@ -133,6 +122,15 @@ msgstr "Vui lòng nâng cấp hệ điều hành của bạn."
 msgctxt "#32042"
 msgid "For more information, see https://kodi.wiki/view/Linux"
 msgstr "Để biết thêm thông tin, hãy xem https://kodi.wiki/view/Linux"
+
+# empty strings from id 32025 to 32029
+#~ msgctxt "#32030"
+#~ msgid "A new stable version of Kodi is available."
+#~ msgstr "Đã có phiên bản ổn định mới của Kodi."
+
+#~ msgctxt "#32031"
+#~ msgid "Visit http://kodi.tv for more information."
+#~ msgstr "Truy cập http://kodi.tv để biết thêm thông tin."
 
 #~ msgctxt "#32035"
 #~ msgid "It is recommended that you to upgrade to a newer version."

--- a/service.xbmc.versioncheck/resources/language/resource.language.zh_cn/strings.po
+++ b/service.xbmc.versioncheck/resources/language/resource.language.zh_cn/strings.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: XBMC Addons\n"
-"Report-Msgid-Bugs-To: translations@kodi.tv\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "PO-Revision-Date: 2021-10-25 10:08+0000\n"
 "Last-Translator: Christian Gade <gade@kodi.tv>\n"
@@ -90,16 +90,6 @@ msgid "Linux: Upgrade using apt"
 msgstr "Linux：使用 apt 来升级"
 
 #. Used in OK dialog
-msgctxt "#32030"
-msgid "A new stable version of Kodi is available."
-msgstr "有新的稳定版 Kodi 可用。"
-
-#. Direct people to the website. Used in OK dialog
-msgctxt "#32031"
-msgid "Visit http://kodi.tv for more information."
-msgstr "更多信息访问 http://kodi.tv。"
-
-#. Used in OK dialog
 msgctxt "#32032"
 msgid "A new stable version of Kodi is available."
 msgstr "有新的稳定版 Kodi 可用。"
@@ -131,6 +121,14 @@ msgstr "请更新您的操作系统。"
 msgctxt "#32042"
 msgid "For more information, see https://kodi.wiki/view/Linux"
 msgstr "更多详情，请访问 https://kodi.wiki/view/Linux"
+
+#~ msgctxt "#32030"
+#~ msgid "A new stable version of Kodi is available."
+#~ msgstr "有新的稳定版 Kodi 可用。"
+
+#~ msgctxt "#32031"
+#~ msgid "Visit http://kodi.tv for more information."
+#~ msgstr "更多信息访问 http://kodi.tv。"
 
 #~ msgctxt "#32035"
 #~ msgid "It is recommended that you to upgrade to a newer version."

--- a/service.xbmc.versioncheck/resources/language/resource.language.zh_tw/strings.po
+++ b/service.xbmc.versioncheck/resources/language/resource.language.zh_tw/strings.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: XBMC Addons\n"
-"Report-Msgid-Bugs-To: translations@kodi.tv\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "PO-Revision-Date: 2021-11-10 20:25+0000\n"
 "Last-Translator: JuenTingShie <t104340042@ntut.org.tw>\n"
@@ -90,17 +90,6 @@ msgctxt "#32024"
 msgid "Linux: Upgrade using apt"
 msgstr "Linux：使用apt升級"
 
-# empty strings from id 32025 to 32029
-#. Used in OK dialog
-msgctxt "#32030"
-msgid "A new stable version of Kodi is available."
-msgstr "有新的穩定版Kodi可用。"
-
-#. Direct people to the website. Used in OK dialog
-msgctxt "#32031"
-msgid "Visit http://kodi.tv for more information."
-msgstr "更多資訊請參閱 http://kodi.tv。"
-
 #. Used in OK dialog
 msgctxt "#32032"
 msgid "A new stable version of Kodi is available."
@@ -133,6 +122,15 @@ msgstr "請更新您的作業系統。"
 msgctxt "#32042"
 msgid "For more information, see https://kodi.wiki/view/Linux"
 msgstr "更多資訊請參閱 https://kodi.wiki/view/Linux"
+
+# empty strings from id 32025 to 32029
+#~ msgctxt "#32030"
+#~ msgid "A new stable version of Kodi is available."
+#~ msgstr "有新的穩定版Kodi可用。"
+
+#~ msgctxt "#32031"
+#~ msgid "Visit http://kodi.tv for more information."
+#~ msgstr "更多資訊請參閱 http://kodi.tv。"
 
 #~ msgctxt "#32035"
 #~ msgid "It is recommended that you to upgrade to a newer version."

--- a/service.xbmc.versioncheck/resources/lib/version_check/common.py
+++ b/service.xbmc.versioncheck/resources/lib/version_check/common.py
@@ -163,7 +163,7 @@ def dialog_yes_no(line1=0, line2=0):
     return xbmcgui.Dialog().yesno(ADDON_NAME, '[CR]'.join([localise(line1), localise(line2)]))
 
 
-def upgrade_message(msg):
+def linux_upgrade_message(msg):
     """ Prompt user with upgrade suggestion message
 
     :param msg: string id for prompt message
@@ -172,15 +172,18 @@ def upgrade_message(msg):
     wait_for_end_of_video()
 
     if ADDON.getSetting('lastnotified_version') < ADDON_VERSION:
-        xbmcgui.Dialog().ok(
+        answer = xbmcgui.Dialog().ok(
             ADDON_NAME,
             '[CR]'.join([localise(msg), localise(32001), localise(32002)])
         )
     else:
+        answer = False
         log('Already notified one time for upgrading.')
 
+    return answer
 
-def upgrade_message2(version_installed, version_available, version_stable, old_version):
+
+def non_linux_upgrade_message(version_installed, version_available, version_stable, old_version):
     """ Prompt user with upgrade suggestion message
 
     :param version_installed: currently installed version
@@ -215,25 +218,17 @@ def upgrade_message2(version_installed, version_available, version_stable, old_v
     if ADDON.getSetting('lastnotified_version') == '0.1.24':
         ADDON.setSetting('lastnotified_stable', msg_stable)
 
-    # Show different dialogs depending if there's a newer stable available.
+    # Show different dialogs depending on if there's a newer stable available.
     # Also split them between xbmc and kodi notifications to reduce possible confusion.
     # People will find out once they visit the website.
     # For stable only notify once and when there's a newer stable available.
     # Ignore any add-on updates as those only count for != stable
     if old_version == 'stable' and ADDON.getSetting('lastnotified_stable') != msg_stable:
-        if xbmcaddon.Addon('xbmc.addon').getAddonInfo('version') < '13.9.0':
-            xbmcgui.Dialog().ok(ADDON_NAME, '[CR]'.join([msg, localise(32030), localise(32031)]))
-        else:
-            xbmcgui.Dialog().ok(ADDON_NAME, '[CR]'.join([msg, localise(32032), localise(32033)]))
+        xbmcgui.Dialog().ok(ADDON_NAME, '[CR]'.join([msg, localise(32032), localise(32033)]))
         ADDON.setSetting('lastnotified_stable', msg_stable)
 
     elif old_version != 'stable' and ADDON.getSetting('lastnotified_version') != msg_available:
-        if xbmcaddon.Addon('xbmc.addon').getAddonInfo('version') < '13.9.0':
-            # point them to xbmc.org
-            xbmcgui.Dialog().ok(ADDON_NAME, '[CR]'.join([msg, localise(32035), localise(32031)]))
-        else:
-            # use kodi.tv
-            xbmcgui.Dialog().ok(ADDON_NAME, '[CR]'.join([msg, localise(32035), localise(32033)]))
+        xbmcgui.Dialog().ok(ADDON_NAME, '[CR]'.join([msg, localise(32035), localise(32033)]))
 
         ADDON.setSetting('lastnotified_version', msg_available)
 

--- a/service.xbmc.versioncheck/resources/lib/version_check/shell_handler_apt.py
+++ b/service.xbmc.versioncheck/resources/lib/version_check/shell_handler_apt.py
@@ -17,10 +17,12 @@ import sys
 from .common import log
 from .handler import Handler
 
+
 try:
     from subprocess import check_output
 except ImportError:
-    check_output = None
+    def check_output(*args, **kwargs):
+        return
     log('ImportError: subprocess')
 
 
@@ -53,7 +55,12 @@ class ShellHandlerApt(Handler):
             return False, False
 
         try:
-            result = check_output([_cmd], shell=True).split('\n')
+            result = check_output([_cmd], shell=True)
+            try:
+                result = result.decode('utf-8')
+            except (AttributeError, UnicodeDecodeError):
+                pass
+            result = result.split('\n')
         except Exception as error:  # pylint: disable=broad-except
             log('ShellHandlerApt: exception while executing shell command %s: %s' % (_cmd, error))
             return False, False

--- a/service.xbmc.versioncheck/resources/versions.txt
+++ b/service.xbmc.versioncheck/resources/versions.txt
@@ -3,6 +3,33 @@
     "releases": {
         "stable": [
             {
+                "major": "21",
+                "minor": "0",
+                "tag": "stable",
+                "tagversion":"",
+                "revision": "20240406-60c4500054",
+                "extrainfo": "final",
+                "addon_support": "yes"
+            },
+            {
+                "major": "20",
+                "minor": "5",
+                "tag": "stable",
+                "tagversion":"",
+                "revision": "20240303-4b95737efa",
+                "extrainfo": "final",
+                "addon_support": "yes"
+            },
+            {
+                "major": "20",
+                "minor": "2",
+                "tag": "stable",
+                "tagversion":"",
+                "revision": "20230629-5f418d0b13",
+                "extrainfo": "final",
+                "addon_support": "yes"
+            },
+            {
                 "major": "20",
                 "minor": "1",
                 "tag": "stable",
@@ -618,6 +645,15 @@
             }
         ],
         "beta": [
+            {
+                "major": "21",
+                "minor": "0",
+                "tag": "beta",
+                "tagversion":"1",
+                "revision": "20231018-64d1844655",
+                "extrainfo": "beta1",
+                "addon_support": "yes"
+            },
             {
                 "major": "19",
                 "minor": "0",


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: Version Check
  - Add-on ID: service.xbmc.versioncheck
  - Version number: 0.5.30
  - Kodi/repository version: leia

- **Code location**
  - URL: https://github.com/XBMC-Addons/service.xbmc.versioncheck
  
Kodi Version Check only supports a number of platforms/distros as releases may differ between them. For more information visit the kodi.tv website.

### Description of changes:


- add Kodi 21.0 release
- add Kodi 20.5 release
- add webOS indentification
- upgrade and exception fixes |contrib: clement-dufour|
- Update translations from Weblate
        

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
