### PR TITLE
[script.wetrakr] 1.1.9

### DIFF
--- a/script.wetrakr/addon.xml
+++ b/script.wetrakr/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon id="script.wetrakr"
        name="WeTrakr Scrobbler"
-       version="1.1.6"
+       version="1.1.9"
        provider-name="WeTrakr">
   <requires>
     <import addon="xbmc.python" version="3.0.1"/>
@@ -23,6 +23,15 @@
     <website>https://wetrakr.com</website>
     <source>https://github.com/wetrakr/wetrakr-kodi</source>
     <news>
+v1.1.9
+- Defer the "Now Playing" toast until playback crosses the 5% mark — the threshold WeTrakr uses to consider a session active and start scrobbling. The backend "playing" event is still sent at start; only the user-facing notification is deferred.
+
+v1.1.8
+- Use Kodi's native Dialog().notification during playback to avoid the WindowDialog that triggered an audio sink renegotiation under E-AC3 passthrough (Vero 4K+ stream stalls)
+
+v1.1.7
+- Build the branded notification dialog on a background thread so player callbacks never block the main thread
+
 v1.1.6
 - Dispatch all scrobble HTTP calls on a daemon thread to fix UI freezes on slower devices
 
@@ -31,14 +40,6 @@ v1.1.5
 
 v1.1.4
 - Ship episode payload even when the show isn't in Kodi's library
-
-v1.1.3
-- Non-blocking notifications
-- Per-event toggles for scrobbling and rating
-
-v1.1.2
-- Render rating stars as PNG images
-- Drop unicode dependency
     </news>
     <assets>
       <icon>icon.png</icon>

--- a/script.wetrakr/resources/lib/notification.py
+++ b/script.wetrakr/resources/lib/notification.py
@@ -4,10 +4,19 @@ notification.py — Branded WeTrakr notification popup.
 Shows a small notification in the top-right corner with the WeTrakr
 "We" logo, purple accent bar, and dark panel background.
 
-The auto-close runs in a background thread so the caller (usually a
-xbmc.Player callback) returns immediately. Blocking the main thread
-with xbmc.sleep made Kodi unresponsive — among other things, the
-fast-forward keys stopped working while a notification was on screen.
+Two render paths:
+
+* During video playback we use Kodi's native ``Dialog().notification``.
+  The native toast is drawn inside the current skin overlay, so it
+  does not push a new entry onto the window stack. On bitstream
+  passthrough setups (e.g. Vero 4K+ with E-AC3 passthrough) opening
+  a ``WindowDialog`` mid-playback forces an audio sink renegotiation,
+  which stalls the video stream for several seconds and ultimately
+  ends playback.
+
+* Outside of playback we still use the branded ``WeTrakrNotification``
+  ``WindowDialog`` — built, shown, slept on and closed entirely on a
+  background daemon thread so the caller never blocks.
 """
 
 import os
@@ -104,25 +113,65 @@ class WeTrakrNotification(xbmcgui.WindowDialog):
         self.close()
 
 
-def notify(title, message, duration=3000):
-    """Show a branded WeTrakr notification popup (non-blocking).
+def _native_notify(title, message, duration):
+    """Use Kodi's built-in ``Dialog().notification`` toast.
 
-    The dialog is shown immediately and a background thread waits for
-    `duration` ms before closing it. The caller returns right away so
-    Kodi's main thread (and player input) keeps flowing.
+    Renders inside the active skin overlay (no new window stack entry),
+    so it's safe to call during bitstream-passthrough playback without
+    forcing an audio sink renegotiation.
     """
-    dialog = WeTrakrNotification(title, message)
-    dialog.show()
+    try:
+        icon = os.path.join(
+            xbmcaddon.Addon('script.wetrakr').getAddonInfo('path'),
+            'resources', 'media', 'we.png',
+        )
+        xbmcgui.Dialog().notification(title, message, icon, duration, False)
+    except Exception as e:
+        xbmc.log(
+            "[WeTrakr] native notify error: {}".format(str(e)),
+            xbmc.LOGERROR,
+        )
 
-    def _close_after_delay():
-        try:
-            xbmc.sleep(duration)
-        finally:
-            try:
-                dialog.close()
-            except Exception:
-                pass
 
-    t = threading.Thread(target=_close_after_delay, name='WeTrakrNotifyClose')
+def _branded_notify(title, message, duration):
+    """Show the branded ``WindowDialog`` popup on a background thread."""
+    try:
+        dialog = WeTrakrNotification(title, message)
+        dialog.show()
+        xbmc.sleep(duration)
+        dialog.close()
+    except Exception as e:
+        xbmc.log(
+            "[WeTrakr] notify error: {}".format(str(e)),
+            xbmc.LOGERROR,
+        )
+
+
+def _is_video_playing():
+    try:
+        return xbmc.Player().isPlayingVideo()
+    except Exception:
+        return False
+
+
+def notify(title, message, duration=3000):
+    """Show a WeTrakr notification (fire-and-forget).
+
+    During video playback this delegates to Kodi's native toast to
+    avoid stalling the player on passthrough setups. Outside of
+    playback we render the branded dialog on a background thread.
+    """
+    if _is_video_playing():
+        t = threading.Thread(
+            target=_native_notify,
+            args=(title, message, duration),
+            name='WeTrakrNotifyNative',
+        )
+    else:
+        t = threading.Thread(
+            target=_branded_notify,
+            args=(title, message, duration),
+            name='WeTrakrNotify',
+        )
     t.daemon = True
     t.start()

--- a/script.wetrakr/resources/lib/player.py
+++ b/script.wetrakr/resources/lib/player.py
@@ -61,6 +61,7 @@ class WeTrakrPlayer(xbmc.Player):
         self.total_time = 0
         self.scrobbled = False
         self.playing_sent = False
+        self.scrobble_notified = False
         self.media_type = None
         self.last_progress = 0.0
         self.poster_art = None
@@ -148,7 +149,10 @@ class WeTrakrPlayer(xbmc.Player):
                 item_type
             ))
 
-            # Send "playing" event (async — don't block player callback)
+            # Send "playing" event (async — don't block player callback).
+            # The user-facing toast is deferred to check_progress() once
+            # playback crosses the 5% mark — that's when WeTrakr considers
+            # the session a real "Now Playing" and starts scrobbling.
             if settings["track_playing"]:
                 api = self._get_api(settings)
                 if api:
@@ -156,16 +160,9 @@ class WeTrakrPlayer(xbmc.Player):
                         "playing", item, self.current_show, progress=0.0
                     )
                     self.playing_sent = True
-                    title_display = item.get("title", "")
-                    if item_type == "episode":
-                        title_display = "{} S{:02d}E{:02d}".format(
-                            item.get("showtitle", ""), item.get("season", 0), item.get("episode", 0)
-                        )
                     _dispatch_async(
                         api.send_event, payload, debug=settings["debug"]
                     )
-                    if settings["notify_playing"]:
-                        _notify("Now Playing", title_display)
 
         except Exception as e:
             self._log("onAVStarted error: {}".format(str(e)), xbmc.LOGERROR)
@@ -270,6 +267,19 @@ class WeTrakrPlayer(xbmc.Player):
                         api.send_event, payload, debug=settings["debug"]
                     )
                     self._log("Playing update dispatched: {:.1f}%".format(progress))
+
+            # Show the "started scrobbling" toast once playback crosses 5% —
+            # that's the threshold WeTrakr uses to consider a session active.
+            if (
+                progress >= 5.0
+                and not self.scrobble_notified
+                and settings["notify_playing"]
+            ):
+                self.scrobble_notified = True
+                _notify(
+                    "Scrobbling in WeTrakr",
+                    "Reached 5% of progress. Started scrobbling, check Now Playing in WeTrakr.",
+                )
 
             # Scrobble once threshold is reached
             if progress >= settings["threshold"] and settings["track_watched"]:


### PR DESCRIPTION
Bumps `script.wetrakr` from 1.1.6 to 1.1.9 on the `omega` branch.

PRs #2840 (1.1.8) and #2842 (1.1.9) were merged against `master` by mistake, so Kodi 21 users are still on 1.1.6. This PR brings the same changes to `omega` so they reach the Omega mirror.

Changelog (cumulative since 1.1.6):

- **1.1.7** — Build the branded notification dialog on a background thread so player callbacks never block the main thread.
- **1.1.8** — Use Kodi's native `Dialog().notification` during playback to avoid a `WindowDialog` that triggered an audio sink renegotiation under E-AC3 passthrough (Vero 4K+ stream stalls).
- **1.1.9** — Defer the "Now Playing" toast until playback crosses the 5% mark (the threshold WeTrakr uses to consider a session active). The backend `playing` event is still sent at start; only the user-facing notification is deferred.

Source: https://github.com/wetrakr/wetrakr-kodi