### PR TITLE
[service.subtitles.rvm.addic7ed@matrix] 3.2.1

### DIFF
--- a/service.subtitles.rvm.addic7ed/addic7ed/parser.py
+++ b/service.subtitles.rvm.addic7ed/addic7ed/parser.py
@@ -159,13 +159,13 @@ def parse_episode(sub_cells, languages):
                     download_cell = lang_cell.find_next('td', {'colspan': '3'})
                     download_button = download_cell.find(
                         'a',
-                        class_='buttonDownload',
+                        class_='face-button',
                         href=updated_download_re
                     )
                     if download_button is None:
                         download_button = download_cell.find(
                             'a',
-                            class_='buttonDownload',
+                            class_='face-button',
                             href=original_download_re
                         )
                     download_row = download_button.parent.parent

--- a/service.subtitles.rvm.addic7ed/addic7ed/simple_requests.py
+++ b/service.subtitles.rvm.addic7ed/addic7ed/simple_requests.py
@@ -89,7 +89,7 @@ class Response:
     def __init__(self):
         self.encoding: str = 'utf-8'
         self.status_code: int = -1
-        self.headers: Dict[str, str] = {}
+        self._headers: Optional[HTTPMessage] = None
         self.url: str = ''
         self.content: bytes = b''
         self._text = None
@@ -102,6 +102,17 @@ class Response:
         return self.__str__()
 
     @property
+    def headers(self) -> HTTPMessage:
+        return self._headers
+
+    @headers.setter
+    def headers(self, value: HTTPMessage):
+        charset = value.get_content_charset()
+        if charset is not None:
+            self.encoding = charset
+        self._headers = value
+
+    @property
     def ok(self) -> bool:
         return self.status_code < 400
 
@@ -111,7 +122,10 @@ class Response:
         :return: Response payload as decoded text
         """
         if self._text is None:
-            self._text = self.content.decode(self.encoding)
+            try:
+                self._text = self.content.decode(self.encoding)
+            except UnicodeDecodeError:
+                self._text = self.content.decode('utf-8', 'replace')
         return self._text
 
     def json(self) -> Optional[Union[Dict[str, Any], List[Any]]]:

--- a/service.subtitles.rvm.addic7ed/addic7ed/utils.py
+++ b/service.subtitles.rvm.addic7ed/addic7ed/utils.py
@@ -16,8 +16,6 @@
 import json
 import logging
 import os
-import re
-from collections import namedtuple
 
 import xbmc
 

--- a/service.subtitles.rvm.addic7ed/addon.xml
+++ b/service.subtitles.rvm.addic7ed/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon id="service.subtitles.rvm.addic7ed"
   name="Addic7ed.com"
-  version="3.2.0"
+  version="3.2.1"
   provider-name="Roman V.M.">
 <requires>
   <import addon="xbmc.python" version="3.0.0"/>
@@ -29,8 +29,8 @@
     <icon>icon.png</icon>
     <fanart>fanart.jpg</fanart>
   </assets>
-  <news>3.2.0:
-- Removed Python 2 compatibility.</news>
+  <news>3.2.1:
+- Fixed issues with downloading subtitles.</news>
   <reuselanguageinvoker>true</reuselanguageinvoker>
 </extension>
 </addon>


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: Addic7ed.com
  - Add-on ID: service.subtitles.rvm.addic7ed
  - Version number: 3.2.1
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/romanvm/service.addic7ed
  
Subtitles service for Addic7ed.com. It supports only TV shows.

### Description of changes:

3.2.1:
- Fixed issues with downloading subtitles.

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
