### PR TITLE
[service.subtitles.rvm.addic7ed@matrix] 3.2.2

### DIFF
--- a/service.subtitles.rvm.addic7ed/addic7ed/addon.py
+++ b/service.subtitles.rvm.addic7ed/addic7ed/addon.py
@@ -13,26 +13,105 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import os
+import hashlib
+import json
+import re
+from pathlib import Path
 
 import xbmcaddon
 from xbmcvfs import translatePath
 
-__all__ = ['ADDON_ID', 'ADDON', 'ADDON_VERSION', 'PATH', 'PROFILE', 'ICON', 'get_ui_string']
+__all__ = ['ADDON_ID', 'ADDON', 'ADDON_VERSION', 'PATH', 'PROFILE', 'ICON', 'GettextEmulator']
 
 ADDON = xbmcaddon.Addon()
 ADDON_ID = ADDON.getAddonInfo('id')
 ADDON_VERSION = ADDON.getAddonInfo('version')
-PATH = translatePath(ADDON.getAddonInfo('path'))
-PROFILE = translatePath(ADDON.getAddonInfo('profile'))
-ICON = os.path.join(PATH, 'icon.png')
+
+PATH = Path(translatePath(ADDON.getAddonInfo('path')))
+PROFILE = Path(translatePath(ADDON.getAddonInfo('profile')))
+ICON = str(PATH / 'icon.png')
 
 
-def get_ui_string(string_id):
+class GettextEmulator:
     """
-    Get language string by ID
-
-    :param string_id: UI string ID
-    :return: UI string
+    Emulate GNU Gettext by mapping resource.language.en_gb UI strings to their numeric string IDs
     """
-    return ADDON.getLocalizedString(string_id)
+    _instance = None
+
+    class LocalizationError(Exception):  # pylint: disable=missing-docstring
+        pass
+
+    def __new__(cls):
+        if cls._instance is None:
+            cls._instance = super().__new__(cls)
+        return cls._instance
+
+    def __init__(self):
+        self._en_gb_string_po_path = (PATH / 'resources' / 'language' /
+                                      'resource.language.en_gb' / 'strings.po')
+        if not self._en_gb_string_po_path.exists():
+            raise self.LocalizationError(
+                'Missing resource.language.en_gb strings.po localization file')
+        if not PROFILE.exists():
+            PROFILE.mkdir()
+        self._string_mapping_path = PROFILE / 'strings-map.json'
+        self.strings_mapping = self._load_strings_mapping()
+
+    def _load_strings_po(self):  # pylint: disable=missing-docstring
+        with self._en_gb_string_po_path.open('r', encoding='utf-8') as fo:
+            return fo.read()
+
+    def _load_strings_mapping(self):
+        """
+        Load mapping of resource.language.en_gb UI strings to their IDs
+
+        If a mapping file is missing or resource.language.en_gb strins.po file has been updated,
+        a new mapping file is created.
+
+        :return: UI strings mapping
+        """
+        strings_po = self._load_strings_po()
+        strings_po_md5 = hashlib.md5(strings_po.encode('utf-8')).hexdigest()
+        try:
+            with self._string_mapping_path.open('r', encoding='utf-8') as fo:
+                mapping = json.load(fo)
+            if mapping['md5'] != strings_po_md5:
+                raise IOError('resource.language.en_gb strings.po has been updated')
+        except (IOError, ValueError):
+            strings_mapping = self._parse_strings_po(strings_po)
+            mapping = {
+                'strings': strings_mapping,
+                'md5': strings_po_md5,
+            }
+            with self._string_mapping_path.open('w', encoding='utf-8') as fo:
+                json.dump(mapping, fo)
+        return mapping['strings']
+
+    @staticmethod
+    def _parse_strings_po(strings_po):
+        """
+        Parse resource.language.en_gb strings.po file contents into a mapping of UI strings
+        to their numeric IDs.
+
+        :param strings_po: the content of strings.po file as a text string
+        :return: UI strings mapping
+        """
+        id_string_pairs = re.findall(r'^msgctxt "#(\d+?)"\r?\nmsgid "(.*)"\r?$', strings_po, re.M)
+        return {string: int(string_id) for string_id, string in id_string_pairs if string}
+
+    @classmethod
+    def gettext(cls, en_string: str) -> str:
+        """
+        Return a localized UI string by a resource.language.en_gb source string
+
+        :param en_string: resource.language.en_gb UI string
+        :return: localized UI string
+        """
+        emulator = cls()
+        try:
+            string_id = emulator.strings_mapping[en_string]
+        except KeyError as exc:
+            raise cls.LocalizationError(
+                f'Unable to find "{en_string}" string in resource.language.en_gb/strings.po'
+            ) from exc
+        return ADDON.getLocalizedString(string_id)

--- a/service.subtitles.rvm.addic7ed/addic7ed/simple_requests.py
+++ b/service.subtitles.rvm.addic7ed/addic7ed/simple_requests.py
@@ -108,7 +108,7 @@ class Response:
     @headers.setter
     def headers(self, value: HTTPMessage):
         charset = value.get_content_charset()
-        if charset is not None:
+        if charset:
             self.encoding = charset
         self._headers = value
 
@@ -124,7 +124,7 @@ class Response:
         if self._text is None:
             try:
                 self._text = self.content.decode(self.encoding)
-            except UnicodeDecodeError:
+            except (UnicodeDecodeError, LookupError):
                 self._text = self.content.decode('utf-8', 'replace')
         return self._text
 

--- a/service.subtitles.rvm.addic7ed/addon.xml
+++ b/service.subtitles.rvm.addic7ed/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon id="service.subtitles.rvm.addic7ed"
   name="Addic7ed.com"
-  version="3.2.1"
+  version="3.2.2"
   provider-name="Roman V.M.">
 <requires>
   <import addon="xbmc.python" version="3.0.0"/>
@@ -29,8 +29,9 @@
     <icon>icon.png</icon>
     <fanart>fanart.jpg</fanart>
   </assets>
-  <news>3.2.1:
-- Fixed issues with downloading subtitles.</news>
+  <news>3.2.2:
+- Fixed the issue with an empty content-charset header.
+- Internal changes.</news>
   <reuselanguageinvoker>true</reuselanguageinvoker>
 </extension>
 </addon>


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: Addic7ed.com
  - Add-on ID: service.subtitles.rvm.addic7ed
  - Version number: 3.2.2
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/romanvm/service.addic7ed
  
Subtitles service for Addic7ed.com. It supports only TV shows.

### Description of changes:

3.2.2:
- Fixed the issue with an empty content-charset header.
- Internal changes.

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
