### PR TITLE
[script.xbmcbackup] 1.7.3

### DIFF
--- a/script.xbmcbackup/addon.xml
+++ b/script.xbmcbackup/addon.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="script.xbmcbackup"
-    name="Backup" version="1.7.2" provider-name="robweber">
+    name="Backup" version="1.7.3" provider-name="robweber">
   <requires>
     <import addon="xbmc.python" version="3.0.0"/>
     <import addon="script.module.dateutil" version="2.8.0" />
@@ -24,9 +24,8 @@
 		<screenshot>resources/images/screenshot3.jpg</screenshot>
 		<screenshot>resources/images/screenshot4.jpg</screenshot>
     </assets>
-    <news>Version 1.7.2
-Fix bug with gui settings restore
-strptime Python bugfix
+    <news>Version 1.7.3
+additional strptime modifications to fix scheduler behavior
 </news>
     <summary lang="ar_SA">إنسخ إحتياطياً قاعده بيانات إكس بى إم سى وملفات اﻹعدادات فى حاله وقوع إنهيار مع إمكانيه اﻹسترجاع</summary>
     <summary lang="bg_BG">Добавката може да създава резервни копия и възстановява базата данни и настройките на Kodi, в случай на срив или повреда на файловете.</summary>

--- a/script.xbmcbackup/resources/lib/authorizers.py
+++ b/script.xbmcbackup/resources/lib/authorizers.py
@@ -15,13 +15,9 @@ except ImportError:
     pass
 
 # fix for datetime.strptime bug https://kodi.wiki/view/Python_Problems#datetime.strptime
-class proxydt(datetime.datetime):
+def patch_strptime(date_string, format):
+    return datetime.datetime(*(time.strptime(date_string, format)[:6]))
 
-    @classmethod
-    def strptime(cls, date_string, format):
-        return datetime.datetime(*(time.strptime(date_string, format)[:6]))
-
-datetime.datetime = proxydt
 
 class QRCode(xbmcgui.WindowXMLDialog):
     def __init__(self, *args, **kwargs):
@@ -139,24 +135,21 @@ class DropboxAuthorizer:
 
     def _setToken(self, token):
         # write the token files
-        token_file = open(xbmcvfs.translatePath(utils.data_dir() + self.TOKEN_FILE), 'w')
-
-        token_file.write(json.dumps({"access_token": token.access_token, "refresh_token": token.refresh_token, "expiration": str(token.expires_at)}))
-        token_file.close()
+        with open(xbmcvfs.translatePath(utils.data_dir() + self.TOKEN_FILE), 'w') as token_file:
+            token_file.write(json.dumps({"access_token": token.access_token, "refresh_token": token.refresh_token, "expiration": str(token.expires_at)}))
 
     def _getToken(self):
         result = {}
         # get token, if it exists
         if(xbmcvfs.exists(xbmcvfs.translatePath(utils.data_dir() + self.TOKEN_FILE))):
-            token_file = open(xbmcvfs.translatePath(utils.data_dir() + self.TOKEN_FILE))
-            token = token_file.read()
+            token = ""
+            with open(xbmcvfs.translatePath(utils.data_dir() + self.TOKEN_FILE), 'r') as token_file:
+                token = token_file.read()
 
             if(token.strip() != ""):
                 result = json.loads(token)
                 # convert expiration back to a datetime object
-                result['expiration'] = datetime.datetime.strptime(result['expiration'], "%Y-%m-%d %H:%M:%S.%f")
-
-            token_file.close()
+                result['expiration'] = patch_strptime(result['expiration'], "%Y-%m-%d %H:%M:%S.%f")
 
         return result
 


### PR DESCRIPTION
### Description

- fixed issue with Scheduler [running in a loop](https://github.com/robweber/xbmcbackup/issues/251). Issue stemmed from previous strptime fix affecting correct calculation of cron values
- changed previous strptime bug fix by applying specific patch to authorizers file where this bug was initially seen

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [script.foo.bar] 1.0.0

Additional information :
- Submitting your add-on to this specific branch makes it available to any Kodi version equal or higher than the branch name with the applicable Kodi dependencies limits.
- [add-on development](http://kodi.wiki/view/Add-on_development) wiki page.
- Kodi [pydocs](http://kodi.wiki/view/PyDocs) provide information about the Python API
- [PEP8](https://www.python.org/dev/peps/pep-0008/) codingstyle which is considered best practise but not mandatory.
- This add-on repository has automated code guideline check which could help you improve your coding. You can find the results of these check at [Codacy](https://www.codacy.com/app/Kodi/repo-scripts/dashboard). You can create your own account as well to continuously monitor your python coding before submitting to repo.
- Development questions can be asked in the [add-on development](http://forum.kodi.tv/forumdisplay.php?fid=26) section on the Kodi forum.
