### PR TITLE
[weather.ozweather@matrix] 2.2.0

### DIFF
--- a/weather.ozweather/README.md
+++ b/weather.ozweather/README.md
@@ -11,7 +11,7 @@ Available from the Kodi official repository (i.e. don't install from here - just
 
 Retrieves BOM data including current conditions, 7-day forecast, and animated radar images.
 
-Script works fine stand-alone for standard high quality Australian weather data, but you need to make skin changes for the best bit, which is the animated BOM radar support.  See the Kodi [wiki page](http://wiki.xbmc.org/index.php?title=Add-on:Oz_Weather) for full details and links to a tool to make this very easy (or the actual modified skin files, if you wish to do this manually).
+Script works fine stand-alone for standard high quality Australian weather data, but you need to make skin changes for the best bit, which is the animated BOM radar support.  See the Kodi [wiki page](http://wiki.xbmc.org/index.php?title=Add-on:OzWeather) for full details and links to a tool to make this very easy (or the actual modified skin files, if you wish to do this manually).
 
 Contributions of skin files for other skins gratefully accepted....just message me on the forums with your skin files.
 

--- a/weather.ozweather/addon.xml
+++ b/weather.ozweather/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="weather.ozweather" name="OzWeather" version="2.1.9" provider-name="Bossanova808">
+<addon id="weather.ozweather" name="OzWeather" version="2.2.0" provider-name="Bossanova808">
 	<requires>
 		<import addon="xbmc.python" version="3.0.0"/>
     	<import addon="script.module.requests" version="2.22.0+matrix.1"/>
@@ -23,8 +23,8 @@
        		<icon>icon.png</icon>
        		<fanart>fanart.jpg</fanart>
 		</assets>
-		<news>v2.1.9
-- Fix ABC weather video scraping due to upstream changes
+		<news>v2.2.0
+- More robust fix for ABC weather video scraping due to upstream changes - explicitly find the weather video
     	</news>
 	</extension>
 </addon>

--- a/weather.ozweather/changelog.txt
+++ b/weather.ozweather/changelog.txt
@@ -1,3 +1,6 @@
+v2.2.0
+- More robust fix for ABC weather video scraping due to upstream changes - explicitly find the weather video
+
 v2.1.9
 - Fix ABC weather video scraping due to upstream changes
 

--- a/weather.ozweather/resources/lib/abc/abc_video.py
+++ b/weather.ozweather/resources/lib/abc/abc_video.py
@@ -57,7 +57,14 @@ def get_abc_weather_video_link():
 
         items = json_object['props']['pageProps']['channelpage']['components'][0]['component']['props']['list']
 
-        data = next((item for item in items if item.get('player', {}).get('config', {}).get('sources')), None)
+        # Logger.debug(f"ABC list items: {[{k: v for k, v in item.items() if k != 'player'} for item in items]}")
+
+        data = next(
+            (item for item in items
+             if 'weather' in item.get('card', {}).get('title', {}).get('children', '').lower()
+             and item.get('player', {}).get('config', {}).get('sources')),
+            None
+        )
         if not data:
             Logger.error("No player sources found in ABC JSON")
             return ""
@@ -74,9 +81,9 @@ def get_abc_weather_video_link():
 
         def quality_key(source):
             if 'fileSize' in source:
-                return source['fileSize']
+                return ('fileSize', source['fileSize'])
             match = re.search(r'(\d+)p', source.get('label', '0'))
-            return int(match.group(1)) if match else 0
+            return ('label', int(match.group(1)) if match else 0)
 
         url = sorted(urls, key=quality_key, reverse=True)[0].get('file', '')
 


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: OzWeather
  - Add-on ID: weather.ozweather
  - Version number: 2.2.0
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/bossanova808/weather.ozweather
  
Weather forecasting and radar images for Australia using Bureau of Meteorology data.  For full features (animated radars & ABC weather videos) - make sure you install the replacement skin files - see information at the addon wiki (https://kodi.wiki/index.php?title=Add-on:Oz_Weather).

### Description of changes:

v2.2.0
- More robust fix for ABC weather video scraping due to upstream changes - explicitly find the weather video
    	

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
