### PR TITLE
[script.module.bossanova808@matrix] 1.0.3

### DIFF
--- a/script.module.bossanova808/addon.xml
+++ b/script.module.bossanova808/addon.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.module.bossanova808" name="Bossanova808 Dependencies" version="1.0.2" provider-name="bossanova808">
+<addon id="script.module.bossanova808" name="Bossanova808 Dependencies" version="1.0.3" provider-name="bossanova808">
     <requires>
         <import addon="xbmc.python" version="3.0.0"/>
+        <import addon="script.module.infotagger" version="0.0.7"/>
     </requires>
     <extension point="xbmc.python.module" library="resources/lib" />
     <extension point="xbmc.addon.metadata">
@@ -10,9 +11,13 @@
         <license>GPL-3.0-only</license>
         <website>https://github.com/bossanova808/script.module.bossanova808</website>
         <source>https://github.com/bossanova808/script.module.bossanova808</source>
-        <news>v1.0.2
-- Fix for previous, for systems using older Python
-- Add some more helper functions
+        <news>v1.0.3
+- Defensive coding pass: guard against malformed/missing settings and RPC responses instead of crashing
+- Log OS, module version, and Kodi's actual debug logging status at addon startup
+- Redact sensitive-looking local variables when logging an unhandled exception
+- Always prefix log lines with addon name/version, even for non-string messages
+- Add a shared Playback class for tracking/resuming what's currently playing (library, PVR, and addon sources), for use by other Bossanova808 addons
+- Requires script.module.infotagger
 </news>
         <assets>
             <icon>resources/icon.png</icon>

--- a/script.module.bossanova808/changelog.txt
+++ b/script.module.bossanova808/changelog.txt
@@ -1,13 +1,20 @@
-v1.0.2
+v1.0.3 (2026-08-06)
+- Defensive coding pass: guard against malformed/missing settings and RPC responses instead of crashing
+- Log OS, module version, and Kodi's actual debug logging status at addon startup
+- Redact sensitive-looking local variables when logging an unhandled exception
+- Always prefix log lines with addon name/version, even for non-string messages
+- Reduce noisy window-property debug logging
+
+v1.0.2 (2025-10-06)
 - Fix for previous, for systems using older Python
 - Add some more helper functions
 
-v1.0.1
+v1.0.1 (2025-09-21)
 - Updates for Piers and some defensive programming
 
-v1.0.0 
+v1.0.0 (2025-09-21)
 - Initial release
 
-v0.0.1
+v0.0.1 (2024-10-10)
 - Alpha pre-release
 

--- a/script.module.bossanova808/resources/lib/bossanova808/constants.py
+++ b/script.module.bossanova808/resources/lib/bossanova808/constants.py
@@ -1,5 +1,6 @@
 import sys
 import re
+import platform
 import xbmc
 import xbmcvfs
 import xbmcgui
@@ -24,6 +25,14 @@ KODI_VERSION = xbmc.getInfoLabel('System.BuildVersion')
 version_label = KODI_VERSION or ''
 version_match = re.search(r'\d+', version_label)
 KODI_MAJOR_VERSION = int(version_match.group(0)) if version_match else 21
-USER_AGENT = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Safari/537.36"
+# This module's own version - independent of ADDON_VERSION above, which is the *calling* addon's
+# version. Handy in logs, since this module updates independently of the addons that use it.
+try:
+    BOSSANOVA808_VERSION = xbmcaddon.Addon(id='script.module.bossanova808').getAddonInfo('version')
+except RuntimeError:
+    BOSSANOVA808_VERSION = None
+OS_PLATFORM = platform.platform()
+# Update this periodically - some sites/CDNs reject requests from very old browser versions
+USER_AGENT = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/128.0.0.0 Safari/537.36"
 HOME_WINDOW = xbmcgui.Window(10000)
 WEATHER_WINDOW = xbmcgui.Window(12600)

--- a/script.module.bossanova808/resources/lib/bossanova808/exception_logger.py
+++ b/script.module.bossanova808/resources/lib/bossanova808/exception_logger.py
@@ -19,10 +19,11 @@
 """Exception logger with extended diagnostic info"""
 
 import inspect
+import re
 from contextlib import contextmanager
 from platform import uname
 from pprint import pformat
-from typing import Text, Callable, Generator
+from typing import Callable, Generator
 import sys
 
 # noinspection PyUnresolvedReferences
@@ -30,9 +31,13 @@ import xbmc
 # noinspection PyPackages
 from .logger import Logger
 
+# Local variable names matching this are logged as <redacted> rather than dumped in full,
+# so an unhandled exception near credential-handling code doesn't write secrets to kodi.log
+_SENSITIVE_NAME_PATTERN = re.compile(r'(key|token|password|passwd|pwd|secret|credential|auth|cookie|session)', re.IGNORECASE)
+
 
 def _format_vars(variables):
-    # type: (dict) -> Text
+    # type: (dict) -> str
     """
     Format variables dictionary
 
@@ -44,12 +49,20 @@ def _format_vars(variables):
     var_list.sort(key=lambda i: i[0])
     lines = []
     for var, val in var_list:
-        lines.append('{} = {}'.format(var, pformat(val)))
+        if _SENSITIVE_NAME_PATTERN.search(var):
+            lines.append('{} = <redacted>'.format(var))
+            continue
+        try:
+            formatted = pformat(val)
+        except Exception as format_exc:
+            # A broken __repr__ on a local variable must not shadow the real exception being logged
+            formatted = '<unformattable: {}>'.format(format_exc)
+        lines.append('{} = {}'.format(var, formatted))
     return '\n'.join(lines)
 
 
 def _format_code_context(frame_info):
-    # type: (tuple) -> Text
+    # type: (tuple) -> str
     context = ''
     if frame_info[4] is not None:
         for i, line in enumerate(frame_info[4], frame_info[2] - frame_info[5]):
@@ -73,7 +86,7 @@ Local variables:
 
 
 def _format_frame_info(frame_info):
-    # type: (tuple) -> Text
+    # type: (tuple) -> str
     return FRAME_INFO_TEMPLATE.format(
             file_path=frame_info[1],
             lineno=frame_info[2],
@@ -106,7 +119,7 @@ sys.path:
 
 @contextmanager
 def log_exception(logger_func=Logger.error):
-    # type: (Callable[[Text], None]) -> Generator[None, None, None]
+    # type: (Callable[[str], None]) -> Generator[None, None, None]
     """
     Diagnostic helper context manager
 

--- a/script.module.bossanova808/resources/lib/bossanova808/logger.py
+++ b/script.module.bossanova808/resources/lib/bossanova808/logger.py
@@ -5,7 +5,33 @@ import xbmc
 
 from typing import Any
 # noinspection PyPackages
-from .constants import ADDON_NAME, ADDON_VERSION, KODI_VERSION, KODI_MAJOR_VERSION, ADDON_ARGUMENTS
+from .constants import ADDON_NAME, ADDON_VERSION, KODI_VERSION, KODI_MAJOR_VERSION, ADDON_ARGUMENTS, \
+    BOSSANOVA808_VERSION, OS_PLATFORM
+
+# xbmc.getUserAgent() always returns a non-empty string inside real Kodi, and is used here purely
+# as a cheap "are we actually running inside Kodi" probe - it returns falsy under the lightweight
+# xbmc stubs used when unit testing a module outside Kodi. Computed once, since this can't change
+# part-way through a running addon process.
+_IN_KODI = bool(xbmc.getUserAgent())
+
+
+def _debug_logging_enabled() -> bool:
+    """
+    Whether debug logging is currently active - true if either Settings > System > Logging >
+    'Enable debug logging' is on, or the active profile's advancedsettings.xml sets an explicit
+    <loglevel> of 1 or higher. The latter can enable debug logging while the GUI setting above
+    still reads False, since advancedsettings.xml overrides it without changing that setting.
+    """
+    if xbmc.getCondVisibility("System.GetBool(debug.showloginfo)"):
+        return True
+    # Local import: utilities.py imports Logger from this module, so importing it at module level
+    # here would be circular. By the time this runs, module loading has long finished, so it's safe.
+    from .utilities import get_advancedsetting
+    loglevel = get_advancedsetting('loglevel')
+    try:
+        return bool(loglevel) and int(loglevel) >= 1
+    except ValueError:
+        return False
 
 
 class Logger:
@@ -20,12 +46,12 @@ class Logger:
             be formatted using `pformat` before logging.
         :param level: The log level for the message, default `xbmc.LOGDEBUG`.
         """
-        # (The below test will fail if we're unit testing a module)
-        if xbmc.getUserAgent():
+        if _IN_KODI:
+            prefix = f'### {ADDON_NAME.replace("Kodi ","")} {ADDON_VERSION}: '
             if isinstance(message, str):
-                xbmc.log(f'### {ADDON_NAME.replace("Kodi ","")} {ADDON_VERSION}: {message}', level)
+                xbmc.log(prefix + message, level)
             else:
-                xbmc.log(pformat(message), level)
+                xbmc.log(prefix + pformat(message), level)
         else:
             # ONLY USED WHEN UNIT TESTING A MODULE!
             pprint(message)
@@ -81,7 +107,10 @@ class Logger:
         if extra_messages:
             Logger.info(*extra_messages)
         Logger.info(f'Kodi {KODI_VERSION} (Major version {KODI_MAJOR_VERSION})')
+        Logger.info(f'OS: {OS_PLATFORM}')
         Logger.info(f'Python {sys.version}')
+        Logger.info(f'script.module.bossanova808 version: {BOSSANOVA808_VERSION}')
+        Logger.info(f'Kodi debug logging enabled: {_debug_logging_enabled()}')
         if ADDON_ARGUMENTS != "['']":
             Logger.info(f'Run {ADDON_ARGUMENTS}')
         else:

--- a/script.module.bossanova808/resources/lib/bossanova808/playback.py
+++ b/script.module.bossanova808/resources/lib/bossanova808/playback.py
@@ -1,0 +1,350 @@
+import os
+import json
+from dataclasses import dataclass, asdict
+from typing import Optional
+
+import xbmc
+import xbmcgui
+
+# noinspection PyPackages
+from .utilities import clean_art_url, send_kodi_json
+# noinspection PyPackages
+from .logger import Logger
+# noinspection PyUnresolvedReferences
+from infotagger.listitem import ListItemInfoTag
+
+
+@dataclass
+class Playback:
+    """
+    Stores whatever data can be determined about the currently playing (video) item in Kodi -
+    what it is, where it's from (library/PVR/addon/file), and enough metadata to identify and
+    resume it later. Video only - no audio/song support.
+    """
+    file: Optional[str] = None
+    path: Optional[str] = None
+    type: Optional[str] = None  # episode, movie, musicvideo, video (per Kodi types)
+    source: Optional[str] = None  # kodi_library, pvr_live, pvr_recording, addon, file
+    dbid: Optional[int] = None
+    tvshowdbid: Optional[int] = None
+    totalseasons: Optional[int] = None
+    title: Optional[str] = None
+    label: Optional[str] = None
+    label2: Optional[str] = None
+    thumbnail: Optional[str] = None
+    fanart: Optional[str] = None
+    poster: Optional[str] = None
+    icon: Optional[str] = None
+    year: Optional[int] = None
+    showtitle: Optional[str] = None
+    season: Optional[int] = None
+    episode: Optional[int] = None
+    resumetime: Optional[int] = None
+    totaltime: Optional[int] = None
+    duration: Optional[int] = None
+    channelname: Optional[str] = None
+    channelnumberlabel: Optional[str] = None
+    channelgroup: Optional[str] = None
+
+    @property
+    def pluginlabel(self) -> str:
+        """
+        Create a more full label, e.g. Showname (2x03) - Episode title
+
+        :return: A human-readable label for this playback
+        """
+        label = self.title or self.label or self.channelname or (os.path.basename(self.path) if self.path else None) or "Unknown"
+        if self.showtitle:
+            if (self.season is not None and self.season >= 0) and (self.episode is not None and self.episode >= 0):
+                label = f"{self.showtitle} ({self.season}x{self.episode:02d}) - {self.title or label}"
+            elif self.season is not None and self.season >= 0:
+                label = f"{self.showtitle} ({self.season}x?) - {self.title or label}"
+            else:
+                label = f"{self.showtitle} - {self.title or label}"
+        elif self.channelname:
+            if self.source == "pvr_live":
+                label = f"{self.channelname} (PVR Live)"
+            else:
+                label = f"{label} (PVR Recording {self.channelname})"
+
+        if self.source == "addon":
+            label = f"{label} (* Add-on)"
+        return label
+
+    @property
+    def pluginlabel_short(self) -> str:
+        """
+        Create a shorter label, e.g. Showname (2x03)
+        """
+        label = self.title or self.label or self.channelname or (os.path.basename(self.path) if self.path else None) or "Unknown"
+        if self.showtitle:
+            if (self.season is not None and self.season >= 0) and (self.episode is not None and self.episode >= 0):
+                label = f"{self.showtitle} ({self.season}x{self.episode:02d})"
+            elif self.season is not None and self.season >= 0:
+                label = f"{self.showtitle} ({self.season}x?)"
+            else:
+                label = f"{self.showtitle}"
+
+        return label
+
+    @property
+    def resume_timestamp(self) -> str:
+        """
+        A human-readable "M:SS" rendering of resumetime, or an empty string if there's no
+        meaningful (non-zero) resumetime set - handy for notifications/logging, e.g.
+        f"Resuming: {label}{f' at {playback.resume_timestamp}' if playback.resume_timestamp else ''}"
+        """
+        if not self.resumetime:
+            return ""
+        mins, secs = divmod(int(self.resumetime), 60)
+        return f"{mins}:{secs:02d}"
+
+    def _is_addon_playback(self) -> bool:
+        """
+        Determine if playback originates from an addon
+
+        :return: True if playback is from an addon, False otherwise
+        """
+        path_lower = (self.path or '').lower()
+
+        # Method 1: Check for plugin:// URLs (most reliable)
+        if path_lower.startswith('plugin://'):
+            return True
+
+        # Method 2: Check ListItem.Path infolabel for plugin URLs
+        listitem_path_lower = xbmc.getInfoLabel('ListItem.Path').lower()
+        if listitem_path_lower.startswith('plugin://'):
+            return True
+
+        # Method 3: Check if an addon ID is associated with the current item
+        addon_id = xbmc.getInfoLabel('ListItem.Property(Addon.ID)')
+        if addon_id:
+            return True
+
+        # Method 4: Check container path (for addon-generated content)
+        container_path_lower = xbmc.getInfoLabel('Container.FolderPath').lower()
+        if container_path_lower.startswith('plugin://'):
+            return True
+
+        # Method 5: Conservative HTTP fallback for local addon proxies only
+        if path_lower.startswith(('http://', 'https://')):
+            # Exclude known WebDAV/cloud storage patterns
+            webdav_patterns = [
+                    '/dav/', 'webdav', '.nextcloud.', 'owncloud', '/remote.php/', 'dropbox', 'googledrive', 'onedrive',
+            ]
+
+            if not any(pattern in path_lower for pattern in webdav_patterns):
+                # Additional check: look for typical addon URL structures
+                if any(indicator in path_lower for indicator in ('plugin', 'addon')):
+                    Logger.debug("Classified as addon via HTTP fallback heuristic", path_lower)
+                    return True
+            # If we still have an Addon.ID or container is a plugin, treat as addon
+            addon_id_http = xbmc.getInfoLabel('ListItem.Property(Addon.ID)')
+            container_path_lower_http = xbmc.getInfoLabel('Container.FolderPath').lower()
+            if addon_id_http or container_path_lower_http.startswith('plugin://'):
+                return True
+            # Accept loopback hosts commonly used by addon proxy/resolvers
+            if any(host in path_lower for host in ('127.0.0.1', 'localhost', '[::1]')):
+                Logger.debug("Classified as addon via localhost HTTP fallback", path_lower)
+                return True
+
+        return False
+
+    def update(self, new_details: dict) -> None:
+        """
+        Update a Playback object with new details
+
+        :param new_details: a dictionary (need not be complete) of the Playback object's new details
+        """
+        for key, value in new_details.items():
+            if hasattr(self, key):
+                setattr(self, key, value)
+            else:
+                Logger.error(f"Playback.update: Unknown key [{key}]")
+
+    def toJson(self) -> str:
+        """
+        Return the Playback object as JSON
+
+        :return: the Playback object as JSON
+        """
+        return json.dumps(asdict(self), ensure_ascii=False, indent=2)
+
+    def update_playback_details(self, file: str, item: xbmcgui.ListItem) -> None:
+        """
+        Update the Playback object with details from a playing Kodi ListItem object and InfoLabels
+
+        :param file: the current file Kodi is playing (from xbmc.Player().getPlayingFile())
+        :param item: the current Kodi playing item (from xbmc.Player().getPlayingItem())
+        """
+
+        self.path = item.getPath()
+        self.file = file
+        self.label = item.getLabel()
+        self.label2 = item.getLabel2()
+
+        # Callers may update resumetime/totaltime themselves as playback progresses, but initialise
+        # here in case of early exits etc.
+        if self.source != "pvr_live":
+            # Getting from the player directly is more reliable than using item.getVideoInfoTag() etc
+            self.totaltime = self.duration = int(xbmc.Player().getTotalTime())
+            self.resumetime = int(xbmc.Player().getTime())
+
+        # Determine the Playback source - Kodi Library (...get DBID), PVR, Addon, or Non-Library file?
+        dbid_label = xbmc.getInfoLabel('VideoPlayer.DBID')
+        try:
+            self.dbid = int(dbid_label) if dbid_label else None
+        except ValueError:
+            self.dbid = None
+
+        if self.dbid:
+            self.source = "kodi_library"
+        elif xbmc.getCondVisibility('PVR.IsPlayingTV') or xbmc.getCondVisibility('PVR.IsPlayingRadio'):
+            self.source = "pvr_live"
+        elif (self.path or '').lower().startswith('pvr://recordings/'):
+            self.source = "pvr_recording"
+        elif self._is_addon_playback():
+            self.source = "addon"
+        else:
+            Logger.debug("Not from Kodi library, PVR, or addon - treating as a non-library media file")
+            self.source = "file"
+
+        # TITLE
+        if self.source != "pvr_live":
+            self.title = xbmc.getInfoLabel('VideoPlayer.Title')
+        else:
+            self.title = xbmc.getInfoLabel('VideoPlayer.ChannelName')
+
+        # MEDIA TYPE (see also source above, e.g. to distinguish PVR from non library video)
+        if xbmc.getInfoLabel('VideoPlayer.TVShowTitle'):
+            self.type = "episode"
+            tvshowdbid_label = xbmc.getInfoLabel('VideoPlayer.TvShowDBID')
+            try:
+                self.tvshowdbid = int(tvshowdbid_label) if tvshowdbid_label else None
+            except ValueError:
+                self.tvshowdbid = None
+
+        elif self.dbid:
+            # A dbid alone doesn't distinguish movie from musicvideo - both live in the video
+            # library with a dbid. Musicvideos carry artist metadata that movies don't.
+            self.type = "musicvideo" if xbmc.getInfoLabel('VideoPlayer.Artist') else "movie"
+        elif xbmc.getInfoLabel('VideoPlayer.ChannelName'):
+            self.type = "video"  # use standard mediatype; PVR tracked via self.source
+        else:
+            self.type = "video"
+
+        # ARTWORK - POSTER, FANART THUMBNAIL and ICON
+        self.poster = clean_art_url(xbmc.getInfoLabel('Player.Art(tvshow.poster)') or xbmc.getInfoLabel('Player.Art(poster)') or xbmc.getInfoLabel('Player.Art(thumb)'))
+        self.fanart = clean_art_url(xbmc.getInfoLabel('Player.Art(fanart)'))
+        thumbnail = xbmc.getInfoLabel('Player.Art(thumb)') or (item.getArt('thumb') or '')
+        self.thumbnail = clean_art_url(thumbnail)
+        icon = xbmc.getInfoLabel('Player.Art(icon)') or (item.getArt('icon') or '')
+        self.icon = clean_art_url(icon)
+
+        # OTHER DETAILS
+        # PVR Live/Recordings
+        self.channelname = xbmc.getInfoLabel('VideoPlayer.ChannelName')
+        self.channelnumberlabel = xbmc.getInfoLabel('VideoPlayer.ChannelNumberLabel')
+        self.channelgroup = xbmc.getInfoLabel('VideoPlayer.ChannelGroup')
+        # Episodes & Movies
+        year_label = xbmc.getInfoLabel('VideoPlayer.Year')
+        try:
+            self.year = int(year_label) if year_label else None
+        except ValueError:
+            self.year = None
+        # Episodes
+        self.showtitle = xbmc.getInfoLabel('VideoPlayer.TVShowTitle')
+        season_label = xbmc.getInfoLabel('VideoPlayer.Season')
+        episode_label = xbmc.getInfoLabel('VideoPlayer.Episode')
+        try:
+            self.season = int(season_label) if season_label else None
+        except ValueError:
+            self.season = None
+        try:
+            self.episode = int(episode_label) if episode_label else None
+        except ValueError:
+            self.episode = None
+        # Episodes -> we also want the number of seasons so callers can force-browse to the
+        # appropriate spot after a resumed playback
+        if self.tvshowdbid:
+            json_dict = {
+                    "jsonrpc":"2.0",
+                    "id":"VideoLibrary.GetSeasons",
+                    "method":"VideoLibrary.GetSeasons",
+                    "params":{
+                            "tvshowid":self.tvshowdbid,
+                    },
+            }
+
+            properties_json = send_kodi_json(f'Get seasons details for tv show {self.showtitle}', json_dict)
+            if not properties_json or 'result' not in properties_json:
+                Logger.error("VideoLibrary.GetSeasons returned no result")
+                self.totalseasons = None
+                # Continue without seasons info
+                return
+
+            if 'error' in properties_json:
+                Logger.error("VideoLibrary.GetSeasons returned error:", properties_json['error'])
+                self.totalseasons = None
+                return
+            properties = properties_json['result']
+
+            # {'limits': {'end': 2, 'start': 0, 'total': 2}, 'seasons': [...]}
+            total_limit = properties.get('limits', {}).get('total')
+            self.totalseasons = total_limit if isinstance(total_limit, int) else None
+            if self.totalseasons is None and 'seasons' in properties:
+                self.totalseasons = len(properties['seasons'])
+
+    # noinspection PyMethodMayBeStatic
+    def create_list_item_from_playback(self) -> xbmcgui.ListItem:
+        """
+        Create a Kodi ListItem object from a Playback object, with as much metadata attached as
+        possible (title, artwork, episode/season, resume point) so Kodi's UI has something
+        meaningful to display, rather than e.g. a bare "stream" label.
+
+        :return: ListItem: a Kodi ListItem object constructed from the Playback object
+        """
+
+        Logger.debug("Creating list item from playback:", self)
+
+        list_item = xbmcgui.ListItem(label=self.pluginlabel, path=self.file if self.source not in ["addon", "pvr_live"] else self.path)
+        art = {key:value for key, value in {"thumb":self.thumbnail, "poster":self.poster, "fanart":self.fanart, "icon":self.icon}.items() if value}
+        if art:
+            list_item.setArt(art)
+        list_item.setProperty('IsPlayable', 'true')
+
+        # PVR channels are not really videos! See: https://forum.kodi.tv/showthread.php?tid=381623&pid=3232826#pid3232826
+        # So that's all we need to do for PVR playbacks
+        if self.source == "pvr_live":
+            return list_item
+
+        # Otherwise, it's an episode/movie/file etc...set the InfoVideoTag stuff
+        tag = ListItemInfoTag(list_item, "video")
+        duration_seconds = None
+        if self.duration is not None:
+            duration_seconds = self.duration
+        elif self.totaltime is not None:
+            duration_seconds = self.totaltime
+
+        # Infotagger seems the best way to do this currently as is well tested
+        # I found directly setting things on InfoVideoTag to be buggy/inconsistent
+        infolabels = {
+                'mediatype':self.type,
+                'dbid':self.dbid,
+                'title':self.title,
+                'path':self.path,
+                'year':self.year,
+                'tvshowtitle':self.showtitle,
+                'episode':self.episode,
+                'season':self.season,
+                'duration':duration_seconds,
+        }
+        tag.set_info(infolabels)
+
+        # Required, otherwise immediate resumed playback won't resume properly
+        # These keys are correct, even if CodeRabbit says they are not - see https://github.com/jurialmunkey/script.module.infotagger/blob/f138c1dd7201a8aff7541292fbfc61ed7b3a9aa1/resources/modules/infotagger/listitem.py#L204
+        tag.set_resume_point({'ResumeTime':float(self.resumetime or 0.0), 'TotalTime':float(self.totaltime or 0.0)})
+        if self.tvshowdbid:
+            list_item.setProperty('tvshowdbid', str(self.tvshowdbid))
+
+        return list_item

--- a/script.module.bossanova808/resources/lib/bossanova808/utilities.py
+++ b/script.module.bossanova808/resources/lib/bossanova808/utilities.py
@@ -32,7 +32,6 @@ def set_property(window: xbmcgui.Window, name: str, value: str | None = None) ->
 
     value = str(value)
     if value:
-        Logger.debug(f'Setting window property {name} to value {value}')
         window.setProperty(name, value)
     else:
         clear_property(window, name)
@@ -45,7 +44,6 @@ def clear_property(window: xbmcgui.Window, name: str) -> None:
     :param window:
     :param name:
     """
-    Logger.debug(f'Clearing window property {name}')
     window.clearProperty(name)
 
 
@@ -69,15 +67,7 @@ def get_property_as_bool(window: xbmcgui.Window, name: str) -> bool | None:
     :param name: the name of the property to get
     :return: the value of the window property in boolean form, or None if not set
     """
-    value = get_property(window, name)
-    if value is None:
-        return None
-    lowered = value.strip().lower()
-    if lowered in ("true", "1", "yes", "on"):
-        return True
-    if lowered in ("false", "0", "no", "off"):
-        return False
-    return None
+    return _parse_bool_string(get_property(window, name))
 
 
 def send_kodi_json(human_description: str, json_dict_or_string: str | dict) -> dict | None:
@@ -90,7 +80,11 @@ def send_kodi_json(human_description: str, json_dict_or_string: str | dict) -> d
     """
     Logger.debug(f'KODI JSON RPC command: {human_description}', json_dict_or_string)
     if isinstance(json_dict_or_string, dict):
-        json_dict_or_string = json.dumps(json_dict_or_string)
+        try:
+            json_dict_or_string = json.dumps(json_dict_or_string)
+        except TypeError as e:
+            Logger.error(f'Unable to encode JSON RPC command for {human_description}:', e)
+            return None
     result = xbmc.executeJSONRPC(json_dict_or_string)
     try:
         result = json.loads(result)
@@ -123,10 +117,19 @@ def get_setting_as_bool(setting: str) -> bool | None:
     :param setting: The addon setting to return
     :return: the setting value as boolean, or None if not found
     """
-    value = get_setting(setting)
+    return _parse_bool_string(get_setting(setting))
+
+
+def _parse_bool_string(value: str | None) -> bool | None:
+    """
+    Parse a loosely-formatted string as a boolean
+
+    :param value: the string to parse, or None
+    :return: True/False if value is a recognised boolean string, otherwise None
+    """
     if value is None:
         return None
-    lowered = value.lower()
+    lowered = value.strip().lower()
     if lowered in ("true", "1", "yes", "on"):
         return True
     if lowered in ("false", "0", "no", "off"):
@@ -159,8 +162,8 @@ def get_advancedsetting(setting_path: str) -> str | None:
     """
     Helper function to extract a setting from Kodi's advancedsettings.xml file,
     Remember: cast the result appropriately and provide the Kodi default value as a fallback if the setting is not found.
-    E.g.::
-        Store.ignore_seconds_at_start = int(get_advancedsetting('./video/ignoresecondsatstart')) or 180
+    E.g.:
+        Store.ignore_seconds_at_start = int(get_advancedsetting('video/ignoresecondsatstart')) or 180
 
     :param setting_path: The advanced setting, in 'section/setting' (i.e. path) form, to look for (e.g. video/ignoresecondsatstart)
     :return: The setting value if found, None if not found/advancedsettings.xml doesn't exist
@@ -186,7 +189,11 @@ def get_advancedsetting(setting_path: str) -> str | None:
         return None
     # Normalise: accept either 'section/setting' or './section/setting'
     normalised_path = setting_path if setting_path.startswith('.') else f'./{setting_path.lstrip("./")}'
-    setting_element = root.find(normalised_path)
+    try:
+        setting_element = root.find(normalised_path)
+    except SyntaxError:
+        Logger.error(f"Invalid setting path: {setting_path}")
+        return None
 
     if setting_element is not None:
         text = (setting_element.text or "").strip()
@@ -241,10 +248,17 @@ def version_tuple(version_str: str) -> tuple:
     Helper function to return a version tuple from a version string "2.1.5" -> (2, 1 , 5)
     Useful for comparisons, e.g. if version_tuple(version) <= version_tuple('2.1.5')
 
+    Non-numeric suffixes on a segment (e.g. the "3~alpha1" in "1.2.3~alpha1") are ignored,
+    since Kodi addon versions can legally include them and this is used purely for comparison.
+
     :param version_str: the addon version string
     :return: version in tuple form (1, 2, 3)
     """
-    return tuple(map(int, version_str.split('.')))
+    parts = []
+    for segment in version_str.split('.'):
+        match = re.match(r'\d+', segment)
+        parts.append(int(match.group(0)) if match else 0)
+    return tuple(parts)
 
 
 def get_resume_point(library_type: str, dbid: int) -> float | None:


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: Bossanova808 Dependencies
  - Add-on ID: script.module.bossanova808
  - Version number: 1.0.3
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/bossanova808/script.module.bossanova808
  
Common code needed by Bossanova808 addons

### Description of changes:

v1.0.3
- Defensive coding pass: guard against malformed/missing settings and RPC responses instead of crashing
- Log OS, module version, and Kodi's actual debug logging status at addon startup
- Redact sensitive-looking local variables when logging an unhandled exception
- Always prefix log lines with addon name/version, even for non-string messages
- This update also adds a new shared Playback class (`resources/lib/bossanova808/playback.py`). 

This 'new' (really it's old & tested) Playback class centralises the logic for identifying what's currently playing in Kodi - library/PVR/addon/file source, media type, artwork, episode/season info, etc - so multiple addons can share one tested implementation instead of each maintaining their own copy.  It's being extracted out of `plugin.switchback` (which will be updated to use it in a follow-up submission), and `script.service.playbackresumer` will adopt it as well. No behavioural change to this module's existing consumers from this addition.


### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
