### PR TITLE
[script.module.inputstreamhelper@matrix] 0.8.0

### DIFF
--- a/script.module.inputstreamhelper/README.md
+++ b/script.module.inputstreamhelper/README.md
@@ -19,7 +19,6 @@
 ```python
 # -*- coding: utf-8 -*-
 """InputStream Helper Demo"""
-from __future__ import absolute_import, division, unicode_literals
 import sys
 import inputstreamhelper
 import xbmc
@@ -91,6 +90,10 @@ Please report any issues or bug reports on the [GitHub Issues](https://github.co
 This module is licensed under the **The MIT License**. Please see the [LICENSE.txt](LICENSE.txt) file for details.
 
 ## Releases
+### v0.8.0 (2025-09-19)
+- Fix Widevine CDM installation on Windows, Linux and Macintosh (@mediaminister)
+- Add support for LG webOS (@Uukrull)
+
 ### v0.7.0 (2024-09-24)
 - Get rid of distutils dependency (@horstle, @emilsvennesson)
 - Option to get Widevine from lacros image (@horstle)

--- a/script.module.inputstreamhelper/addon.xml
+++ b/script.module.inputstreamhelper/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.module.inputstreamhelper" name="InputStream Helper" version="0.7.0" provider-name="emilsvennesson, dagwieers, mediaminister, horstle">
+<addon id="script.module.inputstreamhelper" name="InputStream Helper" version="0.8.0" provider-name="emilsvennesson, dagwieers, mediaminister, horstle">
   <requires>
     <!--py3 compliant-->
     <import addon="xbmc.python" version="3.0.0"/>
@@ -25,6 +25,10 @@
     <description lang="hr_HR">Jednostavan Kodi modul koji olakšava razvijanje dodataka koji se temelje na InputStream dodatku i reprodukciji DRM zaštićenog sadržaja.</description>
     <description lang="ru_RU">Простой модуль для Kodi, который облегчает жизнь разработчикам дополнений, с использованием InputStream дополнений и воспроизведения DRM контента.</description>
     <news>
+v0.8.0 (2025-09-19)
+- Fix Widevine CDM installation on Windows, Linux and Macintosh
+- Add support for LG webOS
+
 v0.7.0 (2024-09-24)
 - Get rid of distutils dependency
 - Option to get Widevine from lacros image

--- a/script.module.inputstreamhelper/default.py
+++ b/script.module.inputstreamhelper/default.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 ''' This is the actual InputStream Helper API script entry point '''
 
-from __future__ import absolute_import, division, unicode_literals
 import sys
 from lib.inputstreamhelper.api import run
 

--- a/script.module.inputstreamhelper/lib/inputstreamhelper/__init__.py
+++ b/script.module.inputstreamhelper/lib/inputstreamhelper/__init__.py
@@ -2,9 +2,7 @@
 # MIT License (see LICENSE.txt or https://opensource.org/licenses/MIT)
 """Implements the main InputStream Helper class"""
 
-from __future__ import absolute_import, division, unicode_literals
 import os
-import json
 
 from . import config
 from .kodiutils import (addon_version, browsesingle, delete, exists, get_proxies, get_setting, get_setting_bool, get_setting_float, get_setting_int, jsonrpc,
@@ -12,12 +10,12 @@ from .kodiutils import (addon_version, browsesingle, delete, exists, get_proxies
                         set_setting, set_setting_bool, textviewer, translate_path, yesno_dialog)
 from .utils import arch, download_path, http_download, parse_version, remove_tree, system_os, temp_path, unzip, userspace64
 from .widevine.arm import dl_extract_widevine_chromeos, extract_widevine_chromeos, install_widevine_arm
-from .widevine.arm_lacros import cdm_from_lacros, latest_lacros
+from .widevine.arm_lacros import cdm_from_lacros
 from .widevine.widevine import (backup_path, has_widevinecdm, ia_cdm_path,
                                 install_cdm_from_backup, latest_widevine_version,
                                 load_widevine_config, missing_widevine_libs, widevine_config_path,
                                 widevine_eula, widevinecdm_path)
-from .widevine.repo import cdm_from_repo, choose_widevine_from_repo, latest_widevine_available_from_repo
+from .widevine.repo import cdm_from_repo, latest_widevine_available_from_repo
 from .unicodes import compat_path
 
 # NOTE: Work around issue caused by platform still using os.popen()
@@ -33,8 +31,7 @@ class InputStreamException(Exception):
 def cleanup_decorator(func):
     """Decorator which runs cleanup before and after a function"""
 
-    def clean_before_after(self, *args, **kwargs):  # pylint: disable=missing-docstring
-        # pylint only complains about a missing docstring on py2.7?
+    def clean_before_after(self, *args, **kwargs):
         self.cleanup()
         result = func(self, *args, **kwargs)
         self.cleanup()
@@ -68,10 +65,7 @@ class Helper:
         # Add proxy support to HTTP requests
         proxies = get_proxies()
         if proxies:
-            try:  # Python 3
-                from urllib.request import build_opener, install_opener, ProxyHandler
-            except ImportError:  # Python 2
-                from urllib2 import build_opener, install_opener, ProxyHandler
+            from urllib.request import build_opener, install_opener, ProxyHandler
             install_opener(build_opener(ProxyHandler(proxies)))
 
     def __repr__(self):
@@ -178,12 +172,9 @@ class Helper:
         return True
 
     @staticmethod
-    def _install_widevine_from_repo(bpath, choose_version=False):
+    def _install_widevine_from_repo(bpath):
         """Install Widevine CDM from Google's library CDM repository"""
-        if choose_version:
-            cdm = choose_widevine_from_repo()
-        else:
-            cdm = latest_widevine_available_from_repo()
+        cdm = latest_widevine_available_from_repo(config.WIDEVINE_OS_MAP[system_os()], config.WIDEVINE_ARCH_MAP_REPO[arch()])
 
         if not cdm:
             return cdm
@@ -197,7 +188,8 @@ class Helper:
         if dl_path:
             progress = progress_dialog()
             progress.create(heading=localize(30043), message=localize(30044))  # Extracting Widevine CDM
-            unzip(dl_path, os.path.join(bpath, cdm_version, ''))
+            unzip(dl_path, os.path.join(bpath, cdm_version, ''), file_to_unzip=[config.WIDEVINE_LICENSE_FILE,
+                  config.WIDEVINE_MANIFEST_FILE, config.WIDEVINE_CDM_FILENAME[system_os()]])
 
             return (progress, cdm_version)
 
@@ -231,7 +223,7 @@ class Helper:
             return False
 
         if cdm_from_repo():
-            result = self._install_widevine_from_repo(backup_path(), choose_version=choose_version)
+            result = self._install_widevine_from_repo(backup_path())
         else:
             if choose_version:
                 log(1, "Choosing a version to install is only implemented if the lib is found in googles repo.")
@@ -359,7 +351,7 @@ class Helper:
 
     def _check_widevine(self):
         """Checks that all Widevine components are installed and available."""
-        if system_os() == 'Android':  # no checks needed for Android
+        if system_os() == 'Android' or system_os() == 'webOS':  # no checks needed for Android or webOS
             return True
 
         if not exists(widevine_config_path()):
@@ -369,7 +361,7 @@ class Helper:
 
         if cdm_from_repo():  # check that widevine arch matches system arch
             wv_config = load_widevine_config()
-            if config.WIDEVINE_ARCH_MAP_REPO[arch()] != wv_config['arch']:
+            if config.WIDEVINE_ARCH_MAP_REPO[arch()] != wv_config['platforms'][0]['arch']:
                 log(4, 'Widevine/system arch mismatch. Reinstall is required.')
                 ok_dialog(localize(30001), localize(30031))  # An update of Widevine is required
                 return self.install_widevine()
@@ -471,6 +463,8 @@ class Helper:
 
         if system_os() == 'Android':
             text += localize(30820) + '\n'
+        elif system_os() == 'webOS':
+            text += localize(30826) + '\n'
         else:
             from time import localtime, strftime
             if get_setting_float('last_modified', 0.0):

--- a/script.module.inputstreamhelper/lib/inputstreamhelper/api.py
+++ b/script.module.inputstreamhelper/lib/inputstreamhelper/api.py
@@ -2,7 +2,6 @@
 # MIT License (see LICENSE.txt or https://opensource.org/licenses/MIT)
 """This is the actual InputStream Helper API script"""
 
-from __future__ import absolute_import, division, unicode_literals
 from . import Helper
 from .kodiutils import ADDON, log
 

--- a/script.module.inputstreamhelper/lib/inputstreamhelper/config.py
+++ b/script.module.inputstreamhelper/lib/inputstreamhelper/config.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 # MIT License (see LICENSE.txt or https://opensource.org/licenses/MIT)
 """Configuration variables for inpustreamhelper"""
-from __future__ import absolute_import, division, unicode_literals
 
 
 INPUTSTREAM_PROTOCOLS = {
@@ -20,7 +19,8 @@ WIDEVINE_CDM_FILENAME = {
     'Android': None,
     'Linux': 'libwidevinecdm.so',
     'Windows': 'widevinecdm.dll',
-    'Darwin': 'libwidevinecdm.dylib'
+    'Darwin': 'libwidevinecdm.dylib',
+    'webOS': None
 }
 
 ARCH_MAP = {
@@ -44,12 +44,12 @@ WIDEVINE_SUPPORTED_ARCHS = [
 
 WIDEVINE_ARCH_MAP_REPO = {
     'x86_64': 'x64',
-    'x86': 'ia32',
+    'x86': 'x86',
     'arm64': 'arm64'
 }
 
 WIDEVINE_OS_MAP = {
-    'Linux': 'linux',
+    'Linux': 'Linux',
     'Windows': 'win',
     'Darwin': 'mac'
 }
@@ -58,21 +58,23 @@ WIDEVINE_SUPPORTED_OS = [
     'Android',
     'Linux',
     'Windows',
-    'Darwin'
+    'Darwin',
+    'webOS'
 ]
 
 WIDEVINE_MINIMUM_KODI_VERSION = {
     'Android': '18.0',
     'Windows': '18.0',
     'Linux': '18.0',
-    'Darwin': '18.0'
+    'Darwin': '18.0',
+    'webOS': '22.0'
 }
 
 WIDEVINE_VERSIONS_URL = 'https://dl.google.com/widevine-cdm/versions.txt'
 
 WIDEVINE_DOWNLOAD_URL = 'https://dl.google.com/widevine-cdm/{version}-{os}-{arch}.zip'
 
-WIDEVINE_LICENSE_FILE = 'LICENSE.txt'
+WIDEVINE_LICENSE_FILE = 'LICENSE'
 
 WIDEVINE_MANIFEST_FILE = 'manifest.json'
 
@@ -83,22 +85,23 @@ CHROMEOS_RECOVERY_URL = 'https://dl.google.com/dl/edgedl/chromeos/recovery/recov
 # To keep the Chrome OS ARM(64) hardware ID list up to date, the following resources can be used:
 # https://www.chromium.org/chromium-os/developer-information-for-chrome-os-devices
 # https://chromiumdash.appspot.com/serving-builds?deviceCategory=Chrome%20OS
-# Last updated: 2023-03-24
+# Last updated: 2024-10-13
+# current Chrome OS version: 16002.44.0, Widevine version: 4.10.2662.3
 CHROMEOS_RECOVERY_ARM_BNAMES = [
-    'asurada',
-    'bob',
-    'cherry',
-    'elm',
-    'hana',
-    'jacuzzi',
-    'kevin',
-    'kukui',
-    'scarlet',
-    'strongbad',
+    'bob',  # no longer updated, still latest wv. last: https://dl.google.com/dl/edgedl/chromeos/recovery/chromeos_15509.81.0_bob_recovery_stable-channel_mp-v2.bin.zip
+    'elm',  # probably 64bit soon. current: https://dl.google.com/dl/edgedl/chromeos/recovery/chromeos_15886.44.0_elm_recovery_stable-channel_mp-v6.bin.zip
+    'hana',  # probably 64bit soon. current: https://dl.google.com/dl/edgedl/chromeos/recovery/chromeos_15964.59.0_hana_recovery_stable-channel_mp-v11.bin.zip
+    'kevin',  # no longer updated, still latest wv. last: https://dl.google.com/dl/edgedl/chromeos/recovery/chromeos_15509.81.0_kevin_recovery_stable-channel_mp-v2.bin.zip
+    'scarlet',  # no longer updated, still latest wv. last: https://dl.google.com/dl/edgedl/chromeos/recovery/chromeos_15509.81.0_scarlet_recovery_stable-channel_mp-v8.bin.zip
 ]
 
 CHROMEOS_RECOVERY_ARM64_BNAMES = [
+    'asurada',
+    'cherry',
     'corsola',
+    'jacuzzi',
+    'kukui',
+    'strongbad',
     'trogdor',
 ]
 

--- a/script.module.inputstreamhelper/lib/inputstreamhelper/kodiutils.py
+++ b/script.module.inputstreamhelper/lib/inputstreamhelper/kodiutils.py
@@ -2,7 +2,6 @@
 # MIT License (see LICENSE.txt or https://opensource.org/licenses/MIT)
 """Implements Kodi Helper functions"""
 
-from __future__ import absolute_import, division, unicode_literals
 from contextlib import contextmanager
 import xbmc
 import xbmcaddon
@@ -11,7 +10,6 @@ from xbmcgui import DialogProgress, DialogProgressBG
 try:  # Kodi v19 or newer
     from xbmcvfs import translatePath
 except ImportError:  # Kodi v18 and older
-    # pylint: disable=ungrouped-imports
     from xbmc import translatePath
 
 from .unicodes import from_unicode, to_unicode
@@ -105,7 +103,7 @@ def addon_version(addon_name=None):
     return get_addon_info('version', addon)
 
 
-def browsesingle(type, heading, shares='', mask='', useThumbs=False, treatAsFolder=False, defaultt=None):  # pylint: disable=invalid-name,redefined-builtin
+def browsesingle(type, heading, shares='', mask='', useThumbs=False, treatAsFolder=False, defaultt=None):  # pylint: disable=invalid-name,redefined-builtin,too-many-positional-arguments
     """Show a Kodi browseSingle dialog"""
     from xbmcgui import Dialog
     if not heading:
@@ -184,6 +182,7 @@ def get_setting_bool(key, default=None):
     try:
         return ADDON.getSettingBool(key)
     except (AttributeError, TypeError):  # On Krypton or older, or when not a boolean
+        log(3, 'get setting bool')
         value = get_setting(key, default)
         if value not in ('false', 'true'):
             return default

--- a/script.module.inputstreamhelper/lib/inputstreamhelper/unicodes.py
+++ b/script.module.inputstreamhelper/lib/inputstreamhelper/unicodes.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 # MIT License (see LICENSE.txt or https://opensource.org/licenses/MIT)
 """Implements Unicode Helper functions"""
-from __future__ import absolute_import, division, unicode_literals
 
 
 def to_unicode(text, encoding='utf-8', errors='strict'):

--- a/script.module.inputstreamhelper/lib/inputstreamhelper/unsquash.py
+++ b/script.module.inputstreamhelper/lib/inputstreamhelper/unsquash.py
@@ -26,7 +26,7 @@ from math import log2, ceil
 from .kodiutils import log
 
 
-class ZstdDecompressor: # pylint: disable=too-few-public-methods
+class ZstdDecompressor:  # pylint: disable=too-few-public-methods
     """
     zstdandard decompressor class
 
@@ -39,7 +39,7 @@ class ZstdDecompressor: # pylint: disable=too-few-public-methods
         self.zstddecomp.argtypes = (c_void_p, c_size_t, c_void_p, c_size_t)
         self.iserror = libzstd.ZSTD_isError
 
-    def decompress(self, comp_data, comp_size, outsize=8*2**10):
+    def decompress(self, comp_data, comp_size, outsize=8 * 2 ** 10):
         """main function, decompresses binary string <src>"""
         if len(comp_data) != comp_size:
             raise IOError("Decompression failed! Length of compressed data doesn't match given size.")
@@ -167,6 +167,7 @@ class FragmentBlockEntry:
     start_block: int
     size: int
     unused: int  # This field has no meaning
+
 
 class SquashFs:
     """
@@ -353,7 +354,7 @@ class SquashFs:
             header = self._directory_header(data)
             data = data[12:]
 
-            for _ in range(header.count+1):
+            for _ in range(header.count + 1):
                 dentry = self._directory_entry(data)
                 if dentry.name == bname:
                     log(0, f"found {bname} in dentry {dentry} after dir header {header}")

--- a/script.module.inputstreamhelper/lib/inputstreamhelper/utils.py
+++ b/script.module.inputstreamhelper/lib/inputstreamhelper/utils.py
@@ -2,8 +2,6 @@
 # MIT License (see LICENSE.txt or https://opensource.org/licenses/MIT)
 """Implements various Helper functions"""
 
-from __future__ import absolute_import, division, unicode_literals
-
 import os
 import re
 import struct
@@ -11,7 +9,6 @@ from functools import total_ordering
 from socket import timeout
 from ssl import SSLError
 from time import time
-from typing import NamedTuple
 from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
 
@@ -23,33 +20,36 @@ from .unicodes import compat_path, from_unicode, to_unicode
 
 
 @total_ordering
-class Version(NamedTuple):
-    """Minimal version class used for parse_version. Should be enough for our purpose."""
-    major: int = 0
-    minor: int = 0
-    micro: int = 0
-    nano: int = 0
+class Version:
+    """Implements Version"""
+    def __init__(self, *components):
+        self.components = list(components)
 
     def __str__(self):
-        return f"{self.major}.{self.minor}.{self.micro}.{self.nano}"
+        return '.'.join(map(str, self.components))
 
     def __lt__(self, other):
-        if self.major != other.major:
-            return self.major < other.major
-        if self.minor != other.minor:
-            return self.minor < other.minor
-        if self.micro != other.micro:
-            return self.micro < other.micro
+        # extended comparison that accounts for different lengths by padding with zeros
+        max_length = max(len(self.components), len(other.components))
+        # extend both lists with zeros up to the maximum length
+        extended_self = self.components + [0] * (max_length - len(self.components))
+        extended_other = other.components + [0] * (max_length - len(other.components))
 
-        return self.nano < other.nano
+        for self_comp, other_comp in zip(extended_self, extended_other):
+            if self_comp < other_comp:
+                return True
+            if self_comp > other_comp:
+                return False
+        return False  # return False if all comparisons are equal
 
     def __eq__(self, other):
-        return all((self.major == other.major, self.minor == other.minor, self.micro == other.micro, self.nano == other.nano))
+        # Uses the same logic for equality
+        return not self < other and not other < self
 
 
 def temp_path():
     """Return temporary path, usually ~/.kodi/userdata/addon_data/script.module.inputstreamhelper/temp/"""
-    tmp_path = translate_path(os.path.join(get_setting('temp_path', 'special://masterprofile/addon_data/script.module.inputstreamhelper'), 'temp', ''))
+    tmp_path = translate_path(os.path.join(get_setting('temp_path', 'special://masterprofile/addon_data/script.module.inputstreamhelper'), 'temp'))
     if not exists(tmp_path):
         mkdirs(tmp_path)
 
@@ -73,26 +73,26 @@ def download_path(url):
     return os.path.join(temp_path(), filename)
 
 
-def _http_request(url, headers=None, time_out=10):
-    """Perform an HTTP request and return request"""
+def _http_request(url, data=None, headers=None, time_out=10):
+    """Perform an HTTP request and return response"""
     log(0, 'Request URL: {url}', url=url)
 
     try:
+        request = Request(url)
         if headers:
-            request = Request(url, headers=headers)
-        else:
-            request = Request(url)
-        req = urlopen(request, timeout=time_out)
-        log(0, 'Response code: {code}', code=req.getcode())
-        if 400 <= req.getcode() < 600:
-            raise HTTPError('HTTP {} Error for url: {}'.format(req.getcode(), url), response=req)
+            request.headers = headers
+        if data:
+            request.data = data
+        response = urlopen(request, timeout=time_out)  # pylint: disable=consider-using-with
+        log(0, 'Response code: {code}', code=response.getcode())
+        if 400 <= response.getcode() < 600:
+            raise HTTPError
     except (HTTPError, URLError) as err:
         log(2, 'Download failed with error {}'.format(err))
         if yesno_dialog(localize(30004), '{line1}\n{line2}'.format(line1=localize(30063), line2=localize(30065))):  # Internet down, try again?
             return _http_request(url, headers, time_out)
         return None
-
-    return req
+    return response
 
 
 def http_get(url):
@@ -112,13 +112,25 @@ def http_head(url):
     req = Request(url)
     req.get_method = lambda: 'HEAD'
     try:
-        resp = urlopen(req)
-        return resp.getcode()
+        with urlopen(req) as response:
+            return response.getcode()
     except HTTPError as exc:
         return exc.getcode()
 
 
-def http_download(url, message=None, checksum=None, hash_alg='sha1', dl_size=None, background=False):  # pylint: disable=too-many-statements
+def http_post(url, data, headers):
+    """Perform an HTTP POST request and return content"""
+    resp = _http_request(url, data, headers)
+    if resp is None:
+        return None
+
+    content = resp.read()
+    # NOTE: Do not log reponse (as could be large)
+    # log(0, 'Response: {response}', response=content)
+    return content.decode("utf-8")
+
+
+def http_download(url, message=None, checksum=None, hash_alg='sha1', dl_size=None, background=False):  # pylint: disable=too-many-positional-arguments, too-many-statements
     """Makes HTTP request and displays a progress dialog on download."""
     if checksum:
         from hashlib import md5, sha1
@@ -218,11 +230,19 @@ def unzip(source, destination, file_to_unzip=None, result=[]):  # pylint: disabl
     if not exists(destination):
         mkdirs(destination)
 
+    from shutil import copyfileobj
     from zipfile import ZipFile
     with ZipFile(compat_path(source)) as zip_obj:
         for filename in zip_obj.namelist():
-            if file_to_unzip and filename != file_to_unzip:
-                continue
+            if file_to_unzip:
+                # normalize to list
+                if isinstance(file_to_unzip, str):
+                    files = [file_to_unzip]
+                else:
+                    files = list(file_to_unzip)
+
+                if os.path.basename(filename) not in files:
+                    continue
 
             # Detect and remove (dangling) symlinks before extraction
             fullname = os.path.join(destination, filename)
@@ -230,7 +250,11 @@ def unzip(source, destination, file_to_unzip=None, result=[]):  # pylint: disabl
                 log(3, 'Remove (dangling) symlink at {symlink}', symlink=fullname)
                 delete(fullname)
 
-            zip_obj.extract(filename, compat_path(destination))
+            source = zip_obj.open(filename)
+            target = open(os.path.join(compat_path(destination), os.path.basename(filename)), 'wb')
+            with source, target:
+                copyfileobj(source, target)
+
             result.append(True)  # Pass by reference for Thread
 
     return bool(result)
@@ -245,6 +269,8 @@ def system_os():
     from xbmc import getCondVisibility
     if getCondVisibility('system.platform.android'):
         sys_name = 'Android'
+    elif getCondVisibility('system.platform.webos'):
+        sys_name = 'webOS'
     else:
         from platform import system
         sys_name = system()
@@ -373,8 +399,5 @@ def parse_version(vstring):
             vnums.append(int(numeric_part.group()))
         else:
             vnums.append(0)  # default to 0 if no numeric part found
-
-    # ensure the version tuple always has 4 components
-    vnums = (vnums + [0] * 4)[:4]
 
     return Version(*vnums)

--- a/script.module.inputstreamhelper/lib/inputstreamhelper/widevine/arm.py
+++ b/script.module.inputstreamhelper/lib/inputstreamhelper/widevine/arm.py
@@ -2,7 +2,6 @@
 # MIT License (see LICENSE.txt or https://opensource.org/licenses/MIT)
 """Implements ARM specific widevine functions"""
 
-from __future__ import absolute_import, division, unicode_literals
 import os
 import json
 
@@ -100,7 +99,7 @@ def install_widevine_arm_chromeos(backup_path):
         extracted = dl_extract_widevine_chromeos(url, backup_path, arm_device)
         if extracted:
             recovery_file = os.path.join(backup_path, arm_device['version'], os.path.basename(config.CHROMEOS_RECOVERY_URL))
-            with open_file(recovery_file, 'w') as reco_file:  # pylint: disable=unspecified-encoding
+            with open_file(recovery_file, 'w') as reco_file:
                 reco_file.write(json.dumps(devices, indent=4))
 
             return extracted
@@ -112,7 +111,7 @@ def dl_extract_widevine_chromeos(url, backup_path, arm_device=None):
     """Download the ChromeOS image and extract Widevine from it"""
     if arm_device:
         dl_path = http_download(url, message=localize(30022), checksum=arm_device['sha1'], hash_alg='sha1',
-                                   dl_size=int(arm_device['zipfilesize']))  # Downloading the recovery image
+                                dl_size=int(arm_device['zipfilesize']))  # Downloading the recovery image
         image_version = arm_device['version']
     else:
         dl_path = http_download(url, message=localize(30022))

--- a/script.module.inputstreamhelper/lib/inputstreamhelper/widevine/arm_chromeos.py
+++ b/script.module.inputstreamhelper/lib/inputstreamhelper/widevine/arm_chromeos.py
@@ -2,7 +2,6 @@
 # MIT License (see LICENSE.txt or https://opensource.org/licenses/MIT)
 """Implements a class with methods related to the Chrome OS image"""
 
-from __future__ import absolute_import, division, unicode_literals
 import os
 from struct import calcsize, unpack
 from zipfile import ZipFile

--- a/script.module.inputstreamhelper/lib/inputstreamhelper/widevine/arm_lacros.py
+++ b/script.module.inputstreamhelper/lib/inputstreamhelper/widevine/arm_lacros.py
@@ -46,7 +46,6 @@ def extract_widevine_lacros(dl_path, backup_path, img_version):
         log(4, err)
         return False
 
-
     with open_file(os.path.join(bpath, config.WIDEVINE_MANIFEST_FILE), "r") as manifest_file:
         manifest_json = json.load(manifest_file)
 

--- a/script.module.inputstreamhelper/lib/inputstreamhelper/widevine/widevine.py
+++ b/script.module.inputstreamhelper/lib/inputstreamhelper/widevine/widevine.py
@@ -2,8 +2,6 @@
 # MIT License (see LICENSE.txt or https://opensource.org/licenses/MIT)
 """Implements generic widevine functions used across architectures"""
 
-from __future__ import absolute_import, division, unicode_literals
-
 import os
 from time import time
 
@@ -35,17 +33,16 @@ def install_cdm_from_backup(version):
 def widevine_eula():
     """Displays the Widevine EULA and prompts user to accept it."""
     if cdm_from_repo():
-        cdm_version = latest_widevine_available_from_repo().get('version')
         cdm_os = config.WIDEVINE_OS_MAP[system_os()]
         cdm_arch = config.WIDEVINE_ARCH_MAP_REPO[arch()]
     else:  # Grab the license from the x86 files
         log(0, 'Acquiring Widevine EULA from x86 files.')
-        cdm_version = '4.10.2830.0' # fine to hardcode as it's only used for the EULA
         cdm_os = 'mac'
         cdm_arch = 'x64'
 
-    url = config.WIDEVINE_DOWNLOAD_URL.format(version=cdm_version, os=cdm_os, arch=cdm_arch)
-    dl_path = http_download(url, message=localize(30025), background=True)  # Acquiring EULA
+    cdm = latest_widevine_available_from_repo(cdm_os, cdm_arch)
+
+    dl_path = http_download(cdm.get('url'), message=localize(30025), background=True)  # Acquiring EULA
     if not dl_path:
         return False
 
@@ -96,10 +93,11 @@ def widevinecdm_path():
 
 def has_widevinecdm():
     """Whether a Widevine CDM is installed on the system"""
-    if system_os() == 'Android':  # Widevine CDM is built into Android
+    if system_os() == 'Android' or system_os() == 'webOS':  # Widevine CDM is built into Android and webOS
         return True
 
     widevinecdm = widevinecdm_path()
+    log(3, widevinecdm)
     if widevinecdm is None:
         return False
     if not exists(widevinecdm):
@@ -162,7 +160,7 @@ def missing_widevine_libs():
 def latest_widevine_version():
     """Returns the latest available version of Widevine CDM/Chrome OS/Lacros Image."""
     if cdm_from_repo():
-        return latest_widevine_available_from_repo().get('version')
+        return latest_widevine_available_from_repo(config.WIDEVINE_OS_MAP[system_os()], config.WIDEVINE_ARCH_MAP_REPO[arch()]).get('version')
 
     if cdm_from_lacros():
         return latest_lacros()

--- a/script.module.inputstreamhelper/resources/language/resource.language.en_gb/strings.po
+++ b/script.module.inputstreamhelper/resources/language/resource.language.en_gb/strings.po
@@ -323,6 +323,10 @@ msgctxt "#30825"
 msgid "It was extracted from {image} image version [B]{version}[/B]"
 msgstr ""
 
+msgctxt "#30826"
+msgid "[B]Widevine CDM[/B] is [B]built into webOS[/B]"
+msgstr ""
+
 msgctxt "#30830"
 msgid "Please report issues to: [COLOR yellow]{url}[/COLOR]"
 msgstr ""

--- a/script.module.inputstreamhelper/resources/settings.xml
+++ b/script.module.inputstreamhelper/resources/settings.xml
@@ -8,18 +8,18 @@
         <setting label="30901" help="30902" type="action" action="RunScript(script.module.inputstreamhelper, info)"/>
         <setting type="sep"/>
         <setting label="30903" help="30904" type="bool" id="disabled" default="false" visible="false"/>
-        <setting label="30905" help="30906" type="slider" id="update_frequency" default="31" range="1,3,90" option="int" enable="eq(-1,false)" visible="![System.Platform.Android | String.StartsWith(System.BuildVersion, 17)]"/>
-        <setting label="30907" help="30908" type="folder" id="temp_path" source="" option="writeable" default="special://masterprofile/addon_data/script.module.inputstreamhelper" visible="![System.Platform.Android | String.StartsWith(System.BuildVersion, 17)]"/>
-        <setting label="30913" help="30914" type="slider" id="backups" default="4" range="0,1,20" option="int" visible="![System.Platform.Android | String.StartsWith(System.BuildVersion, 17)]"/>
-        <setting type="sep" visible="![System.Platform.Android | String.StartsWith(System.BuildVersion, 17)]"/>
-        <setting label="30909" help="30910" type="action" action="RunScript(script.module.inputstreamhelper, widevine_install, True)" enable="String.StartsWith(System.BuildVersion,18) + System.HasAddon(inputstream.adaptive) | System.AddonIsEnabled(inputstream.adaptive)" visible="![System.Platform.Android | String.StartsWith(System.BuildVersion, 17)]"/>
-        <setting label="30911" help="30912" type="action" action="RunScript(script.module.inputstreamhelper, widevine_remove)" enable="String.StartsWith(System.BuildVersion,18) + System.HasAddon(inputstream.adaptive) | System.AddonIsEnabled(inputstream.adaptive)" visible="![System.Platform.Android | String.StartsWith(System.BuildVersion, 17)]"/>
-        <setting label="30915" help="30916" type="action" action="RunScript(script.module.inputstreamhelper, rollback)" enable="String.StartsWith(System.BuildVersion,18) + System.HasAddon(inputstream.adaptive) | System.AddonIsEnabled(inputstream.adaptive)" visible="![System.Platform.Android | String.StartsWith(System.BuildVersion, 17)]"/>
+        <setting label="30905" help="30906" type="slider" id="update_frequency" default="31" range="1,3,90" option="int" enable="eq(-1,false)" visible="![System.Platform.Android | System.Platform.webOS | String.StartsWith(System.BuildVersion, 17)]"/>
+        <setting label="30907" help="30908" type="folder" id="temp_path" source="" option="writeable" default="special://masterprofile/addon_data/script.module.inputstreamhelper" visible="![System.Platform.Android | System.Platform.webOS | String.StartsWith(System.BuildVersion, 17)]"/>
+        <setting label="30913" help="30914" type="slider" id="backups" default="4" range="0,1,20" option="int" visible="![System.Platform.Android | System.Platform.webOS | String.StartsWith(System.BuildVersion, 17)]"/>
+        <setting type="sep" visible="![System.Platform.Android | System.Platform.webOS | String.StartsWith(System.BuildVersion, 17)]"/>
+        <setting label="30909" help="30910" type="action" action="RunScript(script.module.inputstreamhelper, widevine_install, True)" enable="String.StartsWith(System.BuildVersion,18) + System.HasAddon(inputstream.adaptive) | System.AddonIsEnabled(inputstream.adaptive)" visible="![System.Platform.Android | System.Platform.webOS | String.StartsWith(System.BuildVersion, 17)]"/>
+        <setting label="30911" help="30912" type="action" action="RunScript(script.module.inputstreamhelper, widevine_remove)" enable="String.StartsWith(System.BuildVersion,18) + System.HasAddon(inputstream.adaptive) | System.AddonIsEnabled(inputstream.adaptive)" visible="![System.Platform.Android | System.Platform.webOS | String.StartsWith(System.BuildVersion, 17)]"/>
+        <setting label="30915" help="30916" type="action" action="RunScript(script.module.inputstreamhelper, rollback)" enable="String.StartsWith(System.BuildVersion,18) + System.HasAddon(inputstream.adaptive) | System.AddonIsEnabled(inputstream.adaptive)" visible="![System.Platform.Android | System.Platform.webOS | String.StartsWith(System.BuildVersion, 17)]"/>
     </category>
     <category label="30950"> <!-- Debug -->
         <setting label="30903" help="30904" type="bool" id="disabled" default="false"/>
         <setting label="30904" type="text" enable="false"/> <!-- disabled_warning -->
-        <setting label="30955" help="30956" type="action" action="RunScript(script.module.inputstreamhelper, widevine_install_from)" enable="String.StartsWith(System.BuildVersion,18) + System.HasAddon(inputstream.adaptive) | System.AddonIsEnabled(inputstream.adaptive)" visible="![System.Platform.Android | String.StartsWith(System.BuildVersion, 17)]"/>
+        <setting label="30955" help="30956" type="action" action="RunScript(script.module.inputstreamhelper, widevine_install_from)" enable="String.StartsWith(System.BuildVersion,18) + System.HasAddon(inputstream.adaptive) | System.AddonIsEnabled(inputstream.adaptive)" visible="![System.Platform.Android | System.Platform.webOS | String.StartsWith(System.BuildVersion, 17)]"/>
         <setting label="30953" help="30954" type="text" id="image_url" subsetting="true" option="urlencoded" default="https://dl.google.com/dl/edgedl/chromeos/recovery/chromeos_14092.77.0_veyron-fievel_recovery_stable-channel_fievel-mp.bin.zip"/>
     </category>
 </settings>


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: InputStream Helper
  - Add-on ID: script.module.inputstreamhelper
  - Version number: 0.8.0
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/emilsvennesson/script.module.inputstreamhelper
  
A simple Kodi module that makes life easier for add-on developers relying on InputStream based add-ons and DRM playback.

### Description of changes:


v0.8.0 (2025-09-19)
- Fix Widevine CDM installation on Windows, Linux and Macintosh
- Add support for LG webOS

v0.7.0 (2024-09-24)
- Get rid of distutils dependency
- Option to get Widevine from lacros image
- Remove support for Python 2 and pre-Matrix Kodi versions

v0.6.1 (2023-05-30)
- Performance improvements on Linux ARM
- This will be the last release for Python 2 i.e. Kodi 18 (Leia) and below. The next release will require Python 3 and Kodi 19 (Matrix) or higher.

v0.6.0 (2023-05-03)
- Initial support for AARCH64 Linux
- Initial support for AARCH64 Macs
- New option to install a specific version on most platforms

v0.5.10 (2022-04-18)
- Fix automatic submission of release
- Update German translation
- Fix update_frequency setting
- Fix install_from
- Improve/Fix Widevine extraction from Chrome OS images

v0.5.9 (2022-03-22)
- Update Croatian translation
- Replace deprecated LooseVersion
- Fix http_get decode error
- Option to install Widevine from specified source
    

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
