### PR TITLE
[service.xbmc.versioncheck@matrix] 0.5.30+matrix.1

### DIFF
--- a/service.xbmc.versioncheck/addon.xml
+++ b/service.xbmc.versioncheck/addon.xml
@@ -1,12 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="service.xbmc.versioncheck" name="Version Check" version="0.5.27+matrix.1" provider-name="Team Kodi">
+<addon id="service.xbmc.versioncheck" name="Version Check" version="0.5.28+matrix.1" provider-name="Team Kodi">
   <requires>
     <import addon="xbmc.python" version="3.0.0"/>
   </requires>
   <extension point="xbmc.service" library="resources/lib/runner.py"/>
   <extension point="xbmc.addon.metadata">
     <news>
-- Fix crash when lsb_release cannot be executed on linux
+- add Kodi 20.1 release
+- Update translations from Weblate
         </news>
     <assets>
       <icon>icon.png</icon>

--- a/service.xbmc.versioncheck/resources/versions.txt
+++ b/service.xbmc.versioncheck/resources/versions.txt
@@ -4,6 +4,15 @@
         "stable": [
             {
                 "major": "20",
+                "minor": "1",
+                "tag": "stable",
+                "tagversion":"",
+                "revision": "20230312-289ec664e3",
+                "extrainfo": "final",
+                "addon_support": "yes"
+            },
+            {
+                "major": "20",
                 "minor": "0",
                 "tag": "stable",
                 "tagversion":"",


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: Version Check
  - Add-on ID: service.xbmc.versioncheck
  - Version number: 0.5.30+matrix.1
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/XBMC-Addons/service.xbmc.versioncheck
  
Kodi Version Check only supports a number of platforms/distros as releases may differ between them. For more information visit the kodi.tv website.

### Description of changes:


- add Kodi 21.0 release
- add Kodi 20.5 release
- add webOS indentification
- upgrade and exception fixes |contrib: clement-dufour|
- Update translations from Weblate
        

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
