### PR TITLE
[script.cabertoss@matrix] 1.0.1

### DIFF
--- a/script.cabertoss/addon.xml
+++ b/script.cabertoss/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.cabertoss" name="Caber Toss" version="1.0.0" provider-name="bossanova808">
+<addon id="script.cabertoss" name="Caber Toss" version="1.0.1" provider-name="bossanova808">
     <requires>
         <import addon="xbmc.python" version="3.0.0"/>
         <import addon="script.module.bossanova808" version="1.0.0"/>
@@ -14,16 +14,21 @@ A script to quickly toss your Kodi logs from your Kodi client machine to somewhe
 
 When something unexpected or bad happens, just run this add-on to copy the latest Kodi logs to your chosen destination.
 
-Even better, bind this to a remote button (use `Runscript(script.cabertoss)`) - so you can carry on with your relaxing and deal with the issue later (without having to wade through all the stuff you did after the issue happened!).
+Even better, bind this to a remote button (use `Runscript(script.cabertoss)`) - so you can carry on with your relaxing at the time, and deal with the issue later (without having to wade through all the stuff you did after the issue happened!).
         </description>
         <platform>all</platform>
         <license>GPL-3.0-only</license>
         <website>https://github.com/bossanova808/script.cabertoss</website>
         <source>https://github.com/bossanova808/script.cabertoss</source>
-        <forum />
-        <email />
-        <news>
-            v1.0.0 Initial release
+        <forum>https://forum.kodi.tv/showthread.php?tid=379304</forum>
+        <email>bossanova808@gmail.com</email>
+        <news>v1.0.1
+- Improve compatibility with network shares            
+- Improve compatibility with Windows and *ELEC
+- Add hostname to logs folder, helps if using with multiple systems
+- Don't copy crashlogs older than three days
+- Language improvements
+- Add 'Working...' notification to make more responsive (copying larger log files can take a moment)
         </news>
         <assets>
             <icon>resources/icon.png</icon>

--- a/script.cabertoss/changelog.txt
+++ b/script.cabertoss/changelog.txt
@@ -1,4 +1,12 @@
+v1.0.1
+- Improve compatibility with network shares            
+- Improve compatibility with Windows and *ELEC
+- Add hostname to logs folder, helps if using with multiple systems
+- Don't copy crashlogs older than three days
+- Language improvements
+- Add 'Working...' notification to make more responsive (copying larger log files can take a moment)
+
 v1.0.0
-Initial release
+- Initial release
 
 

--- a/script.cabertoss/resources/language/resource.language.en_gb/strings.po
+++ b/script.cabertoss/resources/language/resource.language.en_gb/strings.po
@@ -48,3 +48,7 @@ msgstr "
 msgctxt "#32029"
 msgid "Something went wrong, (ironically) check your logs!"
 msgstr "
+
+msgctxt "#32030"
+msgid "Working..."
+msgstr "

--- a/script.cabertoss/resources/lib/clean.py
+++ b/script.cabertoss/resources/lib/clean.py
@@ -1,0 +1,15 @@
+import re
+
+
+def clean_log(content):
+    """
+    Remove username/password details from log file content
+
+    @param content:
+    @return:
+    """
+    replaces = (('//.+?:.+?@', '//USER:PASSWORD@'), ('<user>.+?</user>', '<user>USER</user>'), ('<pass>.+?</pass>', '<pass>PASSWORD</pass>'),)
+
+    for pattern, repl in replaces:
+        sanitised = re.sub(pattern, repl, content)
+        return sanitised

--- a/script.cabertoss/resources/lib/store.py
+++ b/script.cabertoss/resources/lib/store.py
@@ -1,5 +1,6 @@
 from bossanova808.constants import *
 from bossanova808.logger import Logger
+from resources.lib.clean import *
 
 
 class Store:
@@ -12,7 +13,6 @@ class Store:
 
     # Static class variables, referred to elsewhere by Store.whatever
     # https://docs.python.org/3/faq/programming.html#how-do-i-create-static-class-data-and-static-class-methods
-    replaces = (('//.+?:.+?@', '//USER:PASSWORD@'), ('<user>.+?</user>', '<user>USER</user>'), ('<pass>.+?</pass>', '<pass>PASSWORD</pass>'),)
     destination_path = None
 
     def __init__(self):
@@ -29,7 +29,8 @@ class Store:
         """
         Logger.info("Loading configuration from settings")
         Store.destination_path = ADDON.getSetting('log_path')
-        Logger.info(f'Logs will be tossed to: {Store.destination_path}')
+
+        Logger.info(f'Logs will be tossed to: {clean_log(Store.destination_path)}')
 
 
 

--- a/script.cabertoss/resources/settings.xml
+++ b/script.cabertoss/resources/settings.xml
@@ -7,10 +7,14 @@
                     <level>0</level>
                     <default/>
                     <constraints>
+                        <sources>
+                            <source>files</source>
+                        </sources>
+                        <writable>true</writable>
                         <allowempty>true</allowempty>
                     </constraints>
                     <control type="button" format="path">
-                        <heading>32026</heading>
+                        <heading>32001</heading>
                     </control>
                 </setting>
             </group>


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: Caber Toss
  - Add-on ID: script.cabertoss
  - Version number: 1.0.1
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/bossanova808/script.cabertoss
  

A script to quickly toss your Kodi logs from your Kodi client machine to somewhere more handy, for easier review.

When something unexpected or bad happens, just run this add-on to copy the latest Kodi logs to your chosen destination.

Even better, bind this to a remote button (use `Runscript(script.cabertoss)`) - so you can carry on with your relaxing at the time, and deal with the issue later (without having to wade through all the stuff you did after the issue happened!).
        

### Description of changes:

v1.0.1
- Improve compatibility with network shares            
- Improve compatibility with Windows and *ELEC
- Add hostname to logs folder, helps if using with multiple systems
- Don't copy crashlogs older than three days
- Language improvements
- Add 'Working...' notification to make more responsive (copying larger log files can take a moment)
        

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
