### PR TITLE
[script.xbmc.unpausejumpback@matrix] 3.0.8

### DIFF
--- a/script.xbmc.unpausejumpback/addon.xml
+++ b/script.xbmc.unpausejumpback/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.xbmc.unpausejumpback" name="Unpause Jumpback" version="3.0.7" provider-name="bossanova808,Memphiz,Lucleonhart,schumi2004,dkadioglu">
+<addon id="script.xbmc.unpausejumpback" name="Unpause Jumpback" version="3.0.8" provider-name="bossanova808,Memphiz,Lucleonhart,schumi2004,dkadioglu">
   <requires>
     <import addon="xbmc.python" version="3.0.0"/>
     <import addon="script.module.bossanova808" version="1.0.2"/>
@@ -32,8 +32,8 @@
     <source>https://github.com/bossanova808/script.xbmc.unpausejumpback/</source>
     <forum>https://forum.kodi.tv/showthread.php?tid=355778</forum>
     <email>bossonav808@gmail.com</email>
-    <news>v3.0.7
-- (User request) jumpback even if pause occurs within jumpback window
+    <news>v3.0.8
+- Fix playback stutter at the start of a video when using the Play Random Videos add-on, caused by v3.0.7's jump-back-within-window logic misfiring on a Kodi playback-start timer quirk
     </news>
     <assets>
       <icon>icon.png</icon>

--- a/script.xbmc.unpausejumpback/changelog.txt
+++ b/script.xbmc.unpausejumpback/changelog.txt
@@ -1,49 +1,53 @@
-v3.0.7
+v3.0.8 (2026-08-03)
+- Fix playback stutter at the start of a video when using the Play Random Videos add-on, caused by v3.0.7's jump-back-within-window logic misfiring on a Kodi playback-start timer quirk
+- https://forum.kodi.tv/showthread.php?tid=355778&pid=3300427#pid3300427
+
+v3.0.7 (2026-07-01)
 - (User request) jumpback even if pause occurs within jumpback window
 - https://forum.kodi.tv/showthread.php?tid=355778&pid=3294811#pid3294811
 
-v3.0.6
+v3.0.6 (2025-10-06)
 - Minor updates for Piers (use new module Logger functions)
 
-v3.0.5
+v3.0.5 (2025-02-10)
 - fix for more possibles instances of "Kodi is not playing any media file" when skipping beyond end of file
 
-v3.0.4
+v3.0.4 (2024-10-15)
 - Remove old common code, use new module
 
-v3.0.3
+v3.0.3 (2021-11-10)
 - Minor bugfix for http/s sources
 
-v3.0.2
+v3.0.2 (2021-06-13)
 - fix "Kodi is not playing any media file" when skipping beyond end of file
 
-v3.0.1
+v3.0.1 (2020-12-14)
 - Minor bugfix with http/s sources (plugins)
 
-v3.0.0
+v3.0.0 (2020-07-10)
 - Update for Matrix / Python3 (work borrowed from https://github.com/dkadioglu/script.xbmc.unpausejumpback)
 - Add setting for jump back occurring at time of un-pause vs. at time of pause
 - Bug fixes & tidy-ups
 
-v2.3.3
+v2.3.3 (2015-08-10)
 - fixed format of authors tag in addon.xml
 - removed the XBMC from the name
 
-v2.3.2
+v2.3.2 (2014-11-09)
 - jump back "in the background" when paused (i.e. while still paused instead of upon resuming)
 
-v2.3.1
+v2.3.1 (2014-03-21)
 - revert jumpback after playback started due to XBMC video timer bug - can not add this until xbmc properly reports the playback position immediately on playback start
 
-v2.3.0
+v2.3.0 (2014-02-13)
 - add jumpback after playback started from non zero starting time (needs gotham for working properly!)
 
-v2.2.0
+v2.2.0 (2013-04-07)
 - add exclude settings
 - add jumpback/forward after fwd or rwd based on the fwd/rwd speed (can be adjusted for each speed separately for fwd and rwd).
 
-v2.1.0
+v2.1.0 (2013-01-16)
 - add setting for specifying the minimum pause time before jumping back
 
-v2.0.0
+v2.0.0 (2012-07-05)
 - initial commit for frodo

--- a/script.xbmc.unpausejumpback/resources/lib/unpause_jumpback.py
+++ b/script.xbmc.unpausejumpback/resources/lib/unpause_jumpback.py
@@ -344,18 +344,19 @@ class MyPlayer(xbmc.Player):
                 Logger.info(f"Ignored because '{_filename}' is in exclusion settings.")
                 return
             else:
-                if self.jump_back_secs_after_pause > 0 and current_time > 0:
-                    if current_time > self.jump_back_secs_after_pause:
-                        resume_time = current_time - self.jump_back_secs_after_pause
-                        Logger.info(f"Resuming playback from saved time: {int(current_time)} "
-                                    f"with jump back seconds: {self.jump_back_secs_after_pause}, "
-                                    f"thus resume time: {int(resume_time)}")
-                        self.seekTime(resume_time)
-                    else:
-                        # Saved resume point is within the jump back window - round off to the very start instead of not seeking at all
-                        Logger.info(f"Saved resume time ({int(current_time)}) is within the jump back window - "
-                                    f"resuming from 0:00 instead")
-                        self.seekTime(0)
+                # Note: unlike onPlayBackPaused/onPlayBackResumed, we deliberately do NOT round off to 0:00
+                # when current_time is within the jump back window here. Shortly after playback starts,
+                # Kodi can report a small non-zero getTime() that reflects real elapsed decode time rather
+                # than an actual saved resume bookmark (an old XBMC/Kodi timer quirk - see v2.3.1 changelog).
+                # Treating that as "resume near the start" causes a spurious seek-to-0 stutter on sources
+                # with a bit of startup latency (reported with the Play Random Videos add-on), even though
+                # the video was never actually resuming from a saved point.
+                if 0 < self.jump_back_secs_after_pause < current_time:
+                    resume_time = current_time - self.jump_back_secs_after_pause
+                    Logger.info(f"Resuming playback from saved time: {int(current_time)} "
+                                f"with jump back seconds: {self.jump_back_secs_after_pause}, "
+                                f"thus resume time: {int(resume_time)}")
+                    self.seekTime(resume_time)
 
     def onPlayBackSpeedChanged(self, speed):
         """


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: Unpause Jumpback
  - Add-on ID: script.xbmc.unpausejumpback
  - Version number: 3.0.8
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/bossanova808/script.xbmc.unpausejumpback/
  

        This addon will jump back a number of seconds whenever a video is un-paused - to make sure you don't miss anything.
        You can set the amount of seconds to jump back, and the minimum duration of the pause before the addon will trigger a jump back.
        It also allows to jump back or forward after rewind or fast-forward of a specified amount of seconds to compensate for over-shooting.
        (Originally created by Memphiz, up-keep taken over by bossanova808 in 2020 for Kodi Matrix and beyond).
    

### Description of changes:

v3.0.8
- Fix playback stutter at the start of a video when using the Play Random Videos add-on, caused by v3.0.7's jump-back-within-window logic misfiring on a Kodi playback-start timer quirk
- User reported issue: https://forum.kodi.tv/showthread.php?tid=355778&pid=3300427#pid3300427 and confirmed the fix: https://forum.kodi.tv/showthread.php?tid=355778&pid=3300574#pid3300574
    

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
