### PR TITLE
[script.service.playbackresumer@matrix] 2.0.8

### DIFF
--- a/script.service.playbackresumer/addon.xml
+++ b/script.service.playbackresumer/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.service.playbackresumer" name="Kodi Playback Resumer" version="2.0.7" provider-name="bossanova808, bradvido88">
+<addon id="script.service.playbackresumer" name="Kodi Playback Resumer" version="2.0.8" provider-name="bossanova808, bradvido88">
   <requires>
     <import addon="xbmc.python" version="3.0.0"/>
     <import addon="script.module.bossanova808" version="1.0.0"/>
@@ -7,8 +7,12 @@
   <extension point="xbmc.service" library="default.py" />
   <extension point="xbmc.addon.metadata">
     <summary lang="en_GB">Periodically sets the resume point of videos and can automatically resume last played video if Kodi crashes.</summary>
+    <summary lang="sv_SE">Ställer in återuppspelningspunkten för videor med jämna mellanrum och kan automatiskt återuppspela den senast spelade videon om Kodi kraschar.</summary>
     <description lang="en_GB">
         Runs as a service and will periodically update the resume point while videos are playing, so you can re-start from where you were in the event of a crash.  It can also automatically resume a video if Kodi was shutdown while playing it. See setting to configure how often the resume point is set, and whether to automatically resume.
+    </description>
+    <description lang="sv_SE">
+        Körs som en tjänst och uppdaterar regelbundet återuppspelningspunkten vid spelning medan videor spelas upp, så att du kan starta om från där du var i händelse av ett krascher. Den kan också automatiskt återuppspela en video om Kodi stängdes av vid spelning. Se inställningarna för att konfigurera hur ofta återuppspelningspunkten ska ställas in och om den ska återuppspelas automatiskt.
     </description>
     <platform>all</platform>
 	  <license>GPL-3.0-only</license>
@@ -16,13 +20,14 @@
     <source>https://github.com/bossanova808/script.service.playbackresumer</source>
     <forum>https://forum.kodi.tv/showthread.php?tid=355383</forum>
     <email>bossanova808@gmail.com</email>
-    <news>v2.0.7
-- Remove old common code, use new module
+    <news>v2.0.8
+- Minor changes for Piers
     </news>
     <assets>
       <icon>icon.png</icon>
     </assets>
   </extension>
 </addon>
+
 
 

--- a/script.service.playbackresumer/changelog.txt
+++ b/script.service.playbackresumer/changelog.txt
@@ -1,5 +1,10 @@
-v2.0.6
+v2.0.8
+- Minor changes for Piers
 
+v2.0.7
+- Remove old common code, use new module
+
+v2.0.6
 - Add support for non library videos
 
 v2.0.5

--- a/script.service.playbackresumer/resources/language/resource.language.sv_se/strings.po
+++ b/script.service.playbackresumer/resources/language/resource.language.sv_se/strings.po
@@ -1,0 +1,63 @@
+# XBMC Media Center Swedish language file
+# Addon Name: XBMC Playback Resumer
+# Addon id: script.service.playbackresumer
+# Addon version: 1.2.0
+# Addon Provider: bradvido88,bossanova808
+msgid ""
+msgstr ""
+"Project-Id-Version: XBMC-Addons\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
+"POT-Creation-Date: 2014-01-12 02:29+0000\n"
+"PO-Revision-Date: 2025-10-01 11:42+0200\n"
+"Last-Translator: Daniel Nylander <github@danielnylander.se>\n"
+"Language-Team: sv\n"
+"Language: sv\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 3.7\n"
+
+msgctxt "Addon Summary"
+msgid "Periodically sets the resume point while videos are playing and optionally automatically resumes last played video if XBMC crashes or is shutdown during playback."
+msgstr "Ställer regelbundet in återupptagningspunkten medan videor spelas upp och återupptar automatiskt den senast spelade videon om XBMC kraschar eller stängs av under uppspelning."
+
+msgctxt "Addon Description"
+msgid "This addon runs in the background as a service and will periodically update the resume point while videos are playing. It will also automatically resume a video if XBMC was shutdown while playing it. See setting to configure how often the resume point is set and whether to automatically resume."
+msgstr "Detta tillägg körs i bakgrunden som en tjänst och kommer regelbundet att uppdatera återuppspelningspunkten medan videor spelas upp. Det kommer också automatiskt att återuppta en video om XBMC stängdes av medan den spelades. Se Inställning för att konfigurera hur ofta återuppspelningspunkten ska ställas in och om den ska återupptas automatiskt."
+
+msgctxt "#32000"
+msgid "Resumer"
+msgstr "Återuppspelare"
+
+msgctxt "#32001"
+msgid "Save resume point every X seconds"
+msgstr "Spara återuppspelningspunkt var X:e sekund"
+
+msgctxt "#32002"
+msgid "Auto-Resume playback at startup"
+msgstr "Återuppta uppspelningen automatiskt vid start"
+
+msgctxt "#32003"
+msgid "Auto-Play a random video if nothing is playing"
+msgstr "Spela automatiskt upp en slumpmässig video om inget spelas"
+
+msgctxt "#32030"
+msgid "Exclude"
+msgstr "Exkludera"
+
+msgctxt "#32031"
+msgid "Exclude Live TV"
+msgstr "Exkludera direktsänd TV"
+
+msgctxt "#32032"
+msgid "Exclude HTTP sources"
+msgstr "Exkludera HTTP-källor"
+
+msgctxt "#32033"
+msgid "Exclude path"
+msgstr "Exkludera sökväg"
+
+msgctxt "#32034"
+msgid "Folder's path (and subfolders)"
+msgstr "Mappens sökväg (och undermappar)"

--- a/script.service.playbackresumer/resources/lib/monitor.py
+++ b/script.service.playbackresumer/resources/lib/monitor.py
@@ -11,8 +11,12 @@ class KodiEventMonitor(xbmc.Monitor):
         Logger.debug('KodiEventMonitor __init__')
 
     def onSettingsChanged(self):
+        """
+        Handle Kodi settings changes by reloading the add-on configuration from settings.
+        
+        Invoked when Kodi reports settings have changed; calls the Store to reload configuration so runtime state reflects updated settings.
+        """
         Logger.info('onSettingsChanged - reload them.')
         Store.load_config_from_settings()
 
-    def onAbortRequested(self):
-        Logger.debug('onAbortRequested')
+

--- a/script.service.playbackresumer/resources/lib/playback_resumer.py
+++ b/script.service.playbackresumer/resources/lib/playback_resumer.py
@@ -1,20 +1,26 @@
-from bossanova808.utilities import *
-# noinspection PyPackages
-from .store import Store
 import xbmc
 # noinspection PyPackages
 from .monitor import KodiEventMonitor
 # noinspection PyPackages
 from .player import KodiPlayer
+# noinspection PyPackages
+from .store import Store
+
+from bossanova808.logger import Logger
 
 
 def run():
     """
-    This is 'main'
-
-    :return:
+    Start the addon: initialize logging and global state, configure Kodi monitor and player, attempt to resume or start playback, then run the main event loop until an abort is requested.
+    
+    This function:
+    - Starts the logger and creates the global Store.
+    - Instantiates and stores Kodi event monitor and player objects.
+    - Attempts to resume previous playback; if nothing resumed and no video is playing, triggers autoplay when enabled.
+    - Enters a loop that waits for an abort request and exits when one is detected.
+    - Stops the logger before returning.
     """
-    footprints()
+    Logger.start()
     # load settings and create the store for our globals
     Store()
     Store.kodi_event_monitor = KodiEventMonitor(xbmc.Monitor)
@@ -26,7 +32,8 @@ def run():
 
     while not Store.kodi_event_monitor.abortRequested():
         if Store.kodi_event_monitor.waitForAbort(1):
+            Logger.debug('onAbortRequested')
             # Abort was requested while waiting. We should exit
             break
 
-    footprints(False)
+    Logger.stop()

--- a/script.service.playbackresumer/resources/lib/store.py
+++ b/script.service.playbackresumer/resources/lib/store.py
@@ -1,10 +1,13 @@
-from bossanova808.utilities import *
-from bossanova808.logger import Logger
 import os
 import json
 import xml.etree.ElementTree as ElementTree
 
 import xbmc
+import xbmcvfs
+
+from bossanova808.constants import PROFILE, ADDON
+from bossanova808.logger import Logger
+from bossanova808.utilities import get_setting, get_setting_as_bool
 
 
 class Store:


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: Kodi Playback Resumer
  - Add-on ID: script.service.playbackresumer
  - Version number: 2.0.8
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/bossanova808/script.service.playbackresumer
  

        Runs as a service and will periodically update the resume point while videos are playing, so you can re-start from where you were in the event of a crash.  It can also automatically resume a video if Kodi was shutdown while playing it. See setting to configure how often the resume point is set, and whether to automatically resume.
    

### Description of changes:

v2.0.8
- Modernisation and cleanup
- PyDocs
- Add submitted Swedish translation 
    

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
