### PR TITLE
[script.wetrakr] 1.2.1

### DIFF
--- a/script.wetrakr/addon.xml
+++ b/script.wetrakr/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon id="script.wetrakr"
        name="WeTrakr Scrobbler"
-       version="1.1.9"
+       version="1.2.1"
        provider-name="WeTrakr">
   <requires>
     <import addon="xbmc.python" version="3.0.1"/>
@@ -23,23 +23,17 @@
     <website>https://wetrakr.com</website>
     <source>https://github.com/wetrakr/wetrakr-kodi</source>
     <news>
+v1.2.1
+- Fix video stutter (1-2s freeze) caused by notifications shown mid-playback. Toasts are now suppressed while a video plays; the "Scrobbled" confirmation appears once when playback ends.
+
+v1.2.0
+- Recover automatically from a stale token: on an HTTP 401/403 the add-on marks the saved token invalid and re-runs the device-code login, instead of silently dropping events.
+
 v1.1.9
-- Defer the "Now Playing" toast until playback crosses the 5% mark — the threshold WeTrakr uses to consider a session active and start scrobbling. The backend "playing" event is still sent at start; only the user-facing notification is deferred.
+- Defer the "Now Playing" toast until playback crosses the 5% mark, the point WeTrakr starts scrobbling.
 
 v1.1.8
-- Use Kodi's native Dialog().notification during playback to avoid the WindowDialog that triggered an audio sink renegotiation under E-AC3 passthrough (Vero 4K+ stream stalls)
-
-v1.1.7
-- Build the branded notification dialog on a background thread so player callbacks never block the main thread
-
-v1.1.6
-- Dispatch all scrobble HTTP calls on a daemon thread to fix UI freezes on slower devices
-
-v1.1.5
-- Fall back to VideoPlayer.UniqueID infolabel when JSON-RPC uniqueid is empty (Jellyfin for Kodi, Plex Kodi Connect)
-
-v1.1.4
-- Ship episode payload even when the show isn't in Kodi's library
+- Use Kodi's native notification during playback to avoid an audio sink renegotiation under E-AC3 passthrough.
     </news>
     <assets>
       <icon>icon.png</icon>

--- a/script.wetrakr/resources/lib/api.py
+++ b/script.wetrakr/resources/lib/api.py
@@ -7,6 +7,7 @@ Uses urllib (available in Kodi Python) to avoid external dependencies.
 
 import json
 import xbmc
+import xbmcaddon
 
 try:
     from urllib.request import Request, urlopen
@@ -14,6 +15,20 @@ try:
 except ImportError:
     # Python 2 fallback (Kodi 18 Leia and earlier)
     from urllib2 import Request, urlopen, URLError, HTTPError
+
+
+def _flag_auth_invalid():
+    """Persist that the saved token was rejected by the server (HTTP 401/403).
+
+    The background service watches this flag and forces a fresh device-code
+    login. Without it, a stale/orphaned token keeps "working" locally (the
+    add-on still fires events and shows the Scrobbling popup) while every event
+    is silently dropped server-side. See Tigerman58, 2026-06-27.
+    """
+    try:
+        xbmcaddon.Addon("script.wetrakr").setSetting("auth_invalid", "true")
+    except Exception:
+        pass
 
 
 class WeTrakrAPI:
@@ -53,6 +68,17 @@ class WeTrakrAPI:
                 xbmc.log("[WeTrakr] Response: {}".format(status), xbmc.LOGINFO)
             return 200 <= status < 300
         except HTTPError as e:
+            if e.code in (401, 403):
+                # The server no longer recognises this token (orphaned/expired).
+                # Flag it so the service triggers a re-login instead of looping
+                # forever sending events that get dropped.
+                xbmc.log(
+                    "[WeTrakr] Auth rejected (HTTP {}): saved token no longer valid "
+                    "— re-login required".format(e.code),
+                    xbmc.LOGWARNING
+                )
+                _flag_auth_invalid()
+                return False
             xbmc.log(
                 "[WeTrakr] HTTP error {}: {}".format(e.code, e.reason),
                 xbmc.LOGWARNING

--- a/script.wetrakr/resources/lib/auth.py
+++ b/script.wetrakr/resources/lib/auth.py
@@ -47,10 +47,22 @@ def _get_api_url():
 
 
 def is_authenticated():
-    """Check if we have a saved access token."""
+    """True only if we have a saved token the server hasn't rejected.
+
+    A present-but-rejected token (auth_invalid == 'true') counts as NOT
+    authenticated, so the service re-runs the device-code flow on next launch
+    instead of trusting a stale/orphaned token forever.
+    """
     addon = xbmcaddon.Addon("script.wetrakr")
+    if addon.getSetting("auth_invalid") == "true":
+        return False
     token = addon.getSetting("api_token")
     return bool(token and token.strip())
+
+
+def token_was_rejected():
+    """True if a scrobble was rejected with HTTP 401/403 (stale token)."""
+    return xbmcaddon.Addon("script.wetrakr").getSetting("auth_invalid") == "true"
 
 
 def get_token():
@@ -60,10 +72,11 @@ def get_token():
 
 
 def logout():
-    """Clear saved token."""
+    """Clear saved token and reset the rejection flag."""
     addon = xbmcaddon.Addon("script.wetrakr")
     addon.setSetting("api_token", "")
     addon.setSetting("username", "")
+    addon.setSetting("auth_invalid", "false")
     _log("Logged out")
 
 
@@ -399,10 +412,11 @@ def run_device_auth_flow():
         xbmc.sleep(2500)
         dialog.close()
 
-        # Save credentials
+        # Save credentials (and clear any previous rejection flag)
         addon = xbmcaddon.Addon("script.wetrakr")
         addon.setSetting("api_token", result['access_token'])
         addon.setSetting("username", username)
+        addon.setSetting("auth_invalid", "false")
 
         _notify("WeTrakr", "Connected as {}".format(username), 5000)
         _log("Device auth completed for user: {}".format(username))

--- a/script.wetrakr/resources/lib/notification.py
+++ b/script.wetrakr/resources/lib/notification.py
@@ -154,24 +154,35 @@ def _is_video_playing():
         return False
 
 
-def notify(title, message, duration=3000):
+def notify(title, message, duration=3000, force=False):
     """Show a WeTrakr notification (fire-and-forget).
 
-    During video playback this delegates to Kodi's native toast to
-    avoid stalling the player on passthrough setups. Outside of
-    playback we render the branded dialog on a background thread.
+    Rendering ANY toast while a video is actively playing forces Kodi's skin
+    overlay/compositor to repaint over the video, which stutters playback for
+    1-2s on a wide range of devices — Android boxes, Nvidia Shield, Xiaomi,
+    Linux Flatpak — regardless of audio passthrough. This was confirmed
+    universal in the 2026-07 user survey (the native toast added in 1.1.8 did
+    NOT eliminate it), and users reported the lag disappears entirely once
+    notifications are disabled.
+
+    So during playback we skip the toast altogether. Callers that must show a
+    confirmation (the deferred "Scrobbled" toast) call again from
+    onPlayBackEnded/onPlayBackStopped with force=True, when the video is already
+    ending and a repaint is imperceptible.
     """
-    if _is_video_playing():
-        t = threading.Thread(
-            target=_native_notify,
-            args=(title, message, duration),
-            name='WeTrakrNotifyNative',
-        )
-    else:
-        t = threading.Thread(
-            target=_branded_notify,
-            args=(title, message, duration),
-            name='WeTrakrNotify',
-        )
+    playing = _is_video_playing()
+    if playing and not force:
+        return
+
+    # Forced during the stop/end transition → use the lightweight native toast
+    # (no window-stack push) to stay safe on passthrough setups. Outside of
+    # playback we render the branded dialog.
+    target = _native_notify if playing else _branded_notify
+
+    t = threading.Thread(
+        target=target,
+        args=(title, message, duration),
+        name='WeTrakrNotify',
+    )
     t.daemon = True
     t.start()

--- a/script.wetrakr/resources/lib/player.py
+++ b/script.wetrakr/resources/lib/player.py
@@ -65,6 +65,10 @@ class WeTrakrPlayer(xbmc.Player):
         self.media_type = None
         self.last_progress = 0.0
         self.poster_art = None
+        # Title of a scrobble whose "Scrobbled" toast is deferred until playback
+        # ends (see _send_scrobble / _flush_scrobble_notify). None = nothing
+        # pending. Deferring avoids the mid-playback repaint stutter.
+        self._scrobble_notify_title = None
 
     def _get_settings(self):
         """Read current add-on settings."""
@@ -179,6 +183,7 @@ class WeTrakrPlayer(xbmc.Player):
         except Exception as e:
             self._log("onPlayBackEnded error: {}".format(str(e)), xbmc.LOGERROR)
         finally:
+            self._flush_scrobble_notify()
             self._reset_state()
 
     def onPlayBackPaused(self):
@@ -232,6 +237,7 @@ class WeTrakrPlayer(xbmc.Player):
         except Exception as e:
             self._log("onPlayBackStopped error: {}".format(str(e)), xbmc.LOGERROR)
         finally:
+            self._flush_scrobble_notify()
             self._reset_state()
 
     # -----------------------------------------------------------------
@@ -456,5 +462,22 @@ class WeTrakrPlayer(xbmc.Player):
                 self._log("Scrobble failed: {}".format(title), xbmc.LOGWARNING)
 
         _dispatch_async(_send)
+        # Defer the "Scrobbled" toast: showing it now — mid-playback — stutters
+        # video on most devices (2026-07 survey). Stash the title and flush it
+        # once, with force=True, from onPlayBackEnded/onPlayBackStopped, when the
+        # player has stopped and a repaint is imperceptible.
         if settings["notify_scrobble"]:
-            _notify("WeTrakr", "Scrobbled: {}".format(title))
+            self._scrobble_notify_title = title
+
+    def _flush_scrobble_notify(self):
+        """Emit the deferred 'Scrobbled' toast, if any, now that playback ended.
+
+        Called from onPlayBackEnded/onPlayBackStopped before state is reset. Uses
+        force=True so the toast renders even though isPlayingVideo() may briefly
+        still report True during the stop transition — the video is ending, so
+        the repaint no longer stutters anything.
+        """
+        title = self._scrobble_notify_title
+        if title:
+            self._scrobble_notify_title = None
+            _notify("WeTrakr", "Scrobbled: {}".format(title), force=True)

--- a/script.wetrakr/resources/lib/service_runner.py
+++ b/script.wetrakr/resources/lib/service_runner.py
@@ -10,6 +10,7 @@ import xbmcaddon
 
 from resources.lib import auth
 from resources.lib.player import WeTrakrPlayer
+from resources.lib.notification import notify as _notify
 
 POLL_INTERVAL = 30  # seconds between progress checks
 
@@ -31,10 +32,26 @@ def run():
 
     monitor = xbmc.Monitor()
     player = WeTrakrPlayer()
+    warned_reauth = False
 
     while not monitor.abortRequested():
-        if player.isPlayingVideo() and player.current_item and not player.scrobbled:
-            player.check_progress()
+        # If a scrobble was rejected with 401/403, the saved token is stale and
+        # the user must reconnect. Never open the auth dialog while a video is
+        # playing — a WindowDialog mid-playback renegotiates the renderer and can
+        # freeze passthrough audio. Warn once (non-blocking) and re-login only
+        # once playback has stopped.
+        if auth.token_was_rejected():
+            if not warned_reauth:
+                _notify("WeTrakr", "Connection expired — please reconnect", 8000)
+                warned_reauth = True
+            if not player.isPlayingVideo():
+                xbmc.log("[WeTrakr] Stale token — re-running device code flow", xbmc.LOGINFO)
+                auth.run_device_auth_flow()
+                warned_reauth = False
+        else:
+            warned_reauth = False
+            if player.isPlayingVideo() and player.current_item and not player.scrobbled:
+                player.check_progress()
 
         if monitor.waitForAbort(POLL_INTERVAL):
             break

--- a/script.wetrakr/resources/settings.xml
+++ b/script.wetrakr/resources/settings.xml
@@ -4,6 +4,9 @@
     <setting id="username" type="text" label="User" default="" enable="false" />
     <setting id="api_url" type="text" label="API URL" default="https://api.wetrakr.com" />
     <setting id="api_token" type="text" label="API Token" default="" visible="false" />
+    <!-- Set to "true" by api.py when the server rejects the token (HTTP 401/403);
+         is_authenticated() then returns False so the service forces a re-login. -->
+    <setting id="auth_invalid" type="bool" label="Auth invalid" default="false" visible="false" />
   </category>
 
   <category label="Scrobbling">


### PR DESCRIPTION
Version bump for **script.wetrakr** (WeTrakr Scrobbler): 1.1.9 → 1.2.1.

I'm the add-on author/maintainer. Changes since 1.1.9:

- **1.2.1 — Fix video stutter from mid-playback notifications.** Rendering any toast while a video plays forced Kodi to repaint over the video, stalling playback for 1–2s on many devices (Android boxes, Nvidia Shield, Linux), independent of audio passthrough. Notifications are now suppressed during active playback; the single "Scrobbled" confirmation is shown once at the end of playback instead.
- **1.2.0 — Automatic recovery from a stale/orphaned token.** When the server rejects an event (HTTP 401/403), the add-on flags its saved token as invalid and re-runs the device-code login (on next launch or when playback stops) instead of silently dropping events.
- Minor rating-dialog assets and helper tidy-ups.

No new dependencies. Targeting `omega` (Kodi 21).