### PR TITLE
[script.xbmc.unpausejumpback@matrix] 3.0.5

### DIFF
--- a/script.xbmc.unpausejumpback/addon.xml
+++ b/script.xbmc.unpausejumpback/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.xbmc.unpausejumpback" name="Unpause Jumpback" version="3.0.4" provider-name="bossanova808,Memphiz,Lucleonhart,schumi2004,dkadioglu">
+<addon id="script.xbmc.unpausejumpback" name="Unpause Jumpback" version="3.0.5" provider-name="bossanova808,Memphiz,Lucleonhart,schumi2004,dkadioglu">
   <requires>
     <import addon="xbmc.python" version="3.0.0"/>
     <import addon="script.module.bossanova808" version="1.0.0"/>
@@ -25,8 +25,8 @@
     <source>https://github.com/bossanova808/script.xbmc.unpausejumpback/</source>
     <forum>https://forum.kodi.tv/showthread.php?tid=355778</forum>
     <email>bossonav808@gmail.com</email>
-    <news>v3.0.4
-- Remove old common code, use new module
+    <news>v3.0.5
+- fix for more possibles instances of "Kodi is not playing any media file" when skipping beyond end of file
     </news>
     <assets>
       <icon>icon.png</icon>

--- a/script.xbmc.unpausejumpback/changelog.txt
+++ b/script.xbmc.unpausejumpback/changelog.txt
@@ -1,3 +1,6 @@
+v3.0.5
+- fix for more possibles instances of "Kodi is not playing any media file" when skipping beyond end of file
+
 v3.0.4
 - Remove old common code, use new module
 


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: Unpause Jumpback
  - Add-on ID: script.xbmc.unpausejumpback
  - Version number: 3.0.5
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/bossanova808/script.xbmc.unpausejumpback/
  

        This addon will jump back a number of seconds whenever a video is un-paused - to make sure you don't miss anything.
        You can set the amount of seconds to jump back, and the minimum duration of the pause before the addon will trigger a jump back.
        It also allows to jump back or forward after rewind or fast-forward of a specified amount of seconds to compensate for over-shooting.
        (Originally created by Memphiz, up-keep taken over by bossanova808 in 2020 for Kodi Matrix and beyond).
    

### Description of changes:

v3.0.5
- fix for more possibles instances of "Kodi is not playing any media file" when skipping beyond end of file
    

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
