### PR TITLE
[script.timers] 3.9.1

### DIFF
--- a/script.timers/addon.xml
+++ b/script.timers/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.timers" name="Timers" version="3.9.0" provider-name="Heckie">
+<addon id="script.timers" name="Timers" version="3.9.1" provider-name="Heckie">
   <requires>
     <import addon="xbmc.python" version="3.0.0" />
   </requires>
@@ -66,6 +66,9 @@
     <website>https://github.com/Heckie75/kodi-addon-timers</website>
     <source>https://github.com/Heckie75/kodi-addon-timers</source>
     <news>
+v3.9.1 (2024-06-30)
+- Bugfix: Prevent exception after changing already running non-fading-timer to fading-timer
+
 v3.9.0 (2023-11-11)
 - Add new system action 'restart Kodi'
 - Add new extra feature to prevent display off when audio is playing

--- a/script.timers/resources/lib/player/player.py
+++ b/script.timers/resources/lib/player/player.py
@@ -172,6 +172,7 @@ class Player(xbmc.Player):
             _rst = self._running_stop_at_end_timer
             self._reset()
             if _rst[0] and not _rst[1]:
+                xbmc.log("set timer to be already stopped: %s" % str(_rst[0]), xbmc.LOGINFO)
                 self._running_stop_at_end_timer = (_rst[0], True)
                 showNotification(_rst[0], msg_id=32289)
 
@@ -210,6 +211,8 @@ class Player(xbmc.Player):
                 self.stopPlayer(PICTURE)
             elif timer != self._running_stop_at_end_timer[0] or not self._running_stop_at_end_timer[1]:
                 self.stop()
+            else:
+                xbmc.log("Skip timer's stop action since timer's playback has already been stopped by user: %s" % str(self._running_stop_at_end_timer[0]), xbmc.LOGINFO)
 
             self._reset(type=timer.media_type)
             xbmc.sleep(self._RESPITE)

--- a/script.timers/resources/lib/timer/scheduler.py
+++ b/script.timers/resources/lib/timer/scheduler.py
@@ -99,6 +99,9 @@ class Scheduler(xbmc.Monitor):
             if former_timer.is_fading_timer():
                 changed |= (former_timer.vol_min != timer_from_storage.vol_min)
                 changed |= (former_timer.vol_max != timer_from_storage.vol_max)
+            elif timer_from_storage.is_fading_timer():
+                changed = True
+                restart = True                
 
             return changed, restart
 


### PR DESCRIPTION
### Description
v3.9.1 (2024-06-30)
- Bugfix: Prevent exception after changing already running non-fading-timer to fading-timer

### Checklist:
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [script.foo.bar] 1.0.0