### PR TITLE
[script.service.hue@matrix] 2.0.16

### DIFF
--- a/script.service.hue/addon.xml
+++ b/script.service.hue/addon.xml
@@ -1,4 +1,4 @@
-<addon id="script.service.hue" name="Hue Service" provider-name="zim514" version="2.0.15">
+<addon id="script.service.hue" name="Hue Service" provider-name="zim514" version="2.0.16">
     <requires>
         <import addon="xbmc.python" version="3.0.0"/>
         <import addon="script.module.requests" version="2.31.0"/>
@@ -20,10 +20,8 @@
         </assets>
         <source>https://github.com/zim514/script.service.hue</source>
         <forum>https://forum.kodi.tv/showthread.php?tid=344886</forum>
-        <news>v2.0.15
-- Hide disabled menu action when service is disabled
-- Fix inconsistent activation code
-- Crash fix
+        <news>v2.0.16
+- Fix Video scenes triggering with Audio
 
 </news>
         <summary lang="ca_ES">Automatitza les llums Hue amb la reproducció de Kodi</summary>

--- a/script.service.hue/resources/lib/lightgroup.py
+++ b/script.service.hue/resources/lib/lightgroup.py
@@ -55,6 +55,9 @@ class LightGroup(xbmc.Player):
         elif not self.bridge.connected:
             log(f"[SCRIPT.SERVICE.HUE] Bridge not connected")
             return
+        elif self.media_type != self._playback_type():
+            log(f"[SCRIPT.SERVICE.HUE] LightGroup[{self.light_group_id}]: Wrong media type")
+            return
         else:
             log(f"[SCRIPT.SERVICE.HUE] LightGroup[{self.light_group_id}] onPlaybackStarted. play_behavior: {play_enabled}, media_type: {self.media_type} == playback_type: {self._playback_type()}")
             if self.media_type == self._playback_type() and self._playback_type() == VIDEO:
@@ -186,12 +189,12 @@ class LightGroup(xbmc.Player):
 
     def _playback_type(self):
         if self.isPlayingVideo():
-            media_type = VIDEO
+            return VIDEO
         elif self.isPlayingAudio():
-            media_type = AUDIO
+            return AUDIO
         else:
-            media_type = None
-        return media_type
+            return None
+
 
 
 class ActivationChecker:


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: Hue Service
  - Add-on ID: script.service.hue
  - Version number: 2.0.16
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/zim514/script.service.hue
  
Automate your Hue lights with Kodi. Use scenes configured in the official Hue app. Can use Hue's sunset time to automatically disable the service during daytime and turn on the lights at sunset during playback. Includes Ambilight support.

### Description of changes:

v2.0.16
- Fix Video scenes triggering with Audio



### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
