### PR TITLE
[script.service.hue@matrix] 2.2.1

### DIFF
--- a/script.service.hue/addon.xml
+++ b/script.service.hue/addon.xml
@@ -1,4 +1,4 @@
-<addon id="script.service.hue" name="Hue Service" provider-name="zim514" version="2.1.1">
+<addon id="script.service.hue" name="Hue Service" provider-name="zim514" version="2.2.1">
     <requires>
         <import addon="xbmc.python" version="3.0.0"/>
         <import addon="script.module.requests" version="2.31.0"/>
@@ -20,7 +20,12 @@
         </assets>
         <source>https://github.com/zim514/script.service.hue</source>
         <forum>https://forum.kodi.tv/showthread.php?tid=344886</forum>
-        <news>v2.1
+        <news>v2.2.0bump
+- Add mDNS bridge discovery, replacing N-UPnP
+- Improve retry/error handling for Hue API requests
+- Fix bridge connection, discovery, and reconnection bugs
+
+v2.1
 - Update Hue connection for new HTTPS requirement
 - Update bridge version check
 - Fix audio trigger (Thanks to @NamelessCoder)

--- a/script.service.hue/resources/language/resource.language.ast_es/strings.po
+++ b/script.service.hue/resources/language/resource.language.ast_es/strings.po
@@ -1,0 +1,514 @@
+# Kodi Media Center language file
+# Addon Name: Hue Service
+# Addon id: script.service.hue
+# Addon Provider: zim514
+msgid ""
+msgstr ""
+"PO-Revision-Date: 2024-08-05 13:29+0000\n"
+"Last-Translator: \"Enol P.\" <enolp@softastur.org>\n"
+"Language-Team: Asturian (Spain) <https://kodi.weblate.cloud/projects/kodi-add-ons-scripts/script-service-hue/ast_es/>\n"
+"Language: ast_es\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Generator: Weblate 5.6.2\n"
+
+msgctxt "Addon Summary"
+msgid "Automate Hue lights with Kodi playback"
+msgstr ""
+
+msgctxt "Addon Description"
+msgid "Automate your Hue lights with Kodi. Use scenes configured in the official Hue app. Can use Hue's sunset time to automatically disable the service during daytime and turn on the lights at sunset during playback. Includes Ambilight support."
+msgstr ""
+
+msgctxt "Addon Disclaimer"
+msgid "Requires a Hue Bridge V2 (Square). Ambilight not available on all hardware."
+msgstr ""
+
+msgctxt "#32100"
+msgid "Video Scenes"
+msgstr ""
+
+msgctxt "#32102"
+msgid "Audio Scenes"
+msgstr ""
+
+msgctxt "#32201"
+msgid "Start/Resume"
+msgstr ""
+
+msgctxt "#32202"
+msgid "Pause"
+msgstr ""
+
+msgctxt "#32203"
+msgid "Stop"
+msgstr ""
+
+msgctxt "#30036"
+msgid "Scene:"
+msgstr ""
+
+msgctxt "#32511"
+msgid "Scene ID"
+msgstr ""
+
+msgctxt "#32512"
+msgid "Select..."
+msgstr ""
+
+msgctxt "#30500"
+msgid "Bridge"
+msgstr ""
+
+msgctxt "#30501"
+msgid "Discover Hue Bridge / Enter IP"
+msgstr ""
+
+msgctxt "#30502"
+msgid "Bridge IP"
+msgstr ""
+
+msgctxt "#30503"
+msgid "Bridge User"
+msgstr ""
+
+msgctxt "#30505"
+msgid "Enable Schedule (24h format)"
+msgstr ""
+
+msgctxt "#30506"
+msgid "Start time:"
+msgstr ""
+
+msgctxt "#30507"
+msgid "End time:"
+msgstr ""
+
+msgctxt "#30508"
+msgid "Disable during daytime"
+msgstr ""
+
+#. If watching a movie or TV show, and sunset occurs, activate the scene in that moment
+msgctxt "#30509"
+msgid "Activate during playback at sunset"
+msgstr ""
+
+msgctxt "#30510"
+msgid "General"
+msgstr "Xeneral"
+
+msgctxt "#30511"
+msgid "Schedule"
+msgstr ""
+
+msgctxt "#30512"
+msgid "Scenes"
+msgstr ""
+
+msgctxt "#30513"
+msgid "Play Scene Enabled"
+msgstr ""
+
+msgctxt "#30514"
+msgid "Pause Scene Enabled"
+msgstr ""
+
+msgctxt "#30515"
+msgid "Stop Scene Enabled"
+msgstr ""
+
+#. If any light in the selected scene is on, ignore the schedule restrictions
+msgctxt "#30516"
+msgid "Disable time check if any light already on"
+msgstr ""
+
+#. If any of the lights in the scene are off, don't activate the related scene
+msgctxt "#30517"
+msgid "Don't enable scene if any light is off"
+msgstr ""
+
+msgctxt "#30521"
+msgid "[B][I]Warning: Not supported on all hardware[/B][/I]"
+msgstr ""
+
+msgctxt "#30522"
+msgid "CPU & Hue performance"
+msgstr ""
+
+msgctxt "#30523"
+msgid "Ambilight"
+msgstr ""
+
+msgctxt "#32101"
+msgid "Advanced"
+msgstr ""
+
+msgctxt "#32106"
+msgid "Video Activation Rules"
+msgstr ""
+
+msgctxt "#6101"
+msgid "Select Lights"
+msgstr ""
+
+msgctxt "#30520"
+msgid "Enabled"
+msgstr ""
+
+msgctxt "#9001"
+msgid "Press connect button on Hue bridge"
+msgstr ""
+
+msgctxt "#30000"
+msgid "Hue Service"
+msgstr ""
+
+msgctxt "#30004"
+msgid "Check your bridge and network"
+msgstr ""
+
+msgctxt "#30006"
+msgid "Hue connected"
+msgstr ""
+
+msgctxt "#30008"
+msgid "Bridge not found"
+msgstr ""
+
+msgctxt "#30010"
+msgid "User not found"
+msgstr ""
+
+msgctxt "#30011"
+msgid "Complete!"
+msgstr ""
+
+msgctxt "#30013"
+msgid "Cancelled"
+msgstr ""
+
+msgctxt "#30015"
+msgid "Select Hue Lights..."
+msgstr ""
+
+msgctxt "#30017"
+msgid "Found bridge: "
+msgstr ""
+
+msgctxt "#30018"
+msgid "Discover bridge..."
+msgstr ""
+
+msgctxt "#30021"
+msgid "Bridge connection failed"
+msgstr ""
+
+msgctxt "#30022"
+msgid "Discovery started"
+msgstr ""
+
+msgctxt "#30023"
+msgid "Bridge not configured"
+msgstr ""
+
+msgctxt "#30024"
+msgid "Check Hue Bridge configuration"
+msgstr ""
+
+msgctxt "#30034"
+msgid "Cancel"
+msgstr ""
+
+msgctxt "#30035"
+msgid "Lights:"
+msgstr ""
+
+msgctxt "#30037"
+msgid "Save"
+msgstr ""
+
+msgctxt "#30043"
+msgid "Error"
+msgstr ""
+
+msgctxt "#30047"
+msgid "Connection lost. Check settings. Shutting down"
+msgstr ""
+
+msgctxt "#30050"
+msgid "N-UPnP discovery..."
+msgstr ""
+
+msgctxt "#30005"
+msgid "Searching for bridge..."
+msgstr ""
+
+msgctxt "#30052"
+msgid "Invalid start or end time, schedule disabled"
+msgstr ""
+
+msgctxt "#30058"
+msgid "Light Names:"
+msgstr ""
+
+msgctxt "#30065"
+msgid "Update interval (ms)"
+msgstr ""
+
+msgctxt "#30066"
+msgid "Hue transition time (ms)"
+msgstr ""
+
+msgctxt "#30067"
+msgid "Frame capture size"
+msgstr ""
+
+msgctxt "#30068"
+msgid "Show Hue bridge capacity errors"
+msgstr ""
+
+#. Minimum duration of the media before activating light scene
+msgctxt "#30800"
+msgid "Minimum duration (Minutes)"
+msgstr ""
+
+msgctxt "#30801"
+msgid "Enable for Movies"
+msgstr ""
+
+msgctxt "#30802"
+msgid "Enable for TV episodes"
+msgstr ""
+
+msgctxt "#30803"
+msgid "Enable for music videos"
+msgstr ""
+
+msgctxt "#30804"
+msgid "Enable for other videos (Discs)"
+msgstr ""
+
+msgctxt "#30805"
+msgid "Enable for live TV"
+msgstr ""
+
+msgctxt "#30809"
+msgid "Saturation"
+msgstr ""
+
+msgctxt "#30810"
+msgid "Minimum Brightness"
+msgstr ""
+
+msgctxt "#30811"
+msgid "Maximum Brightness"
+msgstr ""
+
+msgctxt "#30813"
+msgid "Average image processing time:"
+msgstr ""
+
+msgctxt "#30814"
+msgid "On playback stop"
+msgstr ""
+
+msgctxt "#30815"
+msgid "Resume light state"
+msgstr ""
+
+msgctxt "#30816"
+msgid "Resume transition time (secs.)"
+msgstr ""
+
+msgctxt "#30071"
+msgid "Only colour lights are supported"
+msgstr ""
+
+#. Old or deperacted bridge firmware or hardware
+msgctxt "#30072"
+msgid "Unsupported Hue Bridge"
+msgstr ""
+
+msgctxt "#30055"
+msgid "Disabled"
+msgstr ""
+
+msgctxt "#30060"
+msgid "Play"
+msgstr ""
+
+#. Must end with a space, status string is appended
+msgctxt "#30061"
+msgid "Hue Status: "
+msgstr ""
+
+msgctxt "#30062"
+msgid "Settings"
+msgstr ""
+
+msgctxt "#30063"
+msgid "Disabled by daytime"
+msgstr ""
+
+msgctxt "#30064"
+msgid "ERROR: Scene not found, it may have been deleted"
+msgstr ""
+
+msgctxt "#30080"
+msgid "The following error occurred:"
+msgstr ""
+
+msgctxt "#30081"
+msgid "Automatically report this error?"
+msgstr ""
+
+msgctxt "#30069"
+msgid "No lights selected for Ambilight."
+msgstr ""
+
+msgctxt "#30070"
+msgid "Ok"
+msgstr ""
+
+msgctxt "#30075"
+msgid "Hue Bridge over capacity"
+msgstr ""
+
+msgctxt "#30076"
+msgid "Network not ready"
+msgstr ""
+
+msgctxt "#30077"
+msgid "The Hue Bridge is over capacity. Increase refresh rate or reduce the number of Ambilights."
+msgstr ""
+
+msgctxt "#30078"
+msgid "Bridge not found[CR]Check your bridge and network."
+msgstr ""
+
+msgctxt "#30082"
+msgid "Press link button on bridge. Waiting for 90 seconds..."
+msgstr ""
+
+msgctxt "#30083"
+msgid "Unknown"
+msgstr ""
+
+msgctxt "#30084"
+msgid "User Found![CR]Saving settings..."
+msgstr ""
+
+msgctxt "#30086"
+msgid "User not found[CR]Check your bridge and network."
+msgstr ""
+
+msgctxt "#30073"
+msgid "Do not show again"
+msgstr ""
+
+msgctxt "#30001"
+msgid "Hue Bridge V1 (Round) is unsupported. Hue Bridge V2 (Square) is required."
+msgstr ""
+
+#. For ambilight, different color gamuts are supported. This means the colour gamut could not be fetched and the light is probably not compatible with ambilight.
+msgctxt "#30012"
+msgid "Unknown colour gamut for light:"
+msgstr ""
+
+msgctxt "#30016"
+msgid "Report errors"
+msgstr ""
+
+msgctxt "#30020"
+msgid "Never report errors"
+msgstr ""
+
+msgctxt "#30032"
+msgid "Hue Service Error"
+msgstr ""
+
+msgctxt "#30029"
+msgid "Connection Error"
+msgstr ""
+
+msgctxt "#30014"
+msgid "Error: Lights incompatible with Ambilight"
+msgstr ""
+
+msgctxt "#30007"
+msgid "Bridge not found automatically. Please make sure your bridge is up to date and has access to the internet. [CR]Would you like to enter your bridge IP manually?"
+msgstr ""
+
+msgctxt "#30009"
+msgid "Connecting..."
+msgstr ""
+
+msgctxt "#30019"
+msgid "Bridge outdated. Please update your bridge."
+msgstr ""
+
+msgctxt "#30033"
+msgid "Reconnected"
+msgstr ""
+
+#. Time at which the service should be disabled in the morning, paired with "Disable during daytime", until sunset
+msgctxt "#31334"
+msgid "Morning disable time:"
+msgstr ""
+
+#. Amount of time for the light scene transition to fade in, in seconds.
+msgctxt "#31335"
+msgid "Transition time (seconds):"
+msgstr ""
+
+#. Number of minutes before or after sunset to consider as sunset
+msgctxt "#31336"
+msgid "Sunset Offset:"
+msgstr ""
+
+#. Help text for sunset offset setting
+msgctxt "#31337"
+msgid "Adjust sunset back or forwards by this many minutes"
+msgstr ""
+
+#. Help text for "morning disable time" setting
+msgctxt "#31338"
+msgid "Time at which to disable the service in the morning"
+msgstr ""
+
+#. Help text for 'Disable during daytime'
+msgctxt "#31339"
+msgid "Disable the service between configured time and sunset"
+msgstr ""
+
+#. Help text for 'activate at sunset'
+msgctxt "#31340"
+msgid "Activate scenes at sunset, during playback"
+msgstr ""
+
+msgctxt "#30002"
+msgid "Bridge overloaded, stopping ambilight"
+msgstr ""
+
+msgctxt "#30025"
+msgid "Bridge unauthorized, please reconfigure."
+msgstr ""
+
+msgctxt "#30026"
+msgid "Connection failed, retrying..."
+msgstr ""
+
+#. Default status in an empty configuration field; eg. scene/lights are not selected
+msgctxt "#30003"
+msgid "Not selected"
+msgstr ""
+
+msgctxt "#30027"
+msgid "ERROR: Light not found, it may have been deleted"
+msgstr ""
+
+msgctxt "#30028"
+msgid "Configure Hue Home location to use Sunset time, defaulting to 19:00"
+msgstr ""

--- a/script.service.hue/resources/language/resource.language.eo/strings.po
+++ b/script.service.hue/resources/language/resource.language.eo/strings.po
@@ -4,17 +4,10 @@
 # Addon Provider: zim514
 msgid ""
 msgstr ""
-"Project-Id-Version: \n"
-"POT-Creation-Date: \n"
-"PO-Revision-Date: 2022-03-09 14:05+0000\n"
-"Last-Translator: Christian Gade <gade@kodi.tv>\n"
-"Language-Team: Occitan (France) <https://kodi.weblate.cloud/projects/kodi-add-ons-scripts/script-service-hue/oc_fr/>\n"
-"Language: oc_fr\n"
+"Language: eo\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 4.11.2\n"
 
 msgctxt "Addon Summary"
 msgid "Automate Hue lights with Kodi playback"
@@ -30,11 +23,11 @@ msgstr ""
 
 msgctxt "#32100"
 msgid "Video Scenes"
-msgstr "Video Scenes"
+msgstr ""
 
 msgctxt "#32102"
 msgid "Audio Scenes"
-msgstr "Audio Scenes"
+msgstr ""
 
 msgctxt "#32201"
 msgid "Start/Resume"
@@ -50,7 +43,7 @@ msgstr ""
 
 msgctxt "#30036"
 msgid "Scene:"
-msgstr "Scene:"
+msgstr ""
 
 msgctxt "#32511"
 msgid "Scene ID"
@@ -66,7 +59,7 @@ msgstr ""
 
 msgctxt "#30501"
 msgid "Discover Hue Bridge / Enter IP"
-msgstr "Discover Hue Bridge / Enter IP"
+msgstr ""
 
 msgctxt "#30502"
 msgid "Bridge IP"
@@ -90,7 +83,7 @@ msgstr ""
 
 msgctxt "#30508"
 msgid "Disable during daytime"
-msgstr "Disable during daytime"
+msgstr ""
 
 #. If watching a movie or TV show, and sunset occurs, activate the scene in that moment
 msgctxt "#30509"
@@ -99,7 +92,7 @@ msgstr ""
 
 msgctxt "#30510"
 msgid "General"
-msgstr "General"
+msgstr ""
 
 msgctxt "#30511"
 msgid "Schedule"
@@ -145,11 +138,11 @@ msgstr ""
 
 msgctxt "#32101"
 msgid "Advanced"
-msgstr "Avançat"
+msgstr ""
 
 msgctxt "#32106"
 msgid "Video Activation Rules"
-msgstr "Video Activation Rules"
+msgstr ""
 
 msgctxt "#6101"
 msgid "Select Lights"
@@ -352,11 +345,11 @@ msgstr ""
 
 msgctxt "#30063"
 msgid "Disabled by daytime"
-msgstr "Disabled by daytime"
+msgstr ""
 
 msgctxt "#30064"
 msgid "ERROR: Scene not found, it may have been deleted"
-msgstr "ERROR: Scene not found, it may have been deleted"
+msgstr ""
 
 msgctxt "#30080"
 msgid "The following error occurred:"
@@ -514,7 +507,3 @@ msgstr ""
 msgctxt "#30028"
 msgid "Configure Hue Home location to use Sunset time, defaulting to 19:00"
 msgstr ""
-
-#~ msgctxt "#30002"
-#~ msgid "ERROR: Scene not created"
-#~ msgstr "ERROR: Scene not created"

--- a/script.service.hue/resources/language/resource.language.mi/strings.po
+++ b/script.service.hue/resources/language/resource.language.mi/strings.po
@@ -4,17 +4,10 @@
 # Addon Provider: zim514
 msgid ""
 msgstr ""
-"Project-Id-Version: \n"
-"POT-Creation-Date: \n"
-"PO-Revision-Date: 2022-03-09 14:05+0000\n"
-"Last-Translator: Christian Gade <gade@kodi.tv>\n"
-"Language-Team: Ossetian <https://kodi.weblate.cloud/projects/kodi-add-ons-scripts/script-service-hue/os_os/>\n"
-"Language: os_os\n"
+"Language: mi\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 4.11.2\n"
 
 msgctxt "Addon Summary"
 msgid "Automate Hue lights with Kodi playback"
@@ -30,11 +23,11 @@ msgstr ""
 
 msgctxt "#32100"
 msgid "Video Scenes"
-msgstr "Video Scenes"
+msgstr ""
 
 msgctxt "#32102"
 msgid "Audio Scenes"
-msgstr "Audio Scenes"
+msgstr ""
 
 msgctxt "#32201"
 msgid "Start/Resume"
@@ -50,7 +43,7 @@ msgstr ""
 
 msgctxt "#30036"
 msgid "Scene:"
-msgstr "Scene:"
+msgstr ""
 
 msgctxt "#32511"
 msgid "Scene ID"
@@ -66,7 +59,7 @@ msgstr ""
 
 msgctxt "#30501"
 msgid "Discover Hue Bridge / Enter IP"
-msgstr "Discover Hue Bridge / Enter IP"
+msgstr ""
 
 msgctxt "#30502"
 msgid "Bridge IP"
@@ -90,7 +83,7 @@ msgstr ""
 
 msgctxt "#30508"
 msgid "Disable during daytime"
-msgstr "Disable during daytime"
+msgstr ""
 
 #. If watching a movie or TV show, and sunset occurs, activate the scene in that moment
 msgctxt "#30509"
@@ -99,7 +92,7 @@ msgstr ""
 
 msgctxt "#30510"
 msgid "General"
-msgstr "Сӕйраг"
+msgstr ""
 
 msgctxt "#30511"
 msgid "Schedule"
@@ -149,7 +142,7 @@ msgstr ""
 
 msgctxt "#32106"
 msgid "Video Activation Rules"
-msgstr "Video Activation Rules"
+msgstr ""
 
 msgctxt "#6101"
 msgid "Select Lights"
@@ -352,11 +345,11 @@ msgstr ""
 
 msgctxt "#30063"
 msgid "Disabled by daytime"
-msgstr "Disabled by daytime"
+msgstr ""
 
 msgctxt "#30064"
 msgid "ERROR: Scene not found, it may have been deleted"
-msgstr "ERROR: Scene not found, it may have been deleted"
+msgstr ""
 
 msgctxt "#30080"
 msgid "The following error occurred:"
@@ -514,7 +507,3 @@ msgstr ""
 msgctxt "#30028"
 msgid "Configure Hue Home location to use Sunset time, defaulting to 19:00"
 msgstr ""
-
-#~ msgctxt "#30002"
-#~ msgid "ERROR: Scene not created"
-#~ msgstr "ERROR: Scene not created"

--- a/script.service.hue/resources/language/resource.language.prs/strings.po
+++ b/script.service.hue/resources/language/resource.language.prs/strings.po
@@ -4,17 +4,10 @@
 # Addon Provider: zim514
 msgid ""
 msgstr ""
-"Project-Id-Version: \n"
-"POT-Creation-Date: \n"
-"PO-Revision-Date: 2021-09-20 10:04+0000\n"
-"Last-Translator: Christian Gade <gade@kodi.tv>\n"
-"Language-Team: Kannada (India) <https://kodi.weblate.cloud/projects/kodi-add-ons-scripts/script-service-hue/kn_in/>\n"
-"Language: kn_in\n"
+"Language: prs\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=n > 1;\n"
-"X-Generator: Weblate 4.8\n"
 
 msgctxt "Addon Summary"
 msgid "Automate Hue lights with Kodi playback"
@@ -30,11 +23,11 @@ msgstr ""
 
 msgctxt "#32100"
 msgid "Video Scenes"
-msgstr "Video Scenes"
+msgstr ""
 
 msgctxt "#32102"
 msgid "Audio Scenes"
-msgstr "Audio Scenes"
+msgstr ""
 
 msgctxt "#32201"
 msgid "Start/Resume"
@@ -50,7 +43,7 @@ msgstr ""
 
 msgctxt "#30036"
 msgid "Scene:"
-msgstr "Scene:"
+msgstr ""
 
 msgctxt "#32511"
 msgid "Scene ID"
@@ -66,7 +59,7 @@ msgstr ""
 
 msgctxt "#30501"
 msgid "Discover Hue Bridge / Enter IP"
-msgstr "Discover Hue Bridge / Enter IP"
+msgstr ""
 
 msgctxt "#30502"
 msgid "Bridge IP"
@@ -90,7 +83,7 @@ msgstr ""
 
 msgctxt "#30508"
 msgid "Disable during daytime"
-msgstr "Disable during daytime"
+msgstr ""
 
 #. If watching a movie or TV show, and sunset occurs, activate the scene in that moment
 msgctxt "#30509"
@@ -149,7 +142,7 @@ msgstr ""
 
 msgctxt "#32106"
 msgid "Video Activation Rules"
-msgstr "Video Activation Rules"
+msgstr ""
 
 msgctxt "#6101"
 msgid "Select Lights"
@@ -352,11 +345,11 @@ msgstr ""
 
 msgctxt "#30063"
 msgid "Disabled by daytime"
-msgstr "Disabled by daytime"
+msgstr ""
 
 msgctxt "#30064"
 msgid "ERROR: Scene not found, it may have been deleted"
-msgstr "ERROR: Scene not found, it may have been deleted"
+msgstr ""
 
 msgctxt "#30080"
 msgid "The following error occurred:"
@@ -514,7 +507,3 @@ msgstr ""
 msgctxt "#30028"
 msgid "Configure Hue Home location to use Sunset time, defaulting to 19:00"
 msgstr ""
-
-#~ msgctxt "#30002"
-#~ msgid "ERROR: Scene not created"
-#~ msgstr "ERROR: Scene not created"

--- a/script.service.hue/resources/language/resource.language.szl/strings.po
+++ b/script.service.hue/resources/language/resource.language.szl/strings.po
@@ -1,0 +1,509 @@
+# Kodi Media Center language file
+# Addon Name: Hue Service
+# Addon id: script.service.hue
+# Addon Provider: zim514
+msgid ""
+msgstr ""
+"Language: szl\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgctxt "Addon Summary"
+msgid "Automate Hue lights with Kodi playback"
+msgstr ""
+
+msgctxt "Addon Description"
+msgid "Automate your Hue lights with Kodi. Use scenes configured in the official Hue app. Can use Hue's sunset time to automatically disable the service during daytime and turn on the lights at sunset during playback. Includes Ambilight support."
+msgstr ""
+
+msgctxt "Addon Disclaimer"
+msgid "Requires a Hue Bridge V2 (Square). Ambilight not available on all hardware."
+msgstr ""
+
+msgctxt "#32100"
+msgid "Video Scenes"
+msgstr ""
+
+msgctxt "#32102"
+msgid "Audio Scenes"
+msgstr ""
+
+msgctxt "#32201"
+msgid "Start/Resume"
+msgstr ""
+
+msgctxt "#32202"
+msgid "Pause"
+msgstr ""
+
+msgctxt "#32203"
+msgid "Stop"
+msgstr ""
+
+msgctxt "#30036"
+msgid "Scene:"
+msgstr ""
+
+msgctxt "#32511"
+msgid "Scene ID"
+msgstr ""
+
+msgctxt "#32512"
+msgid "Select..."
+msgstr ""
+
+msgctxt "#30500"
+msgid "Bridge"
+msgstr ""
+
+msgctxt "#30501"
+msgid "Discover Hue Bridge / Enter IP"
+msgstr ""
+
+msgctxt "#30502"
+msgid "Bridge IP"
+msgstr ""
+
+msgctxt "#30503"
+msgid "Bridge User"
+msgstr ""
+
+msgctxt "#30505"
+msgid "Enable Schedule (24h format)"
+msgstr ""
+
+msgctxt "#30506"
+msgid "Start time:"
+msgstr ""
+
+msgctxt "#30507"
+msgid "End time:"
+msgstr ""
+
+msgctxt "#30508"
+msgid "Disable during daytime"
+msgstr ""
+
+#. If watching a movie or TV show, and sunset occurs, activate the scene in that moment
+msgctxt "#30509"
+msgid "Activate during playback at sunset"
+msgstr ""
+
+msgctxt "#30510"
+msgid "General"
+msgstr ""
+
+msgctxt "#30511"
+msgid "Schedule"
+msgstr ""
+
+msgctxt "#30512"
+msgid "Scenes"
+msgstr ""
+
+msgctxt "#30513"
+msgid "Play Scene Enabled"
+msgstr ""
+
+msgctxt "#30514"
+msgid "Pause Scene Enabled"
+msgstr ""
+
+msgctxt "#30515"
+msgid "Stop Scene Enabled"
+msgstr ""
+
+#. If any light in the selected scene is on, ignore the schedule restrictions
+msgctxt "#30516"
+msgid "Disable time check if any light already on"
+msgstr ""
+
+#. If any of the lights in the scene are off, don't activate the related scene
+msgctxt "#30517"
+msgid "Don't enable scene if any light is off"
+msgstr ""
+
+msgctxt "#30521"
+msgid "[B][I]Warning: Not supported on all hardware[/B][/I]"
+msgstr ""
+
+msgctxt "#30522"
+msgid "CPU & Hue performance"
+msgstr ""
+
+msgctxt "#30523"
+msgid "Ambilight"
+msgstr ""
+
+msgctxt "#32101"
+msgid "Advanced"
+msgstr ""
+
+msgctxt "#32106"
+msgid "Video Activation Rules"
+msgstr ""
+
+msgctxt "#6101"
+msgid "Select Lights"
+msgstr ""
+
+msgctxt "#30520"
+msgid "Enabled"
+msgstr ""
+
+msgctxt "#9001"
+msgid "Press connect button on Hue bridge"
+msgstr ""
+
+msgctxt "#30000"
+msgid "Hue Service"
+msgstr ""
+
+msgctxt "#30004"
+msgid "Check your bridge and network"
+msgstr ""
+
+msgctxt "#30006"
+msgid "Hue connected"
+msgstr ""
+
+msgctxt "#30008"
+msgid "Bridge not found"
+msgstr ""
+
+msgctxt "#30010"
+msgid "User not found"
+msgstr ""
+
+msgctxt "#30011"
+msgid "Complete!"
+msgstr ""
+
+msgctxt "#30013"
+msgid "Cancelled"
+msgstr ""
+
+msgctxt "#30015"
+msgid "Select Hue Lights..."
+msgstr ""
+
+msgctxt "#30017"
+msgid "Found bridge: "
+msgstr ""
+
+msgctxt "#30018"
+msgid "Discover bridge..."
+msgstr ""
+
+msgctxt "#30021"
+msgid "Bridge connection failed"
+msgstr ""
+
+msgctxt "#30022"
+msgid "Discovery started"
+msgstr ""
+
+msgctxt "#30023"
+msgid "Bridge not configured"
+msgstr ""
+
+msgctxt "#30024"
+msgid "Check Hue Bridge configuration"
+msgstr ""
+
+msgctxt "#30034"
+msgid "Cancel"
+msgstr ""
+
+msgctxt "#30035"
+msgid "Lights:"
+msgstr ""
+
+msgctxt "#30037"
+msgid "Save"
+msgstr ""
+
+msgctxt "#30043"
+msgid "Error"
+msgstr ""
+
+msgctxt "#30047"
+msgid "Connection lost. Check settings. Shutting down"
+msgstr ""
+
+msgctxt "#30050"
+msgid "N-UPnP discovery..."
+msgstr ""
+
+msgctxt "#30005"
+msgid "Searching for bridge..."
+msgstr ""
+
+msgctxt "#30052"
+msgid "Invalid start or end time, schedule disabled"
+msgstr ""
+
+msgctxt "#30058"
+msgid "Light Names:"
+msgstr ""
+
+msgctxt "#30065"
+msgid "Update interval (ms)"
+msgstr ""
+
+msgctxt "#30066"
+msgid "Hue transition time (ms)"
+msgstr ""
+
+msgctxt "#30067"
+msgid "Frame capture size"
+msgstr ""
+
+msgctxt "#30068"
+msgid "Show Hue bridge capacity errors"
+msgstr ""
+
+#. Minimum duration of the media before activating light scene
+msgctxt "#30800"
+msgid "Minimum duration (Minutes)"
+msgstr ""
+
+msgctxt "#30801"
+msgid "Enable for Movies"
+msgstr ""
+
+msgctxt "#30802"
+msgid "Enable for TV episodes"
+msgstr ""
+
+msgctxt "#30803"
+msgid "Enable for music videos"
+msgstr ""
+
+msgctxt "#30804"
+msgid "Enable for other videos (Discs)"
+msgstr ""
+
+msgctxt "#30805"
+msgid "Enable for live TV"
+msgstr ""
+
+msgctxt "#30809"
+msgid "Saturation"
+msgstr ""
+
+msgctxt "#30810"
+msgid "Minimum Brightness"
+msgstr ""
+
+msgctxt "#30811"
+msgid "Maximum Brightness"
+msgstr ""
+
+msgctxt "#30813"
+msgid "Average image processing time:"
+msgstr ""
+
+msgctxt "#30814"
+msgid "On playback stop"
+msgstr ""
+
+msgctxt "#30815"
+msgid "Resume light state"
+msgstr ""
+
+msgctxt "#30816"
+msgid "Resume transition time (secs.)"
+msgstr ""
+
+msgctxt "#30071"
+msgid "Only colour lights are supported"
+msgstr ""
+
+#. Old or deperacted bridge firmware or hardware
+msgctxt "#30072"
+msgid "Unsupported Hue Bridge"
+msgstr ""
+
+msgctxt "#30055"
+msgid "Disabled"
+msgstr ""
+
+msgctxt "#30060"
+msgid "Play"
+msgstr ""
+
+#. Must end with a space, status string is appended
+msgctxt "#30061"
+msgid "Hue Status: "
+msgstr ""
+
+msgctxt "#30062"
+msgid "Settings"
+msgstr ""
+
+msgctxt "#30063"
+msgid "Disabled by daytime"
+msgstr ""
+
+msgctxt "#30064"
+msgid "ERROR: Scene not found, it may have been deleted"
+msgstr ""
+
+msgctxt "#30080"
+msgid "The following error occurred:"
+msgstr ""
+
+msgctxt "#30081"
+msgid "Automatically report this error?"
+msgstr ""
+
+msgctxt "#30069"
+msgid "No lights selected for Ambilight."
+msgstr ""
+
+msgctxt "#30070"
+msgid "Ok"
+msgstr ""
+
+msgctxt "#30075"
+msgid "Hue Bridge over capacity"
+msgstr ""
+
+msgctxt "#30076"
+msgid "Network not ready"
+msgstr ""
+
+msgctxt "#30077"
+msgid "The Hue Bridge is over capacity. Increase refresh rate or reduce the number of Ambilights."
+msgstr ""
+
+msgctxt "#30078"
+msgid "Bridge not found[CR]Check your bridge and network."
+msgstr ""
+
+msgctxt "#30082"
+msgid "Press link button on bridge. Waiting for 90 seconds..."
+msgstr ""
+
+msgctxt "#30083"
+msgid "Unknown"
+msgstr ""
+
+msgctxt "#30084"
+msgid "User Found![CR]Saving settings..."
+msgstr ""
+
+msgctxt "#30086"
+msgid "User not found[CR]Check your bridge and network."
+msgstr ""
+
+msgctxt "#30073"
+msgid "Do not show again"
+msgstr ""
+
+msgctxt "#30001"
+msgid "Hue Bridge V1 (Round) is unsupported. Hue Bridge V2 (Square) is required."
+msgstr ""
+
+#. For ambilight, different color gamuts are supported. This means the colour gamut could not be fetched and the light is probably not compatible with ambilight.
+msgctxt "#30012"
+msgid "Unknown colour gamut for light:"
+msgstr ""
+
+msgctxt "#30016"
+msgid "Report errors"
+msgstr ""
+
+msgctxt "#30020"
+msgid "Never report errors"
+msgstr ""
+
+msgctxt "#30032"
+msgid "Hue Service Error"
+msgstr ""
+
+msgctxt "#30029"
+msgid "Connection Error"
+msgstr ""
+
+msgctxt "#30014"
+msgid "Error: Lights incompatible with Ambilight"
+msgstr ""
+
+msgctxt "#30007"
+msgid "Bridge not found automatically. Please make sure your bridge is up to date and has access to the internet. [CR]Would you like to enter your bridge IP manually?"
+msgstr ""
+
+msgctxt "#30009"
+msgid "Connecting..."
+msgstr ""
+
+msgctxt "#30019"
+msgid "Bridge outdated. Please update your bridge."
+msgstr ""
+
+msgctxt "#30033"
+msgid "Reconnected"
+msgstr ""
+
+#. Time at which the service should be disabled in the morning, paired with "Disable during daytime", until sunset
+msgctxt "#31334"
+msgid "Morning disable time:"
+msgstr ""
+
+#. Amount of time for the light scene transition to fade in, in seconds.
+msgctxt "#31335"
+msgid "Transition time (seconds):"
+msgstr ""
+
+#. Number of minutes before or after sunset to consider as sunset
+msgctxt "#31336"
+msgid "Sunset Offset:"
+msgstr ""
+
+#. Help text for sunset offset setting
+msgctxt "#31337"
+msgid "Adjust sunset back or forwards by this many minutes"
+msgstr ""
+
+#. Help text for "morning disable time" setting
+msgctxt "#31338"
+msgid "Time at which to disable the service in the morning"
+msgstr ""
+
+#. Help text for 'Disable during daytime'
+msgctxt "#31339"
+msgid "Disable the service between configured time and sunset"
+msgstr ""
+
+#. Help text for 'activate at sunset'
+msgctxt "#31340"
+msgid "Activate scenes at sunset, during playback"
+msgstr ""
+
+msgctxt "#30002"
+msgid "Bridge overloaded, stopping ambilight"
+msgstr ""
+
+msgctxt "#30025"
+msgid "Bridge unauthorized, please reconfigure."
+msgstr ""
+
+msgctxt "#30026"
+msgid "Connection failed, retrying..."
+msgstr ""
+
+#. Default status in an empty configuration field; eg. scene/lights are not selected
+msgctxt "#30003"
+msgid "Not selected"
+msgstr ""
+
+msgctxt "#30027"
+msgid "ERROR: Light not found, it may have been deleted"
+msgstr ""
+
+msgctxt "#30028"
+msgid "Configure Hue Home location to use Sunset time, defaulting to 19:00"
+msgstr ""

--- a/script.service.hue/resources/lib/__init__.py
+++ b/script.service.hue/resources/lib/__init__.py
@@ -16,8 +16,15 @@ STRDEBUG = False  # Show string ID in UI
 FORCEDEBUGLOG = False # Force output of debug logs regardless of Kodi logging setting
 TIMEOUT = 1 # requests default timeout
 MAX_RETRIES = 7
-NOTIFICATION_THRESHOLD = 2
+NOTIFICATION_THRESHOLD = 3
 MINIMUM_COLOR_DISTANCE = 0.005
+
+
+class HueApiError(Exception):
+    """Non-retryable HTTP error from the Hue Bridge API."""
+    def __init__(self, status_code, message=""):
+        self.status_code = status_code
+        super().__init__(f"HTTP {status_code}: {message}")
 BRIDGE_SETTINGS_CHANGED = Event()
 AMBI_RUNNING = Event()
 PROCESS_TIMES = deque(maxlen=100)

--- a/script.service.hue/resources/lib/hue.py
+++ b/script.service.hue/resources/lib/hue.py
@@ -5,16 +5,16 @@
 
 import json
 from socket import getfqdn
-from urllib.parse import urljoin
 
 import requests
 import urllib3
 import xbmcgui,xbmcvfs
 from requests.exceptions import HTTPError, ConnectionError, Timeout
 
-from . import ADDON, TIMEOUT, NOTIFICATION_THRESHOLD, MAX_RETRIES, reporting
+from . import ADDON, TIMEOUT, NOTIFICATION_THRESHOLD, MAX_RETRIES, HueApiError, reporting
 from .kodiutils import notification, convert_time, log
 from .language import get_string as _
+from .mdns_discovery import discover_hue_bridge_mdns
 
 
 class Hue(object):
@@ -28,14 +28,11 @@ class Hue(object):
         self.connected: bool = False
         self.devices: dict = None
         self.bridge_id = None
-        self.retries = 0
-        self.max_retries = 5
-        self.max_timeout = 5
         self.base_url = None
         self.sunset = None
         self.settings_monitor = settings_monitor
 
-        log(f"[SCRIPT.SERVICE.HUE] v2 init: ip: {self.settings_monitor.ip}, key: {self.settings_monitor.key}")
+        log(f"[SCRIPT.SERVICE.HUE] init: ip: {self.settings_monitor.ip}, key: {self.settings_monitor.key}")
         if discover:
             self.discover()
         elif self.settings_monitor.ip != "" or self.settings_monitor.key != "":
@@ -44,93 +41,125 @@ class Hue(object):
             log("[SCRIPT.SERVICE.HUE] No bridge IP or user key provided. Bridge not configured.")
             notification(_("Hue Service"), _("Bridge not configured"), icon=xbmcgui.NOTIFICATION_ERROR)
 
-    def make_api_request(self, method, resource, discovery=False, **kwargs):
-        # Discovery and account creation not yet supported on API V2. This flag uses a V1 URL and supports new IPs.
-        if discovery:
-            log(f"[SCRIPT.SERVICE.HUE] v2 make_request: Discovery mode.")
+    def make_api_request(self, method, resource, **kwargs):
+        ip_discovered = False
         for attempt in range(MAX_RETRIES):
-            # Prepare the URL for the request
-            log(f"[SCRIPT.SERVICE.HUE] v2 ip: {self.settings_monitor.ip}, key: {self.settings_monitor.key}")
-            base_url = self.base_url if not discovery else f"https://{self.discoveredIP}/api/"
-            log(f"[SCRIPT.SERVICE.HUE] v2 make_request: base_url: {base_url}")
-            url = urljoin(base_url, resource)
-            #log(f"[SCRIPT.SERVICE.HUE] v2 make_request: base_url: {base_url}, url: {url}, method: {method}, kwargs: {kwargs}")
+            url = f"{self.base_url}{resource}"
+            if attempt == 0 or ip_discovered:
+                log(f"[SCRIPT.SERVICE.HUE] make_request: {method} {url}")
             try:
-                # Make the request
                 response = self.session.request(method, url, timeout=TIMEOUT, **kwargs)
                 response.raise_for_status()
                 return response.json()
             except ConnectionError as x:
-                # If a ConnectionError occurs, try to handle a new IP, except in discovery mode
-                log(f"[SCRIPT.SERVICE.HUE] v2 make_request: ConnectionError: {x}")
-                if self._discover_new_ip() and not discovery:
-                    # If handling a new IP is successful, retry the request
-                    log(f"[SCRIPT.SERVICE.HUE] v2 make_request: New IP handled successfully. Retrying request.")
-                    continue
-                else:
-                    # If handling a new IP fails, abort the request
-                    log(f"[SCRIPT.SERVICE.HUE] v2 make_request: Failed to handle new IP. Aborting request.")
-                    return None
-
+                log(f"[SCRIPT.SERVICE.HUE] make_request: ConnectionError: {x}")
+                if not ip_discovered:
+                    ip_discovered = self._discover_new_ip()
             except HTTPError as x:
-                # Handle HTTP errors
-                if x.response.status_code == 429:
-                    # If a 429 status code is received, abort and log an error
-                    log(f"[SCRIPT.SERVICE.HUE] v2 make_request: Too Many Requests: {x} \nResponse: {x.response.text}")
-                    return 429
-                elif x.response.status_code in [401, 403]:
-                    log(f"[SCRIPT.SERVICE.HUE] v2 make_request: Unauthorized: {x}\nResponse: {x.response.text}")
+                status = x.response.status_code
+                text = x.response.text
+                if status == 429:
+                    log(f"[SCRIPT.SERVICE.HUE] make_request: Too Many Requests: {x}\nResponse: {text}")
+                    raise HueApiError(429, text)
+                elif status in [401, 403]:
+                    log(f"[SCRIPT.SERVICE.HUE] make_request: Unauthorized: {x}\nResponse: {text}")
                     notification(_("Hue Service"), _("Bridge unauthorized, please reconfigure."), icon=xbmcgui.NOTIFICATION_ERROR)
                     ADDON.setSettingString("bridgeUser", "")
-                    return 401
-                elif x.response.status_code == 404:
-                    log(f"[SCRIPT.SERVICE.HUE] v2 make_request: Not Found: {x}\nResponse: {x.response.text}")
-                    return 404
-                elif x.response.status_code == 500:
-                    log(f"[SCRIPT.SERVICE.HUE] v2 make_request: Internal Bridge Error: {x}\nResponse: {x.response.text}")
-                    return 500
+                    raise HueApiError(401, text)
+                elif status == 404:
+                    log(f"[SCRIPT.SERVICE.HUE] make_request: Not Found: {x}\nResponse: {text}")
+                    raise HueApiError(404, text)
+                elif status == 500:
+                    log(f"[SCRIPT.SERVICE.HUE] make_request: Internal Bridge Error: {x}\nResponse: {text}")
                 else:
-                    log(f"[SCRIPT.SERVICE.HUE] v2 make_request: HTTPError: {x}\nResponse: {x.response.text}")
-                    reporting.process_exception(f"Response: {x.response.text}, Exception: {x}", logging=True)
-                    return x.response.status_code
-            except (Timeout, json.JSONDecodeError) as x:
-                log(f"[SCRIPT.SERVICE.HUE] v2 make_request: Timeout/JSONDecodeError: Response: {x.response}\n{x}")
+                    log(f"[SCRIPT.SERVICE.HUE] make_request: HTTPError: {x}\nResponse: {text}")
+                    reporting.process_exception(f"Response: {text}, Exception: {x}", logging=True)
+                    raise HueApiError(status, text)
+            except Timeout as x:
+                log(f"[SCRIPT.SERVICE.HUE] make_request: Timeout: {x}")
+            except json.JSONDecodeError as x:
+                log(f"[SCRIPT.SERVICE.HUE] make_request: JSONDecodeError: {x}")
             except requests.RequestException as x:
-                # Report other kinds of RequestExceptions
-                log(f"[SCRIPT.SERVICE.HUE] v2 make_request: RequestException: {x}")
+                log(f"[SCRIPT.SERVICE.HUE] make_request: RequestException: {x}")
                 reporting.process_exception(x)
-            # Calculate the retry time and log the retry attempt
             retry_time = 2 ** attempt
-            if retry_time >= 7 and attempt >= NOTIFICATION_THRESHOLD:
+            if attempt >= NOTIFICATION_THRESHOLD:
                 notification(_("Hue Service"), _("Connection failed, retrying..."), icon=xbmcgui.NOTIFICATION_WARNING)
-            log(f"[SCRIPT.SERVICE.HUE] v2 make_request: Retry in {retry_time} seconds, retry {attempt + 1}/{MAX_RETRIES}...")
+            log(f"[SCRIPT.SERVICE.HUE] make_request: Retry in {retry_time}s ({attempt + 1}/{MAX_RETRIES})")
             if self.settings_monitor.waitForAbort(retry_time):
                 break
-        # If all attempts fail, log the failure and set connected to False
-        log(f"[SCRIPT.SERVICE.HUE] v2 make_request: All attempts failed after {MAX_RETRIES} retries. Setting connected to False")
-        self.connected = False
+        log(f"[SCRIPT.SERVICE.HUE] make_request: All {MAX_RETRIES} attempts failed")
         return None
 
+    def _make_v1_request(self, method, resource, ip=None, **kwargs):
+        if ip is None:
+            ip = self.settings_monitor.ip
+        url = f"https://{ip}/api/{resource}"
+        log(f"[SCRIPT.SERVICE.HUE] _make_v1_request: {method} {url}")
+        try:
+            response = self.session.request(method, url, timeout=TIMEOUT, **kwargs)
+            response.raise_for_status()
+            return response.json()
+        except (ConnectionError, HTTPError, Timeout) as exc:
+            log(f"[SCRIPT.SERVICE.HUE] _make_v1_request: {type(exc).__name__}: {exc}")
+            return None
+        except json.JSONDecodeError as exc:
+            log(f"[SCRIPT.SERVICE.HUE] _make_v1_request: JSONDecodeError: {exc}")
+            return None
+
+    def _discover_bridge_ip(self):
+        log("[SCRIPT.SERVICE.HUE] _discover_bridge_ip: Trying mDNS...")
+        ip = discover_hue_bridge_mdns(timeout=2.0)
+        if ip:
+            log(f"[SCRIPT.SERVICE.HUE] _discover_bridge_ip: mDNS found bridge at {ip}")
+            return ip
+        log("[SCRIPT.SERVICE.HUE] _discover_bridge_ip: mDNS failed, trying cloud lookup...")
+        ip = self._discover_cloud()
+        if ip:
+            log(f"[SCRIPT.SERVICE.HUE] _discover_bridge_ip: Cloud found bridge at {ip}")
+            return ip
+        log("[SCRIPT.SERVICE.HUE] _discover_bridge_ip: All discovery methods failed")
+        return None
+
+    def _discover_cloud(self):
+        log("[SCRIPT.SERVICE.HUE] _discover_cloud: Querying discovery.meethue.com")
+        try:
+            response = self.session.get("https://discovery.meethue.com/", timeout=TIMEOUT)
+            response.raise_for_status()
+            result = response.json()
+            if result:
+                ip = result[0]["internalipaddress"]
+                log(f"[SCRIPT.SERVICE.HUE] _discover_cloud: Found bridge at {ip}")
+                return ip
+            log("[SCRIPT.SERVICE.HUE] _discover_cloud: Empty response")
+            return None
+        except (ConnectionError, HTTPError, Timeout) as exc:
+            log(f"[SCRIPT.SERVICE.HUE] _discover_cloud: {type(exc).__name__}: {exc}")
+            return None
+        except (KeyError, IndexError, json.JSONDecodeError) as exc:
+            log(f"[SCRIPT.SERVICE.HUE] _discover_cloud: Parse error: {exc}")
+            return None
+
     def _discover_new_ip(self):
-        if self._discover_endpoint():
-            log(f"[SCRIPT.SERVICE.HUE] v2 _discover_and_handle_new_ip: discover_endpoint SUCCESS, bridge IP: {self.settings_monitor.ip}")
-            # TODO:  add new discovery methods here, like mDNS, when I can figure out how to make it multiplatform and not binary
-            ADDON.setSettingString("bridgeIP", self.discoveredIP)
-            if self.connect():
-                log(f"[SCRIPT.SERVICE.HUE] v2 _discover_and_handle_new_ip: connect SUCCESS")
-                return True
-        log(f"[SCRIPT.SERVICE.HUE] v2 _discover_and_handle_new_ip: discover_endpoint FAIL, bridge IP: {self.settings_monitor.ip}")
+        new_ip = self._discover_bridge_ip()
+        if new_ip:
+            log(f"[SCRIPT.SERVICE.HUE] _discover_new_ip: Found bridge at {new_ip}")
+            ADDON.setSettingString("bridgeIP", new_ip)
+            self.base_url = f"https://{new_ip}/clip/v2/resource/"
+            return True
+        log("[SCRIPT.SERVICE.HUE] _discover_new_ip: Discovery failed")
         return False
 
     def connect(self):
-        log(f"[SCRIPT.SERVICE.HUE] v2 connect: ip: {self.settings_monitor.ip}, key: {self.settings_monitor.key}")
+        log(f"[SCRIPT.SERVICE.HUE] connect: ip: {self.settings_monitor.ip}, key: {self.settings_monitor.key}")
         if self.settings_monitor.ip and self.settings_monitor.key:
             self.base_url = f"https://{self.settings_monitor.ip}/clip/v2/resource/"
             self.session.headers.update({'hue-application-key': self.settings_monitor.key})
 
             self.devices = self.make_api_request("GET", "device")
             if not isinstance(self.devices, dict):
-                log(f"[SCRIPT.SERVICE.HUE] v2 connect: Connection error. Setting connected to False.  {type(self.devices)} :  {self.devices}")
+                log(f"[SCRIPT.SERVICE.HUE] connect: Connection error. Setting connected to False.  {type(self.devices)} :  {self.devices}")
+                notification(_("Hue Service"), _("Bridge connection failed"), icon=xbmcgui.NOTIFICATION_ERROR)
                 self.connected = False
                 return False
 
@@ -140,9 +169,10 @@ class Hue(object):
             if self._check_version():
                 self.connected = True
                 self.update_sunset()
-                log(f"[SCRIPT.SERVICE.HUE] v2 connect: Connection successful")
+                log(f"[SCRIPT.SERVICE.HUE] connect: Connection successful")
                 return True
-            log(f"[SCRIPT.SERVICE.HUE] v2 connect: Connection attempts failed. Setting connected to False")
+            log(f"[SCRIPT.SERVICE.HUE] connect: Connection attempts failed. Setting connected to False")
+            notification(_("Hue Service"), _("Bridge connection failed"), icon=xbmcgui.NOTIFICATION_ERROR)
             self.connected = False
             return False
 
@@ -151,123 +181,110 @@ class Hue(object):
         return False
 
     def discover(self):
-        log("[SCRIPT.SERVICE.HUE] v2 Start discover")
-        # Reset settings
-        self.discoveredIP = ""
-        self.key = ""
+        log("[SCRIPT.SERVICE.HUE] Start discover")
         self.connected = False
-
-        ADDON.setSettingString("bridgeIP", "")
-        ADDON.setSettingString("bridgeUser", "")
 
         progress_bar = xbmcgui.DialogProgress()
         progress_bar.create(_('Searching for bridge...'))
         progress_bar.update(5, _("Discovery started"))
 
-        complete = False
-        while not progress_bar.iscanceled() and not complete and not self.settings_monitor.abortRequested():
+        create_user_attempts = 0
+        MAX_CREATE_USER_ATTEMPTS = 1
+        while not progress_bar.iscanceled() and not self.settings_monitor.abortRequested():
+            progress_bar.update(percent=10, message=_("Searching for bridge..."))
+            discovered_ip = self._discover_bridge_ip() or ""
 
-            progress_bar.update(percent=10, message=_("N-UPnP discovery..."))
-            # Try to discover the bridge using N-UPnP
-            ip_discovered = self._discover_endpoint()
-
-            if not ip_discovered and not progress_bar.iscanceled():
-                # If the bridge was not found, ask the user to enter the IP manually
-                log("[SCRIPT.SERVICE.HUE] v2 discover: Bridge not found automatically")
+            if not discovered_ip and not progress_bar.iscanceled():
+                log("[SCRIPT.SERVICE.HUE] discover: Bridge not found automatically")
                 progress_bar.update(percent=10, message=_("Bridge not found"))
-                manual_entry = xbmcgui.Dialog().yesno(_("Bridge not found"), _("Bridge not found automatically. Please make sure your bridge is up to date and has access to the internet. [CR]Would you like to enter your bridge IP manually?")
-                                                      )
-                if manual_entry:
-                    self.discoveredIP = xbmcgui.Dialog().numeric(3, _("Bridge IP"))
-                    log(f"[SCRIPT.SERVICE.HUE] v2 discover: Manual entry: {self.discoveredIP}")
+                manual_entry = xbmcgui.Dialog().yesno(
+                    _("Bridge not found"),
+                    _("Bridge not found automatically. Please make sure your bridge is up to date and has access to the internet. [CR]Would you like to enter your bridge IP manually?")
+                )
+                if not manual_entry:
+                    break
+                discovered_ip = xbmcgui.Dialog().numeric(3, _("Bridge IP"))
+                log(f"[SCRIPT.SERVICE.HUE] discover: Manual entry: {discovered_ip}")
 
-            if self.discoveredIP:
-                progress_bar.update(percent=50, message=_("Connecting..."))
-                # Set the base URL for the API
-                self.base_url = f"https://{self.discoveredIP}/clip/v2/resource/"
-                # Try to connect to the bridge
-                log(f"[SCRIPT.SERVICE.HUE] v2 discover: Attempt connection")
-                config = self.make_api_request("GET", "0/config", discovery=True)  # bypass some checks in discovery mode, and use Hue API V1 until Philipps provides a V2 method
-                log(f"[SCRIPT.SERVICE.HUE] v2 discover: config: {config}")
-                if config is not None and isinstance(config, dict) and not progress_bar.iscanceled():
-                    progress_bar.update(percent=100, message=_("Found bridge: ") + self.discoveredIP)
-                    self.settings_monitor.waitForAbort(1)
+            if not discovered_ip:
+                continue
 
-                    # Try to create a user
-                    bridge_user_created = self._create_user(progress_bar)
+            progress_bar.update(percent=50, message=_("Connecting..."))
+            log(f"[SCRIPT.SERVICE.HUE] discover: Attempt connection to {discovered_ip}")
+            config = self._make_v1_request("GET", "0/config", ip=discovered_ip)
+            log(f"[SCRIPT.SERVICE.HUE] discover: config: {config}")
 
-                    if bridge_user_created:
-                        log(f"[SCRIPT.SERVICE.HUE] v2 discover: User created: {bridge_user_created}")
-                        progress_bar.update(percent=90, message=_("User Found![CR]Saving settings..."))
+            if progress_bar.iscanceled():
+                break
 
-                        # Save the IP and user key to the settings
-                        ADDON.setSettingString("bridgeIP", self.discoveredIP)
-                        ADDON.setSettingString("bridgeUser", bridge_user_created)
+            if not isinstance(config, dict):
+                log("[SCRIPT.SERVICE.HUE] discover: Bridge not reachable, retrying")
+                progress_bar.update(percent=10, message=_("Bridge not found[CR]Check your bridge and network."))
+                discovered_ip = ""
+                if self.settings_monitor.waitForAbort(3):
+                    break
+                continue
 
-                        progress_bar.update(percent=100, message=_("Complete!"))
-                        self.settings_monitor.waitForAbort(5)
-                        progress_bar.close()
-                        log("[SCRIPT.SERVICE.HUE] v2 discover: Bridge discovery complete")
-                        self.connect()
-                        return
+            progress_bar.update(percent=100, message=_("Found bridge: ") + discovered_ip)
+            self.settings_monitor.waitForAbort(1)
 
-                    elif progress_bar.iscanceled():
-                        log("[SCRIPT.SERVICE.HUE] v2 discover: Discovery cancelled by user")
-                        progress_bar.update(percent=100, message=_("Cancelled"))
-                        progress_bar.close()
+            bridge_user_created = self._create_user(progress_bar, discovered_ip)
 
-                    else:
-                        log(f"[SCRIPT.SERVICE.HUE] v2 discover: User not created, received: {self.settings_monitor.key}")
-                        progress_bar.update(percent=100, message=_("User not found[CR]Check your bridge and network."))
-                        self.settings_monitor.waitForAbort(5)
-                        progress_bar.close()
-                        return
-                elif progress_bar.iscanceled():
-                    log("[SCRIPT.SERVICE.HUE] v2 discover: Discovery cancelled by user")
+            if progress_bar.iscanceled():
+                break
 
-                    progress_bar.update(percent=100, message=_("Cancelled"))
-                    progress_bar.close()
-                else:
-                    progress_bar.update(percent=100, message=_("Bridge not found[CR]Check your bridge and network."))
-                    log("[SCRIPT.SERVICE.HUE] v2 discover: Bridge not found, check your bridge and network")
-                    self.settings_monitor.waitForAbort(5)
-                    progress_bar.close()
+            if bridge_user_created:
+                log(f"[SCRIPT.SERVICE.HUE] discover: User created: {bridge_user_created}")
+                progress_bar.update(percent=90, message=_("User Found![CR]Saving settings..."))
+                ADDON.setSettingString("bridgeIP", discovered_ip)
+                ADDON.setSettingString("bridgeUser", bridge_user_created)
+                progress_bar.update(percent=100, message=_("Complete!"))
+                self.settings_monitor.waitForAbort(5)
+                progress_bar.close()
+                log("[SCRIPT.SERVICE.HUE] discover: Bridge discovery complete")
+                self.connect()
+                return
 
-            log("[SCRIPT.SERVICE.HUE] v2 discover: Discovery process complete")
-            complete = True
-            progress_bar.update(percent=100, message=_("Cancelled"))
-            progress_bar.close()
+            create_user_attempts += 1
+            if create_user_attempts >= MAX_CREATE_USER_ATTEMPTS:
+                log(f"[SCRIPT.SERVICE.HUE] discover: Giving up after {create_user_attempts} failed pairing attempts; existing settings preserved")
+                progress_bar.update(percent=100, message=_("Bridge connection failed"))
 
-        if progress_bar.iscanceled():
-            log("[SCRIPT.SERVICE.HUE] v2 discover: Bridge discovery cancelled by user")
-            progress_bar.update(percent=100, message=_("Cancelled"))
-            progress_bar.close()
+                self.settings_monitor.waitForAbort(3)
 
-    def _create_user(self, progress_bar):
-        # Log start of user creation
-        log("[SCRIPT.SERVICE.HUE] v2 _create_user: In createUser")
+                break
 
-        # Prepare data for POST request
-        data = '{{"devicetype": "kodi#{}", "generateclientkey": true}}'.format(getfqdn())
+            log("[SCRIPT.SERVICE.HUE] discover: User not created, retrying")
+            progress_bar.update(percent=10, message=_("Bridge connection failed"))
+            discovered_ip = ""
+            if self.settings_monitor.waitForAbort(3):
+                break
 
+        log("[SCRIPT.SERVICE.HUE] discover: Discovery cancelled or ended")
+        progress_bar.update(percent=100, message=_("Cancelled"))
+        self.settings_monitor.waitForAbort(1)
+        progress_bar.close()
+
+    def _create_user(self, progress_bar, ip):
+        log("[SCRIPT.SERVICE.HUE] _create_user: In createUser")
+
+        data = {"devicetype": f"kodi#{getfqdn()}", "generateclientkey": True}
+
+        response = None
         time = 0
         timeout = 90
-        progress = 0
         last_progress = -1
 
-        # Loop until timeout, user cancellation, or settings_monitor abort request
         while time <= timeout and not self.settings_monitor.abortRequested() and not progress_bar.iscanceled():
             progress = int((time / timeout) * 100)
 
-            # Update progress bar if progress has changed
             if progress != last_progress:
                 progress_bar.update(percent=progress, message=_("Press link button on bridge. Waiting for 90 seconds..."))
                 last_progress = progress
 
-            response = self.make_api_request("POST", "", discovery=True, data=data)
-            log(f"[SCRIPT.SERVICE.HUE] v2 _create_user: response at iteration {time}: {response}")
+            response = self._make_v1_request("POST", "", ip=ip, json=data)
+            log(f"[SCRIPT.SERVICE.HUE] _create_user: response at iteration {time}: {response}")
 
-            # Break loop if link button has been pressed
             if response and response[0].get('error', {}).get('type') != 101:
                 break
 
@@ -278,28 +295,25 @@ class Hue(object):
             return False
 
         try:
-            # Extract and save username from response
             username = response[0]['success']['username']
-
-            log(f"[SCRIPT.SERVICE.HUE] v2 _create_user: User created: {username}")
+            log(f"[SCRIPT.SERVICE.HUE] _create_user: User created: {username}")
             return username
         except (KeyError, TypeError) as exc:
-            log(f"[SCRIPT.SERVICE.HUE] v2 _create_user: Username not found: {exc}")
+            log(f"[SCRIPT.SERVICE.HUE] _create_user: Username not found: {exc}")
             return False
 
     def _check_version(self):
         try:
-            self.discoveredIP = self.settings_monitor.ip
-            config = self.make_api_request("GET", "config", discovery=True)
-            log(f"[SCRIPT.SERVICE.HUE] v2 _version_check(): config: {config}")
+            config = self._make_v1_request("GET", "config")
+            log(f"[SCRIPT.SERVICE.HUE] _version_check(): config: {config}")
 
             swversion_raw = self.search_dict(config, "swversion")
             if swversion_raw is None:
                 raise KeyError("swversion not found in config")
             swversion = int(swversion_raw)
-            log(f"[SCRIPT.SERVICE.HUE] v2 _version_check(): swversion: {swversion}")
+            log(f"[SCRIPT.SERVICE.HUE] _version_check(): swversion: {swversion}")
         except (KeyError, ValueError, TypeError) as error:
-            log(f"[SCRIPT.SERVICE.HUE] v2 _version_check():  Connected! Bridge too old: {swversion}, error: {error}")
+            log(f"[SCRIPT.SERVICE.HUE] _version_check():  Could not determine bridge version: {error}")
             notification(_("Hue Service"), _("Bridge outdated. Please update your bridge."), icon=xbmcgui.NOTIFICATION_ERROR)
             return False
         except Exception as exc:
@@ -307,16 +321,16 @@ class Hue(object):
             return False
 
         if swversion >= 1948086000:  # minimum bridge version 1.60
-            log(f"[SCRIPT.SERVICE.HUE] v2 connect() software version: {swversion}")
+            log(f"[SCRIPT.SERVICE.HUE] connect() software version: {swversion}")
             return True
 
         notification(_("Hue Service"), _("Bridge outdated. Please update your bridge."), icon=xbmcgui.NOTIFICATION_ERROR)
-        log(f"[SCRIPT.SERVICE.HUE] v2 connect():  Connected! Bridge API too old: {swversion}")
+        log(f"[SCRIPT.SERVICE.HUE] connect():  Connected! Bridge API too old: {swversion}")
         return False
 
     def update_sunset(self):
         geolocation = self.make_api_request("GET", "geolocation")
-        log(f"[SCRIPT.SERVICE.HUE] v2 update_sunset(): geolocation: {geolocation}")
+        log(f"[SCRIPT.SERVICE.HUE] update_sunset(): geolocation: {geolocation}")
         sunset_str = self.search_dict(geolocation, "sunset_time")
         if sunset_str is None or sunset_str == "":
             log(f"[SCRIPT.SERVICE.HUE] Sunset not found; configure Hue geolocalisation")
@@ -325,11 +339,11 @@ class Hue(object):
             return
 
         self.sunset = convert_time(sunset_str)
-        log(f"[SCRIPT.SERVICE.HUE] v2 update_sunset(): sunset: {self.sunset}")
+        log(f"[SCRIPT.SERVICE.HUE] update_sunset(): sunset: {self.sunset}")
 
     def recall_scene(self, scene_id, duration=400):  # 400 is the default used by Hue, defaulting here for consistency
 
-        log(f"[SCRIPT.SERVICE.HUE] v2 recall_scene(): scene_id: {scene_id}, transition_time: {duration}")
+        log(f"[SCRIPT.SERVICE.HUE] recall_scene(): scene_id: {scene_id}, transition_time: {duration}")
 
         json_data = {
             "recall": {
@@ -339,12 +353,12 @@ class Hue(object):
         }
         response = self.make_api_request("PUT", f"scene/{scene_id}", json=json_data)
 
-        log(f"[SCRIPT.SERVICE.HUE] v2 recall_scene(): response: {response}")
+        log(f"[SCRIPT.SERVICE.HUE] recall_scene(): response: {response}")
         return response
 
     def configure_scene(self, group_id, action):
         scene = self.select_hue_scene()
-        log(f"[SCRIPT.SERVICE.HUE] v2 selected scene: {scene}")
+        log(f"[SCRIPT.SERVICE.HUE] selected scene: {scene}")
         if scene is not None:
             # setting ID format example: group0_playSceneID
             ADDON.setSettingString(f"group{group_id}_{action}SceneID", scene[0])
@@ -362,7 +376,7 @@ class Hue(object):
 
         # Merge rooms and zones into areas
         areas_dict = {**rooms_dict, **zones_dict}
-        log(f"[SCRIPT.SERVICE.HUE] v2 get_scenes(): areas_dict: {areas_dict}")
+        log(f"[SCRIPT.SERVICE.HUE] get_scenes(): areas_dict: {areas_dict}")
         # Create a dictionary for scenes
         scenes_dict = {}
         for scene in scenes_data['data']:
@@ -373,19 +387,19 @@ class Hue(object):
             scenes_dict[scene_id] = {'scene_name': scene_name, 'area_id': area_id}
 
         # dict_items = "\n".join([f"{key}: {value}" for key, value in scenes_dict.items()])
-        # log(f"[SCRIPT.SERVICE.HUE] v2 get_scenes(): scenes_dict:\n{dict_items}")
+        # log(f"[SCRIPT.SERVICE.HUE] get_scenes(): scenes_dict:\n{dict_items}")
 
         return scenes_dict, areas_dict
 
     def select_hue_scene(self):
         dialog_progress = xbmcgui.DialogProgress()
         dialog_progress.create("Hue Service", "Searching for scenes...")
-        log("[SCRIPT.SERVICE.HUE] V2 selectHueScene{}")
+        log("[SCRIPT.SERVICE.HUE] selectHueScene{}")
 
         hue_scenes, hue_areas = self.get_scenes_and_areas()
 
         area_items = [xbmcgui.ListItem(label=name) for _, name in hue_areas.items()]
-        log(f"[SCRIPT.SERVICE.HUE] V2 selectHueScene: area_items: {area_items}")
+        log(f"[SCRIPT.SERVICE.HUE] selectHueScene: area_items: {area_items}")
         selected_area_index = xbmcgui.Dialog().select("Select Hue area...", area_items)
 
         if selected_area_index > -1:
@@ -400,10 +414,10 @@ class Hue(object):
                 selected_scene_name = selected_scene_item.getLabel()
                 selected_area_name = area_items[selected_area_index].getLabel()
                 selected_name = f"{selected_scene_name} - {selected_area_name}"
-                log(f"[SCRIPT.SERVICE.HUE] V2 selectHueScene: selected: {selected_id}, name: {selected_name}")
+                log(f"[SCRIPT.SERVICE.HUE] selectHueScene: selected: {selected_id}, name: {selected_name}")
                 dialog_progress.close()
                 return selected_id, selected_name
-        log("[SCRIPT.SERVICE.HUE] V2 selectHueScene: cancelled")
+        log("[SCRIPT.SERVICE.HUE] selectHueScene: cancelled")
         dialog_progress.close()
         return None
 
@@ -426,23 +440,6 @@ class Hue(object):
             if selected:
                 return [hue_lights['data'][i] for i in selected]
         return None
-
-    def _discover_endpoint(self):
-        log("[SCRIPT.SERVICE.HUE] v2 _discover_endpoint.")
-        result: dict = self.make_api_request('GET', 'https://discovery.meethue.com/', discovery=True)
-        if result is None or isinstance(result, int):
-            log(f"[SCRIPT.SERVICE.HUE] v2 _discover_endpoint: make_request failed, result: {result}")
-            return None
-
-        bridge_ip = None
-        if result:
-            try:
-                bridge_ip = result[0]["internalipaddress"]
-            except KeyError:
-                log("[SCRIPT.SERVICE.HUE] v2 _discover_endpoint: No IP found in response")
-                return None
-        self.discoveredIP = bridge_ip
-        return True
 
     @staticmethod
     def get_device_by_archetype(json_data, archetype):

--- a/script.service.hue/resources/lib/mdns_discovery.py
+++ b/script.service.hue/resources/lib/mdns_discovery.py
@@ -1,0 +1,189 @@
+"""Minimal mDNS discovery for Philips Hue bridges.
+
+Uses only Python stdlib (socket, struct) to send a multicast DNS query for
+``_hue._tcp.local.`` and parse the first A record from the response.
+"""
+#      Copyright (C) 2023 Kodi Hue Service (script.service.hue)
+#      This file is part of script.service.hue
+#      SPDX-License-Identifier: MIT
+#      See LICENSE.TXT for more information.
+
+import socket
+import struct
+import time
+
+from .kodiutils import log
+
+MDNS_ADDR = "224.0.0.251"
+MDNS_PORT = 5353
+SERVICE_NAME = "_hue._tcp.local."
+
+# DNS record types
+TYPE_A = 1
+TYPE_PTR = 12
+
+# DNS class
+CLASS_IN = 1
+
+
+def _encode_dns_name(name):
+    """Encode a dotted domain name into DNS wire format.
+
+    Args:
+        name: Dotted domain name (e.g. ``"_hue._tcp.local."``).
+
+    Returns:
+        Bytes in DNS label format.
+    """
+    parts = name.rstrip(".").split(".")
+    result = b""
+    for part in parts:
+        encoded = part.encode("ascii")
+        result += struct.pack("B", len(encoded)) + encoded
+    result += b"\x00"
+    return result
+
+
+def _build_query():
+    """Build a DNS PTR query packet for the Hue service.
+
+    Returns:
+        Bytes containing the complete DNS query packet.
+    """
+    transaction_id = 0x0000
+    flags = 0x0000
+    questions = 1
+    header = struct.pack("!HHHHHH", transaction_id, flags, questions, 0, 0, 0)
+    qname = _encode_dns_name(SERVICE_NAME)
+    question = qname + struct.pack("!HH", TYPE_PTR, CLASS_IN)
+    return header + question
+
+
+def _read_name(data, offset):
+    """Read a DNS name from a response packet, handling compression pointers.
+
+    Args:
+        data: Raw DNS response bytes.
+        offset: Starting byte offset.
+
+    Returns:
+        Tuple of ``(name_string, new_offset)`` where ``new_offset`` points past
+        the name in the original data.
+    """
+    labels = []
+    original_offset = None
+    while True:
+        if offset >= len(data):
+            break
+        length = data[offset]
+        if length == 0:
+            offset += 1
+            break
+        if (length & 0xC0) == 0xC0:
+            if original_offset is None:
+                original_offset = offset + 2
+            pointer = struct.unpack_from("!H", data, offset)[0] & 0x3FFF
+            offset = pointer
+            continue
+        offset += 1
+        labels.append(data[offset:offset + length].decode("ascii", errors="replace"))
+        offset += length
+    name = ".".join(labels)
+    return name, (original_offset if original_offset is not None else offset)
+
+
+def _parse_response(data):
+    """Parse a DNS response and extract the first A record IP address.
+
+    Args:
+        data: Raw DNS response bytes.
+
+    Returns:
+        IP address string from the first A record, or ``None`` if not found.
+    """
+    if len(data) < 12:
+        return None
+
+    qdcount, ancount, nscount, arcount = struct.unpack_from("!HHHH", data, 4)
+    offset = 12
+
+    # Skip questions
+    for _ in range(qdcount):
+        _, offset = _read_name(data, offset)
+        offset += 4  # QTYPE + QCLASS
+
+    # Parse all answer, authority, and additional records looking for A records
+    total_records = ancount + nscount + arcount
+    for _ in range(total_records):
+        if offset >= len(data):
+            break
+        name, offset = _read_name(data, offset)
+        if offset + 10 > len(data):
+            break
+        rtype, rclass, ttl, rdlength = struct.unpack_from("!HHIH", data, offset)
+        offset += 10
+        if rtype == TYPE_A and rdlength == 4:
+            ip = socket.inet_ntoa(data[offset:offset + 4])
+            log(f"[SCRIPT.SERVICE.HUE] mDNS: A record found: {name} -> {ip}")
+            return ip
+        offset += rdlength
+
+    return None
+
+
+def discover_hue_bridge_mdns(timeout=2.0):
+    """Discover a Hue bridge on the local network via mDNS.
+
+    Sends a multicast DNS PTR query for ``_hue._tcp.local.`` and waits for a
+    response containing an A record with the bridge's IP address.
+
+    Args:
+        timeout: Maximum time in seconds to wait for a response (default 2.0).
+
+    Returns:
+        Bridge IP address string, or ``None`` if no bridge was found or mDNS
+        is unavailable (e.g. Android multicast restrictions).
+    """
+    log("[SCRIPT.SERVICE.HUE] mDNS: Querying for _hue._tcp.local.")
+
+    try:
+        sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM, socket.IPPROTO_UDP)
+    except OSError as exc:
+        log(f"[SCRIPT.SERVICE.HUE] mDNS: Cannot create socket: {exc}")
+        return None
+
+    try:
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        sock.settimeout(timeout)
+
+        # Set multicast TTL to 1 (local network only)
+        sock.setsockopt(socket.IPPROTO_IP, socket.IP_MULTICAST_TTL, 1)
+
+        query = _build_query()
+        sock.sendto(query, (MDNS_ADDR, MDNS_PORT))
+        log("[SCRIPT.SERVICE.HUE] mDNS: Query sent, waiting for response...")
+
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                break
+            sock.settimeout(remaining)
+            try:
+                data, addr = sock.recvfrom(4096)
+                log(f"[SCRIPT.SERVICE.HUE] mDNS: Response received from {addr[0]}")
+                ip = _parse_response(data)
+                if ip:
+                    log(f"[SCRIPT.SERVICE.HUE] mDNS: Bridge found at {ip}")
+                    return ip
+            except socket.timeout:
+                break
+
+        log("[SCRIPT.SERVICE.HUE] mDNS: No bridge found within timeout")
+        return None
+
+    except OSError as exc:
+        log(f"[SCRIPT.SERVICE.HUE] mDNS: Network error: {exc}")
+        return None
+    finally:
+        sock.close()


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: Hue Service
  - Add-on ID: script.service.hue
  - Version number: 2.2.1
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/zim514/script.service.hue
  
Automate your Hue lights with Kodi. Use scenes configured in the official Hue app. Can use Hue's sunset time to automatically disable the service during daytime and turn on the lights at sunset during playback. Includes Ambilight support.

### Description of changes:

v2.2.1
- Add mDNS bridge discovery
- Improve retry/error handling for Hue API requests
- Fix bridge connection, discovery, and reconnection bugs


### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
