### PR TITLE
[script.service.checkpreviousepisode@matrix] 0.4.7

### DIFF
--- a/script.service.checkpreviousepisode/addon.xml
+++ b/script.service.checkpreviousepisode/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.service.checkpreviousepisode" version="0.4.6" name="Kodi Check Previous Episode" provider-name="bossanova808, Razzeee, Lucleonhart" >
+<addon id="script.service.checkpreviousepisode" version="0.4.7" name="Kodi Check Previous Episode" provider-name="bossanova808, Razzeee, Lucleonhart" >
   <requires>
     <import addon="xbmc.python" version="3.0.0" />
     <import addon="script.module.yaml" version="3.11.0" />
@@ -16,9 +16,7 @@
     <forum>https://forum.kodi.tv/showthread.php?tid=355464</forum>
     <website>https://kodi.wiki/view/Add-on:XBMC_Check_Previous_Episode</website>
     <source>https://github.com/bossanova808/script.service.checkpreviousepisode</source>
-    <news>v0.4.6
-    - Ignore shows that have already been decided on (i.e. those with a non-zero resume point)
-    </news>
+    <news>v0.4.7 Add Window Property so skinners can dress up the dialog</news>
   <assets>
      <icon>icon.png</icon>
   </assets>

--- a/script.service.checkpreviousepisode/changelog.txt
+++ b/script.service.checkpreviousepisode/changelog.txt
@@ -1,3 +1,6 @@
+v0.4.7
+- Add Window Property so skinners can dress up the dialog
+
 v0.4.6
 - Ignore shows that have already been decided on (i.e. those with a non-zero resume point)
 

--- a/script.service.checkpreviousepisode/resources/lib/common.py
+++ b/script.service.checkpreviousepisode/resources/lib/common.py
@@ -1,11 +1,23 @@
 # -*- coding: utf-8 -*-
+
 """
-Handy utility functions for Kodi Addons
-By bossanova808
-Free in all senses....
-VERSION 0.2.4 2021-08-10
-(For Kodi Matrix & later)
+
+Handy utility functions & constants for Kodi Addons
+For Kodi Matrix & later
+By bossanova808 - freely released
+VERSION 0.2.7 2024-04-19
+
+Changelog:
+0.2.7 - Fix getting the major Kodi version (& change float -> int), as it was failing on e.g. 'RC' being in the string apparently
+0.2.6 - (SkinPatcher) - add float KODI_VERSION_FLOAT constant, alongside string KODI_VERSION
+0.2.5 - (Skin) - move to storing copy of latest in bossanova808 repo and adding this mini changelog
+
+For latest version - ALWAYS COPY BACK ANY CHANGES, plus do changelog, and a version & date bump above:
+https://github.com/bossanova808/repository.bossanova808/blob/main/latest-common/common.py
+
+
 """
+
 import sys
 import traceback
 
@@ -27,6 +39,7 @@ CWD = ADDON.getAddonInfo('path')
 LANGUAGE = ADDON.getLocalizedString
 PROFILE = xbmcvfs.translatePath(ADDON.getAddonInfo('profile'))
 KODI_VERSION = xbmc.getInfoLabel('System.BuildVersion')
+KODI_VERSION_INT = int(KODI_VERSION.split(".")[0])
 USER_AGENT = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Safari/537.36"
 HOME_WINDOW = xbmcgui.Window(10000)
 WEATHER_WINDOW = xbmcgui.Window(12600)
@@ -51,6 +64,8 @@ from resources.lib.common import *
 """
 
 unit_testing = False
+
+# Testing outside of Kodi
 if not xbmc.getUserAgent():
 
     xbmc = None
@@ -65,6 +80,7 @@ if not xbmc.getUserAgent():
             print(f'EXCPT: {traceback.format_exc(exception_instance)}')
 
 
+# Running inside of Kodi
 else:
 
     def log(message, exception_instance=None, level=xbmc.LOGDEBUG):
@@ -192,7 +208,7 @@ def footprints(startup=True):
     """
     if startup:
         log(f'Starting...', level=xbmc.LOGINFO)
-        log(f'Kodi Version: {KODI_VERSION}', level=xbmc.LOGINFO)
+        log(f'Kodi System.BuildVersion: {KODI_VERSION}, which is Kodi major version: {KODI_VERSION_INT}', level=xbmc.LOGINFO)
         log(f'Addon arguments: {ADDON_ARGUMENTS}', level=xbmc.LOGINFO)
     else:
         log(f'Exiting...', level=xbmc.LOGINFO)

--- a/script.service.checkpreviousepisode/resources/lib/monitor.py
+++ b/script.service.checkpreviousepisode/resources/lib/monitor.py
@@ -15,4 +15,3 @@ class KodiEventMonitor(xbmc.Monitor):
 
     def onAbortRequested(self):
         log('onAbortRequested')
-        log("Abort Requested")

--- a/script.service.checkpreviousepisode/resources/lib/player.py
+++ b/script.service.checkpreviousepisode/resources/lib/player.py
@@ -125,7 +125,10 @@ class KodiPlayer(xbmc.Player):
                                     log("Prior episode not watched! -> pausing playback")
                                     self.pause()
 
+                                # Set a window property per Hitcher's request - https://forum.kodi.tv/showthread.php?tid=355464&pid=3191615#pid3191615
+                                HOME_WINDOW.setProperty("CheckPreviousEpisode", "MissingPreviousEpisode")
                                 result = xbmcgui.Dialog().select(LANGUAGE(32020), [LANGUAGE(32021), LANGUAGE(32022), LANGUAGE(32023)], preselect=0)
+                                HOME_WINDOW.setProperty("CheckPreviousEpisode", "")
 
                                 # User has requested we ignore this particular show from now on...
                                 if result == 2:


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: Kodi Check Previous Episode
  - Add-on ID: script.service.checkpreviousepisode
  - Version number: 0.4.7
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/bossanova808/script.service.checkpreviousepisode
  
This service helps prevent spoilers by checking if the previous episode in a series has been watched. If not, it will pause playback and warn you.  Specific shows can be marked to be ignored if episode order does not matter.

### Description of changes:

v0.4.7 Add Window Property so skinners can dress up the dialog

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
