### PR TITLE
[script.timers] 3.9.3

### DIFF
--- a/script.timers/addon.xml
+++ b/script.timers/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.timers" name="Timers" version="3.9.2" provider-name="Heckie">
+<addon id="script.timers" name="Timers" version="3.9.3" provider-name="Heckie">
   <requires>
     <import addon="xbmc.python" version="3.0.0" />
   </requires>
@@ -66,6 +66,9 @@
     <website>https://github.com/Heckie75/kodi-addon-timers</website>
     <source>https://github.com/Heckie75/kodi-addon-timers</source>
     <news>
+v3.9.3 (2024-08-02)
+- Bugfix: Fixed that 'running-high-prio-fading-only-timer' prevents starting other media timers within its period
+
 v3.9.2 (2024-07-21)
 - Bugfix: The repeat flag in Timer Addon doesn't work, issue #39
 
@@ -89,11 +92,6 @@ v3.6.0 (2023-04-16)
 - Fixed resuming slideshow at right position
 - Fixed resuming of enclosing timers especially combination of concurrent media types like video, audio or slideshow
 - Improved notifications and competitive behavior (introduced extra low priority)
-
-v3.5.0 (2023-02-07)
-- New feature: priority of timers and competitive behavior
-- New feature: System action to put playing device on standby via a CEC peripheral
-- Fixed issue so that favourites can be scheduled again
 
 Complete changelog see https://github.com/Heckie75/kodi-addon-timers
     </news>

--- a/script.timers/resources/lib/timer/scheduleraction.py
+++ b/script.timers/resources/lib/timer/scheduleraction.py
@@ -130,7 +130,7 @@ class SchedulerAction:
 
                 enclosingTimers = [t for t in self._runningTimers if (t.current_period.start < timerToStop.current_period.start
                                                                       and t.current_period.end > timerToStop.current_period.end)
-                                   and t.media_type in _types_replaced_by_type]
+                                   and t.is_play_at_start_timer() and t.media_type in _types_replaced_by_type]
 
                 if enclosingTimers and not [t for t in enclosingTimers if timerToStop.priority >= t.priority]:
                     _reset_stop()
@@ -149,7 +149,7 @@ class SchedulerAction:
                         timer.return_vol = self._player.getVolume()
 
                 higher_prio_runnings = [running for running in self._runningTimers if running.priority > timer.priority
-                                        and running.media_type in get_types_replaced_by_type(timer.media_type)]
+                                        and running.is_play_at_start_timer() and running.media_type in get_types_replaced_by_type(timer.media_type)]
 
                 if not higher_prio_runnings and timer.is_play_at_start_timer():
                     self._setTimerToPlayAny(timer)


### PR DESCRIPTION
### Description
v3.9.3 (2024-08-02)
- Bugfix: Fixed that 'running-high-prio-fading-only-timer' prevents starting other media timers within its period

### Checklist:
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [script.foo.bar] 1.0.0