### PR TITLE
[weather.ozweather@matrix] 2.1.9

### DIFF
--- a/weather.ozweather/addon.xml
+++ b/weather.ozweather/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="weather.ozweather" name="OzWeather" version="2.1.8" provider-name="Bossanova808">
+<addon id="weather.ozweather" name="OzWeather" version="2.1.9" provider-name="Bossanova808">
 	<requires>
 		<import addon="xbmc.python" version="3.0.0"/>
     	<import addon="script.module.requests" version="2.22.0+matrix.1"/>
@@ -16,15 +16,15 @@
 		<language>en</language>
 		<license>GPL-3.0-only</license>
 		<forum>https://forum.kodi.tv/showthread.php?tid=116905</forum>
-		<website>https://kodi.wiki/index.php?title=Add-on:Oz_Weather</website>
+		<website>https://kodi.wiki/index.php?title=Add-on:OzWeather</website>
 		<email>bossanova808@gmail.com</email>
 		<source>https://github.com/bossanova808/weather.ozweather</source>
  		<assets>
        		<icon>icon.png</icon>
        		<fanart>fanart.jpg</fanart>
 		</assets>
-		<news>v2.1.8 
-- Add RadarRange label
+		<news>v2.1.9
+- Fix ABC weather video scraping due to upstream changes
     	</news>
 	</extension>
 </addon>

--- a/weather.ozweather/changelog.txt
+++ b/weather.ozweather/changelog.txt
@@ -1,3 +1,6 @@
+v2.1.9
+- Fix ABC weather video scraping due to upstream changes
+
 v2.1.8 
 - Add RadarRange label
 

--- a/weather.ozweather/resources/lib/abc/abc_video.py
+++ b/weather.ozweather/resources/lib/abc/abc_video.py
@@ -1,4 +1,5 @@
 import requests
+import re
 import sys
 import xbmc
 import xbmcgui
@@ -35,7 +36,6 @@ def scrape_and_play_abc_weather_video():
     pass
 
 
-# See bottom of this file for notes on matching the video links (& Store.py for the regex)
 def get_abc_weather_video_link():
     try:
         r = requests.get(Store.ABC_URL, timeout=15)
@@ -45,16 +45,47 @@ def get_abc_weather_video_link():
             error_msg = "ABC __NEXT_DATA__ script not found on page, couldn't extract ABC weather video link"
             Logger.error(error_msg)
             raise ValueError(error_msg)
+
         json_object = json.loads(json_string.string)
+
         # Logger.debug(json_object)
         # Put the json blob into: https://jsonhero.io/j/JU0I9LB4AlLU
         # Gives a path to the needed video as:
         # $.props.pageProps.channelpage.components.0.component.props.list.3.player.config.sources.1.file
         # Rather than grab the URL directly (as place in array might change), grab all the available URLs and get the best quality from it
         # See: https://github.com/bossanova808/weather.ozweather/commit/e6158d704fc160808bf66220da711805860d85c7
-        data = json_object['props']['pageProps']['channelpage']['components'][0]['component']['props']['list'][3]
-        urls = [x for x in data['player']['config']['sources'] if x['type'] == 'video/mp4']
-        return sorted(urls, key=lambda x: x['bitrate'], reverse=True)[0]['file']
+
+        items = json_object['props']['pageProps']['channelpage']['components'][0]['component']['props']['list']
+
+        data = next((item for item in items if item.get('player', {}).get('config', {}).get('sources')), None)
+        if not data:
+            Logger.error("No player sources found in ABC JSON")
+            return ""
+
+        # urls_all = data['player']['config']['sources']
+        # Logger.debug(f"ALL ABC video sources (unfiltered): {urls_all}")
+
+        urls = [x for x in data['player']['config']['sources'] if x.get('type') == 'video/mp4']
+        if not urls:
+            Logger.error("No MP4 sources found in ABC player config")
+            return ""
+
+        Logger.debug(f"ABC video sources available: {[{k: v for k, v in u.items() if k != 'type'} for u in urls]}")
+
+        def quality_key(source):
+            if 'fileSize' in source:
+                return source['fileSize']
+            match = re.search(r'(\d+)p', source.get('label', '0'))
+            return int(match.group(1)) if match else 0
+
+        url = sorted(urls, key=quality_key, reverse=True)[0].get('file', '')
+
+        if not url or not re.match(r'^https?://[^/\s]+', url):
+            Logger.error(f"ABC returned a weird video URL?!: {url}")
+            return ""
+
+        Logger.debug(f"Selected ABC video: {url} (from {len(urls)} sources)")
+        return url
 
     except Exception as inst:
         Logger.error(f"Couldn't get ABC video URL from scraped page: {inst}")


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: OzWeather
  - Add-on ID: weather.ozweather
  - Version number: 2.1.9
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/bossanova808/weather.ozweather
  
Weather forecasting and radar images for Australia using Bureau of Meteorology data.  For full features (animated radars & ABC weather videos) - make sure you install the replacement skin files - see information at the addon wiki (https://kodi.wiki/index.php?title=Add-on:OzWeather).

### Description of changes:

v2.1.9
- Fix ABC weather video scraping due to upstream changes
    	

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
