### PR TITLE
[service.languagepreferencemanager] 1.0.4

### DIFF
--- a/service.languagepreferencemanager/addon.xml
+++ b/service.languagepreferencemanager/addon.xml
@@ -2,7 +2,7 @@
 <addon
 	id="service.languagepreferencemanager"
 	name="Language Preference Manager"
-	version="1.0.3"
+	version="1.0.4"
 	provider-name="ace20022/scott967/rockrider69"
 	>
 	<requires>
@@ -31,6 +31,7 @@
             New Keywords Blacklist for Audio tracks. Same principle as for Subtitles, based on track name, to skip some (ex. Commentary, ...)
             Fix Greek and Serbian language codes according to iso639-2/T. Fix some typos.
             Fix multiple 3 digit codes per language (ex. German ger,deu). Now OK also for Conditional Subtitles preferences.
+1.0.4     : Fix and simplify SignsSongs subtagging (was colliding with language codes subtagging ie. pt-br). Thanks to BrutuZ!
 			
 		</news>
 		<assets>

--- a/service.languagepreferencemanager/changelog.txt
+++ b/service.languagepreferencemanager/changelog.txt
@@ -1,3 +1,7 @@
+--- Version 1.0.4
+
+- Fix and simplify Signs & Songs subtagging (was colliding with language codes subtagging ie. pt-br). Thanks to BrutuZ!
+
 --- Version 1.0.3
 
 - Improve 10sec subs latency workaround: new option to disable it (default), or enable it at 'start only' or 'start+resume'.

--- a/service.languagepreferencemanager/resources/lib/prefparser.py
+++ b/service.languagepreferencemanager/resources/lib/prefparser.py
@@ -31,7 +31,6 @@ class PrefParser:
         self.custom_g_t_pref_delim = r'#'
         self.custom_g_t_delim = r','
         self.custom_condSub_delim = r':'
-        self.custom_subtag_delim = r'-'
         
     def parsePrefString(self, pref_string):
         preferences = []
@@ -81,17 +80,11 @@ class PrefParser:
                 else:
                     temp_a = (languageTranslate(pref[0], 3, 0), pref[0])
                     # Searching if a sub tag is present (like Eng:Eng-ss to prioritize Signs&Songs tracks)
-                    ss_tag = 'false'
-                    if (pref[1].find(self.custom_subtag_delim) > 0):
-                        st_pref = pref[1].split(self.custom_subtag_delim)
-                        if len(st_pref) != 2:
-                            print('Custom cond subs prefs parse error: {0}'.format(pref))
-                        else:
-                            if (st_pref[1] == 'ss'):
-                                ss_tag = 'true'
-                            else:
-                                self.log(LOG_INFO, 'Custom cond subs prefs parse error: {0}. Unknown sub tag is ignored'.format(pref))
-                        pref[1] = st_pref[0]
+                    if pref[1].endswith('-ss'):
+                        ss_tag = 'true'
+                        pref[1] = pref[1].rstrip('-ss')
+                    else:
+                        ss_tag = 'false'
                     temp_s = (languageTranslate(pref[1], 3, 0), pref[1])
                     if (temp_a[0] and temp_a[1] and temp_s[0] and temp_s[1]):
                         if (temp_s[1] == 'non'):

--- a/service.languagepreferencemanager/resources/lib/prefutils.py
+++ b/service.languagepreferencemanager/resources/lib/prefutils.py
@@ -245,7 +245,11 @@ class LangPrefMan_Player(xbmc.Player) :
 
             log(LOG_INFO,'Subtitle: genre/tag preference {0} met with intersection {1}'.format(g_t, (self.genres_and_tags & g_t)))
             for pref in preferences:
-                name, codes, forced = pref
+                if len(pref) == 2:
+                    name, codes = pref
+                    forced = 'false'
+                else:
+                    name, codes, forced = pref
                 codes = codes.split(r',')
                 for code in codes:
                     if (code is None):


### PR DESCRIPTION
### Description
- Fix and simplify Signs & Songs subtagging (was colliding with language codes subtagging ie. pt-br). Thanks to BrutuZ!
### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [X] Each add-on submission should be a single commit with using the following style: [script.foo.bar] 1.0.0

Additional information :
- Submitting your add-on to this specific branch makes it available to any Kodi version equal or higher than the branch name with the applicable Kodi dependencies limits.
- [add-on development](http://kodi.wiki/view/Add-on_development) wiki page.
- Kodi [pydocs](http://kodi.wiki/view/PyDocs) provide information about the Python API
- [PEP8](https://www.python.org/dev/peps/pep-0008/) codingstyle which is considered best practise but not mandatory.
- This add-on repository has automated code guideline check which could help you improve your coding. You can find the results of these check at [Codacy](https://www.codacy.com/app/Kodi/repo-scripts/dashboard). You can create your own account as well to continuously monitor your python coding before submitting to repo.
- Development questions can be asked in the [add-on development](http://forum.kodi.tv/forumdisplay.php?fid=26) section on the Kodi forum.
