### PR TITLE
[script.wetrakr] 1.1.6

### DIFF
--- a/script.wetrakr/addon.xml
+++ b/script.wetrakr/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon id="script.wetrakr"
        name="WeTrakr Scrobbler"
-       version="1.1.4"
+       version="1.1.6"
        provider-name="WeTrakr">
   <requires>
     <import addon="xbmc.python" version="3.0.1"/>
@@ -23,6 +23,12 @@
     <website>https://wetrakr.com</website>
     <source>https://github.com/wetrakr/wetrakr-kodi</source>
     <news>
+v1.1.6
+- Dispatch all scrobble HTTP calls on a daemon thread to fix UI freezes on slower devices
+
+v1.1.5
+- Fall back to VideoPlayer.UniqueID infolabel when JSON-RPC uniqueid is empty (Jellyfin for Kodi, Plex Kodi Connect)
+
 v1.1.4
 - Ship episode payload even when the show isn't in Kodi's library
 

--- a/script.wetrakr/resources/lib/api.py
+++ b/script.wetrakr/resources/lib/api.py
@@ -41,7 +41,7 @@ class WeTrakrAPI:
 
         req = Request(self.url, data=body, method="POST")
         req.add_header("Content-Type", "application/json")
-        req.add_header("User-Agent", "WeTrakr-Kodi/1.0.0")
+        req.add_header("User-Agent", "WeTrakr-Kodi/1.1.6")
 
         if debug:
             xbmc.log("[WeTrakr] POST {} | {}".format(self.url, payload), xbmc.LOGINFO)

--- a/script.wetrakr/resources/lib/player.py
+++ b/script.wetrakr/resources/lib/player.py
@@ -6,7 +6,14 @@ Callbacks:
   onAVStarted()       — media stream ready → send 'playing' event
   onPlayBackEnded()   — file finished naturally → send 'scrobble' event
   onPlayBackStopped() — user stopped playback → send 'scrobble' if threshold met
+
+All outbound HTTP calls are dispatched on a daemon thread so Kodi's player
+callbacks return immediately — otherwise the UI freezes for the duration of
+the HTTP round-trip (visible on low-end devices like Vero 4K+ on the
+'completed' scrobble).
 """
+
+import threading
 
 import xbmc
 import xbmcaddon
@@ -16,6 +23,14 @@ from resources.lib.api import WeTrakrAPI
 from resources.lib import utils
 from resources.lib import rating as rating_mod
 from resources.lib.notification import notify as _notify
+
+
+def _dispatch_async(target, *args, **kwargs):
+    """Run a callable in a daemon thread; never blocks the caller."""
+    t = threading.Thread(target=target, args=args, kwargs=kwargs)
+    t.daemon = True
+    t.start()
+    return t
 
 
 class WeTrakrPlayer(xbmc.Player):
@@ -119,22 +134,24 @@ class WeTrakrPlayer(xbmc.Player):
                 item_type
             ))
 
-            # Send "playing" event
+            # Send "playing" event (async — don't block player callback)
             if settings["track_playing"]:
                 api = self._get_api(settings)
                 if api:
                     payload = utils.build_payload(
                         "playing", item, self.current_show, progress=0.0
                     )
-                    if api.send_event(payload, debug=settings["debug"]):
-                        self.playing_sent = True
-                        title_display = item.get("title", "")
-                        if item_type == "episode":
-                            title_display = "{} S{:02d}E{:02d}".format(
-                                item.get("showtitle", ""), item.get("season", 0), item.get("episode", 0)
-                            )
-                        if settings["notify_playing"]:
-                            _notify("Now Playing", title_display)
+                    self.playing_sent = True
+                    title_display = item.get("title", "")
+                    if item_type == "episode":
+                        title_display = "{} S{:02d}E{:02d}".format(
+                            item.get("showtitle", ""), item.get("season", 0), item.get("episode", 0)
+                        )
+                    _dispatch_async(
+                        api.send_event, payload, debug=settings["debug"]
+                    )
+                    if settings["notify_playing"]:
+                        _notify("Now Playing", title_display)
 
         except Exception as e:
             self._log("onAVStarted error: {}".format(str(e)), xbmc.LOGERROR)
@@ -178,7 +195,9 @@ class WeTrakrPlayer(xbmc.Player):
                             "playing", self.current_item, self.current_show,
                             progress=progress
                         )
-                        api.send_event(payload, debug=settings["debug"])
+                        _dispatch_async(
+                            api.send_event, payload, debug=settings["debug"]
+                        )
         except Exception as e:
             self._log("onPlayBackResumed error: {}".format(str(e)), xbmc.LOGERROR)
 
@@ -225,7 +244,7 @@ class WeTrakrPlayer(xbmc.Player):
             self.last_progress = progress
             settings = self._get_settings()
 
-            # Send "playing" update with current progress every 30s
+            # Send "playing" update with current progress every 30s (async)
             if settings["track_playing"]:
                 api = self._get_api(settings)
                 if api:
@@ -233,10 +252,10 @@ class WeTrakrPlayer(xbmc.Player):
                         "playing", self.current_item, self.current_show,
                         progress=progress
                     )
-                    ok = api.send_event(payload, debug=settings["debug"])
-                    self._log("Playing update: {:.1f}% → {}".format(
-                        progress, "OK" if ok else "FAIL"
-                    ))
+                    _dispatch_async(
+                        api.send_event, payload, debug=settings["debug"]
+                    )
+                    self._log("Playing update dispatched: {:.1f}%".format(progress))
 
             # Scrobble once threshold is reached
             if progress >= settings["threshold"] and settings["track_watched"]:
@@ -317,10 +336,11 @@ class WeTrakrPlayer(xbmc.Player):
             if rating_value is None:
                 return
 
-            # Send rating to API
+            # Send rating to API (async — keep UI responsive)
             if self.media_type == "episode":
                 show_ids = utils.extract_ids(self.current_show) if self.current_show else {}
-                api.send_rating(
+                _dispatch_async(
+                    api.send_rating,
                     "episode", title, ids, rating_value,
                     show_title=item.get("showtitle", ""),
                     show_ids=show_ids,
@@ -328,7 +348,9 @@ class WeTrakrPlayer(xbmc.Player):
                     episode=item.get("episode", 0)
                 )
             else:
-                api.send_rating("movie", title, ids, rating_value, year=year)
+                _dispatch_async(
+                    api.send_rating, "movie", title, ids, rating_value, year=year
+                )
 
             _notify("WeTrakr", "Rated {}/10".format(rating_value))
         except Exception as e:
@@ -348,7 +370,7 @@ class WeTrakrPlayer(xbmc.Player):
             return 0.0
 
     def _send_paused(self, progress=0.0):
-        """Send a 'paused' event to WeTrakr."""
+        """Send a 'paused' event to WeTrakr (fire-and-forget)."""
         settings = self._get_settings()
         api = self._get_api(settings)
         if not api:
@@ -365,13 +387,20 @@ class WeTrakrPlayer(xbmc.Player):
             episode = self.current_item.get("episode", 0)
             title = "{} S{:02d}E{:02d}".format(show, season, episode)
 
-        if api.send_event(payload, debug=settings["debug"]):
-            self._log("Paused: {} ({:.0f}%)".format(title, progress))
-            if settings["notify_paused"]:
-                _notify("Paused", "{} ({:.0f}%)".format(title, progress))
+        _dispatch_async(api.send_event, payload, debug=settings["debug"])
+        self._log("Paused dispatched: {} ({:.0f}%)".format(title, progress))
+        if settings["notify_paused"]:
+            _notify("Paused", "{} ({:.0f}%)".format(title, progress))
 
     def _send_scrobble(self, progress=0.0):
-        """Send a 'scrobble' event to WeTrakr and mark as scrobbled."""
+        """
+        Send a 'scrobble' event to WeTrakr (fire-and-forget).
+
+        We mark ``self.scrobbled = True`` *before* dispatching so the player
+        callback returns immediately and we never double-scrobble if a second
+        callback fires while the HTTP request is still in flight. If the
+        request ultimately fails, that's logged from the background thread.
+        """
         settings = self._get_settings()
 
         if not settings["track_watched"]:
@@ -393,11 +422,15 @@ class WeTrakrPlayer(xbmc.Player):
             episode = self.current_item.get("episode", 0)
             title = "{} S{:02d}E{:02d}".format(show, season, episode)
 
-        success = api.send_event(payload, debug=settings["debug"])
-        if success:
-            self.scrobbled = True
-            self._log("Scrobbled: {} ({:.0f}%)".format(title, progress))
-            if settings["notify_scrobble"]:
-                _notify("WeTrakr", "Scrobbled: {}".format(title))
-        else:
-            self._log("Scrobble failed: {}".format(title), xbmc.LOGWARNING)
+        self.scrobbled = True
+
+        def _send():
+            ok = api.send_event(payload, debug=settings["debug"])
+            if ok:
+                self._log("Scrobbled: {} ({:.0f}%)".format(title, progress))
+            else:
+                self._log("Scrobble failed: {}".format(title), xbmc.LOGWARNING)
+
+        _dispatch_async(_send)
+        if settings["notify_scrobble"]:
+            _notify("WeTrakr", "Scrobbled: {}".format(title))

--- a/script.wetrakr/resources/lib/player.py
+++ b/script.wetrakr/resources/lib/player.py
@@ -26,8 +26,22 @@ from resources.lib.notification import notify as _notify
 
 
 def _dispatch_async(target, *args, **kwargs):
-    """Run a callable in a daemon thread; never blocks the caller."""
-    t = threading.Thread(target=target, args=args, kwargs=kwargs)
+    """Run a callable in a daemon thread; never blocks the caller.
+
+    Wraps ``target`` so any exception raised inside the thread is logged
+    via ``xbmc.log`` instead of dying silently — caller try/except blocks
+    don't reach into the worker thread.
+    """
+    def _wrapped():
+        try:
+            target(*args, **kwargs)
+        except Exception as e:
+            xbmc.log(
+                "[WeTrakr] Background thread error: {}".format(str(e)),
+                xbmc.LOGERROR,
+            )
+
+    t = threading.Thread(target=_wrapped)
     t.daemon = True
     t.start()
     return t

--- a/script.wetrakr/resources/lib/utils.py
+++ b/script.wetrakr/resources/lib/utils.py
@@ -51,6 +51,21 @@ def get_tvshow_details(tvshow_id):
     }).get("tvshowdetails", {})
 
 
+def get_player_uniqueids():
+    """Read uniqueid values from the currently playing video via VideoPlayer
+    infolabels. The only reliable path when an item is played from an add-on
+    source (Jellyfin for Kodi, Plex Kodi Connect, ...) that bypasses Kodi's
+    VideoLibrary — JSON-RPC returns an empty uniqueid dict in that case but
+    the player still knows the IDs.
+    """
+    tmdb = _parse_int(xbmc.getInfoLabel('VideoPlayer.UniqueID(tmdb)'))
+    tvdb = _parse_int(xbmc.getInfoLabel('VideoPlayer.UniqueID(tvdb)'))
+    imdb = xbmc.getInfoLabel('VideoPlayer.UniqueID(imdb)') or None
+    if imdb and not imdb.startswith('tt'):
+        imdb = None
+    return {"tmdb": tmdb, "imdb": imdb, "tvdb": tvdb}
+
+
 def extract_ids(item):
     """
     Extract external IDs (tmdb, imdb, tvdb) from a Kodi item.
@@ -93,6 +108,12 @@ def build_payload(event, item, show_item=None, progress=0.0):
     """
     item_type = item.get("type", "unknown")
     ids = extract_ids(item)
+
+    # Add-on sources (Jellyfin for Kodi, Plex Kodi Connect, ...) bypass Kodi's
+    # VideoLibrary and JSON-RPC returns an empty uniqueid dict for them. Pull
+    # the IDs straight from the running player via infolabels as a fallback.
+    if not ids["tmdb"] and not ids["imdb"] and not ids["tvdb"]:
+        ids = get_player_uniqueids()
 
     if item_type == "episode":
         # We send the episode payload even when show_item is missing


### PR DESCRIPTION
Update to WeTrakr Scrobbler (`script.wetrakr`) **v1.1.6**.

### Changes since 1.1.4

**v1.1.6**
- Dispatch all scrobble HTTP calls on a daemon thread so Kodi's player callbacks return immediately. Fixes a multi-second UI freeze observed at the "watched" moment on slower devices (reported on Vero 4K+ running OSMC Kodi 21.1).

**v1.1.5**
- Fall back to the `VideoPlayer.UniqueID` infolabel when JSON-RPC `uniqueid` comes back empty. Enables correct media resolution for items played outside Kodi's local library (Jellyfin for Kodi, Plex Kodi Connect).

The full changelog is also embedded in `addon.xml` under `<news>`.