### PR TITLE
[script.module.inputstreamhelper@matrix] 0.8.1

### DIFF
--- a/script.module.inputstreamhelper/README.md
+++ b/script.module.inputstreamhelper/README.md
@@ -90,6 +90,9 @@ Please report any issues or bug reports on the [GitHub Issues](https://github.co
 This module is licensed under the **The MIT License**. Please see the [LICENSE.txt](LICENSE.txt) file for details.
 
 ## Releases
+### v0.8.1 (2025-09-22)
+- Fix Widevine CDM installation on ARM hardware (@mediaminister)
+
 ### v0.8.0 (2025-09-19)
 - Fix Widevine CDM installation on Windows, Linux and Macintosh (@mediaminister)
 - Add support for LG webOS (@Uukrull)

--- a/script.module.inputstreamhelper/addon.xml
+++ b/script.module.inputstreamhelper/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.module.inputstreamhelper" name="InputStream Helper" version="0.8.0" provider-name="emilsvennesson, dagwieers, mediaminister, horstle">
+<addon id="script.module.inputstreamhelper" name="InputStream Helper" version="0.8.1" provider-name="emilsvennesson, dagwieers, mediaminister, horstle">
   <requires>
     <!--py3 compliant-->
     <import addon="xbmc.python" version="3.0.0"/>
@@ -25,6 +25,9 @@
     <description lang="hr_HR">Jednostavan Kodi modul koji olakšava razvijanje dodataka koji se temelje na InputStream dodatku i reprodukciji DRM zaštićenog sadržaja.</description>
     <description lang="ru_RU">Простой модуль для Kodi, который облегчает жизнь разработчикам дополнений, с использованием InputStream дополнений и воспроизведения DRM контента.</description>
     <news>
+v0.8.1 (2025-09-22)
+- Fix Widevine CDM installation on ARM hardware
+
 v0.8.0 (2025-09-19)
 - Fix Widevine CDM installation on Windows, Linux and Macintosh
 - Add support for LG webOS

--- a/script.module.inputstreamhelper/lib/inputstreamhelper/__init__.py
+++ b/script.module.inputstreamhelper/lib/inputstreamhelper/__init__.py
@@ -141,7 +141,7 @@ class Helper:
             ok_dialog(localize(30004), localize(30007, arch=arch()))  # Widevine not available on this architecture
             return False
 
-        if arch() == 'arm64' and system_os() not in ['Android', 'Darwin'] and userspace64():
+        if arch() == 'arm64' and system_os() not in ['Android', 'Darwin', 'Windows'] and userspace64():
             is_version = parse_version(addon_version(self.inputstream_addon))
             try:
                 compat_version = parse_version(config.MINIMUM_INPUTSTREAM_VERSION_ARM64[self.inputstream_addon])
@@ -270,11 +270,12 @@ class Helper:
         """Removes Widevine CDM"""
         if has_widevinecdm():
             widevinecdm = widevinecdm_path()
-            log(0, 'Removed Widevine CDM at {path}', path=widevinecdm)
-            delete(widevinecdm)
-            notification(localize(30037), localize(30052))  # Success! Widevine successfully removed.
-            set_setting('last_modified', '0.0')
-            return True
+            if widevinecdm:
+                log(0, 'Removed Widevine CDM at {path}', path=widevinecdm)
+                delete(widevinecdm)
+                notification(localize(30037), localize(30052))  # Success! Widevine successfully removed.
+                set_setting('last_modified', '0.0')
+                return True
         notification(localize(30004), localize(30053))  # Error. Widevine CDM not found.
         return False
 
@@ -361,7 +362,13 @@ class Helper:
 
         if cdm_from_repo():  # check that widevine arch matches system arch
             wv_config = load_widevine_config()
-            if config.WIDEVINE_ARCH_MAP_REPO[arch()] != wv_config['platforms'][0]['arch']:
+            if wv_config.get('accept_arch'):
+                wv_config_arch = wv_config.get('accept_arch')[0]
+            elif wv_config.get('platforms'):
+                wv_config_arch = wv_config.get('platforms')[0].get('arch')
+            else:
+                wv_config_arch = wv_config.get('arch')
+            if config.WIDEVINE_ARCH_MAP_REPO[arch()] != wv_config_arch:
                 log(4, 'Widevine/system arch mismatch. Reinstall is required.')
                 ok_dialog(localize(30001), localize(30031))  # An update of Widevine is required
                 return self.install_widevine()

--- a/script.module.inputstreamhelper/lib/inputstreamhelper/config.py
+++ b/script.module.inputstreamhelper/lib/inputstreamhelper/config.py
@@ -26,6 +26,7 @@ WIDEVINE_CDM_FILENAME = {
 ARCH_MAP = {
     'aarch64': 'arm64',
     'aarch64_be': 'arm64',
+    'ARM64': 'arm64',
     'AMD64': 'x86_64',
     'armv7': 'arm',
     'armv8': 'arm',
@@ -85,12 +86,11 @@ CHROMEOS_RECOVERY_URL = 'https://dl.google.com/dl/edgedl/chromeos/recovery/recov
 # To keep the Chrome OS ARM(64) hardware ID list up to date, the following resources can be used:
 # https://www.chromium.org/chromium-os/developer-information-for-chrome-os-devices
 # https://chromiumdash.appspot.com/serving-builds?deviceCategory=Chrome%20OS
-# Last updated: 2024-10-13
-# current Chrome OS version: 16002.44.0, Widevine version: 4.10.2662.3
+# Last updated: 2025-09-21
+# current Chrome OS version: 16328.65.0, Widevine version: 4.10.2662.3
 CHROMEOS_RECOVERY_ARM_BNAMES = [
     'bob',  # no longer updated, still latest wv. last: https://dl.google.com/dl/edgedl/chromeos/recovery/chromeos_15509.81.0_bob_recovery_stable-channel_mp-v2.bin.zip
     'elm',  # probably 64bit soon. current: https://dl.google.com/dl/edgedl/chromeos/recovery/chromeos_15886.44.0_elm_recovery_stable-channel_mp-v6.bin.zip
-    'hana',  # probably 64bit soon. current: https://dl.google.com/dl/edgedl/chromeos/recovery/chromeos_15964.59.0_hana_recovery_stable-channel_mp-v11.bin.zip
     'kevin',  # no longer updated, still latest wv. last: https://dl.google.com/dl/edgedl/chromeos/recovery/chromeos_15509.81.0_kevin_recovery_stable-channel_mp-v2.bin.zip
     'scarlet',  # no longer updated, still latest wv. last: https://dl.google.com/dl/edgedl/chromeos/recovery/chromeos_15509.81.0_scarlet_recovery_stable-channel_mp-v8.bin.zip
 ]
@@ -99,8 +99,11 @@ CHROMEOS_RECOVERY_ARM64_BNAMES = [
     'asurada',
     'cherry',
     'corsola',
+    'geralt',
+    'hana',
     'jacuzzi',
     'kukui',
+    'staryu',
     'strongbad',
     'trogdor',
 ]

--- a/script.module.inputstreamhelper/lib/inputstreamhelper/utils.py
+++ b/script.module.inputstreamhelper/lib/inputstreamhelper/utils.py
@@ -366,6 +366,18 @@ def userspace64():
     return struct.calcsize('P') * 8 == 64
 
 
+def elfbinary64(path):
+    """To check if an ELF binary is 64bit or 32bit"""
+    with open(path, 'rb') as f:
+        f.seek(4)          # skip 0x7F 'E' 'L' 'F'
+        b = f.read(1)
+        if b == b'\x01':
+            return False
+        if b == b'\x02':
+            return True
+        raise ValueError('Not a valid ELF class')
+
+
 def hardlink(src, dest):
     """Hardlink a file when possible, copy when needed"""
     if exists(dest):


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: InputStream Helper
  - Add-on ID: script.module.inputstreamhelper
  - Version number: 0.8.1
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/emilsvennesson/script.module.inputstreamhelper
  
A simple Kodi module that makes life easier for add-on developers relying on InputStream based add-ons and DRM playback.

### Description of changes:


v0.8.1 (2025-09-22)
- Fix Widevine CDM installation on ARM hardware

v0.8.0 (2025-09-19)
- Fix Widevine CDM installation on Windows, Linux and Macintosh
- Add support for LG webOS

v0.7.0 (2024-09-24)
- Get rid of distutils dependency
- Option to get Widevine from lacros image
- Remove support for Python 2 and pre-Matrix Kodi versions

v0.6.1 (2023-05-30)
- Performance improvements on Linux ARM
- This will be the last release for Python 2 i.e. Kodi 18 (Leia) and below. The next release will require Python 3 and Kodi 19 (Matrix) or higher.

v0.6.0 (2023-05-03)
- Initial support for AARCH64 Linux
- Initial support for AARCH64 Macs
- New option to install a specific version on most platforms

v0.5.10 (2022-04-18)
- Fix automatic submission of release
- Update German translation
- Fix update_frequency setting
- Fix install_from
- Improve/Fix Widevine extraction from Chrome OS images

v0.5.9 (2022-03-22)
- Update Croatian translation
- Replace deprecated LooseVersion
- Fix http_get decode error
- Option to install Widevine from specified source
    

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
