### PR TITLE
[script.module.bossanova808@matrix] 1.0.4

### DIFF
--- a/script.module.bossanova808/addon.xml
+++ b/script.module.bossanova808/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.module.bossanova808" name="Bossanova808 Dependencies" version="1.0.3" provider-name="bossanova808">
+<addon id="script.module.bossanova808" name="Bossanova808 Dependencies" version="1.0.4" provider-name="bossanova808">
     <requires>
         <import addon="xbmc.python" version="3.0.0"/>
     </requires>
@@ -10,13 +10,9 @@
         <license>GPL-3.0-only</license>
         <website>https://github.com/bossanova808/script.module.bossanova808</website>
         <source>https://github.com/bossanova808/script.module.bossanova808</source>
-        <news>v1.0.3
-- Defensive coding pass: guard against malformed/missing settings and RPC responses instead of crashing
-- Log OS, module version, and Kodi's actual debug logging status at addon startup
-- Redact sensitive-looking local variables when logging an unhandled exception
-- Always prefix log lines with addon name/version, even for non-string messages
-- Add a shared Playback class for tracking/resuming what's currently playing (library, PVR, and addon sources), with rich metadata (art, plot, cast/crew, ratings etc), for use by other Bossanova808 addons
-- Uses Kodi's modern InfoTagVideo API when available (Nexus+), falling back to the older setInfo()/setProperty() API on Matrix - no extra dependency required
+        <news>v1.0.4
+- Add Playback.identity_key, a stable per-media identity (library dbid+type, falling back to path) for consumers that need to recognise repeat plays of the same item even when the reported path/file differs between plays
+- Add get_playcount_and_resume_point(), combining what were two separate JSON-RPC round trips into one, for consumers that need both
 </news>
         <assets>
             <icon>resources/icon.png</icon>

--- a/script.module.bossanova808/changelog.txt
+++ b/script.module.bossanova808/changelog.txt
@@ -1,3 +1,7 @@
+v1.0.4 (2026-08-08)
+- Add Playback.identity_key, a stable per-media identity (library dbid+type, falling back to path) for consumers that need to recognise repeat plays of the same item even when the reported path/file differs between plays
+- Add get_playcount_and_resume_point(), combining what were two separate JSON-RPC round trips into one, for consumers that need both
+
 v1.0.3 (2026-08-06)
 - Defensive coding pass: guard against malformed/missing settings and RPC responses instead of crashing
 - Log OS, module version, and Kodi's actual debug logging status at addon startup

--- a/script.module.bossanova808/resources/lib/bossanova808/playback.py
+++ b/script.module.bossanova808/resources/lib/bossanova808/playback.py
@@ -139,6 +139,26 @@ class Playback:
         mins, secs = divmod(int(self.resumetime), 60)
         return f"{mins}:{secs:02d}"
 
+    @property
+    def identity_key(self) -> str:
+        """
+        A stable identifier for "the piece of media this Playback represents", for deduplicating/
+        looking up entries across repeated plays of the same thing - independent of exactly which
+        URL Kodi happens to report for a given play. This matters because .path and .file can -
+        and for some sources reliably do - differ between plays of the same media: a direct library
+        click typically records a videodb:// path, while a later addon-triggered replay of that same
+        library item resolves via .file instead (see create_list_item_from_playback()), which for an
+        addon-backed library item (e.g. Jellyfin) can be a session-specific HTTP stream URL that may
+        not even be stable from one play to the next. Library items therefore use their permanent
+        dbid, namespaced by type since movieid/episodeid/musicvideoid are separate Kodi ID spaces;
+        everything else (PVR, addon, non-library file) falls back to path, which is otherwise stable.
+
+        :return: a string that should be equal for two Playbacks representing the same media
+        """
+        if self.source == "kodi_library" and self.dbid:
+            return f"kodi_library:{self.type}:{self.dbid}"
+        return self.path or ""
+
     def _is_addon_playback(self) -> bool:
         """
         Determine if playback originates from an addon

--- a/script.module.bossanova808/resources/lib/bossanova808/utilities.py
+++ b/script.module.bossanova808/resources/lib/bossanova808/utilities.py
@@ -357,6 +357,62 @@ def get_playcount(library_type: str, dbid: int) -> int | None:
     return play_count
 
 
+def get_playcount_and_resume_point(library_type: str, dbid: int) -> tuple[int | None, float | None]:
+    """
+    Get both the playcount and resume point for a given Kodi DB item, in a single JSON-RPC round
+    trip - more efficient than calling get_playcount() and get_resume_point() separately when both
+    are needed, e.g. when refreshing a whole list of library items.
+
+    :param library_type: one of 'episode', 'movie' or 'musicvideo'
+    :param dbid: the Kodi DB item ID
+    :return: (playcount, resume_point) - either may be None if not available/on error
+    """
+
+    params = _get_jsonrpc_video_lib_params(library_type)
+    # Short circuit if there is an issue get the JSON RPC method etc.
+    if not params:
+        return None, None
+    get_method, id_name, result_key = params
+
+    json_dict = {
+            "jsonrpc":"2.0",
+            "id":"getPlayCountAndResumePoint",
+            "method":get_method,
+            "params":{
+                    id_name:dbid,
+                    "properties":["playcount", "resume"],
+            }
+    }
+
+    query = json.dumps(json_dict)
+    json_response = send_kodi_json(f'Get playcount and resume point for {library_type} with dbid: {dbid}', query)
+    if not json_response:
+        Logger.error("Nothing returned from JSON-RPC query")
+        return None, None
+
+    result = json_response.get('result')
+    if not result:
+        Logger.error("No result returned from JSON-RPC query")
+        return None, None
+
+    details = result.get(result_key)
+    if not details:
+        Logger.error("Could not get playcount/resume point")
+        return None, None
+
+    play_count = details.get('playcount')
+    try:
+        resume_point = details['resume']['position']
+    except (KeyError, TypeError) as e:
+        Logger.error("Could not get resume point")
+        Logger.error(e)
+        resume_point = None
+
+    Logger.info(f"Playcount retrieved: {play_count}, resume point retrieved: {resume_point}")
+
+    return play_count, resume_point
+
+
 def footprints(startup: bool = True) -> None:
     """
     TODO - this has moved to Logger - update all addons to use Logger.start/.stop directly, then ultimately remove this!


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: Bossanova808 Dependencies
  - Add-on ID: script.module.bossanova808
  - Version number: 1.0.4
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/bossanova808/script.module.bossanova808
  
Common code needed by Bossanova808 addons

### Description of changes:

v1.0.4
- Add Playback.identity_key, a stable per-media identity (library dbid+type, falling back to path) for consumers that need to recognise repeat plays of the same item even when the reported path/file differs between plays
- Add get_playcount_and_resume_point(), combining what were two separate JSON-RPC round trips into one, for consumers that need both


### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
