### PR TITLE
[script.service.hyperion@nexus] 20.0.2

### DIFF
--- a/script.service.hyperion/addon.xml
+++ b/script.service.hyperion/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.service.hyperion" name="Hyperion Ambilight" version="20.0.1" provider-name="hyperion-project">
+<addon id="script.service.hyperion" name="Hyperion Ambilight" version="20.0.2" provider-name="hyperion-project">
   <requires>
     <import addon="xbmc.addon"  version="20.0.0"/>
     <import addon="xbmc.python" version="3.0.1"/>
@@ -20,6 +20,8 @@
     <source>https://github.com/hyperion-project/hyperion.kodi</source>
     <license>MIT</license>
     <news>
+      20.0.2
+      - Python lower than 3.10 compatibility
       20.0.1
       - Clean-ups
       - Handle missing PIL library on Android

--- a/script.service.hyperion/resources/lib/monitor.py
+++ b/script.service.hyperion/resources/lib/monitor.py
@@ -1,7 +1,7 @@
 """
 Kodi video capturer for Hyperion.
 
-Copyright (c) 2013-2023 Hyperion Team
+Copyright (c) 2013-2024 Hyperion Team
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 """
 from typing import Callable
+from typing import Tuple
 
 import xbmc
 from PIL import Image
@@ -114,7 +115,7 @@ class HyperionMonitor(xbmc.Monitor):
         self._hyperion = Hyperion(settings.address, settings.port)
         self._capture = xbmc.RenderCapture()
 
-    def get_capture_size(self) -> tuple[tuple[int, int], int]:
+    def get_capture_size(self) -> Tuple[Tuple[int, int], int]:
         width = self.settings.capture_width
         aspect_ratio = self._capture.getAspectRatio()
         height = int(width / aspect_ratio)


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: Hyperion Ambilight
  - Add-on ID: script.service.hyperion
  - Version number: 20.0.2
  - Kodi/repository version: nexus

- **Code location**
  - URL: https://github.com/hyperion-project/hyperion.kodi
  
Hyperion is an opensource Bias or Ambient Lighting implementation which runs on many devices.[CR]This addon sends through the Hyperion PROTO-port your current picture to your Hyperion daemon for further processing like black border detection or smoothing.

### Description of changes:


      20.0.2
      - Python lower than 3.10 compatibility
      20.0.1
      - Clean-ups
      - Handle missing PIL library on Android
      20.0.0
      - Kodi 20 (Nexus) support
      - New languages: Hebrew, Italian
    

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
