### PR TITLE
[script.timers] 4.1.2

### DIFF
--- a/script.timers/addon.xml
+++ b/script.timers/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.timers" name="Timers" version="4.1.1" provider-name="Heckie">
+<addon id="script.timers" name="Timers" version="4.1.2" provider-name="Heckie">
   <requires>
     <import addon="xbmc.python" version="3.0.0" />
   </requires>
@@ -66,6 +66,9 @@
     <website>https://github.com/Heckie75/kodi-addon-timers</website>
     <source>https://github.com/Heckie75/kodi-addon-timers</source>
     <news>
+v4.1.2 (2025-04-27)
+* Fixed issue #50: Predefined time in sleep timer is incorrect (prob. if no PVR client is installed)
+
 v4.1.1 (2025-03-24)
 * Minor fixes for Python compatibility
 
@@ -98,9 +101,6 @@ v3.9.0 (2023-11-11)
 - Added new system action 'restart Kodi'
 - Added new extra feature to prevent display off when audio is playing
 - Bugfix: Prevent exception in fader context
-
-v3.8.0 (2023-08-06)
-- Context menu quicktimer: Added dialog if item is already scheduled and ask to replace or delete
 
 Complete changelog see https://github.com/Heckie75/kodi-addon-timers
     </news>

--- a/script.timers/resources/lib/contextmenu/set_sleep.py
+++ b/script.timers/resources/lib/contextmenu/set_sleep.py
@@ -25,7 +25,8 @@ class SetSleep(AbstractSetTimer):
         if is_epg:
             return timer.duration
 
-        if xbmc.getInfoLabel("PVR.EpgEventSeekTime(hh:mm:ss)") != "00:00:00":
+        seektime = xbmc.getInfoLabel("PVR.EpgEventSeekTime(hh:mm:ss)")
+        if seektime and xbmc.getInfoLabel("PVR.EpgEventSeekTime(hh:mm:ss)") != "00:00:00":
             _current = xbmc.getInfoLabel("PVR.EpgEventRemainingTime(hh:mm)")
 
         else:


### PR DESCRIPTION
### Description
v4.1.2 (2025-04-27)
* Fixed issue [50](https://github.com/Heckie75/kodi-addon-timers/issues/50): Predefined time in sleep timer is incorrect (prob. if no PVR client is installed)

### Checklist:
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [script.foo.bar] 1.0.0
