### PR TITLE
[script.xbmc.unpausejumpback@matrix] 3.0.7

### DIFF
--- a/script.xbmc.unpausejumpback/addon.xml
+++ b/script.xbmc.unpausejumpback/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.xbmc.unpausejumpback" name="Unpause Jumpback" version="3.0.6" provider-name="bossanova808,Memphiz,Lucleonhart,schumi2004,dkadioglu">
+<addon id="script.xbmc.unpausejumpback" name="Unpause Jumpback" version="3.0.7" provider-name="bossanova808,Memphiz,Lucleonhart,schumi2004,dkadioglu">
   <requires>
     <import addon="xbmc.python" version="3.0.0"/>
     <import addon="script.module.bossanova808" version="1.0.2"/>
@@ -8,6 +8,7 @@
   <extension point="xbmc.addon.metadata">
     <summary lang="en_GB">Kodi automatic jump back on un-pausing of videos</summary>
     <summary lang="bg_BG">Превърта назад след пауза</summary>
+    <summary lang="sv_SE">Kodi hoppar automatiskt tillbaka när videor återupptas efter paus</summary>
     <description lang="en_GB">
         This addon will jump back a number of seconds whenever a video is un-paused - to make sure you don't miss anything.
         You can set the amount of seconds to jump back, and the minimum duration of the pause before the addon will trigger a jump back.
@@ -19,14 +20,20 @@
         Може да определите колко време назад да ви връща скока както и след колко време в режим "На пауза" да се активира функцията.
         Има и възможност за скок напред / назад след превъртане напред или назад за дефиниран период от време.
     </description>
+    <description lang="sv_SE">
+        Detta tillägg hoppar tillbaka ett antal sekunder varje gång en video spelas upp igen efter paus – så att du inte missar något.
+        Du kan ställa in antalet sekunder som du vill hoppa tillbaka och den minsta pauslängden innan tillägget aktiverar ett hopp tillbaka.
+        Det går också att hoppa tillbaka eller framåt efter att ha spolat tillbaka eller framåt ett visst antal sekunder för att kompensera för överskridande.
+        (Ursprungligen skapat av Memphiz, underhållet övertaget av bossanova808 2020 för Kodi Matrix och senare).
+    </description>
     <platform>all</platform>
     <license>GPL-3.0-only</license>
     <website>https://github.com/bossanova808/script.xbmc.unpausejumpback/</website>
     <source>https://github.com/bossanova808/script.xbmc.unpausejumpback/</source>
     <forum>https://forum.kodi.tv/showthread.php?tid=355778</forum>
     <email>bossonav808@gmail.com</email>
-    <news>v3.0.6
-- Minor updates for Piers (use new module Logger functions)
+    <news>v3.0.7
+- (User request) jumpback even if pause occurs within jumpback window
     </news>
     <assets>
       <icon>icon.png</icon>

--- a/script.xbmc.unpausejumpback/changelog.txt
+++ b/script.xbmc.unpausejumpback/changelog.txt
@@ -1,3 +1,7 @@
+v3.0.7
+- (User request) jumpback even if pause occurs within jumpback window
+- https://forum.kodi.tv/showthread.php?tid=355778&pid=3294811#pid3294811
+
 v3.0.6
 - Minor updates for Piers (use new module Logger functions)
 

--- a/script.xbmc.unpausejumpback/resources/language/resource.language.sv_se/strings.po
+++ b/script.xbmc.unpausejumpback/resources/language/resource.language.sv_se/strings.po
@@ -1,0 +1,107 @@
+# Kodi Media Center Swedish language file
+msgid ""
+msgstr ""
+"Project-Id-Version: XBMC-Addons\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
+"POT-Creation-Date: 2020-04-26 11:43+0000\n"
+"PO-Revision-Date: 2025-10-22 15:45+0200\n"
+"Last-Translator: Daniel Nylander <github@danielnylander.se>\n"
+"Language-Team: sv\n"
+"Language: sv\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 3.8\n"
+
+msgctxt "#32000"
+msgid "Jump back on un-pause"
+msgstr "Hoppa tillbaka vid avpausning"
+
+msgctxt "#32001"
+msgid "Jump back how many seconds?"
+msgstr "Hur många sekunder tillbaka?"
+
+msgctxt "#32002"
+msgid "Minimum pause time before jumpback"
+msgstr "Minsta paustid före tillbakahopp"
+
+msgctxt "#32010"
+msgid "Jump back after fast forward"
+msgstr "Hoppa tillbaka efter snabbspolning"
+
+msgctxt "#32011"
+msgid "Jump after x2"
+msgstr "Hoppa efter x2"
+
+msgctxt "#32012"
+msgid "Jump after x4"
+msgstr "Hoppa efter x4"
+
+msgctxt "#32013"
+msgid "Jump after x8"
+msgstr "Hoppa efter x8"
+
+msgctxt "#32014"
+msgid "Jump after x16"
+msgstr "Hoppa efter x16"
+
+msgctxt "#32015"
+msgid "Jump after x32"
+msgstr "Hoppa efter x32"
+
+msgctxt "#32020"
+msgid "Jump forward after rewind"
+msgstr "Hoppa framåt efter tillbakaspolning"
+
+msgctxt "#32021"
+msgid "Jump after x2"
+msgstr "Hoppa efter x2"
+
+msgctxt "#32022"
+msgid "Jump after x4"
+msgstr "Hoppa efter x4"
+
+msgctxt "#32023"
+msgid "Jump after x8"
+msgstr "Hoppa efter x8"
+
+msgctxt "#32024"
+msgid "Jump after x16"
+msgstr "Hoppa efter x16"
+
+msgctxt "#32025"
+msgid "Jump after x32"
+msgstr "Hoppa efter x32"
+
+msgctxt "#32030"
+msgid "Exclude"
+msgstr "Exkludera"
+
+msgctxt "#32031"
+msgid "Exclude Live TV"
+msgstr "Exkludera direktsänd TV"
+
+msgctxt "#32032"
+msgid "Exclude HTTP sources"
+msgstr "Exkludera HTTP-källor"
+
+msgctxt "#32033"
+msgid "Exclude Path"
+msgstr "Exkludera sökväg"
+
+msgctxt "#32034"
+msgid "Folder's path (and subfolders)"
+msgstr "Mappens sökväg (och undermappar)"
+
+msgctxt "#32040"
+msgid "Actually do jump back at resume (on), or pause (off)"
+msgstr "Hoppar faktiskt tillbaka vid återuppta (på), eller pausa (av)"
+
+msgctxt "#32042"
+msgid "(For low power systems, jump back on pause may behave more smoothly)"
+msgstr "(För system med låg strömeffekt kan hoppa tillbaka vid paus fungera smidigare)"
+
+msgctxt "#32043"
+msgid "Also jump back on playback started from resume point?"
+msgstr "Hoppa även tillbaka vid uppspelning som startats från återupptagningspunkten?"

--- a/script.xbmc.unpausejumpback/resources/lib/unpause_jumpback.py
+++ b/script.xbmc.unpausejumpback/resources/lib/unpause_jumpback.py
@@ -6,7 +6,7 @@ when resuming playback after a pause.
 
 The add-on supports multiple jumpback modes, with configurable timing:
 
-- Jump back on resume (default behavior)
+- Jump back on resume (default behaviour)
 - Jump back on pause (for low-power systems)
 - Jump back on playback start from resume points
 - Jump back after fast-forward/rewind operations
@@ -27,7 +27,7 @@ def run():
     """
     Main entry point for the add-on.
 
-    Initializes the logger, creates player and monitor instances, and runs
+    Initialises the logger, creates player and monitor instances, and runs
     the main monitoring loop. Handles cleanup on exit or abort signals.
 
     The function will continue running until Kodi signals an abort request
@@ -204,8 +204,8 @@ class MyPlayer(xbmc.Player):
         Handle playback resume events (default jumpback mode).
 
         Called when playback is resumed after being paused. This is the default
-        behavior where the pause position remains where the user actually paused,
-        which is usually the desired behavior.
+        behaviour where the pause position remains where the user actually paused,
+        which is usually the desired behaviour.
 
         When jump_back_on_resume is enabled:
         - Checks exclusion settings for the current file
@@ -239,12 +239,17 @@ class MyPlayer(xbmc.Player):
                 current_time = self.getTime()
                 if (self.jump_back_secs_after_pause != 0
                         and self.isPlayingVideo()
-                        and current_time > self.jump_back_secs_after_pause
+                        and current_time > 0
                         and self.paused_time > 0
                         and (time.time() - self.paused_time) > self.wait_for_jumpback):
-                    resume_time = current_time - self.jump_back_secs_after_pause
-                    self.seekTime(resume_time)
-                    Logger.info(f'Resumed, with {int(self.jump_back_secs_after_pause)}s jump back')
+                    if current_time > self.jump_back_secs_after_pause:
+                        resume_time = current_time - self.jump_back_secs_after_pause
+                        self.seekTime(resume_time)
+                        Logger.info(f'Resumed, with {int(self.jump_back_secs_after_pause)}s jump back')
+                    else:
+                        # Paused within the jump back window - round off to the very start instead of not seeking at all
+                        self.seekTime(0)
+                        Logger.info('Resumed near the start of the video - jumping back to 0:00 instead')
 
                 self.paused_time = 0
 
@@ -282,13 +287,22 @@ class MyPlayer(xbmc.Player):
             Logger.info(f'Playback paused - ignoring because [{_filename}] is in exclusion settings.')
             return
 
-        # For low power systems, perform jumpback during pause period
-        # Prevents janky resume experience but paused image also jumps back
-        if not self.jump_back_on_resume and self.isPlayingVideo() and 0 < self.jump_back_secs_after_pause < self.getTime():
-            jump_back_point = self.getTime() - self.jump_back_secs_after_pause
-            Logger.info(f'Playback paused - jumping back {self.jump_back_secs_after_pause}s to: {int(jump_back_point)} seconds')
-            xbmc.executebuiltin(
+        # For low-power systems, or simply if preferred by the user, perform jumpback during the paused period
+        # Prevents janky resume experience, but paused image also jumps back so if e.g. you're trying to read something, you'll lose the image
+        if not self.jump_back_on_resume and self.isPlayingVideo() and self.jump_back_secs_after_pause > 0:
+            current_time = self.getTime()
+            if current_time > self.jump_back_secs_after_pause:
+                jump_back_point = current_time - self.jump_back_secs_after_pause
+                Logger.info(f'Playback paused - jumping back {self.jump_back_secs_after_pause}s to: {int(jump_back_point)} seconds')
+                xbmc.executebuiltin(
                     f'AlarmClock(JumpbackPaused, Seek(-{self.jump_back_secs_after_pause}), 00:00:{int(self.wait_for_jumpback):02d}, silent), silent)')
+            elif current_time > 0:
+                # Paused within the jump back window - round off to the very start instead of not seeking at all.
+                # Note: we deliberately seek back by -current_time (relative) rather than an absolute Seek(0),
+                # as Kodi's Seek builtin silently no-ops on a literal 0 argument when used with an AlarmClock, it seems
+                Logger.info('Playback paused near the start of the video - jumping back to 0:00 instead')
+                xbmc.executebuiltin(
+                    f'AlarmClock(JumpbackPaused, Seek(-{int(current_time) + 1}), 00:00:{int(self.wait_for_jumpback):02d}, silent), silent)')
 
     def onAVStarted(self):
         """
@@ -330,12 +344,18 @@ class MyPlayer(xbmc.Player):
                 Logger.info(f"Ignored because '{_filename}' is in exclusion settings.")
                 return
             else:
-                if current_time > 0 and 0 < self.jump_back_secs_after_pause < current_time:
-                    resume_time = current_time - self.jump_back_secs_after_pause
-                    Logger.info(f"Resuming playback from saved time: {int(current_time)} "
-                                f"with jump back seconds: {self.jump_back_secs_after_pause}, "
-                                f"thus resume time: {int(resume_time)}")
-                    self.seekTime(resume_time)
+                if self.jump_back_secs_after_pause > 0 and current_time > 0:
+                    if current_time > self.jump_back_secs_after_pause:
+                        resume_time = current_time - self.jump_back_secs_after_pause
+                        Logger.info(f"Resuming playback from saved time: {int(current_time)} "
+                                    f"with jump back seconds: {self.jump_back_secs_after_pause}, "
+                                    f"thus resume time: {int(resume_time)}")
+                        self.seekTime(resume_time)
+                    else:
+                        # Saved resume point is within the jump back window - round off to the very start instead of not seeking at all
+                        Logger.info(f"Saved resume time ({int(current_time)}) is within the jump back window - "
+                                    f"resuming from 0:00 instead")
+                        self.seekTime(0)
 
     def onPlayBackSpeedChanged(self, speed):
         """
@@ -351,7 +371,7 @@ class MyPlayer(xbmc.Player):
         - Speeds supported: 2x, 4x, 8x, 16x, 32x
 
         Args:
-            speed (int): The new playback speed (1 = normal, >1 = fast-forward, 
+            speed (int): The new playback speed (1 = normal, >1 = fast-forward,
                         <0 = rewind, 0 = paused)
         """
         prev_speed = self.last_playback_speed
@@ -416,7 +436,7 @@ class MyMonitor(xbmc.Monitor):
     """
 
     def __init__(self):
-        """Initialize the MyMonitor instance."""
+        """Initialise the MyMonitor instance."""
         super().__init__()
         Logger.debug('MyMonitor - init')
 
@@ -425,7 +445,7 @@ class MyMonitor(xbmc.Monitor):
         Handle add-on settings change events.
 
         Called when the user changes settings in the add-on configuration.
-        Reloads settings in the player if it's initialized, or defers loading
+        Reloads settings in the player if it's initialised, or defers loading
         until the player is available.
 
         This ensures that configuration changes take effect immediately without


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: Unpause Jumpback
  - Add-on ID: script.xbmc.unpausejumpback
  - Version number: 3.0.7
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/bossanova808/script.xbmc.unpausejumpback/
  

        This addon will jump back a number of seconds whenever a video is un-paused - to make sure you don't miss anything.
        You can set the amount of seconds to jump back, and the minimum duration of the pause before the addon will trigger a jump back.
        It also allows to jump back or forward after rewind or fast-forward of a specified amount of seconds to compensate for over-shooting.
        (Originally created by Memphiz, up-keep taken over by bossanova808 in 2020 for Kodi Matrix and beyond).
    

### Description of changes:

v3.0.7
- (User request) jumpback even if pause occurs within jumpback window
    

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
