### PR TITLE
[weather.ozweather@matrix] 2.1.5

### DIFF
--- a/weather.ozweather/addon.xml
+++ b/weather.ozweather/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="weather.ozweather" name="Oz Weather" version="2.1.3" provider-name="Bossanova808">
+<addon id="weather.ozweather" name="Oz Weather" version="2.1.5" provider-name="Bossanova808">
 	<requires>
 		<import addon="xbmc.python" version="3.0.0"/>
     	<import addon="script.module.requests" version="2.22.0+matrix.1"/>
@@ -23,11 +23,8 @@
        		<icon>icon.png</icon>
        		<fanart>fanart.jpg</fanart>
 		</assets>
-		<news>v2.1.3
-- Bugfix for 2.1.2, fix missed import
-v2.1.2
-- Remove old common code, instead use new script.module.bossanova808
-- Fix for occasional error with missing national radar background
+		<news>v2.1.5 Minor fixes
+- Fix feels like calculation when data not returned by BOM, and Current.Wind
     	</news>
 	</extension>
 </addon>

--- a/weather.ozweather/changelog.txt
+++ b/weather.ozweather/changelog.txt
@@ -1,3 +1,6 @@
+v2.1.5 Minor fixes
+- Fix feels like calculation when data not returned by BOM, and Current.Wind
+
 v2.1.3
 - Bugfix for 2.1.2, fix missed import
 


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: Oz Weather
  - Add-on ID: weather.ozweather
  - Version number: 2.1.5
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/bossanova808/weather.ozweather
  
Weather forecasting and radar images for Australia using Bureau of Meteorology data.  For full features (animated radars & ABC weather videos) - make sure you install the replacement skin files - see information at the addon wiki (https://kodi.wiki/index.php?title=Add-on:Oz_Weather).

### Description of changes:

v2.1.5 Minor fixes
- Fix feels like calculation when data not returned by BOM, and Current.Wind
    	

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
