### PR TITLE
[service.subtitles.opensubtitles-com] 1.0.5

### DIFF
--- a/service.subtitles.opensubtitles-com/README.md
+++ b/service.subtitles.opensubtitles-com/README.md
@@ -1,8 +1,12 @@
 OpenSubtitles.com KODI add-on
 =============================
-Search and download subtitles for movies and TV-Series from OpenSubtitles.com. Search in 75 languages, 4.000.000+ subtitles, daily updates.
+Search and download subtitles for movies and TV-Series from OpenSubtitles.com. Search in 75 languages, 8.000.000+ subtitles, daily updates.
 
 REST API implementation based on tomburke25 [python-opensubtitles-rest-api](https://github.com/tomburke25/python-opensubtitles-rest-api)                            
+
+v1.0.5 (2024-07-30)
+- fixed issue with portuguese file names
+- added AI translated filter (thanks Kate6)
 
 v1.0.4 (2024-01-15)
 - Sanitize language query

--- a/service.subtitles.opensubtitles-com/addon.xml
+++ b/service.subtitles.opensubtitles-com/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="service.subtitles.opensubtitles-com"
        name="OpenSubtitles.com"
-       version="1.0.4"
+       version="1.0.5"
        provider-name="amet, opensubtitles, juokelis, opensubtitlesdev">
 	<requires>
 		<import addon="xbmc.python" version="3.0.0"/>
@@ -11,7 +11,7 @@
              library="service.py" />
 	<extension point="xbmc.addon.metadata">
 		<summary lang="en_GB">OpenSubtitles.com</summary>
-		<description lang="en_GB">Search and download subtitles for movies and TV-Series from OpenSubtitles.com. Search in 75 languages, 6.000.000+ subtitles, daily updates. Register/Import your account on OpenSubtitles.com before use.</description>
+		<description lang="en_GB">Search and download subtitles for movies and TV-Series from OpenSubtitles.com. Search in 75 languages, 8.000.000+ subtitles, daily updates. Register/Import your account on OpenSubtitles.com before use.</description>
 		<description lang="ast_ES">Pelis and Subtítulos TV en munches llingües, milenta de subtítulos traducíos y xubíos caldía. Descarga llibre dende la fonte, sofitu API, millones d'usuarios.</description>
 		<description lang="br_FR">Istitloù Filmoù ha TV e meur a yezh, miliadoù a istitloù troet hag uskarget bemdez. Pellgargadenn digoust diouzh ar vammenn, skoazell an API, millionoù a implijerien.</description>
 		<description lang="ca_ES">Subtítols de films i televisió en múltiples idiomes, milers de subtítols traduïts carregats diàriament. Descàrrega gratuïta des de la font, suport de l'API, amb milions d'usuaris.</description>
@@ -52,6 +52,10 @@
 		<description lang="zh_CN">多语种的电影及剧集字幕，每日更新千余条翻译好的字幕。免费下载，提供API接口，已拥有上百万的用户。</description>
 		<disclaimer lang="en_GB">Users need to provide OpenSubtitles.com username and password in add-on configuration. This is our new extension, old opensubtitles.org will not work on this, but the account can be easily imported on opensubtitles.com.</disclaimer>
 		<news>
+v1.0.5 (2024-07-30)
+- fixed issue with portuguese file names
+- added AI translated filter (thanks Kate6)
+
 v1.0.4 (2024-01-15)
 - Sanitize language query
 - Improved sorting

--- a/service.subtitles.opensubtitles-com/changelog.txt
+++ b/service.subtitles.opensubtitles-com/changelog.txt
@@ -1,3 +1,7 @@
+v1.0.5 (2024-07-30)
+- fixed issue with portuguese file names
+- added AI translated filter (thanks Kate6)
+
 v1.0.4 (2024-01-17)
 - Sanitize language query
 - Improved sorting

--- a/service.subtitles.opensubtitles-com/resources/language/resource.language.en_GB/strings.po
+++ b/service.subtitles.opensubtitles-com/resources/language/resource.language.en_GB/strings.po
@@ -67,3 +67,7 @@ msgstr ""
 msgctxt "#32214"
 msgid "Bad username. Make sure you have entered your username and not your email in the username field."
 msgstr ""
+
+msgctxt "#32215"
+msgid "AI Translated"
+msgstr ""

--- a/service.subtitles.opensubtitles-com/resources/language/resource.language.fr_FR/strings.po
+++ b/service.subtitles.opensubtitles-com/resources/language/resource.language.fr_FR/strings.po
@@ -66,3 +66,7 @@ msgstr "Traduction automatique"
 msgctxt "#32214"
 msgid "Bad username. Make sure you have entered your username and not your email in the username field"
 msgstr "Mauvais nom d'utilisateur. Assurez-vous d'avoir saisi votre nom d'utilisateur et non votre adresse email dans le champ du nom d'utilisateur."
+
+msgctxt "#32215"
+msgid "Traductions AI"
+msgstr ""

--- a/service.subtitles.opensubtitles-com/resources/lib/data_collector.py
+++ b/service.subtitles.opensubtitles-com/resources/lib/data_collector.py
@@ -108,6 +108,7 @@ def get_language_data(params):
         "hearing_impaired": __addon__.getSetting("hearing_impaired"),
         "foreign_parts_only": __addon__.getSetting("foreign_parts_only"),
         "machine_translated": __addon__.getSetting("machine_translated"),
+        "ai_translated": __addon__.getSetting("ai_translated"),
         "languages": search_languages_str}
 
      # for language in search_languages:
@@ -123,12 +124,19 @@ def get_language_data(params):
 
 
 def convert_language(language, reverse=False):
+   # language_list = {
+   #     "English": "en",
+   #     "Portuguese (Brazil)": "pt-br",
+   #     "Portuguese": "pt-pt",
+   #     "Chinese (simplified)": "zh-cn",
+   #     "Chinese (traditional)": "zh-tw"}
     language_list = {
         "English": "en",
         "Portuguese (Brazil)": "pt-br",
         "Portuguese": "pt-pt",
         "Chinese (simplified)": "zh-cn",
         "Chinese (traditional)": "zh-tw"}
+
     reverse_language_list = {v: k for k, v in list(language_list.items())}
 
     if reverse:
@@ -146,7 +154,9 @@ def convert_language(language, reverse=False):
 def get_flag(language_code):
     language_list = {
         "pt-pt": "pt",
-        "pt-br": "pb"
+        "pt-br": "pb",
+        "zh-cn": "zh",
+        "zh-tw": "-"
     }
     return language_list.get(language_code.lower(), language_code)
 

--- a/service.subtitles.opensubtitles-com/resources/lib/os/model/request/subtitles.py
+++ b/service.subtitles.opensubtitles-com/resources/lib/os/model/request/subtitles.py
@@ -21,7 +21,7 @@ LANGUAGE_LIST = ["af", "sq", "ar", "an", "hy", "at", "eu", "be", "bn", "bs", "br
 class OpenSubtitlesSubtitlesRequest(OpenSubtitlesRequest):
     def __init__(self, id_: int = None, imdb_id: int = None, tmdb_id: int = None, type_="all", query="", languages="",
                  moviehash="", user_id: int = None, hearing_impaired="include", foreign_parts_only="include",
-                 trusted_sources="include", machine_translated="exclude", ai_translated="exclude", order_by="",
+                 trusted_sources="include", machine_translated="exclude", ai_translated="include", order_by="",
                  order_direction="", parent_feature_id: int = None, parent_imdb_id: int = None,
                  parent_tmdb_id: int = None, season_number: int = None, episode_number: int = None, year: int = None,
                  moviehash_match="include", page: int = None, **catch_overflow):
@@ -52,7 +52,7 @@ class OpenSubtitlesSubtitlesRequest(OpenSubtitlesRequest):
         super().__init__()
 
         # ordered request params with defaults
-        self.DEFAULT_LIST = dict(ai_translated="exclude", episode_number=None, foreign_parts_only="include",
+        self.DEFAULT_LIST = dict(ai_translated="include", episode_number=None, foreign_parts_only="include",
                                  hearing_impaired="include", id=None, imdb_id=None, languages="",
                                  machine_translated="exclude", moviehash="", moviehash_match="include", order_by="",
                                  order_direction="desc", page=None, parent_feature_id=None, parent_imdb_id=None,

--- a/service.subtitles.opensubtitles-com/resources/lib/os/provider.py
+++ b/service.subtitles.opensubtitles-com/resources/lib/os/provider.py
@@ -73,7 +73,7 @@ class OpenSubtitlesProvider:
             logging(f"Username: {self.username}, Password: {self.password}")
 
 
-        self.request_headers = {"Api-Key": self.api_key, "User-Agent": "Opensubtitles.com Kodi plugin v1.0.4" ,"Content-Type": CONTENT_TYPE, "Accept": CONTENT_TYPE}
+        self.request_headers = {"Api-Key": self.api_key, "User-Agent": "Opensubtitles.com Kodi plugin v1.0.5" ,"Content-Type": CONTENT_TYPE, "Accept": CONTENT_TYPE}
 
         self.session = Session()
         self.session.headers = self.request_headers

--- a/service.subtitles.opensubtitles-com/resources/settings.xml
+++ b/service.subtitles.opensubtitles-com/resources/settings.xml
@@ -74,6 +74,20 @@
                         <heading>32213</heading>
                     </control>
                 </setting>
+                 <setting id="ai_translated" type="string" label="32215">
+                    <level>0</level>
+                    <default>include</default>
+                    <constraints>
+                        <options>
+                            <option label="include">include</option>
+                            <option label="exclude">exclude</option>
+                            <option label="only">only</option>
+                        </options>
+                    </constraints>
+                    <control type="list" format="string">
+                        <heading>32215</heading>
+                    </control>
+                </setting>
             </group>
         </category>
     </section>


### PR DESCRIPTION
Description
Fixed issue with file naming for portuguese files (portugal or brasil) and chinese files (chinese traditional or simplified)
Added filter to allow AI translated subtitles from opensubtitles.com


Checklist:
* [x ] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project.

* [ x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document

* [ x] Each add-on submission should be a single commit with using the following style: [script.foo.bar] 1.0.0
Additional information :

* Submitting your add-on to this specific branch makes it available to any Kodi version equal or higher than the branch name with the applicable Kodi dependencies limits.

* [add-on development](http://kodi.wiki/view/Add-on_development) wiki page.

* Kodi [pydocs](http://kodi.wiki/view/PyDocs) provide information about the Python API

* [PEP8](https://www.python.org/dev/peps/pep-0008/) codingstyle which is considered best practise but not mandatory.

* This add-on repository has automated code guideline check which could help you improve your coding. You can find the results of these check at [Codacy](https://www.codacy.com/app/Kodi/repo-scripts/dashboard). You can create your own account as well to continuously monitor your python coding before submitting to repo.

* Development questions can be asked in the [add-on development](http://forum.kodi.tv/forumdisplay.php?fid=26) section on the Kodi forum.