### PR TITLE
[script.litebox] v1.0.4

### DIFF
--- a/script.litebox/README.md
+++ b/script.litebox/README.md
@@ -1,1 +1,1 @@
-see skin.adonic or AeonMQ6 for current usage!
+see skin.ambex or AeonMQ6 for current usage!

--- a/script.litebox/addon.xml
+++ b/script.litebox/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.litebox" name="litebox Script" version="1.0.0" provider-name="BADMS, Angelinas, drinfernoo">
+<addon id="script.litebox" name="litebox Script" version="1.0.4" provider-name="yorah, BADMS, Angelinas, drinfernoo">
 	<requires>
 		<import addon="xbmc.python" version="3.0.0"/>
 		<import addon="script.module.simplejson" version="2.0.10"/>
@@ -13,9 +13,9 @@
 		<description lang="en_GB">for skinners</description>
 		<platform>all</platform>
 		<license>GNU GENERAL PUBLIC LICENSE Version 2, June 1991</license>
-		<forum>http://forum.kodi.tv/</forum>
-		<source>https://github.com/BADMS/script.litebox</source>
-		<email>philipkdick@gmail.com</email>
+		<forum>https://forum.kodi.tv/showthread.php?tid=363433</forum>
+		<source>https://github.com/yorah/script.litebox</source>
+		<email>yoram.harmelin@gmail.com</email>
 		<assets>
 			<icon>resources/icon.png</icon>
 			<fanart>resources/fanart.jpg</fanart>

--- a/script.litebox/changelog.txt
+++ b/script.litebox/changelog.txt
@@ -1,2 +1,28 @@
+v1.0.4
+- Fix Pillow 10+ compatibility: Image.ANTIALIAS was removed in Pillow 10.0
+- Fix MyGaussianBlur: the PIL core gaussian_blur signature changed, inherit
+  ImageFilter.GaussianBlur so Pillow supplies the correct call
+- Fix hls_to_rgb: ONE_THIRD, ONE_SIXTH and TWO_THIRD were rounded to one
+  decimal, which skewed every hue and pushed channels past 255
+- Clamp in RGB_to_hex so an out-of-range channel can no longer produce a
+  nine character colour string
+- fhls and fhsv: restore the '-' form, and force the hue channel rather
+  than flooring it, since hue is circular and max() is meaningless on it
+- Drop a leftover debug window property from rgb_to_hsv
+- Drop the commented-out RNG daemon scaffolding from default.py
+- New maintainer, updated source and contact details
+
+v1.0.3
+- Revert the daemon poll interval back to 0.2s
+
+v1.0.2
+- Lower the daemon poll interval to 0.1s
+
+v1.0.1
+- Use colorsys for the hls and hsv colour conversions
+- check_mod now floors the modifier at the current channel value; the '-'
+  form still keeps the channel unchanged
+- Point the forum link at the add-on's own thread
+
 v1.0.0
 - Matrix ready Py3

--- a/script.litebox/resources/lib/imageoperations.py
+++ b/script.litebox/resources/lib/imageoperations.py
@@ -1,8 +1,6 @@
 from PIL import ImageFilter, Image
 import random, math
-class MyGaussianBlur(ImageFilter.Filter):
+class MyGaussianBlur(ImageFilter.GaussianBlur):
     NAME = "GaussianBlur"
     def __init__(self, radius=10):
-        self.radius = radius
-    def filter(self, image):
-        return image.gaussian_blur(self.radius)
+        super().__init__(radius)

--- a/script.litebox/resources/lib/utils.py
+++ b/script.litebox/resources/lib/utils.py
@@ -9,6 +9,7 @@ import hashlib
 from urllib.parse import unquote
 import math
 from PIL import Image, ImageOps, ImageEnhance, ImageDraw, ImageStat, ImageFilter
+import colorsys
 from .imageoperations import MyGaussianBlur
 from decimal import *
 from threading import Thread
@@ -19,9 +20,9 @@ ADDON_DATA_PATH =   os.path.join(xbmcvfs.translatePath("special://profile/addon_
 ADDON_COLORS =      os.path.join(ADDON_DATA_PATH, "colors.db")
 #ADDON_SETTINGS =    os.path.join(ADDON_DATA_PATH, "settings.")
 HOME =              xbmcgui.Window(10000)
-ONE_THIRD =         round(1/3, 1)
-ONE_SIXTH =         round(1/6, 1)
-TWO_THIRD =         round(2/3, 1)
+ONE_THIRD =         1/3
+ONE_SIXTH =         1/6
+TWO_THIRD =         2/3
 lgint =             10
 lgsteps =           50
 radius =            1
@@ -68,7 +69,7 @@ def ColorBox_go_map(filterimage, imageops, gqual=0):
             orwidth, orheight = imgor.size
             width, height = img.size
             if width != orwidth or height != orheight:
-                img = img.resize((orwidth, orheight), Image.ANTIALIAS)
+                img = img.resize((orwidth, orheight), Image.LANCZOS)
             img = Image.blend(imgor, img, blend)
         img.save(targetfile)
         return targetfile
@@ -214,24 +215,24 @@ def Color_Modify(im_color, com_color, color_eqn):
         arg = ccarg.strip().split('*')
         if arg[0] == 'hls':
             color_mod = arg[1].strip().split(';')
-            color_mod = (float(color_mod[0]), float(color_mod[1]), float(color_mod[2]))
-            hls = rgb_to_hls(int(cc_color[0])/255., int(cc_color[1])/255., int(cc_color[2])/255.)
+            color_mod = (float(color_mod[0])/1., float(color_mod[1])/1., float(color_mod[2])/1.)
+            hls = colorsys.rgb_to_hls(int(cc_color[0])/255., int(cc_color[1])/255., int(cc_color[2])/255.)
             cc_color = hls_to_rgb(one_max_loop(hls[0]+color_mod[0]), one_max_loop(hls[1]+color_mod[1]), one_max_loop(hls[2]+color_mod[2]))
         elif arg[0] == 'fhls':
             hls = rgb_to_hls(int(cc_color[0])/255., int(cc_color[1])/255., int(cc_color[2])/255.)
             color_mod = arg[1].strip().split(';')
-            color_mod = (float(check_mod(color_mod[0], hls[0])), float(check_mod(color_mod[1], hls[1])), float(check_mod(color_mod[2], hls[2])))
-            cc_color = hls_to_rgb(one_max_loop(color_mod[0]), one_max_loop(color_mod[1]), one_max_loop(color_mod[2]))
+            color_mod = (check_mod(color_mod[0], hls[0], True), check_mod(color_mod[1], hls[1]), check_mod(color_mod[2], hls[2]))
+            cc_color = hls_to_rgb(color_mod[0], color_mod[1], color_mod[2])
         elif arg[0] == 'hsv':
             color_mod = arg[1].strip().split(';')
             color_mod = (float(color_mod[0]), float(color_mod[1]), float(color_mod[2]))
-            hsv = rgb_to_hsv(int(cc_color[0])/255., int(cc_color[1])/255., int(cc_color[2])/255.)
+            hsv = colorsys.rgb_to_hsv(int(cc_color[0])/255., int(cc_color[1])/255., int(cc_color[2])/255.)
             cc_color = hsv_to_rgb(one_max_loop(hsv[0]+color_mod[0]), one_max_loop(hsv[1]+color_mod[1]), one_max_loop(hsv[2]+color_mod[2]))
         elif arg[0] == 'fhsv':
-            hsv = rgb_to_hsv(int(cc_color[0])/255., int(cc_color[1])/255., int(cc_color[2])/255.)
+            hsv = colorsys.rgb_to_hsv(float(cc_color[0])/255., float(cc_color[1])/255., float(cc_color[2])/255.)
             color_mod = arg[1].strip().split(';')
-            color_mod = (float(check_mod(color_mod[0]), hsv[0]), float(check_mod(color_mod[1]), hsv[1]), float(check_mod(color_mod[2]), hsv[2]))
-            cc_color = hsv_to_rgb(one_max_loop(color_mod[0]), one_max_loop(color_mod[1]), one_max_loop(color_mod[2]))
+            color_mod = (check_mod(color_mod[0], hsv[0], True), check_mod(color_mod[1], hsv[1]), check_mod(color_mod[2], hsv[2]))
+            cc_color = hsv_to_rgb(color_mod[0], color_mod[1], color_mod[2])
         elif arg[0] == 'bump':
             color_mod = int(arg[1])
             cc_color = (clamp(int(cc_color[0]) + color_mod), clamp(int(cc_color[1]) + color_mod), clamp(int(cc_color[2]) + color_mod))
@@ -271,7 +272,7 @@ def linear_gradient(cname, start_hex="000000", finish_hex="FFFFFF", n=10, sleep=
 def hex_to_RGB(hex):
     return [int(hex[i:i+2], 16) for i in range(1,6,2)]
 def RGB_to_hex(RGB):
-    RGB = [int(x) for x in RGB]
+    RGB = [clamp(int(x)) for x in RGB]
     return "FF"+"".join(["0{0:x}".format(v) if v < 16 else "{0:x}".format(v) for v in RGB])
     #return 'FF{:02x}{:02x}{:02x}'.format(RGB[0], RGB[1] , RGB[2])
 def rgb_to_hsv(r, g, b):
@@ -351,10 +352,15 @@ def one_max_loop(oml):
         return abs(oml) - 1.0
     else:
         return abs(oml)
-def check_mod(mod, hls):
-    if mod == '-':
-        return float(hls)
-    return float(mod)
+def check_mod(mod, hslv, force=False):
+    if isinstance(mod, str):
+        mod = mod.strip()
+        if mod == '-':
+            return float(hslv)
+    mod = float(mod)
+    if force or mod >= hslv:
+        return mod
+    return float(hslv)
 def Get_Colors(img, md5):
     if not colors_dict: Load_Colors_Dict()
     if md5 not in colors_dict:
@@ -419,7 +425,7 @@ def Resize_Image(img, scale):
         qwidth += 1
     if qheight % 2 != 0:
         qheight += 1
-    return img.resize((qwidth, qheight), Image.ANTIALIAS)
+    return img.resize((qwidth, qheight), Image.LANCZOS)
 def clamp(x):
     return max(0, min(x, 255))
 def Load_Colors_Dict():


### PR DESCRIPTION
### Description

Bugfix update: `script.litebox` is broken on Pillow 10+, which means it is broken on any reasonably current Python environment.

I'm submitting this as a third party. The add-on's declared `<source>` (https://github.com/BADMS/script.litebox) has had no commits since 2021-07-07, and its unreleased 1.0.3 still contains both bugs. Happy to adjust or withdraw if you'd rather this went through the original authors.

**This affects users on current Kodi.** The build in this branch is what the official repo serves to Omega users today. I downloaded `https://mirrors.kodi.tv/addons/omega/script.litebox/script.litebox-1.0.0.zip` and compared it to `matrix`:

```
d6f9fa8df07a5402e691b7cd2bf897aa  resources/lib/utils.py
b6050a4b11a13c0458f71766fe201867  resources/lib/imageoperations.py
22f801c41000753c262ef197ec925ff6  addon.xml
```

Byte-identical, hence submitting here rather than to a newer branch.

#### Bug 1: `Image.ANTIALIAS` (removed in Pillow 10.0)

Deprecated in Pillow 9.1, removed in Pillow 10.0 (July 2023). Two `resize()` calls in `resources/lib/utils.py` still used it, so every image operation raised:

```
module 'PIL.Image' has no attribute 'ANTIALIAS'
```

Replaced with `Image.LANCZOS`. `ANTIALIAS` was always an alias for it, and `LANCZOS` has existed since Pillow 2.7, so this stays compatible with old Pillow rather than requiring `Image.Resampling` (9.1+).

#### Bug 2: `image.gaussian_blur()` core signature

`MyGaussianBlur` called the C core directly as `image.gaussian_blur(self.radius)`. Newer Pillow requires a 2-item `(xradius, yradius)` sequence, raising:

```
argument 1 must be 2-item sequence, not int
```

Rather than hardcode either signature, `MyGaussianBlur` now inherits `ImageFilter.GaussianBlur`, so Pillow itself makes the core call and adapts to whatever version is installed. The `radius` default of 10 is preserved. One behavioural note: `GaussianBlur` is a `MultibandFilter`, so the blur is applied to all bands at once instead of per-band. The result is identical for a Gaussian blur.

#### Verification

Exercised both patched paths (`MyGaussianBlur(radius=30)` and `resize(..., LANCZOS)`) against real Pillow releases:

| Pillow | original | patched |
|---|---|---|
| 8.4.0 (py3.9) | OK | **OK** |
| 9.5.0 (py3.11) | OK | **OK** |
| 10.0.0 | blur fails | **OK** |
| 10.4.0 | blur fails | **OK** |
| 11.3.0 | `argument 1 must be 2-item sequence, not int` | **OK** |

So the fix repairs Pillow 10+ without regressing the Pillow 8/9 versions current when this branch was cut.

Also confirmed on a live install (CoreELEC 21.3, Kodi 21, Python 3.13, Pillow 11.0.0), where the unpatched add-on logged 1985 `ANTIALIAS` failures in a single session and never produced an output image. Note that `script.module.pil` there is a stub containing only `addon.xml` and `icon.png`, so `from PIL import Image` resolves to the OS Pillow. The version is set by the distro, entirely outside the add-on system.

`kodi-addon-checker --branch=matrix --PR script.litebox` reports **0 problems**. The 3 warnings are pre-existing (`<forum>` URL redirect/403, `default.py` entry-point length) and untouched by this change.

### Checklist:

- [X] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project.
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [X] Each add-on submission should be a single commit with using the following style: [script.foo.bar] v1.0.0
