### PR TITLE
[script.module.inputstreamhelper@matrix] 0.8.2

### DIFF
--- a/script.module.inputstreamhelper/README.md
+++ b/script.module.inputstreamhelper/README.md
@@ -90,6 +90,9 @@ Please report any issues or bug reports on the [GitHub Issues](https://github.co
 This module is licensed under the **The MIT License**. Please see the [LICENSE.txt](LICENSE.txt) file for details.
 
 ## Releases
+### v0.8.2 (2025-09-25)
+- Fix Widevine CDM installation on 32-bit Windows (@mediaminister)
+
 ### v0.8.1 (2025-09-22)
 - Fix Widevine CDM installation on ARM hardware (@mediaminister)
 

--- a/script.module.inputstreamhelper/addon.xml
+++ b/script.module.inputstreamhelper/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.module.inputstreamhelper" name="InputStream Helper" version="0.8.1" provider-name="emilsvennesson, dagwieers, mediaminister, horstle">
+<addon id="script.module.inputstreamhelper" name="InputStream Helper" version="0.8.2" provider-name="emilsvennesson, dagwieers, mediaminister, horstle">
   <requires>
     <!--py3 compliant-->
     <import addon="xbmc.python" version="3.0.0"/>
@@ -17,6 +17,7 @@
     <summary lang="es_ES">Kodi InputStream y reproducción DRM echa fácil</summary>
     <summary lang="fr_FR">La lecture Kodi InputStream et DRM en toute simplicité</summary>
     <summary lang="hr_HR">Kodi InputStream olakšava reprodukciju DRM zaštićenog sadržaja</summary>
+    <summary lang="sv_SE">Kodi InputStream och DRM-uppspelning på ett enkelt sätt</summary>
     <description lang="de_DE">Dieses einfache Kodi-Modul macht das Leben für Addon Entwickler einfacher, die auf InputStream basierte Addons und DRM Wiedergabe angewiesen sind.</description>
     <description lang="el_GR">Μία απλή μονάδα για το Kodi η οποία διευκολύνει την ζωή των προγραμματιστών οι οποίοι εξαρτώνται από τα πρόσθετσ InputStream και αναπαραγωγή τύπου DRM.</description>
     <description lang="en_GB">A simple Kodi module that makes life easier for add-on developers relying on InputStream based add-ons and DRM playback.</description>
@@ -24,7 +25,11 @@
     <description lang="fr_FR">Un simple module Kodi qui simplifie la vie des développeurs de modules complémentaires en s’appuyant sur des modules complémentaires basés sur InputStream et sur la lecture de DRM.</description>
     <description lang="hr_HR">Jednostavan Kodi modul koji olakšava razvijanje dodataka koji se temelje na InputStream dodatku i reprodukciji DRM zaštićenog sadržaja.</description>
     <description lang="ru_RU">Простой модуль для Kodi, который облегчает жизнь разработчикам дополнений, с использованием InputStream дополнений и воспроизведения DRM контента.</description>
+    <description lang="sv_SE">En enkel Kodi-modul som underlättar livet för tilläggsutvecklare som förlitar sig på InputStream-baserade tillägg och DRM-uppspelning.</description>
     <news>
+v0.8.2 (2025-09-25)
+- Fix Widevine CDM installation on 32-bit Windows
+
 v0.8.1 (2025-09-22)
 - Fix Widevine CDM installation on ARM hardware
 

--- a/script.module.inputstreamhelper/lib/inputstreamhelper/__init__.py
+++ b/script.module.inputstreamhelper/lib/inputstreamhelper/__init__.py
@@ -363,12 +363,12 @@ class Helper:
         if cdm_from_repo():  # check that widevine arch matches system arch
             wv_config = load_widevine_config()
             if wv_config.get('accept_arch'):
-                wv_config_arch = wv_config.get('accept_arch')[0]
+                wv_config_arch = wv_config.get('accept_arch')
             elif wv_config.get('platforms'):
                 wv_config_arch = wv_config.get('platforms')[0].get('arch')
             else:
                 wv_config_arch = wv_config.get('arch')
-            if config.WIDEVINE_ARCH_MAP_REPO[arch()] != wv_config_arch:
+            if config.WIDEVINE_ARCH_MAP_REPO[arch()] not in wv_config_arch:
                 log(4, 'Widevine/system arch mismatch. Reinstall is required.')
                 ok_dialog(localize(30001), localize(30031))  # An update of Widevine is required
                 return self.install_widevine()

--- a/script.module.inputstreamhelper/lib/inputstreamhelper/utils.py
+++ b/script.module.inputstreamhelper/lib/inputstreamhelper/utils.py
@@ -395,7 +395,8 @@ def hardlink(src, dest):
 def remove_tree(path):
     """Remove an entire directory tree"""
     from shutil import rmtree
-    rmtree(compat_path(path))
+    if exists(path):
+        rmtree(compat_path(path))
 
 
 def parse_version(vstring):

--- a/script.module.inputstreamhelper/resources/settings.xml
+++ b/script.module.inputstreamhelper/resources/settings.xml
@@ -1,25 +1,233 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<settings>
-    <category label="30900"> <!-- Expert -->
-        <setting id="last_modified" default="0.0" visible="false"/>
-        <setting id="last_check" default="0.0" visible="false"/>
-        <setting id="update_declined_at" default="0.0" visible="false"/>
-        <setting id="version" default="" visible="false"/>
-        <setting label="30901" help="30902" type="action" action="RunScript(script.module.inputstreamhelper, info)"/>
-        <setting type="sep"/>
-        <setting label="30903" help="30904" type="bool" id="disabled" default="false" visible="false"/>
-        <setting label="30905" help="30906" type="slider" id="update_frequency" default="31" range="1,3,90" option="int" enable="eq(-1,false)" visible="![System.Platform.Android | System.Platform.webOS | String.StartsWith(System.BuildVersion, 17)]"/>
-        <setting label="30907" help="30908" type="folder" id="temp_path" source="" option="writeable" default="special://masterprofile/addon_data/script.module.inputstreamhelper" visible="![System.Platform.Android | System.Platform.webOS | String.StartsWith(System.BuildVersion, 17)]"/>
-        <setting label="30913" help="30914" type="slider" id="backups" default="4" range="0,1,20" option="int" visible="![System.Platform.Android | System.Platform.webOS | String.StartsWith(System.BuildVersion, 17)]"/>
-        <setting type="sep" visible="![System.Platform.Android | System.Platform.webOS | String.StartsWith(System.BuildVersion, 17)]"/>
-        <setting label="30909" help="30910" type="action" action="RunScript(script.module.inputstreamhelper, widevine_install, True)" enable="String.StartsWith(System.BuildVersion,18) + System.HasAddon(inputstream.adaptive) | System.AddonIsEnabled(inputstream.adaptive)" visible="![System.Platform.Android | System.Platform.webOS | String.StartsWith(System.BuildVersion, 17)]"/>
-        <setting label="30911" help="30912" type="action" action="RunScript(script.module.inputstreamhelper, widevine_remove)" enable="String.StartsWith(System.BuildVersion,18) + System.HasAddon(inputstream.adaptive) | System.AddonIsEnabled(inputstream.adaptive)" visible="![System.Platform.Android | System.Platform.webOS | String.StartsWith(System.BuildVersion, 17)]"/>
-        <setting label="30915" help="30916" type="action" action="RunScript(script.module.inputstreamhelper, rollback)" enable="String.StartsWith(System.BuildVersion,18) + System.HasAddon(inputstream.adaptive) | System.AddonIsEnabled(inputstream.adaptive)" visible="![System.Platform.Android | System.Platform.webOS | String.StartsWith(System.BuildVersion, 17)]"/>
-    </category>
-    <category label="30950"> <!-- Debug -->
-        <setting label="30903" help="30904" type="bool" id="disabled" default="false"/>
-        <setting label="30904" type="text" enable="false"/> <!-- disabled_warning -->
-        <setting label="30955" help="30956" type="action" action="RunScript(script.module.inputstreamhelper, widevine_install_from)" enable="String.StartsWith(System.BuildVersion,18) + System.HasAddon(inputstream.adaptive) | System.AddonIsEnabled(inputstream.adaptive)" visible="![System.Platform.Android | System.Platform.webOS | String.StartsWith(System.BuildVersion, 17)]"/>
-        <setting label="30953" help="30954" type="text" id="image_url" subsetting="true" option="urlencoded" default="https://dl.google.com/dl/edgedl/chromeos/recovery/chromeos_14092.77.0_veyron-fievel_recovery_stable-channel_fievel-mp.bin.zip"/>
-    </category>
+<?xml version="1.0" ?>
+<settings version="1">
+	<section id="script.module.inputstreamhelper">
+		<category id="expert" label="30900" help=""> <!-- Expert -->
+			<group id="1">
+				<setting id="last_modified" type="string" help="">
+					<level>0</level>
+					<default>0.0</default>
+					<dependencies>
+						<dependency type="visible">
+							<condition on="property" name="InfoBool">false</condition>
+						</dependency>
+					</dependencies>
+					<control type="edit" format="string">
+						<heading/>
+					</control>
+				</setting>
+				<setting id="last_check" type="string" help="">
+					<level>0</level>
+					<default>0.0</default>
+					<dependencies>
+						<dependency type="visible">
+							<condition on="property" name="InfoBool">false</condition>
+						</dependency>
+					</dependencies>
+					<control type="edit" format="string">
+						<heading/>
+					</control>
+				</setting>
+				<setting id="update_declined_at" type="string" help="">
+					<level>0</level>
+					<default>0.0</default>
+					<dependencies>
+						<dependency type="visible">
+							<condition on="property" name="InfoBool">false</condition>
+						</dependency>
+					</dependencies>
+					<control type="edit" format="string">
+						<heading/>
+					</control>
+				</setting>
+				<setting id="version" type="string" help="">
+					<level>0</level>
+					<default/>
+					<constraints>
+						<allowempty>true</allowempty>
+					</constraints>
+					<dependencies>
+						<dependency type="visible">
+							<condition on="property" name="InfoBool">false</condition>
+						</dependency>
+					</dependencies>
+					<control type="edit" format="string">
+						<heading/>
+					</control>
+				</setting>
+				<setting id="info" type="action" label="30901" help="30902">
+					<level>0</level>
+					<data>RunScript(script.module.inputstreamhelper, info)</data>
+					<constraints>
+						<allowempty>true</allowempty>
+					</constraints>
+					<control type="button" format="action"/>
+				</setting>
+			</group>
+			<group id="2">
+				<setting id="update_frequency" type="integer" label="30905" help="30906">
+					<level>0</level>
+					<default>31</default>
+					<constraints>
+						<minimum>1</minimum>
+						<step>3</step>
+						<maximum>90</maximum>
+					</constraints>
+					<dependencies>
+						<dependency type="enable">
+							<condition operator="is" setting="disabled">false</condition>
+						</dependency>
+						<dependency type="visible">
+    						<condition on="property" name="InfoBool">![System.Platform.Android|System.Platform.webOS|String.StartsWith(System.BuildVersion,17)]</condition>
+						</dependency>
+					</dependencies>
+					<control type="slider" format="integer">
+						<popup>false</popup>
+					</control>
+				</setting>
+				<setting id="temp_path" type="path" label="30907" help="30908">
+					<level>0</level>
+					<default>special://masterprofile/addon_data/script.module.inputstreamhelper</default>
+					<constraints>
+						<sources>
+							<source/>
+						</sources>
+					</constraints>
+					<dependencies>
+						<dependency type="visible">
+    						<condition on="property" name="InfoBool">![System.Platform.Android|System.Platform.webOS|String.StartsWith(System.BuildVersion,17)]</condition>
+						</dependency>
+					</dependencies>
+					<control type="button" format="path">
+						<heading>30907</heading>
+					</control>
+				</setting>
+				<setting id="backups" type="integer" label="30913" help="30914">
+					<level>0</level>
+					<default>4</default>
+					<constraints>
+						<minimum>0</minimum>
+						<step>1</step>
+						<maximum>20</maximum>
+					</constraints>
+					<dependencies>
+						<dependency type="visible">
+    						<condition on="property" name="InfoBool">![System.Platform.Android|System.Platform.webOS|String.StartsWith(System.BuildVersion,17)]</condition>
+						</dependency>
+					</dependencies>
+					<control type="slider" format="integer">
+						<popup>false</popup>
+					</control>
+				</setting>
+			</group>
+			<group id="3">
+				<setting id="widevine_install" type="action" label="30909" help="30910">
+					<level>0</level>
+					<data>RunScript(script.module.inputstreamhelper, widevine_install, True)</data>
+					<constraints>
+						<allowempty>true</allowempty>
+					</constraints>
+					<dependencies>
+						<dependency type="enable">
+							<and>
+								<condition on="property" name="InfoBool">Integer.IsGreaterOrEqual(System.BuildVersionCode,18)</condition>
+								<condition on="property" name="InfoBool">System.HasAddon(inputstream.adaptive)|System.AddonIsEnabled(inputstream.adaptive)</condition>
+							</and>
+						</dependency>
+						<dependency type="visible">
+    						<condition on="property" name="InfoBool">![System.Platform.Android|System.Platform.webOS|String.StartsWith(System.BuildVersion,17)]</condition>
+						</dependency>
+					</dependencies>
+					<control type="button" format="action"/>
+				</setting>
+				<setting id="widevine_remove" type="action" label="30911" help="30912">
+					<level>0</level>
+					<data>RunScript(script.module.inputstreamhelper, widevine_remove)</data>
+					<constraints>
+						<allowempty>true</allowempty>
+					</constraints>
+					<dependencies>
+						<dependency type="enable">
+							<and>
+								<condition on="property" name="InfoBool">Integer.IsGreaterOrEqual(System.BuildVersionCode,18)</condition>
+								<condition on="property" name="InfoBool">System.HasAddon(inputstream.adaptive)|System.AddonIsEnabled(inputstream.adaptive)</condition>
+							</and>
+						</dependency>
+						<dependency type="visible">
+    						<condition on="property" name="InfoBool">![System.Platform.Android|System.Platform.webOS|String.StartsWith(System.BuildVersion,17)]</condition>
+						</dependency>
+					</dependencies>
+					<control type="button" format="action"/>
+				</setting>
+				<setting id="rollback" type="action" label="30915" help="30916">
+					<level>0</level>
+					<data>RunScript(script.module.inputstreamhelper, rollback)</data>
+					<constraints>
+						<allowempty>true</allowempty>
+					</constraints>
+					<dependencies>
+						<dependency type="enable">
+							<and>
+								<condition on="property" name="InfoBool">Integer.IsGreaterOrEqual(System.BuildVersionCode,18)</condition>
+								<condition on="property" name="InfoBool">System.HasAddon(inputstream.adaptive)|System.AddonIsEnabled(inputstream.adaptive)</condition>
+							</and>
+						</dependency>
+						<dependency type="visible">
+    						<condition on="property" name="InfoBool">![System.Platform.Android|System.Platform.webOS|String.StartsWith(System.BuildVersion,17)]</condition>
+						</dependency>
+					</dependencies>
+					<control type="button" format="action"/>
+				</setting>
+			</group>
+		</category>
+		<category id="debug" label="30950" help=""> <!-- Debug -->
+			<group id="1">
+				<setting id="disabled" type="boolean" label="30903" help="">
+					<level>0</level>
+					<default>false</default>
+					<control type="toggle"/>
+				</setting>
+				<setting id="disabled_warning" type="string" label="30904" help=""> <!-- disabled_warning -->
+					<level>0</level>
+					<default/>
+					<constraints>
+						<allowempty>true</allowempty>
+					</constraints>
+					<dependencies>
+						<dependency type="enable">
+							<condition on="property" name="InfoBool">false</condition>
+						</dependency>
+					</dependencies>
+					<control type="edit" format="string">
+						<heading>30904</heading>
+					</control>
+				</setting>
+				<setting id="widevine_install_from" type="action" label="30955" help="30956">
+					<level>0</level>
+					<data>RunScript(script.module.inputstreamhelper, widevine_install_from)</data>
+					<constraints>
+						<allowempty>true</allowempty>
+					</constraints>
+					<dependencies>
+						<dependency type="enable">
+							<and>
+								<condition on="property" name="InfoBool">Integer.IsGreaterOrEqual(System.BuildVersionCode,18)</condition>
+								<condition on="property" name="InfoBool">System.HasAddon(inputstream.adaptive)|System.AddonIsEnabled(inputstream.adaptive)</condition>
+							</and>
+						</dependency>
+						<dependency type="visible">
+    						<condition on="property" name="InfoBool">![System.Platform.Android|System.Platform.webOS|String.StartsWith(System.BuildVersion,17)]</condition>
+						</dependency>
+					</dependencies>
+					<control type="button" format="action"/>
+				</setting>
+				<setting id="image_url" type="urlencodedstring" label="30953" help="30954" parent="">
+					<level>0</level>
+					<default>https://dl.google.com/dl/edgedl/chromeos/recovery/chromeos_16328.65.0_jacuzzi_recovery_stable-channel_JacuzziMPKeys-v19.bin.zip</default>
+					<control type="edit" format="urlencoded">
+						<heading>30953</heading>
+					</control>
+				</setting>
+			</group>
+		</category>
+	</section>
 </settings>


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: InputStream Helper
  - Add-on ID: script.module.inputstreamhelper
  - Version number: 0.8.2
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/emilsvennesson/script.module.inputstreamhelper
  
A simple Kodi module that makes life easier for add-on developers relying on InputStream based add-ons and DRM playback.

### Description of changes:


v0.8.2 (2025-09-25)
- Fix Widevine CDM installation on 32-bit Windows

v0.8.1 (2025-09-22)
- Fix Widevine CDM installation on ARM hardware

v0.8.0 (2025-09-19)
- Fix Widevine CDM installation on Windows, Linux and Macintosh
- Add support for LG webOS

v0.7.0 (2024-09-24)
- Get rid of distutils dependency
- Option to get Widevine from lacros image
- Remove support for Python 2 and pre-Matrix Kodi versions

v0.6.1 (2023-05-30)
- Performance improvements on Linux ARM
- This will be the last release for Python 2 i.e. Kodi 18 (Leia) and below. The next release will require Python 3 and Kodi 19 (Matrix) or higher.

v0.6.0 (2023-05-03)
- Initial support for AARCH64 Linux
- Initial support for AARCH64 Macs
- New option to install a specific version on most platforms

v0.5.10 (2022-04-18)
- Fix automatic submission of release
- Update German translation
- Fix update_frequency setting
- Fix install_from
- Improve/Fix Widevine extraction from Chrome OS images

v0.5.9 (2022-03-22)
- Update Croatian translation
- Replace deprecated LooseVersion
- Fix http_get decode error
- Option to install Widevine from specified source
    

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
