### PR TITLE
[script.module.inputstreamhelper@matrix] 0.7.0

### DIFF
--- a/script.module.inputstreamhelper/README.md
+++ b/script.module.inputstreamhelper/README.md
@@ -91,6 +91,11 @@ Please report any issues or bug reports on the [GitHub Issues](https://github.co
 This module is licensed under the **The MIT License**. Please see the [LICENSE.txt](LICENSE.txt) file for details.
 
 ## Releases
+### v0.7.0 (2024-09-24)
+- Get rid of distutils dependency (@horstle, @emilsvennesson)
+- Option to get Widevine from lacros image (@horstle)
+- Remove support for Python 2 and pre-Matrix Kodi versions (@horstle)
+
 ### v0.6.1 (2023-05-30)
 - Performance improvements on Linux ARM (@horstle)
 - This will be the last release for Python 2 i.e. Kodi 18 (Leia) and below. The next release will require Python 3 and Kodi 19 (Matrix) or higher.

--- a/script.module.inputstreamhelper/addon.xml
+++ b/script.module.inputstreamhelper/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.module.inputstreamhelper" name="InputStream Helper" version="0.6.1+matrix.1" provider-name="emilsvennesson, dagwieers, mediaminister, horstle">
+<addon id="script.module.inputstreamhelper" name="InputStream Helper" version="0.7.0" provider-name="emilsvennesson, dagwieers, mediaminister, horstle">
   <requires>
     <!--py3 compliant-->
     <import addon="xbmc.python" version="3.0.0"/>
@@ -25,6 +25,11 @@
     <description lang="hr_HR">Jednostavan Kodi modul koji olakšava razvijanje dodataka koji se temelje na InputStream dodatku i reprodukciji DRM zaštićenog sadržaja.</description>
     <description lang="ru_RU">Простой модуль для Kodi, который облегчает жизнь разработчикам дополнений, с использованием InputStream дополнений и воспроизведения DRM контента.</description>
     <news>
+v0.7.0 (2024-09-24)
+- Get rid of distutils dependency
+- Option to get Widevine from lacros image
+- Remove support for Python 2 and pre-Matrix Kodi versions
+
 v0.6.1 (2023-05-30)
 - Performance improvements on Linux ARM
 - This will be the last release for Python 2 i.e. Kodi 18 (Leia) and below. The next release will require Python 3 and Kodi 19 (Matrix) or higher.

--- a/script.module.inputstreamhelper/lib/inputstreamhelper/config.py
+++ b/script.module.inputstreamhelper/lib/inputstreamhelper/config.py
@@ -102,11 +102,15 @@ CHROMEOS_RECOVERY_ARM64_BNAMES = [
     'trogdor',
 ]
 
+CHROMEOS_BLOCK_SIZE = 512
+
+LACROS_DOWNLOAD_URL = "https://gsdview.appspot.com/chromeos-localmirror/distfiles/chromeos-lacros-{arch}-squash-zstd-{version}"
+
+LACROS_LATEST = "https://chromiumdash.appspot.com/fetch_releases?channel=Stable&platform=Lacros&num=1"
+
 MINIMUM_INPUTSTREAM_VERSION_ARM64 = {
     'inputstream.adaptive': '20.3.5',
 }
-
-CHROMEOS_BLOCK_SIZE = 512
 
 HLS_MINIMUM_IA_VERSION = '2.0.10'
 

--- a/script.module.inputstreamhelper/lib/inputstreamhelper/unsquash.py
+++ b/script.module.inputstreamhelper/lib/inputstreamhelper/unsquash.py
@@ -1,0 +1,441 @@
+# -*- coding: utf-8 -*-
+# MIT License (see LICENSE.txt or https://opensource.org/licenses/MIT)
+"""
+Minimal implementation of Squashfs for extracting files from an image.
+
+Information sourced from:
+https://dr-emann.github.io/squashfs/
+https://github.com/plougher/squashfs-tools/blob/master/squashfs-tools/squashfs_fs.h
+
+Assumptions made:
+- Zstd is used for compression.
+- Directory table consists of only one metadata block.
+- There is only one file with the specific name i.e. no file of the same name in another directory.
+- We only need to read inodes of basic files.
+"""
+
+import os
+
+from ctypes import CDLL, c_void_p, c_size_t, create_string_buffer
+from ctypes.util import find_library
+
+from struct import unpack, calcsize
+from dataclasses import dataclass
+from math import log2, ceil
+
+from .kodiutils import log
+
+
+class ZstdDecompressor: # pylint: disable=too-few-public-methods
+    """
+    zstdandard decompressor class
+
+    It's a class to avoid having to load the zstd library for every decompression.
+    """
+    def __init__(self):
+        libzstd = CDLL(find_library("zstd"))
+        self.zstddecomp = libzstd.ZSTD_decompress
+        self.zstddecomp.restype = c_size_t
+        self.zstddecomp.argtypes = (c_void_p, c_size_t, c_void_p, c_size_t)
+        self.iserror = libzstd.ZSTD_isError
+
+    def decompress(self, comp_data, comp_size, outsize=8*2**10):
+        """main function, decompresses binary string <src>"""
+        if len(comp_data) != comp_size:
+            raise IOError("Decompression failed! Length of compressed data doesn't match given size.")
+
+        dest = create_string_buffer(outsize)
+
+        actual_outsize = self.zstddecomp(dest, len(dest), comp_data, len(comp_data))
+        if self.iserror(actual_outsize):
+            raise IOError(f"Decompression failed! Error code: {actual_outsize}")
+        return dest[:actual_outsize]  # outsize is always a multiple of 8K, but real size may be smaller
+
+
+@dataclass(frozen=True)
+class SBlk:  # pylint: disable=too-many-instance-attributes
+    """superblock as dataclass, does some checks after initialization"""
+    s_magic: int
+    inodes: int
+    mkfs_time: int
+    block_size: int
+    fragments: int
+    compression: int
+    block_log: int
+    flags: int
+    no_ids: int
+    s_major: int
+    s_minor: int
+    root_inode: int
+    bytes_used: int
+    id_table_start: int
+    xattr_id_table_start: int
+    inode_table_start: int
+    directory_table_start: int
+    fragment_table_start: int
+    lookup_table_start: int
+
+    def __post_init__(self):
+        """Some sanity checks"""
+        squashfs_magic = 0x73717368  # Has to be present in every valid squashfs image
+        if self.s_magic != squashfs_magic:
+            raise IOError("Squashfs magic doesn't match!")
+
+        if log2(self.block_size) != self.block_log:
+            raise IOError("block_size and block_log do not match!")
+
+        if bool(self.flags & 0x0004):
+            raise IOError("Check flag should always be unset!")
+
+        if self.s_major != 4 or self.s_minor != 0:
+            raise IOError("Unsupported squashfs version!")
+
+        if self.compression != 6:
+            raise IOError("Image is not compressed using zstd!")
+
+
+@dataclass(frozen=True)
+class MetaDataHeader:
+    """
+    header of metadata blocks.
+
+    Most things are contained in metadata blocks, including:
+    - Compression options
+    - directory table
+    - fragment table
+    - file inodes
+    """
+    compressed: bool
+    size: int
+
+
+@dataclass(frozen=True)
+class InodeHeader:
+    """squashfs_base_inode_header dataclass"""
+    inode_type: int
+    mode: int
+    uid: int
+    guid: int
+    mtime: int
+    inode_number: int
+
+
+@dataclass(frozen=True)
+class BasicFileInode:
+    """
+    This is squashfs_reg_inode_header, but without the base inode header part
+    """
+    start_block: int
+    fragment: int
+    offset: int
+    file_size: int
+    block_list: tuple  # once we remove support for python below 3.9 this can be: tuple[int]
+
+
+@dataclass(frozen=True)
+class DirectoryHeader:
+    """squashfs_dir_header dataclass"""
+    count: int
+    start_block: int
+    inode_number: int
+
+
+@dataclass(frozen=True)
+class DirectoryEntry:
+    """
+    Directory entry dataclass.
+
+    This is squashfs_dir_entry in the squashfs-tools source code,
+    but there "itype" is called "type" and "name_size" is just "size".
+
+    Implements __len__, giving the number of bytes of the whole entry.
+    """
+    offset: int
+    inode_number: int
+    itype: int
+    name_size: int  # name is 1 byte longer than given in name_size
+    name: bytes
+
+    def __len__(self):
+        """the first four entries are 2 bytes each. name is actually one byte longer than given in name_size"""
+        return 8 + 1 + self.name_size
+
+
+@dataclass(frozen=True)
+class FragmentBlockEntry:
+    """squashfs_fragment_entry dataclass"""
+    start_block: int
+    size: int
+    unused: int  # This field has no meaning
+
+class SquashFs:
+    """
+    Main class to handle a squashfs image, find and extract files from it.
+    """
+    def __init__(self, fpath):
+        self.zdecomp = ZstdDecompressor()
+        self.imfile = open(fpath, "rb")  # pylint: disable=consider-using-with  # we have our own context manager
+        self.sblk = self._get_sblk()
+        self.frag_entries = self._get_fragment_table()
+        log(0, "squashfs image initialized")
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.imfile.close()
+
+    def _get_sblk(self):
+        """
+        Read and check the superblock.
+        """
+        fmt = "<5I6H8Q"
+        size = calcsize(fmt)
+
+        self.imfile.seek(0)
+        return SBlk(*unpack(fmt, self.imfile.read(size)))
+
+    @staticmethod
+    def _fragment_block_entry(chunk):
+        """
+        Interpret <chunk> as fragment block entry.
+        """
+        fmt = "<Q2I"
+        chunk = chunk[:calcsize(fmt)]
+        return FragmentBlockEntry(*unpack(fmt, chunk))
+
+    def _get_fragment_table(self):
+        """
+        Read the fragment table.
+
+        Returns the entries as tuple.
+        """
+        mblocks_num = ceil(self.sblk.fragments / 512)
+        fmt = f"<{mblocks_num}Q"
+        size = calcsize(fmt)
+
+        self.imfile.seek(self.sblk.fragment_table_start)
+        mblocks_poss = unpack(fmt, self.imfile.read(size))
+
+        frag_entries = []
+        for pos in mblocks_poss:
+            data = self._get_metablock(pos)
+            while len(data) > 0:
+                entry = self._fragment_block_entry(data)
+                frag_entries.append(entry)
+                data = data[16:]  # each entry is 16 bytes
+
+        return tuple(frag_entries)
+
+    @staticmethod
+    def _get_size(csize):
+        """
+        For fragment entries and fragment blocks, the information if the data is compressed or not is contained in the (1 << 24) bit of the size.
+        """
+        compressed = not bool(csize & 0x1000000)
+        size = csize & 0xffffff
+        return compressed, size
+
+    @staticmethod
+    def _metadata_header(chunk):
+        """
+        Interprets <chunk> as header of a metadata block
+        """
+        header = unpack("<H", chunk)[0]
+        compressed = not bool(header & 0x8000)
+        size = header & 0x7fff
+
+        return MetaDataHeader(compressed, size)
+
+    def _get_metablock(self, block_pos):
+        """
+        Reads the header of a metadata block at block_pos and returns the extraced data.
+        """
+        self.imfile.seek(block_pos)
+
+        mheader = self._metadata_header(self.imfile.read(2))
+
+        data = self.imfile.read(mheader.size)
+        if mheader.compressed:
+            data = self.zdecomp.decompress(data, mheader.size)
+
+        return data
+
+    @staticmethod
+    def _inode_header(chunk):
+        """
+        Interprets <chunk> as inode header.
+        """
+        fmt = "<4H2I"
+        chunk = chunk[:calcsize(fmt)]
+        return InodeHeader(*unpack(fmt, chunk))
+
+    def _basic_file_inode(self, chunk):
+        """
+        Interprets <chunk> as inode of a basic file.
+        """
+        rest_fmt = "<4I"
+        rest_size = calcsize(rest_fmt)
+        rest_chunk, block_sizes_chunk = chunk[:rest_size], chunk[rest_size:]
+        start_block, fragment, offset, file_size = unpack(rest_fmt, rest_chunk)
+
+        num_blocks = ceil(file_size / self.sblk.block_size)
+        if fragment != 0xffffffff:  # There is a fragment. In that case block_sizes is only a list of the full blocks
+            num_blocks -= 1
+
+        bsizes_fmt = f"<{num_blocks}I"
+        bsizes_size = calcsize(bsizes_fmt)
+        block_sizes_chunk = block_sizes_chunk[:bsizes_size]
+        block_sizes = unpack(bsizes_fmt, block_sizes_chunk)
+        return BasicFileInode(start_block, fragment, offset, file_size, block_sizes)
+
+    @staticmethod
+    def _directory_header(chunk):
+        """
+        Interprets <chunk> as a header in the directory table.
+        """
+        fmt = "<3I"
+        chunk = chunk[:calcsize(fmt)]
+        return DirectoryHeader(*unpack(fmt, chunk))
+
+    @staticmethod
+    def _directory_entry(chunk):
+        """
+        Interprets <chunk> as an entry in the directory table.
+        """
+        rest_fmt = "<HhHH"
+        rest_size = calcsize(rest_fmt)
+        rest_chunk, name_chunk = chunk[:rest_size], chunk[rest_size:]
+        rest = unpack(rest_fmt, rest_chunk)
+
+        name_len = rest[-1] + 1  # name is 1 byte longer than given in name_size
+        name_fmt = f"<{name_len}s"
+        name_chunk = name_chunk[:name_len]  # calcsize(name_fmt) should be equal to name_len
+
+        name = unpack(name_fmt, name_chunk)
+        return DirectoryEntry(*rest, *name)
+
+    def _get_fragment(self, file_inode):
+        """
+        Get the fragment of a file.
+
+        The fragment is the last part of a file.
+        If the files size is not divisible by sblk.block_size, that last part may simply be stored in another block,
+        or as a fragment in a fragment block (together with other fragments).
+        """
+        if file_inode.fragment == 0xffffffff:  # There is no fragment.
+            return b''
+
+        entry = self.frag_entries[file_inode.fragment]
+
+        self.imfile.seek(entry.start_block)
+
+        compressed, size = self._get_size(entry.size)
+        data = self.imfile.read(size)
+
+        if compressed:
+            data = self.zdecomp.decompress(data, size, self.sblk.block_size)
+
+        dstart = file_inode.offset
+        dlen = file_inode.file_size % self.sblk.block_size
+        data = data[dstart:dstart + dlen]
+
+        return data
+
+    def _get_dentry(self, name):
+        """
+        Searches the directory table for the entry for <name>.
+        """
+        data = self._get_metablock(self.sblk.directory_table_start)
+        bname = name.encode()
+
+        while len(data) > 0:
+            header = self._directory_header(data)
+            data = data[12:]
+
+            for _ in range(header.count+1):
+                dentry = self._directory_entry(data)
+                if dentry.name == bname:
+                    log(0, f"found {bname} in dentry {dentry} after dir header {header}")
+                    return header, dentry
+
+                data = data[len(dentry):]
+
+        raise FileNotFoundError(f"{name} not found!")
+
+    def _get_inode_from_pos(self, block_pos, pos_in_block):
+        """
+        Get the inode for a basic file from the starting point of the block and the position in the block.
+        """
+        data = self._get_metablock(block_pos)
+        data = data[pos_in_block:]
+
+        header = self._inode_header(data)
+        data = data[16:]
+
+        if header.inode_type == 2:  # 2 is a basic file
+            return self._basic_file_inode(data)
+
+        log(4, "inode types other than basic file are not implemented!")
+        return None
+
+    def _get_inode(self, name):
+        """
+        Get the inode for a basic file by its name.
+        """
+        head_entry = self._get_dentry(name)
+        if not head_entry:
+            return head_entry
+
+        dhead, dentry = head_entry
+
+        block_pos = self.sblk.inode_table_start + dhead.start_block
+        pos_in_block = dentry.offset
+
+        return self._get_inode_from_pos(block_pos, pos_in_block)
+
+    def read_file_blocks(self, filename):
+        """
+        Generator where each iteration returns a block of file <filename> as bytes.
+        """
+
+        inode = self._get_inode(filename)
+
+        fragment = self._get_fragment(inode)
+        file_len = len(fragment)
+
+        self.imfile.seek(inode.start_block)
+        curr_pos = self.imfile.tell()
+
+        for bsize in inode.block_list:
+            compressed, size = self._get_size(bsize)
+
+            if curr_pos != self.imfile.tell():
+                log(3, "Pointer not at correct position. Moving.")
+                self.imfile.seek(curr_pos)
+
+            block = self.imfile.read(size)
+            curr_pos = self.imfile.tell()
+
+            if compressed:
+                block = self.zdecomp.decompress(block, size, self.sblk.block_size)
+
+            file_len += len(block)
+            yield block
+
+        if file_len != inode.file_size:
+            msg = f"""
+            Size of extracted file not correct. Something went wrong!
+            calculated file_len: {file_len}, given file_size: {inode.file_size}
+            """
+            raise IOError(msg)
+
+        yield fragment
+
+    def extract_file(self, filename, target_dir):
+        """
+        Extracts file <filename> to <target_dir>
+        """
+        with open(os.path.join(target_dir, filename), "wb") as outfile:
+            for block in self.read_file_blocks(filename):
+                outfile.write(block)

--- a/script.module.inputstreamhelper/lib/inputstreamhelper/widevine/arm.py
+++ b/script.module.inputstreamhelper/lib/inputstreamhelper/widevine/arm.py
@@ -8,8 +8,9 @@ import json
 
 from .. import config
 from ..kodiutils import browsesingle, localize, log, ok_dialog, open_file, progress_dialog, yesno_dialog
-from ..utils import diskspace, http_download, http_get, parse_version, sizeof_fmt, store, system_os, update_temp_path, userspace64
+from ..utils import diskspace, http_download, http_get, parse_version, sizeof_fmt, system_os, update_temp_path, userspace64
 from .arm_chromeos import ChromeOSImage
+from .arm_lacros import cdm_from_lacros, install_widevine_arm_lacros
 
 
 def select_best_chromeos_image(devices):
@@ -65,8 +66,8 @@ def chromeos_config():
     return json.loads(http_get(config.CHROMEOS_RECOVERY_URL))
 
 
-def install_widevine_arm(backup_path):
-    """Installs Widevine CDM on ARM-based architectures."""
+def install_widevine_arm_chromeos(backup_path):
+    """Installs Widevine CDM extracted from a Chrome OS image on ARM-based architectures."""
     # Select newest and smallest ChromeOS image
     devices = chromeos_config()
     arm_device = select_best_chromeos_image(devices)
@@ -96,7 +97,7 @@ def install_widevine_arm(backup_path):
         log(2, 'Downloading ChromeOS image for Widevine: {boardname} ({version})'.format(**arm_device))
         url = arm_device['url']
 
-        extracted = dl_extract_widevine(url, backup_path, arm_device)
+        extracted = dl_extract_widevine_chromeos(url, backup_path, arm_device)
         if extracted:
             recovery_file = os.path.join(backup_path, arm_device['version'], os.path.basename(config.CHROMEOS_RECOVERY_URL))
             with open_file(recovery_file, 'w') as reco_file:  # pylint: disable=unspecified-encoding
@@ -107,22 +108,20 @@ def install_widevine_arm(backup_path):
     return False
 
 
-def dl_extract_widevine(url, backup_path, arm_device=None):
+def dl_extract_widevine_chromeos(url, backup_path, arm_device=None):
     """Download the ChromeOS image and extract Widevine from it"""
     if arm_device:
-        downloaded = http_download(url, message=localize(30022), checksum=arm_device['sha1'], hash_alg='sha1',
+        dl_path = http_download(url, message=localize(30022), checksum=arm_device['sha1'], hash_alg='sha1',
                                    dl_size=int(arm_device['zipfilesize']))  # Downloading the recovery image
         image_version = arm_device['version']
     else:
-        downloaded = http_download(url, message=localize(30022))
+        dl_path = http_download(url, message=localize(30022))
         image_version = os.path.basename(url).split('_')[1]
         # minimal info for config.json, "version" is definitely needed e.g. in load_widevine_config:
         arm_device = {"file": os.path.basename(url), "url": url, "version": image_version}
 
-    if downloaded:
-        image_path = store('download_path')
-
-        progress = extract_widevine(backup_path, image_path, image_version)
+    if dl_path:
+        progress = extract_widevine_chromeos(backup_path, dl_path, image_version)
         if not progress:
             return False
 
@@ -135,7 +134,7 @@ def dl_extract_widevine(url, backup_path, arm_device=None):
     return False
 
 
-def extract_widevine(backup_path, image_path, image_version):
+def extract_widevine_chromeos(backup_path, image_path, image_version):
     """Extract Widevine from the given ChromeOS image"""
     progress = progress_dialog()
     progress.create(heading=localize(30043), message=localize(30044))  # Extracting Widevine CDM
@@ -150,3 +149,11 @@ def extract_widevine(backup_path, image_path, image_version):
         return False
 
     return progress
+
+
+def install_widevine_arm(backup_path):
+    """Wrapper for installing widevine either from Chrome browser image or Chrome OS image"""
+    if cdm_from_lacros():
+        return install_widevine_arm_lacros(backup_path)
+
+    return install_widevine_arm_chromeos(backup_path)

--- a/script.module.inputstreamhelper/lib/inputstreamhelper/widevine/arm_lacros.py
+++ b/script.module.inputstreamhelper/lib/inputstreamhelper/widevine/arm_lacros.py
@@ -1,0 +1,77 @@
+# -*- coding: utf-8 -*-
+# MIT License (see LICENSE.txt or https://opensource.org/licenses/MIT)
+"""Implements ARM specific widevine functions for Lacros image"""
+
+import os
+import json
+from ctypes.util import find_library
+
+from .repo import cdm_from_repo
+from .. import config
+from ..kodiutils import exists, localize, log, mkdirs, open_file, progress_dialog
+from ..utils import http_download, http_get, system_os, userspace64
+from ..unsquash import SquashFs
+
+
+def cdm_from_lacros():
+    """Whether the Widevine CDM can/should be extracted from a lacros image"""
+    return not cdm_from_repo() and bool(find_library("zstd"))  # The lacros images are compressed with zstd
+
+
+def latest_lacros():
+    """Finds the version of the latest stable lacros image"""
+    latest = json.loads(http_get(config.LACROS_LATEST))[0]["version"]
+    log(0, f"latest lacros image version is {latest}")
+    return latest
+
+
+def extract_widevine_lacros(dl_path, backup_path, img_version):
+    """Extract Widevine from the given Lacros image"""
+    progress = progress_dialog()
+    progress.create(heading=localize(30043), message=localize(30044))  # Extracting Widevine CDM, prepping image
+
+    fnames = (config.WIDEVINE_CDM_FILENAME[system_os()], config.WIDEVINE_MANIFEST_FILE, "LICENSE")  # Here it's not LICENSE.txt, as defined in the config.py
+    bpath = os.path.join(backup_path, img_version)
+    if not exists(bpath):
+        mkdirs(bpath)
+
+    try:
+        with SquashFs(dl_path) as sfs:
+            for num, fname in enumerate(fnames):
+                sfs.extract_file(fname, bpath)
+                progress.update(int(90 / len(fnames) * (num + 1)), localize(30048))  # Extracting from image
+
+    except (IOError, FileNotFoundError) as err:
+        log(4, "SquashFs raised an error")
+        log(4, err)
+        return False
+
+
+    with open_file(os.path.join(bpath, config.WIDEVINE_MANIFEST_FILE), "r") as manifest_file:
+        manifest_json = json.load(manifest_file)
+
+    manifest_json.update({"img_version": img_version})
+
+    with open_file(os.path.join(bpath, config.WIDEVINE_MANIFEST_FILE), "w") as manifest_file:
+        json.dump(manifest_json, manifest_file, indent=2)
+
+    log(0, f"Successfully extracted all files from lacros image {os.path.basename(dl_path)}")
+    return progress
+
+
+def install_widevine_arm_lacros(backup_path, img_version=None):
+    """Installs Widevine CDM extracted from a Chrome browser SquashFS image on ARM-based architectures."""
+
+    if not img_version:
+        img_version = latest_lacros()
+
+    url = config.LACROS_DOWNLOAD_URL.format(version=img_version, arch=("arm64" if userspace64() else "arm"))
+
+    dl_path = http_download(url, message=localize(30072))
+
+    if dl_path:
+        progress = extract_widevine_lacros(dl_path, backup_path, img_version)
+        if progress:
+            return (progress, img_version)
+
+    return False

--- a/script.module.inputstreamhelper/lib/inputstreamhelper/widevine/repo.py
+++ b/script.module.inputstreamhelper/lib/inputstreamhelper/widevine/repo.py
@@ -1,0 +1,76 @@
+# -*- coding: utf-8 -*-
+# MIT License (see LICENSE.txt or https://opensource.org/licenses/MIT)
+"""Implements functions specific to systems where the widevine library is available from Google's repository"""
+
+from __future__ import absolute_import, division, unicode_literals
+
+from .. import config
+from ..kodiutils import localize, log, select_dialog
+from ..utils import arch, http_get, http_head, parse_version, system_os
+
+
+def cdm_from_repo():
+    """Whether the Widevine CDM is available from Google's library CDM repository"""
+    # Based on https://source.chromium.org/chromium/chromium/src/+/master:third_party/widevine/cdm/widevine.gni
+    if 'x86' in arch() or arch() == 'arm64' and system_os() == 'Darwin':
+        return True
+    return False
+
+
+def widevines_available_from_repo():
+    """Returns all available Widevine CDM versions and urls from Google's library CDM repository"""
+    cdm_versions = http_get(config.WIDEVINE_VERSIONS_URL).strip('\n').split('\n')
+    try:
+        cdm_os = config.WIDEVINE_OS_MAP[system_os()]
+        cdm_arch = config.WIDEVINE_ARCH_MAP_REPO[arch()]
+    except KeyError:
+        cdm_os = "mac"
+        cdm_arch = "x64"
+    available_cdms = []
+    for cdm_version in cdm_versions:
+        cdm_url = config.WIDEVINE_DOWNLOAD_URL.format(version=cdm_version, os=cdm_os, arch=cdm_arch)
+        http_status = http_head(cdm_url)
+        if http_status == 200:
+            available_cdms.append({'version': cdm_version, 'url': cdm_url})
+
+    if not available_cdms:
+        log(4, "could not find any available cdm in repo")
+
+    return available_cdms
+
+
+def latest_widevine_available_from_repo(available_cdms=None):
+    """Returns the latest available Widevine CDM version and url from Google's library CDM repository"""
+    if not available_cdms:
+        available_cdms = widevines_available_from_repo()
+
+    try:
+        latest = available_cdms[-1]  # That's probably correct, but the following for loop makes sure
+    except IndexError:
+        # widevines_available_from_repo() already logged if there are no available cdms
+        return None
+
+    for cdm in available_cdms:
+        if parse_version(cdm['version']) > parse_version(latest['version']):
+            latest = cdm
+
+    return latest
+
+
+def choose_widevine_from_repo():
+    """Choose from the widevine versions available in Google's library CDM repository"""
+    available_cdms = widevines_available_from_repo()
+    latest = latest_widevine_available_from_repo(available_cdms)
+
+    opts = tuple(cdm['version'] for cdm in available_cdms)
+    preselect = opts.index(latest['version'])
+
+    version_index = select_dialog(localize(30069), opts, preselect=preselect)
+    if version_index == -1:
+        log(1, 'User did not choose a version to install!')
+        return False
+
+    cdm = available_cdms[version_index]
+    log(0, 'User chose to install Widevine version {version} from {url}', version=cdm['version'], url=cdm['url'])
+
+    return cdm

--- a/script.module.inputstreamhelper/resources/language/resource.language.en_gb/strings.po
+++ b/script.module.inputstreamhelper/resources/language/resource.language.en_gb/strings.po
@@ -281,6 +281,10 @@ msgctxt "#30071"
 msgid "Could not find the Widevine CDM by a quick scan. Now doing a proper search, but this might take very long..."
 msgstr ""
 
+msgctxt "#30072"
+msgid "Downloading the image..."
+msgstr ""
+
 
 ### INFORMATION DIALOG
 msgctxt "#30800"
@@ -313,6 +317,10 @@ msgstr ""
 
 msgctxt "#30824"
 msgid "It is installed at [B]{path}[/B]"
+msgstr ""
+
+msgctxt "#30825"
+msgid "It was extracted from {image} image version [B]{version}[/B]"
 msgstr ""
 
 msgctxt "#30830"


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: InputStream Helper
  - Add-on ID: script.module.inputstreamhelper
  - Version number: 0.7.0
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/emilsvennesson/script.module.inputstreamhelper
  
A simple Kodi module that makes life easier for add-on developers relying on InputStream based add-ons and DRM playback.

### Description of changes:


v0.7.0 (2024-09-24)
- Get rid of distutils dependency
- Option to get Widevine from lacros image
- Remove support for Python 2 and pre-Matrix Kodi versions

v0.6.1 (2023-05-30)
- Performance improvements on Linux ARM
- This will be the last release for Python 2 i.e. Kodi 18 (Leia) and below. The next release will require Python 3 and Kodi 19 (Matrix) or higher.

v0.6.0 (2023-05-03)
- Initial support for AARCH64 Linux
- Initial support for AARCH64 Macs
- New option to install a specific version on most platforms

v0.5.10 (2022-04-18)
- Fix automatic submission of release
- Update German translation
- Fix update_frequency setting
- Fix install_from
- Improve/Fix Widevine extraction from Chrome OS images

v0.5.9 (2022-03-22)
- Update Croatian translation
- Replace deprecated LooseVersion
- Fix http_get decode error
- Option to install Widevine from specified source
    

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
