### PR TITLE
[script.module.inputstreamhelper@matrix] 0.8.5

### DIFF
--- a/script.module.inputstreamhelper/README.md
+++ b/script.module.inputstreamhelper/README.md
@@ -90,6 +90,9 @@ Please report any issues or bug reports on the [GitHub Issues](https://github.co
 This module is licensed under the **The MIT License**. Please see the [LICENSE.txt](LICENSE.txt) file for details.
 
 ## Releases
+### v0.8.5 (2025-12-29)
+- Fix Widevine CDM installation on 32-bit ARM (@mediaminister)
+
 ### v0.8.4 (2025-11-04)
 - Fix Widevine CDM installation on ARM hardware (@mediaminister)
 

--- a/script.module.inputstreamhelper/addon.xml
+++ b/script.module.inputstreamhelper/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.module.inputstreamhelper" name="InputStream Helper" version="0.8.4" provider-name="emilsvennesson, dagwieers, mediaminister, horstle">
+<addon id="script.module.inputstreamhelper" name="InputStream Helper" version="0.8.5" provider-name="emilsvennesson, dagwieers, mediaminister, horstle">
   <requires>
     <!--py3 compliant-->
     <import addon="xbmc.python" version="3.0.0"/>
@@ -27,6 +27,9 @@
     <description lang="ru_RU">Простой модуль для Kodi, который облегчает жизнь разработчикам дополнений, с использованием InputStream дополнений и воспроизведения DRM контента.</description>
     <description lang="sv_SE">En enkel Kodi-modul som underlättar livet för tilläggsutvecklare som förlitar sig på InputStream-baserade tillägg och DRM-uppspelning.</description>
     <news>
+v0.8.5 (2025-12-29)
+- Fix Widevine CDM installation on 32-bit ARM
+
 v0.8.4 (2025-11-04)
 - Fix Widevine CDM installation on ARM hardware
 

--- a/script.module.inputstreamhelper/lib/inputstreamhelper/config.py
+++ b/script.module.inputstreamhelper/lib/inputstreamhelper/config.py
@@ -68,12 +68,8 @@ WIDEVINE_MINIMUM_KODI_VERSION = {
     'Windows': '18.0',
     'Linux': '18.0',
     'Darwin': '18.0',
-    'webOS': '22.0'
+    'webOS': '21.1'
 }
-
-WIDEVINE_VERSIONS_URL = 'https://dl.google.com/widevine-cdm/versions.txt'
-
-WIDEVINE_DOWNLOAD_URL = 'https://dl.google.com/widevine-cdm/{version}-{os}-{arch}.zip'
 
 WIDEVINE_LICENSE_FILE = 'LICENSE'
 
@@ -86,11 +82,10 @@ CHROMEOS_RECOVERY_URL = 'https://dl.google.com/dl/edgedl/chromeos/recovery/recov
 # To keep the Chrome OS ARM(64) hardware ID list up to date, the following resources can be used:
 # https://www.chromium.org/chromium-os/developer-information-for-chrome-os-devices
 # https://chromiumdash.appspot.com/serving-builds?deviceCategory=Chrome%20OS
-# Last updated: 2025-10-10
-# current Chrome OS version: 16371.61.0, Widevine version: 4.10.2662.3
+# Last updated: 2025-12-29
+# current Chrome OS version: 16433.65.0, Widevine version: 4.10.2662.3
 CHROMEOS_RECOVERY_ARM_BNAMES = [
     'bob',  # no longer updated, still latest wv. last: https://dl.google.com/dl/edgedl/chromeos/recovery/chromeos_15509.81.0_bob_recovery_stable-channel_mp-v2.bin.zip
-    'elm',  # probably 64bit soon. current: https://dl.google.com/dl/edgedl/chromeos/recovery/chromeos_15886.44.0_elm_recovery_stable-channel_mp-v6.bin.zip
     'kevin',  # no longer updated, still latest wv. last: https://dl.google.com/dl/edgedl/chromeos/recovery/chromeos_15509.81.0_kevin_recovery_stable-channel_mp-v2.bin.zip
     'scarlet',  # no longer updated, still latest wv. last: https://dl.google.com/dl/edgedl/chromeos/recovery/chromeos_15509.81.0_scarlet_recovery_stable-channel_mp-v8.bin.zip
 ]
@@ -99,6 +94,7 @@ CHROMEOS_RECOVERY_ARM64_BNAMES = [
     'asurada',
     'cherry',
     'corsola',
+    'elm',
     'geralt',
     'hana',
     'jacuzzi',

--- a/script.module.inputstreamhelper/lib/inputstreamhelper/utils.py
+++ b/script.module.inputstreamhelper/lib/inputstreamhelper/utils.py
@@ -267,9 +267,9 @@ def system_os():
         return getattr(system_os, 'cached')
 
     from xbmc import getCondVisibility
-    if getCondVisibility('system.platform.android'):
+    if getCondVisibility('System.Platform.Android'):
         sys_name = 'Android'
-    elif getCondVisibility('system.platform.webos'):
+    elif getCondVisibility('System.Platform.WebOS'):
         sys_name = 'webOS'
     else:
         from platform import system

--- a/script.module.inputstreamhelper/lib/inputstreamhelper/widevine/repo.py
+++ b/script.module.inputstreamhelper/lib/inputstreamhelper/widevine/repo.py
@@ -5,9 +5,7 @@
 import json
 import random
 
-from .. import config
-from ..kodiutils import log
-from ..utils import arch, http_get, http_head, http_post, system_os
+from ..utils import arch, http_post, system_os
 
 
 def cdm_from_repo():
@@ -16,28 +14,6 @@ def cdm_from_repo():
     if 'x86' in arch() or arch() == 'arm64' and system_os() in ('Darwin', 'Windows'):
         return True
     return False
-
-
-def widevines_available_from_repo():
-    """Returns all available Widevine CDM versions and urls from Google's library CDM repository"""
-    cdm_versions = http_get(config.WIDEVINE_VERSIONS_URL).strip('\n').split('\n')
-    try:
-        cdm_os = config.WIDEVINE_OS_MAP[system_os()]
-        cdm_arch = config.WIDEVINE_ARCH_MAP_REPO[arch()]
-    except KeyError:
-        cdm_os = "mac"
-        cdm_arch = "x64"
-    available_cdms = []
-    for cdm_version in cdm_versions:
-        cdm_url = config.WIDEVINE_DOWNLOAD_URL.format(version=cdm_version, os=cdm_os, arch=cdm_arch)
-        http_status = http_head(cdm_url)
-        if http_status == 200:
-            available_cdms.append({'version': cdm_version, 'url': cdm_url})
-
-    if not available_cdms:
-        log(4, "could not find any available cdm in repo")
-
-    return available_cdms
 
 
 def latest_widevine_available_from_repo(cdm_os, cdm_arch):
@@ -69,7 +45,7 @@ def latest_widevine_available_from_repo(cdm_os, cdm_arch):
                 'platform': cdm_os,
             },
             'protocol': '4.0',
-            'updaterversion': '140.0.7339.127'
+            'updaterversion': '142.0.7444.175'
         }
     }
     text = http_post(url, data=json.dumps(payload).encode('utf-8'), headers=headers)

--- a/script.module.inputstreamhelper/resources/settings.xml
+++ b/script.module.inputstreamhelper/resources/settings.xml
@@ -77,7 +77,7 @@
 							<condition operator="is" setting="disabled">false</condition>
 						</dependency>
 						<dependency type="visible">
-    						<condition on="property" name="InfoBool">![System.Platform.Android|System.Platform.webOS|String.StartsWith(System.BuildVersion,17)]</condition>
+    						<condition on="property" name="InfoBool">![System.Platform.Android|System.Platform.WebOS]</condition>
 						</dependency>
 					</dependencies>
 					<control type="slider" format="integer">
@@ -94,7 +94,7 @@
 					</constraints>
 					<dependencies>
 						<dependency type="visible">
-    						<condition on="property" name="InfoBool">![System.Platform.Android|System.Platform.webOS|String.StartsWith(System.BuildVersion,17)]</condition>
+    						<condition on="property" name="InfoBool">![System.Platform.Android|System.Platform.WebOS]</condition>
 						</dependency>
 					</dependencies>
 					<control type="button" format="path">
@@ -111,7 +111,7 @@
 					</constraints>
 					<dependencies>
 						<dependency type="visible">
-    						<condition on="property" name="InfoBool">![System.Platform.Android|System.Platform.webOS|String.StartsWith(System.BuildVersion,17)]</condition>
+    						<condition on="property" name="InfoBool">![System.Platform.Android|System.Platform.WebOS]</condition>
 						</dependency>
 					</dependencies>
 					<control type="slider" format="integer">
@@ -134,7 +134,7 @@
 							</and>
 						</dependency>
 						<dependency type="visible">
-    						<condition on="property" name="InfoBool">![System.Platform.Android|System.Platform.webOS|String.StartsWith(System.BuildVersion,17)]</condition>
+    						<condition on="property" name="InfoBool">![System.Platform.Android|System.Platform.WebOS]</condition>
 						</dependency>
 					</dependencies>
 					<control type="button" format="action"/>
@@ -153,7 +153,7 @@
 							</and>
 						</dependency>
 						<dependency type="visible">
-    						<condition on="property" name="InfoBool">![System.Platform.Android|System.Platform.webOS|String.StartsWith(System.BuildVersion,17)]</condition>
+    						<condition on="property" name="InfoBool">![System.Platform.Android|System.Platform.WebOS]</condition>
 						</dependency>
 					</dependencies>
 					<control type="button" format="action"/>
@@ -172,7 +172,7 @@
 							</and>
 						</dependency>
 						<dependency type="visible">
-    						<condition on="property" name="InfoBool">![System.Platform.Android|System.Platform.webOS|String.StartsWith(System.BuildVersion,17)]</condition>
+    						<condition on="property" name="InfoBool">![System.Platform.Android|System.Platform.WebOS]</condition>
 						</dependency>
 					</dependencies>
 					<control type="button" format="action"/>
@@ -215,7 +215,7 @@
 							</and>
 						</dependency>
 						<dependency type="visible">
-    						<condition on="property" name="InfoBool">![System.Platform.Android|System.Platform.webOS|String.StartsWith(System.BuildVersion,17)]</condition>
+    						<condition on="property" name="InfoBool">![System.Platform.Android|System.Platform.WebOS]</condition>
 						</dependency>
 					</dependencies>
 					<control type="button" format="action"/>


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: InputStream Helper
  - Add-on ID: script.module.inputstreamhelper
  - Version number: 0.8.5
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/emilsvennesson/script.module.inputstreamhelper
  
A simple Kodi module that makes life easier for add-on developers relying on InputStream based add-ons and DRM playback.

### Description of changes:


v0.8.5 (2025-12-29)
- Fix Widevine CDM installation on 32-bit ARM

v0.8.4 (2025-11-04)
- Fix Widevine CDM installation on ARM hardware

v0.8.3 (2025-10-10)
- Fix removing older Widevine CDM backups

v0.8.2 (2025-09-25)
- Fix Widevine CDM installation on 32-bit Windows

v0.8.1 (2025-09-22)
- Fix Widevine CDM installation on ARM hardware

v0.8.0 (2025-09-19)
- Fix Widevine CDM installation on Windows, Linux and Macintosh
- Add support for LG webOS

v0.7.0 (2024-09-24)
- Get rid of distutils dependency
- Option to get Widevine from lacros image
- Remove support for Python 2 and pre-Matrix Kodi versions

v0.6.1 (2023-05-30)
- Performance improvements on Linux ARM
- This will be the last release for Python 2 i.e. Kodi 18 (Leia) and below. The next release will require Python 3 and Kodi 19 (Matrix) or higher.

v0.6.0 (2023-05-03)
- Initial support for AARCH64 Linux
- Initial support for AARCH64 Macs
- New option to install a specific version on most platforms

v0.5.10 (2022-04-18)
- Fix automatic submission of release
- Update German translation
- Fix update_frequency setting
- Fix install_from
- Improve/Fix Widevine extraction from Chrome OS images

v0.5.9 (2022-03-22)
- Update Croatian translation
- Replace deprecated LooseVersion
- Fix http_get decode error
- Option to install Widevine from specified source
    

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
