### PR TITLE
[script.punchplay] 1.1.0

### DIFF
--- a/script.punchplay/addon.xml
+++ b/script.punchplay/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon id="script.punchplay"
        name="PunchPlay Scrobble"
-       version="1.0.2"
+       version="1.1.0"
        provider-name="PunchPlay">
 
   <requires>
@@ -22,7 +22,7 @@
     <forum/>
     <website>https://punchplay.tv</website>
     <source>https://github.com/PunchPlay/script.punchplay</source>
-    <news>1.0.2 - Login dialog now shows a scannable QR code alongside the device code</news>
+    <news>1.1.0 - Rate after watching; one-click Kodi library sync; auto-close login on approval</news>
     <assets>
       <icon>icon.png</icon>
       <fanart>fanart.jpg</fanart>

--- a/script.punchplay/api.py
+++ b/script.punchplay/api.py
@@ -9,9 +9,12 @@ Responsibilities:
   • Device-code login flow with a Kodi progress dialog.
 """
 
+from __future__ import annotations
+
 import base64
 import json
 import os
+import threading
 import time
 import uuid
 import urllib.error
@@ -24,7 +27,7 @@ import xbmcgui
 import xbmcvfs
 
 _ADDON_ID = "script.punchplay"
-_VERSION = "1.0.2"
+_VERSION = "1.1.0"
 
 
 class APIClient:
@@ -203,6 +206,18 @@ class APIClient:
                 )
             return None
 
+    def post_immediate(
+        self,
+        path: str,
+        payload: dict[str, Any],
+        timeout: int = 30,
+    ) -> dict[str, Any]:
+        """
+        POST without offline queue fallback.  Raises on failure.
+        Use for actions like rating where queuing doesn't make sense.
+        """
+        return self._request("POST", path, payload, timeout=timeout)
+
     # ------------------------------------------------------------------
     # Offline queue flush
     # ------------------------------------------------------------------
@@ -292,11 +307,18 @@ class APIClient:
         qr_path: str,
         verification_uri: str,
         user_code: str,
+        device_code: str,
         expires_in: int,
-    ) -> bool:
+    ) -> bool | None:
         """
-        Present the custom LoginDialog.  Returns True on success, False
-        if the dialog cannot be shown so the caller can fall back.
+        Present the QR LoginDialog while polling for approval in the
+        background.
+
+        Returns:
+          True  — login succeeded (dialog auto-closed on approval)
+          False — dialog could not be shown (caller should fall back)
+          None  — user dismissed the dialog manually (caller should
+                  continue with the DialogProgress poll loop)
         """
         try:
             from login_dialog import LoginDialog
@@ -309,7 +331,7 @@ class APIClient:
             )
             minutes = max(1, expires_in // 60)
 
-            dialog = LoginDialog(
+            login_dialog = LoginDialog(
                 bg_path=bg_path,
                 qr_path=qr_path,
                 title=_s(32015),
@@ -321,9 +343,78 @@ class APIClient:
                 expires_label=_s(32005).format(minutes),
                 dismiss_hint=_s(32019),
             )
-            dialog.doModal()
-            del dialog
-            return True
+
+            # Poll for approval in a background thread.  If the user
+            # approves on their phone, the dialog auto-closes.
+            stop_event = threading.Event()
+
+            def poll_loop() -> None:
+                monitor = xbmc.Monitor()
+                deadline = time.monotonic() + expires_in
+                while (
+                    not stop_event.is_set()
+                    and time.monotonic() < deadline
+                    and not monitor.abortRequested()
+                ):
+                    try:
+                        resp = self._request(
+                            "POST",
+                            "/api/auth/device/token",
+                            {
+                                "device_code": device_code,
+                                "device_id": self.device_id,
+                                "device_name": (
+                                    xbmc.getInfoLabel("System.FriendlyName")
+                                    or "Kodi"
+                                ),
+                            },
+                            retry_on_401=False,
+                        )
+                        if resp.get("access_token"):
+                            self._save_tokens(resp)
+                            xbmc.log(
+                                "[PunchPlay] Device-code login succeeded (QR dialog)",
+                                xbmc.LOGINFO,
+                            )
+                            login_dialog.approve()
+                            return
+                    except urllib.error.HTTPError as exc:
+                        xbmc.log(f"[PunchPlay] QR poll: HTTP {exc.code}", xbmc.LOGDEBUG)
+                    except Exception as exc:
+                        xbmc.log(f"[PunchPlay] QR poll error: {exc}", xbmc.LOGWARNING)
+                    # Sleep in short slices so we can react to stop_event.
+                    for _ in range(6):
+                        if stop_event.is_set():
+                            return
+                        time.sleep(0.5)
+
+            thread = threading.Thread(
+                target=poll_loop, name="PunchPlayQRPoll", daemon=True
+            )
+            thread.start()
+
+            login_dialog.doModal()
+
+            # Dialog closed — either by approve() or by the user.
+            stop_event.set()
+            thread.join(timeout=3)
+
+            approved = login_dialog.was_approved
+            del login_dialog
+
+            if approved:
+                xbmcgui.Dialog().notification(
+                    "PunchPlay",
+                    addon.getLocalizedString(32011),
+                    xbmcgui.NOTIFICATION_INFO,
+                    4000,
+                )
+                return True
+
+            # User dismissed manually — caller can fall back to
+            # DialogProgress poll.
+            return None
+
         except Exception as exc:
             xbmc.log(f"[PunchPlay] QR dialog failed: {exc}", xbmc.LOGWARNING)
             return False
@@ -363,18 +454,29 @@ class APIClient:
         # Step 2 — show the code to the user.  Prefer the QR window when
         # the backend provides one; otherwise fall back to a compact
         # text-only dialog that still fits on screen without scrolling.
-        shown_qr_dialog = False
+        #
+        # The QR dialog polls in the background and auto-closes on
+        # approval.  Returns:
+        #   True  → login completed, we're done
+        #   None  → user dismissed manually, fall through to poll loop
+        #   False → dialog failed to show, fall back to text dialog
+        qr_result: bool | None = False
         if verification_uri_qr:
             qr_path = self._write_qr_image(verification_uri_qr)
             if qr_path:
-                shown_qr_dialog = self._show_qr_login_dialog(
+                qr_result = self._show_qr_login_dialog(
                     qr_path=qr_path,
                     verification_uri=verification_uri,
                     user_code=user_code,
+                    device_code=device_code,
                     expires_in=expires_in,
                 )
 
-        if not shown_qr_dialog:
+        if qr_result is True:
+            return True  # Already logged in via QR dialog.
+
+        if qr_result is False:
+            # QR not available or failed — show the compact text dialog.
             dialog.ok(
                 _s(32000),
                 (
@@ -385,6 +487,7 @@ class APIClient:
             )
 
         # Step 3 — poll for the token with a cancellable progress dialog.
+        # (Only reached if QR dialog was dismissed manually or not shown.)
         monitor = xbmc.Monitor()
         deadline = time.monotonic() + expires_in
         progress = xbmcgui.DialogProgress()

--- a/script.punchplay/cache.py
+++ b/script.punchplay/cache.py
@@ -8,6 +8,8 @@ Two tables:
                         down, replayed on the next successful connection.
 """
 
+from __future__ import annotations
+
 import json
 import os
 import sqlite3

--- a/script.punchplay/changelog.txt
+++ b/script.punchplay/changelog.txt
@@ -1,3 +1,22 @@
+v1.1.0 (2026-04-28)
+- Rate movies and episodes right in Kodi after the watched threshold is met.
+  A 1–10 rating dialog appears after the scrobble notification. Configurable
+  via the "Rate after watching" toggle in settings.
+- Rate from context menu: right-click any movie or episode in your Kodi
+  library and select "Rate on PunchPlay" to rate it at any time.
+- One-click Kodi library sync: imports all watched movies and episodes from
+  your Kodi library into PunchPlay. Open Settings → Library → Sync Kodi
+  Library. Items already in your PunchPlay history are automatically skipped.
+
+v1.0.3 (2026-04-25)
+- Fix crash on Python 3.8 (Kodi Nexus on Windows) caused by modern
+  type hint syntax; added `from __future__ import annotations` to all files
+- Fix login poll silently swallowing HTTP errors — expired/access_denied
+  are now properly detected and reported to the user
+- Fix stale QR image on re-login (Kodi texture cache bypass)
+- Wrap os.listdir in try/except for QR cleanup resilience
+- Only update flush timestamp on success (restore correct retry behaviour)
+
 v1.0.2 (2026-04-15)
 - Login dialog now shows a scannable QR code alongside the device code.
   Scan with your phone to open punchplay.tv/link with the code pre-filled.

--- a/script.punchplay/identifier.py
+++ b/script.punchplay/identifier.py
@@ -9,6 +9,8 @@ Priority order:
 Results are cached in SQLite to avoid re-parsing on every play event.
 """
 
+from __future__ import annotations
+
 import os
 import re
 from typing import TYPE_CHECKING, Any

--- a/script.punchplay/login_dialog.py
+++ b/script.punchplay/login_dialog.py
@@ -3,9 +3,13 @@ login_dialog.py — Custom Kodi window showing a QR code alongside the
 device-code login details.
 
 Users with a phone can scan the QR; users on a computer can read the URL
-and code.  The dialog closes on any OK/Back key press, after which the
-normal poll loop runs.
+and code.  The dialog auto-closes when the login is approved, or the
+user can dismiss it with OK/Back.
 """
+
+from __future__ import annotations
+
+import threading
 
 import xbmcgui
 
@@ -40,6 +44,8 @@ class LoginDialog(xbmcgui.WindowDialog):
     ):
         # Kodi's WindowDialog.__init__ is implicit — no super() call needed.
         # Layout is authored at 1280x720; Kodi scales automatically.
+
+        self._approved = threading.Event()
 
         # Backdrop (stretches the 32x32 dark PNG across the full screen).
         self.addControl(xbmcgui.ControlImage(0, 0, 1280, 720, bg_path))
@@ -124,6 +130,20 @@ class LoginDialog(xbmcgui.WindowDialog):
                 textColor="0xFF777777",
             )
         )
+
+    @property
+    def was_approved(self) -> bool:
+        """True if the dialog was closed because the login succeeded."""
+        return self._approved.is_set()
+
+    def approve(self) -> None:
+        """Called from the poll thread when tokens are received."""
+        self._approved.set()
+        # Use executebuiltin to close the dialog on the main thread —
+        # calling self.close() directly from a background thread is
+        # unsafe in Kodi's UI framework.
+        import xbmc
+        xbmc.executebuiltin("Action(Back)")
 
     def onAction(self, action) -> None:  # type: ignore[override]
         if action.getId() in _ACTION_CLOSE_IDS:

--- a/script.punchplay/player.py
+++ b/script.punchplay/player.py
@@ -12,6 +12,9 @@ A heartbeat thread fires every N seconds during active playback and POSTs
 /scrobble/progress.
 """
 
+from __future__ import annotations
+
+import os
 import threading
 import time
 from typing import Any
@@ -21,7 +24,7 @@ import xbmcaddon
 import xbmcgui
 
 _ADDON_ID = "script.punchplay"
-_VERSION = "1.0.2"
+_VERSION = "1.1.0"
 
 
 class PunchPlayPlayer(xbmc.Player):
@@ -58,6 +61,7 @@ class PunchPlayPlayer(xbmc.Player):
             "scrobble_anime": addon.getSettingBool("scrobble_anime"),
             "show_notifications": addon.getSettingBool("show_notifications"),
             "notify_during_playback": addon.getSettingBool("notify_during_playback"),
+            "rate_after_watching": addon.getSettingBool("rate_after_watching"),
         }
 
     def _notify(self, message: str, settings: dict[str, Any]) -> None:
@@ -229,6 +233,8 @@ class PunchPlayPlayer(xbmc.Player):
 
             self._metadata = metadata
             self._is_playing = True
+            self._last_position = 0.0
+            self._last_duration = 0.0
 
             position = self.getTime()
             payload = self._build_payload(metadata, position, duration)
@@ -315,7 +321,7 @@ class PunchPlayPlayer(xbmc.Player):
                 f"pos={payload['position_seconds']}s",
                 xbmc.LOGINFO,
             )
-            self._api.post("/api/scrobble/stop", payload)
+            stop_resp = self._api.post("/api/scrobble/stop", payload)
             if watched:
                 _s = xbmcaddon.Addon(_ADDON_ID).getLocalizedString
                 title = self._metadata.get("title", "")
@@ -330,8 +336,91 @@ class PunchPlayPlayer(xbmc.Player):
                 else:
                     msg = _s(32013).format(title)
                 self._notify(msg, settings)
+
+                # Offer the rating dialog if enabled and not already playing
+                # something else (e.g. immediate next episode).
+                if not settings["rate_after_watching"]:
+                    xbmc.log("[PunchPlay] Rating disabled in settings", xbmc.LOGINFO)
+                elif self.isPlayingVideo():
+                    xbmc.log("[PunchPlay] Skipping rating — another video is playing", xbmc.LOGINFO)
+                else:
+                    tmdb_id = (
+                        (stop_resp.get("tmdb_id") if stop_resp else None)
+                        or self._metadata.get("tmdb_id")
+                    )
+                    xbmc.log(f"[PunchPlay] Rating check: tmdb_id={tmdb_id}", xbmc.LOGINFO)
+                    if tmdb_id:
+                        self._show_rating_dialog(tmdb_id, self._metadata)
+                    else:
+                        xbmc.log("[PunchPlay] No tmdb_id — skipping rating", xbmc.LOGINFO)
         except Exception as exc:
             xbmc.log(f"[PunchPlay] Stop emit error: {exc}", xbmc.LOGDEBUG)
+
+    # ------------------------------------------------------------------
+    # Rating dialog
+    # ------------------------------------------------------------------
+
+    def _show_rating_dialog(
+        self,
+        tmdb_id: int,
+        metadata: dict[str, Any],
+    ) -> None:
+        """Show a 1–10 rating dialog after a successful scrobble."""
+        try:
+            _s = xbmcaddon.Addon(_ADDON_ID).getLocalizedString
+            media_type = metadata.get("media_type", "movie")
+            title = metadata.get("title", "")
+
+            # Build heading: "Rate Inception" or "Rate Breaking Bad S01E02"
+            if media_type == "episode":
+                season = metadata.get("season")
+                episode = metadata.get("episode")
+                if isinstance(season, int) and isinstance(episode, int):
+                    heading = _s(32022).format(title, f"{season:02d}", f"{episode:02d}")
+                else:
+                    heading = _s(32021).format(title)
+            else:
+                heading = _s(32021).format(title)
+
+            from rating_dialog import RatingDialog
+
+            addon = xbmcaddon.Addon(_ADDON_ID)
+            bg_path = os.path.join(
+                addon.getAddonInfo("path"),
+                "resources", "media", "background.png",
+            )
+            rate_dlg = RatingDialog(
+                bg_path=bg_path,
+                heading=heading,
+                initial=5,
+            )
+            rate_dlg.doModal()
+
+            if not rate_dlg.confirmed:
+                del rate_dlg
+                return
+
+            rating = rate_dlg.rating
+            del rate_dlg
+
+            rate_payload: dict[str, Any] = {
+                "media_type": media_type,
+                "tmdb_id": tmdb_id,
+                "rating": rating,
+            }
+            if media_type == "episode":
+                if metadata.get("season") is not None:
+                    rate_payload["season"] = metadata["season"]
+                if metadata.get("episode") is not None:
+                    rate_payload["episode"] = metadata["episode"]
+
+            self._api.post_immediate("/api/scrobble/rate", rate_payload)
+            xbmc.log(
+                f"[PunchPlay] Rated {title!r} {rating}/10",
+                xbmc.LOGINFO,
+            )
+        except Exception as exc:
+            xbmc.log(f"[PunchPlay] Rating dialog error: {exc}", xbmc.LOGDEBUG)
 
     def _handle_stop(self) -> None:
         if self._metadata is None:

--- a/script.punchplay/rating_dialog.py
+++ b/script.punchplay/rating_dialog.py
@@ -1,0 +1,128 @@
+"""
+rating_dialog.py — Star-slider rating dialog.
+
+Left/Right arrows change the rating (1–10), OK confirms, Back cancels.
+Stars fill with gold as the rating increases.
+"""
+
+from __future__ import annotations
+
+import xbmcgui
+
+# Action IDs
+_ACTION_LEFT = 1
+_ACTION_RIGHT = 2
+_ACTION_SELECT = 7
+_ACTION_PARENT_DIR = 9
+_ACTION_PREVIOUS_MENU = 10
+_ACTION_PARENT_DIR2 = 13
+_ACTION_NAV_BACK = 92
+
+_FILLED = "★"   # ★
+_EMPTY = "★"    # ★ (same char, different colour)
+_GOLD = "FFE8B923"
+_GREY = "FF555555"
+
+
+class RatingDialog(xbmcgui.WindowDialog):
+    """Full-screen star-slider rating dialog."""
+
+    def __init__(
+        self,
+        *,
+        bg_path: str,
+        heading: str,
+        initial: int = 5,
+    ):
+        self._rating = max(1, min(10, initial))
+        self._confirmed = False
+
+        # Backdrop
+        self.addControl(xbmcgui.ControlImage(0, 0, 1280, 720, bg_path))
+
+        # Heading
+        self.addControl(
+            xbmcgui.ControlLabel(
+                0, 200, 1280, 40,
+                "[B]" + heading + "[/B]",
+                font="font25",
+                alignment=2,
+                textColor="FFFFFFFF",
+            )
+        )
+
+        # Stars label (updated dynamically)
+        self._stars_label = xbmcgui.ControlLabel(
+            0, 290, 1280, 60,
+            self._render_stars(),
+            font="font45",
+            alignment=2,
+        )
+        self.addControl(self._stars_label)
+
+        # Rating number
+        self._number_label = xbmcgui.ControlLabel(
+            0, 370, 1280, 40,
+            f"[B]{self._rating}/10[/B]",
+            font="font20",
+            alignment=2,
+            textColor="FFFFFFFF",
+        )
+        self.addControl(self._number_label)
+
+        # Arrow hints
+        self.addControl(
+            xbmcgui.ControlLabel(
+                0, 440, 1280, 30,
+                "◄  ─────────  ►",
+                font="font13",
+                alignment=2,
+                textColor="FF777777",
+            )
+        )
+
+        # Footer
+        self.addControl(
+            xbmcgui.ControlLabel(
+                0, 620, 1280, 30,
+                "OK to confirm  ·  Back to skip",
+                font="font12",
+                alignment=2,
+                textColor="FF777777",
+            )
+        )
+
+    def _render_stars(self) -> str:
+        filled = f"[COLOR {_GOLD}]{_FILLED * self._rating}[/COLOR]"
+        empty = f"[COLOR {_GREY}]{_EMPTY * (10 - self._rating)}[/COLOR]"
+        return filled + empty
+
+    def _update_display(self) -> None:
+        self._stars_label.setLabel(self._render_stars())
+        self._number_label.setLabel(f"[B]{self._rating}/10[/B]")
+
+    @property
+    def confirmed(self) -> bool:
+        return self._confirmed
+
+    @property
+    def rating(self) -> int:
+        return self._rating
+
+    def onAction(self, action) -> None:  # type: ignore[override]
+        action_id = action.getId()
+
+        if action_id == _ACTION_RIGHT:
+            if self._rating < 10:
+                self._rating += 1
+                self._update_display()
+        elif action_id == _ACTION_LEFT:
+            if self._rating > 1:
+                self._rating -= 1
+                self._update_display()
+        elif action_id == _ACTION_SELECT:
+            self._confirmed = True
+            self.close()
+        elif action_id in (_ACTION_PARENT_DIR, _ACTION_PREVIOUS_MENU,
+                           _ACTION_PARENT_DIR2, _ACTION_NAV_BACK):
+            self.close()

--- a/script.punchplay/resources/language/resource.language.en_gb/strings.po
+++ b/script.punchplay/resources/language/resource.language.en_gb/strings.po
@@ -27,7 +27,7 @@ msgid "Your code:"
 msgstr ""
 
 msgctxt "#32005"
-msgid "Expires in {0} minutes — press OK to wait for approval."
+msgid "Expires in {0} minutes."
 msgstr ""
 
 msgctxt "#32006"
@@ -83,5 +83,57 @@ msgid "And enter this code:"
 msgstr ""
 
 msgctxt "#32019"
-msgid "Press OK or Back to continue"
+msgid "This will close automatically when connected."
+msgstr ""
+
+msgctxt "#32020"
+msgid "Rate after watching"
+msgstr ""
+
+msgctxt "#32021"
+msgid "Rate {0}"
+msgstr ""
+
+msgctxt "#32022"
+msgid "Rate {0} S{1}E{2}"
+msgstr ""
+
+msgctxt "#32023"
+msgid "Syncing Kodi Library"
+msgstr ""
+
+msgctxt "#32024"
+msgid "Sync Kodi Library"
+msgstr ""
+
+msgctxt "#32025"
+msgid "Syncing movies… {0}/{1}"
+msgstr ""
+
+msgctxt "#32026"
+msgid "Syncing episodes… {0}/{1}"
+msgstr ""
+
+msgctxt "#32027"
+msgid "Imported {0} movies, {1} episodes."
+msgstr ""
+
+msgctxt "#32028"
+msgid "Sync failed: {0}"
+msgstr ""
+
+msgctxt "#32029"
+msgid "No watched items in library."
+msgstr ""
+
+msgctxt "#32030"
+msgid "Connected to PunchPlay"
+msgstr ""
+
+msgctxt "#32031"
+msgid "Already connected."
+msgstr ""
+
+msgctxt "#32032"
+msgid "Not logged in."
 msgstr ""

--- a/script.punchplay/resources/settings.xml
+++ b/script.punchplay/resources/settings.xml
@@ -2,20 +2,25 @@
 <settings>
 
   <category label="Connection">
-    <setting id="backend_url"        type="text"   label="Backend URL"                  default="https://punchplay.tv"/>
+    <setting id="backend_url"        type="text"   label="Backend URL"                  default="https://punchplay.tv" visible="false"/>
     <setting id="login_btn"          type="action" label="Login to PunchPlay"            action="SetProperty(punchplay_login,1,10000)"  option="action"/>
     <setting id="logout_btn"         type="action" label="Logout"                        action="SetProperty(punchplay_logout,1,10000)" option="action"/>
   </category>
 
   <category label="Scrobbling">
-    <setting id="watched_threshold"  type="slider" label="Watched threshold (%)"         default="70"   range="50,5,95" option="int"/>
-    <setting id="min_length"         type="number" label="Minimum file length (minutes)" default="5"/>
-    <setting id="heartbeat_interval" type="number" label="Heartbeat interval (seconds)"  default="30"/>
-    <setting id="scrobble_movies"      type="bool"   label="Scrobble movies"                  default="true"/>
-    <setting id="scrobble_tv"          type="bool"   label="Scrobble TV shows"                default="true"/>
-    <setting id="scrobble_anime"       type="bool"   label="Scrobble anime"                   default="true"/>
-    <setting id="show_notifications"   type="bool"   label="Show scrobble notifications"      default="true"/>
-    <setting id="notify_during_playback" type="bool" label="Show notifications during playback" default="false"/>
+    <setting id="scrobble_movies"        type="bool"   label="Scrobble movies"                    default="true"/>
+    <setting id="scrobble_tv"            type="bool"   label="Scrobble TV shows"                  default="true"/>
+    <setting id="scrobble_anime"         type="bool"   label="Scrobble anime"                     default="true"/>
+    <setting id="rate_after_watching"    type="bool"   label="32020"                               default="true"/>
+    <setting id="show_notifications"     type="bool"   label="Show scrobble notifications"        default="true"/>
+    <setting id="notify_during_playback" type="bool"   label="Show notifications during playback" default="false"/>
+    <setting id="watched_threshold"      type="slider" label="Watched threshold (%)"               default="70"  range="50,5,95" option="int"/>
+    <setting id="min_length"             type="number" label="Minimum file length (minutes)"       default="5"/>
+    <setting id="heartbeat_interval"     type="number" label="Heartbeat interval (seconds)"        default="30"/>
+  </category>
+
+  <category label="Library">
+    <setting id="sync_library_btn" type="action" label="32024" action="SetProperty(punchplay_sync_library,1,10000)" option="action"/>
   </category>
 
 </settings>

--- a/script.punchplay/service.py
+++ b/script.punchplay/service.py
@@ -7,9 +7,14 @@ Responsibilities:
   • Periodically flush the offline scrobble queue (every 60 s when online).
   • Prune stale identifier-cache entries once per day.
   • Reload settings when the user changes them via onSettingsChanged().
+  • One-click Kodi library sync (import watched items to PunchPlay).
 """
 
+from __future__ import annotations
+
+import json
 import time
+from typing import Any
 
 import xbmc
 import xbmcaddon
@@ -67,13 +72,32 @@ class PunchPlayService(xbmc.Monitor):
             # Handle login / logout triggered from the settings screen.
             if _home.getProperty("punchplay_login"):
                 _home.clearProperty("punchplay_login")
-                xbmc.log("[PunchPlay] Login triggered from settings", xbmc.LOGINFO)
-                self._api.device_code_login()
+                if self._api.is_authenticated():
+                    xbmcgui.Dialog().notification(
+                        "PunchPlay",
+                        xbmcaddon.Addon(_ADDON_ID).getLocalizedString(32031),
+                        xbmcgui.NOTIFICATION_INFO, 3000,
+                    )
+                else:
+                    xbmc.log("[PunchPlay] Login triggered from settings", xbmc.LOGINFO)
+                    self._api.device_code_login()
 
             if _home.getProperty("punchplay_logout"):
                 _home.clearProperty("punchplay_logout")
-                xbmc.log("[PunchPlay] Logout triggered from settings", xbmc.LOGINFO)
-                self._api.logout()
+                if not self._api.is_authenticated():
+                    xbmcgui.Dialog().notification(
+                        "PunchPlay",
+                        xbmcaddon.Addon(_ADDON_ID).getLocalizedString(32032),
+                        xbmcgui.NOTIFICATION_INFO, 3000,
+                    )
+                else:
+                    xbmc.log("[PunchPlay] Logout triggered from settings", xbmc.LOGINFO)
+                    self._api.logout()
+
+            if _home.getProperty("punchplay_sync_library"):
+                _home.clearProperty("punchplay_sync_library")
+                xbmc.log("[PunchPlay] Library sync triggered from settings", xbmc.LOGINFO)
+                self._sync_kodi_library()
 
             # Flush offline queue periodically.
             if self._api.is_authenticated() and (now - self._last_flush >= _FLUSH_INTERVAL):
@@ -99,3 +123,185 @@ class PunchPlayService(xbmc.Monitor):
         # Kodi is shutting down — clean up the player.
         self._player.cleanup()
         xbmc.log("[PunchPlay] Service stopped", xbmc.LOGINFO)
+
+    # ------------------------------------------------------------------
+    # Kodi library sync
+    # ------------------------------------------------------------------
+
+    def _sync_kodi_library(self) -> None:
+        """Import all watched items from the Kodi library into PunchPlay."""
+        _s = xbmcaddon.Addon(_ADDON_ID).getLocalizedString
+
+        if not self._api.is_authenticated():
+            xbmcgui.Dialog().notification(
+                "PunchPlay", "Not logged in.", xbmcgui.NOTIFICATION_WARNING, 4000
+            )
+            return
+
+        progress = xbmcgui.DialogProgress()
+        progress.create(_s(32023), _s(32025).format(0, "?"))
+
+        try:
+            movies = self._get_watched_movies()
+            episodes = self._get_watched_episodes()
+
+            if not movies and not episodes:
+                progress.close()
+                xbmcgui.Dialog().notification(
+                    "PunchPlay", _s(32029), xbmcgui.NOTIFICATION_INFO, 4000
+                )
+                return
+
+            total_movies = len(movies)
+            total_episodes = len(episodes)
+            imported_movies = 0
+            imported_episodes = 0
+
+            # ── Sync movies in batches of 50 ────────────────────────────
+            cancelled = False
+            batch_size = 50
+            for i in range(0, total_movies, batch_size):
+                if progress.iscanceled():
+                    cancelled = True
+                    break
+                batch = movies[i : i + batch_size]
+                progress.update(
+                    int(50 * min(i + batch_size, total_movies) / max(total_movies, 1)),
+                    _s(32025).format(min(i + batch_size, total_movies), total_movies),
+                )
+                try:
+                    resp = self._api.post_immediate(
+                        "/api/scrobble/import", {"entries": batch}, timeout=55
+                    )
+                    imported_movies += resp.get("imported", 0)
+                except Exception as exc:
+                    xbmc.log(f"[PunchPlay] Movie batch error: {exc}", xbmc.LOGWARNING)
+
+            # ── Sync episodes in batches of 50 ──────────────────────────
+            if not cancelled:
+                for i in range(0, total_episodes, batch_size):
+                    if progress.iscanceled():
+                        cancelled = True
+                        break
+                    batch = episodes[i : i + batch_size]
+                    pct = 50 + int(50 * min(i + batch_size, total_episodes) / max(total_episodes, 1))
+                    progress.update(
+                        pct,
+                        _s(32026).format(min(i + batch_size, total_episodes), total_episodes),
+                    )
+                    try:
+                        resp = self._api.post_immediate(
+                            "/api/scrobble/import", {"entries": batch}, timeout=55
+                        )
+                        imported_episodes += resp.get("imported", 0)
+                    except Exception as exc:
+                        xbmc.log(f"[PunchPlay] Episode batch error: {exc}", xbmc.LOGWARNING)
+
+            progress.close()
+            if cancelled:
+                xbmc.log(
+                    f"[PunchPlay] Library sync cancelled. "
+                    f"Imported {imported_movies} movies, {imported_episodes} episodes before cancel.",
+                    xbmc.LOGINFO,
+                )
+            else:
+                msg = _s(32027).format(imported_movies, imported_episodes)
+                xbmcgui.Dialog().notification("PunchPlay", msg, xbmcgui.NOTIFICATION_INFO, 6000)
+                xbmc.log(f"[PunchPlay] Library sync: {msg}", xbmc.LOGINFO)
+
+        except Exception as exc:
+            try:
+                progress.close()
+            except Exception:
+                pass
+            xbmc.log(f"[PunchPlay] Library sync failed: {exc}", xbmc.LOGWARNING)
+            xbmcgui.Dialog().notification(
+                "PunchPlay", _s(32028).format(str(exc)[:80]),
+                xbmcgui.NOTIFICATION_ERROR, 5000
+            )
+
+    def _get_watched_movies(self) -> list[dict[str, Any]]:
+        """Query Kodi's JSON-RPC for all watched movies."""
+        raw = xbmc.executeJSONRPC(json.dumps({
+            "jsonrpc": "2.0",
+            "method": "VideoLibrary.GetMovies",
+            "params": {
+                "filter": {
+                    "field": "playcount",
+                    "operator": "greaterthan",
+                    "value": "0",
+                },
+                "properties": [
+                    "title", "year", "imdbnumber", "uniqueid",
+                    "lastplayed", "playcount",
+                ],
+            },
+            "id": 1,
+        }))
+        data = json.loads(raw)
+        results: list[dict[str, Any]] = []
+        for movie in data.get("result", {}).get("movies", []):
+            entry: dict[str, Any] = {
+                "media_type": "movie",
+                "title": movie.get("title", ""),
+                "year": movie.get("year"),
+            }
+            # Extract IDs from uniqueid dict or imdbnumber field.
+            unique_ids = movie.get("uniqueid", {})
+            imdb = unique_ids.get("imdb") or movie.get("imdbnumber") or None
+            tmdb = unique_ids.get("tmdb")
+            if imdb:
+                entry["imdb_id"] = imdb
+            if tmdb:
+                try:
+                    entry["tmdb_id"] = int(tmdb)
+                except (ValueError, TypeError):
+                    pass
+            last_played = movie.get("lastplayed", "")
+            if last_played:
+                entry["watched_at"] = last_played
+            results.append(entry)
+        return results
+
+    def _get_watched_episodes(self) -> list[dict[str, Any]]:
+        """Query Kodi's JSON-RPC for all watched episodes."""
+        raw = xbmc.executeJSONRPC(json.dumps({
+            "jsonrpc": "2.0",
+            "method": "VideoLibrary.GetEpisodes",
+            "params": {
+                "filter": {
+                    "field": "playcount",
+                    "operator": "greaterthan",
+                    "value": "0",
+                },
+                "properties": [
+                    "showtitle", "season", "episode", "uniqueid",
+                    "lastplayed", "playcount",
+                ],
+            },
+            "id": 2,
+        }))
+        data = json.loads(raw)
+        results: list[dict[str, Any]] = []
+        for ep in data.get("result", {}).get("episodes", []):
+            entry: dict[str, Any] = {
+                "media_type": "episode",
+                "title": ep.get("showtitle", ""),
+                "season": ep.get("season"),
+                "episode": ep.get("episode"),
+            }
+            unique_ids = ep.get("uniqueid", {})
+            imdb = unique_ids.get("imdb")
+            tmdb = unique_ids.get("tmdb")
+            if imdb:
+                entry["imdb_id"] = imdb
+            if tmdb:
+                try:
+                    entry["tmdb_id"] = int(tmdb)
+                except (ValueError, TypeError):
+                    pass
+            last_played = ep.get("lastplayed", "")
+            if last_played:
+                entry["watched_at"] = last_played
+            results.append(entry)
+        return results


### PR DESCRIPTION
## Changes
- Windows Login Error — Fixed an error users were getting when trying to login via Windows
- Rate after watching — star-slider dialog (1–10) appears after scrobble threshold is met
- One-click Kodi library sync — imports all watched movies and episodes with original watch dates
- Login dialog auto-closes when approved (polls in background)
- Fix false scrobble on immediate stop after previous watched session
- Login/logout guards prevent redundant actions
- Faster QR login poll (3s)

### Checklist:
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [script.foo.bar] 1.0.0
