### PR TITLE
[script.service.playbackresumer@matrix] 2.0.9

### DIFF
--- a/script.service.playbackresumer/README.md
+++ b/script.service.playbackresumer/README.md
@@ -12,3 +12,14 @@ Support is via the Kodi forum thread: <https://forum.kodi.tv/showthread.php?tid=
 
 (Re-written from the ground up in 2021 by bossanova808, originally inspired by bradvido88 code recovered from the Kodi forum, and from May 2019 updated & maintained in this repo by bossanova808).
 
+
+
+[!["Buy Me A Coffee"](https://www.buymeacoffee.com/assets/img/custom_images/orange_img.png)](https://www.buymeacoffee.com/bossanova808) 
+
+一个简单的插件，在后台自动定期更新当前播放视频的恢复点，确保在 Kodi 崩溃时不会丢失播放进度。
+
+可选功能：在 Kodi 崩溃重启后自动恢复播放，或在启动时触发随机视频播放。
+
+支持通过 Kodi 论坛线程：<https://forum.kodi.tv/showthread.php?tid=355383>
+
+（2021 年由 bossanova808 从头重写，最初灵感来自于从 Kodi 论坛恢复的 bradvido88 代码，从 2019 年 5 月开始由 bossanova808 在本仓库中更新和维护）。

--- a/script.service.playbackresumer/addon.xml
+++ b/script.service.playbackresumer/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.service.playbackresumer" name="Kodi Playback Resumer" version="2.0.8" provider-name="bossanova808, bradvido88">
+<addon id="script.service.playbackresumer" name="Kodi Playback Resumer" version="2.0.9" provider-name="bossanova808, bradvido88">
   <requires>
     <import addon="xbmc.python" version="3.0.0"/>
     <import addon="script.module.bossanova808" version="1.0.0"/>
@@ -8,11 +8,15 @@
   <extension point="xbmc.addon.metadata">
     <summary lang="en_GB">Periodically sets the resume point of videos and can automatically resume last played video if Kodi crashes.</summary>
     <summary lang="sv_SE">Ställer in återuppspelningspunkten för videor med jämna mellanrum och kan automatiskt återuppspela den senast spelade videon om Kodi kraschar.</summary>
+    <summary lang="zh_CN">定期保存视频播放进度，Kodi 崩溃后可自动恢复上次播放内容。</summary>
     <description lang="en_GB">
         Runs as a service and will periodically update the resume point while videos are playing, so you can re-start from where you were in the event of a crash.  It can also automatically resume a video if Kodi was shutdown while playing it. See setting to configure how often the resume point is set, and whether to automatically resume.
     </description>
     <description lang="sv_SE">
         Körs som en tjänst och uppdaterar regelbundet återuppspelningspunkten vid spelning medan videor spelas upp, så att du kan starta om från där du var i händelse av ett krascher. Den kan också automatiskt återuppspela en video om Kodi stängdes av vid spelning. Se inställningarna för att konfigurera hur ofta återuppspelningspunkten ska ställas in och om den ska återuppspelas automatiskt.
+    </description>
+    <description lang="zh_CN">
+        以后台服务形式运行，播放视频时会定期更新播放进度。当程序意外崩溃后，可从上次观看位置继续播放。同时支持在播放期间非正常关闭 Kodi 时自动续播。你可在插件设置中调整进度保存频率，以及开关自动续播功能。
     </description>
     <platform>all</platform>
 	  <license>GPL-3.0-only</license>
@@ -20,14 +24,11 @@
     <source>https://github.com/bossanova808/script.service.playbackresumer</source>
     <forum>https://forum.kodi.tv/showthread.php?tid=355383</forum>
     <email>bossanova808@gmail.com</email>
-    <news>v2.0.8
-- Minor changes for Piers
+    <news>v2.0.9
+- User submitted Chinese language translations (thanks @wabisabi926!)       
     </news>
     <assets>
       <icon>icon.png</icon>
     </assets>
   </extension>
 </addon>
-
-
-

--- a/script.service.playbackresumer/changelog.txt
+++ b/script.service.playbackresumer/changelog.txt
@@ -1,3 +1,6 @@
+v2.0.9
+- User submitted Chinese language translations (thanks @wabisabi926!)
+       
 v2.0.8
 - Minor changes for Piers
 

--- a/script.service.playbackresumer/resources/language/resource.language.zh_cn/strings.po
+++ b/script.service.playbackresumer/resources/language/resource.language.zh_cn/strings.po
@@ -1,0 +1,64 @@
+# XBMC Media Center language file
+# Addon Name: XBMC Playback Resumer
+# Addon id: script.service.playbackresumer
+# Addon version: 1.2.0
+# Addon Provider: bradvido88,bossanova808
+msgid ""
+msgstr ""
+"Project-Id-Version: XBMC-Addons\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
+"POT-Creation-Date: 2026-04-27 09:16+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: wabisabi926\n"
+"Language-Team: LANGUAGE\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: zh_CN\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+msgctxt "Addon Summary"
+msgid "Periodically sets the resume point while videos are playing and optionally automatically resumes last played video if XBMC crashes or is shutdown during playback."
+msgstr "在视频播放时定期设置恢复点，并在 XBMC 崩溃或播放期间关闭时自动恢复上次播放的视频。"
+
+msgctxt "Addon Description"
+msgid "This addon runs in the background as a service and will periodically update the resume point while videos are playing. It will also automatically resume a video if XBMC was shutdown while playing it. See setting to configure how often the resume point is set and whether to automatically resume."
+msgstr "此插件作为服务在后台运行，会在视频播放时定期更新恢复点。如果 XBMC 在播放时关闭，它还会自动恢复视频播放。请参见设置以配置恢复点设置的频率以及是否自动恢复。"
+
+
+msgctxt "#32000"
+msgid "Resumer"
+msgstr "播放恢复"
+
+msgctxt "#32001"
+msgid "Save resume point every X seconds"
+msgstr "每 X 秒保存恢复点"
+
+msgctxt "#32002"
+msgid "Auto-Resume playback at startup"
+msgstr "启动时自动恢复播放"
+
+msgctxt "#32003"
+msgid "Auto-Play a random video if nothing is playing"
+msgstr "如果没有播放内容，自动播放随机视频"
+
+
+msgctxt "#32030"
+msgid "Exclude"
+msgstr "排除"
+
+msgctxt "#32031"
+msgid "Exclude Live TV"
+msgstr "排除直播电视"
+
+msgctxt "#32032"
+msgid "Exclude HTTP sources"
+msgstr "排除 HTTP 源"
+
+msgctxt "#32033"
+msgid "Exclude path"
+msgstr "排除路径"
+
+msgctxt "#32034"
+msgid "Folder's path (and subfolders)"
+msgstr "文件夹路径（及其子文件夹）"


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: Kodi Playback Resumer
  - Add-on ID: script.service.playbackresumer
  - Version number: 2.0.9
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/bossanova808/script.service.playbackresumer
  

        Runs as a service and will periodically update the resume point while videos are playing, so you can re-start from where you were in the event of a crash.  It can also automatically resume a video if Kodi was shutdown while playing it. See setting to configure how often the resume point is set, and whether to automatically resume.
    

### Description of changes:

v2.0.9
- User submitted Chinese language translations (thanks @wabisabi926!)       
    

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
