### PR TITLE
[weather.ozweather@matrix] 2.2.1

### DIFF
--- a/weather.ozweather/addon.xml
+++ b/weather.ozweather/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="weather.ozweather" name="OzWeather" version="2.2.0" provider-name="Bossanova808">
+<addon id="weather.ozweather" name="OzWeather" version="2.2.1" provider-name="Bossanova808">
 	<requires>
 		<import addon="xbmc.python" version="3.0.0"/>
     	<import addon="script.module.requests" version="2.22.0+matrix.1"/>
@@ -23,8 +23,9 @@
        		<icon>icon.png</icon>
        		<fanart>fanart.jpg</fanart>
 		</assets>
-		<news>v2.2.0
-- More robust fix for ABC weather video scraping due to upstream changes - explicitly find the weather video
+		<news>v2.2.1
+- Fix log spam and garbled display text (RainChance, RainAmount, HighTemp, UVIndex, etc. showing "None") for the furthest-out forecast day when the BOM hasn't yet published its data
+- Use shared bossanova808 helpers for settings access and error notifications, for consistency
     	</news>
 	</extension>
 </addon>

--- a/weather.ozweather/changelog.txt
+++ b/weather.ozweather/changelog.txt
@@ -1,65 +1,69 @@
-v2.2.0
+v2.2.1 (2026-08-15)
+- Fix log spam and garbled display text (RainChance, RainAmount, HighTemp, UVIndex, etc. showing "None") for the furthest-out forecast day when the BOM hasn't yet published its data
+- Use shared bossanova808 helpers for settings access and error notifications, for consistency
+
+v2.2.0 (2026-06-06)
 - More robust fix for ABC weather video scraping due to upstream changes - explicitly find the weather video
 
-v2.1.9
+v2.1.9 (2026-05-23)
 - Fix ABC weather video scraping due to upstream changes
 
-v2.1.8 
+v2.1.8 (2026-03-25)
 - Add RadarRange label
 
-v2.1.7 
+v2.1.7 (2026-03-16)
 - Increase locations support from 3 to 6 (implemented by spin35)
 - Update to latest radar list scraped from BOM site
 - Add various new labels for skinning: LocationIndex, LocationGeohash, RadarLocation
 
-v2.1.6 Performance improvements, prep for Piers
+v2.1.6 (2025-09-24) Performance improvements, prep for Piers
 - Improve performance when used with multiple Kodi Profiles by using a shared cache (stored under special://temp/ozweather)
 - A bunch of code improvements and defensive programming to cope with scenarios where things are not at times available
 
 
-v2.1.5 Minor fixes
+v2.1.5 (2025-06-09) Minor fixes
 - Fix feels like calculation when data not returned by BOM, and Current.Wind
 
-v2.1.3
+v2.1.3 (2024-10-22)
 - Bugfix for 2.1.2, fix missed import
 
-v2.1.2
+v2.1.2 (2024-10-16)
 - Remove old common code, instead use new script.module.bossanova808
 - Fix for occasional error with missing national radar background
 
-2.1.1
+2.1.1 (2024-01-09)
 - Add Latitude and Longitude to Window data for skins that display 'season' using (arguably dubious) logic
 
-2.1.0
+2.1.0 (2023-11-27)
 - Fix light_rain icon & update BOM radar list
 
-2.0.9
+2.0.9 (2023-06-05)
 - Better fix for ABC weather video
 
 2.0.8
 - Fix for moved ABC weather videos, update list of radars
 
-2.0.6
+2.0.6 (2023-02-14)
 - Update list of radars
 
-2.0.5
+2.0.5 (2022-02-07)
 - Improve error handling if the BOM disappears for a bit...
-      
-v2.0.4
+
+v2.0.4 (2021-12-13)
 - Remove WeatherZone support due to upstream site being totally revised
 
-v2.0.3
+v2.0.3 (2021-10-08)
 - Set some limits to prevent issues with the BOM suddenly supplying days, not hours, worth of images
 - Fix missing weathercode
 
-v2.0.2
+v2.0.2 (2021-07-11)
 - Minor bugfixes and improvements
 
-v2.0.1
+v2.0.1 (2021-06-18)
 - Deal better with observation stations that don't provide data
 - Set some custom skin labels to improve custom skin file behaviours
 
-v2.0.0
+v2.0.0 (2021-03-26)
 - N.B. If you have run a version before 2.0, please re-configure the addon to set-up your BOM locations!
 - Rewrite to use BOM API directly, leave Weatherzone in as a fallback option if BOM not configured or available
 - Add mechanism to manually purge radar backgrounds via addon settings
@@ -67,49 +71,49 @@ v2.0.0
 - Update settings.xml to new Kodi format
 - Modernise code throughout
 
-v1.2.2
+v1.2.2 (2020-11-11)
  - Change xbmc.translatePath (deprecated) to xbmcvfs.translatePath
  - Fix missing import in locations.py that broke setting new locations
 
-v1.2.1
+v1.2.1 (2020-11-11)
  - Submit to Kodi Matrx repo
  - Add github workflows for addon checking & submission
 
-v1.0.201
+v1.0.201 (2020-04-15)
   - Python 3 version for Matrix
 
-v1.0.2
+v1.0.2 (2020-04-15)
  - Fix for weatherzone moving to ajax loading the forecast data
 
-v1.0.1
+v1.0.1 (2019-05-15)
 - Must scrape all WeatherZone data over https now it seems
 
-v1.0.0
+v1.0.0 (2019-02-14)
 - More robust error handling if scraped data is unexpectedly absent
 
-v0.9.9
+v0.9.9 (2019-02-02)
 - Fixes for national radar
 - Simplify radar downloading
 - Fix logging in the event of exceptions
 
-v0.9.8
+v0.9.8 (2019-01-13)
 - Updates for Leia
 - Fixes for recent ABC and BOM changes
 
-v0.9.7
+v0.9.7 (2017-12-23)
 - Fixes for git hell
 - Fixes for cut and paste error and strip most strings to solve whitespace issues
 
-v0.9.4
+v0.9.4 (2017-12-18)
 - Fixes for Weatherzone page changes
 
-v0.9.3
+v0.9.3 (2017-12-15)
 - Fixes for Krypton, Estuary and BOM source changes
 
-V0.8.9
+V0.8.9 (2017-01-05)
 - Don't crash if no radar is set...
 
-V0.8.8
+V0.8.8 (2016-12-24)
 - Release of below after a few further bugfixes to icons mainly
 
 V0.8.5
@@ -128,92 +132,92 @@ V0.8.4 - Test only release
 - Set appropriate icons for night time weather (after sunset, before sunrise)
 
 
-V0.8.2
+V0.8.2 (2015-07-26)
 - Setting that disables periodic radar background updating fort those platforms with PIL issues
 
-V0.8.1
+V0.8.1 (2015-06-25)
 - Scraping fixes for new weatherzone, mainly moonphase
 
-V0.8.0
+V0.8.0 (2015-01-25)
 - Cope with locales that don't provide pressure information
 
-V0.7.9
+V0.7.9 (2015-01-08)
 - Bring labels in line with Ronie's weather.openweathermap.extended for better cross skin compatibility,
   still supports the old style labels
 - Added Fire Danger ratings and Pressure, Wind Gusts
 
-V0.7.8
+V0.7.8 (2014-11-21)
 - Bugfix for below, Day is not the same as Daily!
 
-V0.7.7
+V0.7.7 (2014-11-18)
 - Bugfix for below, Day is not the same as Daily!
 - add Longdescription new style for one day as that's all we've got
 - added moonphase text
 
-V0.7.6
+V0.7.6 (2014-11-18)
 - Set some more properties with standardised names for better non confluence skin support
 - Add support for banner.png WeatherProviderLogo
 
-V0.7.5
+V0.7.5 (2014-09-09)
 - Updates to scraper due to frickin' reverted Weatherzone changes
 - Should cope with both old and new website versions with some luck
 - Also updated ABC url scraping to be a bit more robust
 
-V0.7.4 
+V0.7.4 (2014-09-02)
 - Updates to scraper due to Weatherzone changes
 
-V0.7.3 
+V0.7.3 (2014-08-13)
 - add new script.module.pil to dependencies
 
-V0.7.2 
+V0.7.2 (2014-08-13)
 - addon.xml per Gotham requirements
 
-V0.7.1
+V0.7.1 (2014-03-08)
 - Fixed ABC weather video link again - apparently they use multiple servers
 
-V0.7.0
+V0.7.0 (2014-03-07)
 - Fixed ABC weather video link
 - Added setting for weather video qualtiy level
 
-V0.6.9
+V0.6.9 (2014-01-21)
 - Unreleased, repo moved to github
 
-V0.6.8
+V0.6.8 (2014-01-16)
 - Deal with blank radar codes in user settings
 - Better tidying up old radar images
 
-V0.6.7
+V0.6.7 (2013-12-17)
 - Added sunrise/sunset, rain predictions to 7 day forecast
 
-V0.6.6
+V0.6.6 (2013-08-15)
 - Use mathematical rounding instead of skin truncating
 
-V0.6.5 
+V0.6.5 (2013-08-10)
 - Bit of defensive programming to deal with parsedom and weatherzone issue
 
-V0.6.4
+V0.6.4 (2013-05-30)
 - pan2 changes merged - adds date labels
 
-V0.6.3
+V0.6.3 (2013-03-16)
 - Can now search by suburb name not just postcode
 
-V0.6.1
+V0.6.1 (2013-03-14)
 - Bump for Frodo
 - Cleanup, better logging (in debug mode)
 - Refactor & incorporate b808 common code (0.0.8)
-- Bugfix for proxy users   
+- Bugfix for proxy users
 
-V0.4.4
+V0.4.4 (2012-11-27)
 - Minor data cleanup as Weatherzone returns crap data sometimes
 
-V0.4.3
+V0.4.3 (2012-09-24)
 - Fixes for fixes for capatilisation :)
 
-V0.4.2
+V0.4.2 (2012-09-20)
 - Fixes for capatilisation
 - Fixes for parsedom 1.2 unicode behaviour
 
-V0.3.8
+V0.3.8 (2012-05-31)
 - Only import PIL if extended features are activated (means on paltforms like Crystalbuntu without PIL you can still get BOM weather data at least.
 - some radars (e.g. IDR072) - were not on the ftp server, they now get pulled in by http
 - backgrounds are refreshed every 24 hours to pick up any changes at the BOM

--- a/weather.ozweather/resources/lib/abc/abc_video.py
+++ b/weather.ozweather/resources/lib/abc/abc_video.py
@@ -16,6 +16,7 @@ if not xbmc.getUserAgent():
 from resources.lib.store import Store
 from bossanova808.constants import CWD
 from bossanova808.logger import Logger
+from bossanova808.notify import Notify
 
 
 def scrape_and_play_abc_weather_video():
@@ -25,7 +26,7 @@ def scrape_and_play_abc_weather_video():
     url = get_abc_weather_video_link()
     # Construct an offscreen list item with metadata...
     if not url:
-        xbmcgui.Dialog().notification("OzWeather", "Couldn't retrieve ABC weather video - sorry!", xbmcgui.NOTIFICATION_ERROR, 4000)
+        Notify.error("Couldn't retrieve ABC weather video - sorry!", 4000)
         return
     item = xbmcgui.ListItem(path=url)
     item.setProperty('mimetype', 'video/mp4')

--- a/weather.ozweather/resources/lib/bom/bom_forecast.py
+++ b/weather.ozweather/resources/lib/bom/bom_forecast.py
@@ -303,8 +303,8 @@ def bom_forecast(geohash):
             # Date (Apr 4)
             set_key(weather_data, i, "ShortDate", forecast_datetime.strftime('%b ') + forecast_datetime.strftime('%d').lstrip('0'))
             # Outlook / Condition (same thing)
-            set_key(weather_data, i, "Outlook", forecast_seven_days[i]['short_text'])
-            set_key(weather_data, i, "Condition", forecast_seven_days[i]['short_text'])
+            set_key(weather_data, i, "Outlook", forecast_seven_days[i]['short_text'] or "")
+            set_key(weather_data, i, "Condition", forecast_seven_days[i]['short_text'] or "")
             #  See end of loop for the extended forecast (OutlookLong, ConditionLong)
             #  as we add warnings and sun protection info.OutlookLong / ConditionLong (same thing) - extended text forecast -
 
@@ -328,9 +328,13 @@ def bom_forecast(geohash):
                 else:
                     icon_code = Store.WEATHER_CODES[icon_descriptor]
             except KeyError:
-                Logger.error(f'Could not find icon code for BOM icon_descriptor: {forecast_seven_days[i]["icon_descriptor"]} and from short text {descriptor_from_short_text}')
-                # Pop the missing icon descriptor into the outlook to make it easier for people to report in the forum thread
-                set_key(weather_data, i, "Outlook", f"[{forecast_seven_days[i]['icon_descriptor']}] {forecast_seven_days[i]['short_text']}")
+                if icon_descriptor is None and not forecast_seven_days[i]['short_text']:
+                    # BOM has not yet published forecast data for this (usually the furthest-out) day - expected/normal, not a real unmapped-icon bug
+                    Logger.debug(f'BOM has not yet published forecast data for day {i} - falling back to the "na" icon')
+                else:
+                    Logger.error(f'Could not find icon code for BOM icon_descriptor: {forecast_seven_days[i]["icon_descriptor"]} and from short text {descriptor_from_short_text}')
+                    # Pop the missing icon descriptor into the outlook to make it easier for people to report in the forum thread
+                    set_key(weather_data, i, "Outlook", f"[{forecast_seven_days[i]['icon_descriptor']}] {forecast_seven_days[i]['short_text']}")
 
             Logger.debug(f"Icon descriptor is: {icon_descriptor}, icon code is {icon_code}")
             set_keys(weather_data, i, ["OutlookIcon", "ConditionIcon"], f'{icon_code}.png')
@@ -352,7 +356,7 @@ def bom_forecast(geohash):
                 elif forecast_seven_days[i]['now']['later_label'] == "Tomorrow's Max":
                     Logger.debug("Using now->temp_later as now->later_label is Tomorrow's Max")
                     temp_max = forecast_seven_days[i]['now']['temp_later']
-            set_keys(weather_data, i, ["HighTemp", "HighTemperature"], temp_max)
+            set_keys(weather_data, i, ["HighTemp", "HighTemperature"], "" if temp_max is None else temp_max)
 
             temp_min = forecast_seven_days[i]['temp_min']
             if i == 0 and not temp_min:
@@ -362,27 +366,36 @@ def bom_forecast(geohash):
                 elif forecast_seven_days[i]['now']['later_label'] == 'Overnight Min':
                     Logger.debug("Using now->temp_later as now->later_label is Overnight Min")
                     temp_min = forecast_seven_days[i]['now']['temp_later']
-            set_keys(weather_data, i, ["LowTemp", "LowTemperature"], temp_min)
+            set_keys(weather_data, i, ["LowTemp", "LowTemperature"], "" if temp_min is None else temp_min)
 
             # Chance & amount of rain
-            set_keys(weather_data, i, ["RainChance", "ChancePrecipitation"], f'{forecast_seven_days[i]["rain"]["chance"]}%')
-            amount_min = forecast_seven_days[i]['rain']['amount']['min'] or '0'
-            amount_max = forecast_seven_days[i]['rain']['amount']['max'] or '0'
-            if amount_min == '0' and amount_max == '0':
-                set_keys(weather_data, i, ["RainChanceAmount", "RainAmount", "Precipitation"], 'None')
+            # rain.chance is only None when BOM hasn't yet published forecast data for this day - distinct from a
+            # genuine 0% chance, which is a real forecast value we do want to show (as is 0mm expected amount)
+            rain_chance = forecast_seven_days[i]['rain']['chance']
+            if rain_chance is None:
+                set_keys(weather_data, i, ["RainChance", "ChancePrecipitation"], "")
+                set_keys(weather_data, i, ["RainChanceAmount", "RainAmount", "Precipitation"], "")
             else:
-                set_keys(weather_data, i, ["RainChanceAmount", "RainAmount", "Precipitation"], f'{amount_min}-{amount_max}mm')
+                set_keys(weather_data, i, ["RainChance", "ChancePrecipitation"], f'{rain_chance}%')
+                amount_min = forecast_seven_days[i]['rain']['amount']['min'] or '0'
+                amount_max = forecast_seven_days[i]['rain']['amount']['max'] or '0'
+                if amount_min == '0' and amount_max == '0':
+                    set_keys(weather_data, i, ["RainChanceAmount", "RainAmount", "Precipitation"], 'None')
+                else:
+                    set_keys(weather_data, i, ["RainChanceAmount", "RainAmount", "Precipitation"], f'{amount_min}-{amount_max}mm')
 
             # UV - Predicted max, text for such, and the recommended 'Wear Sun Protection' period
-            set_key(weather_data, i, 'UVIndex',  f'{forecast_seven_days[i]["uv"]["max_index"]}' or "")
-            if forecast_seven_days[i]['uv']['category']:
-                set_key(weather_data, i, 'UVIndex', f'{forecast_seven_days[i]["uv"]["max_index"]} ({forecast_seven_days[i]["uv"]["category"].title()})' or "")
-                set_key(weather_data, i, 'UVCategory', forecast_seven_days[i]['uv']['category'].title() or "")
+            uv_max_index = forecast_seven_days[i]['uv']['max_index']
+            uv_category = forecast_seven_days[i]['uv']['category']
+            if uv_category:
+                set_key(weather_data, i, 'UVIndex', f'{uv_max_index} ({uv_category.title()})')
+                set_key(weather_data, i, 'UVCategory', uv_category.title())
             else:
-                set_key(weather_data, i, 'UVCategory', "None")
+                set_key(weather_data, i, 'UVIndex', "" if uv_max_index is None else f'{uv_max_index}')
+                set_key(weather_data, i, 'UVCategory', "")
 
             # OutlookLong / Condition Long
-            extended_text = f'{forecast_seven_days[i]["extended_text"]}' or ""
+            extended_text = forecast_seven_days[i]["extended_text"] or ""
 
             # Add sun protection recommendation, if there is one
             if i == 0 and forecast_seven_days[i]['uv']['start_time'] and forecast_seven_days[i]['uv']['end_time']:

--- a/weather.ozweather/resources/lib/forecast.py
+++ b/weather.ozweather/resources/lib/forecast.py
@@ -8,7 +8,7 @@ import xbmc
 import xbmcvfs
 
 from bossanova808.constants import ADDON, ADDON_NAME, ADDON_VERSION, WEATHER_WINDOW, CWD
-from bossanova808.utilities import set_property, clear_property
+from bossanova808.utilities import set_property, clear_property, get_setting
 from bossanova808.logger import Logger
 from resources.lib.store import Store
 
@@ -243,8 +243,8 @@ def get_weather():
         pass
 
     # Retrieve the currently chosen location geohash & radar code
-    geohash = ADDON.getSetting(f'Location{sys.argv[1]}BOMGeoHash')
-    radar = ADDON.getSetting(f'Radar{sys.argv[1]}') or ADDON.getSetting(f'Location{sys.argv[1]}ClosestRadar')
+    geohash = get_setting(f'Location{sys.argv[1]}BOMGeoHash')
+    radar = get_setting(f'Radar{sys.argv[1]}') or get_setting(f'Location{sys.argv[1]}ClosestRadar') or ""
 
     # With the new closest radar system, the radar is stored as e.g. 'Melbourne - IDR023' so strip the name off...
     split_code = radar.split(' - ')
@@ -272,9 +272,9 @@ def get_weather():
     set_property(WEATHER_WINDOW, 'WeatherVersion', ADDON_VERSION)
 
     # Set the location we updated
-    location_in_use = ADDON.getSetting(f'Location{sys.argv[1]}BOM')
-    latitude = ADDON.getSetting(f'Location{sys.argv[1]}Lat')
-    longitude = ADDON.getSetting(f'Location{sys.argv[1]}Lon')
+    location_in_use = get_setting(f'Location{sys.argv[1]}BOM') or ""
+    latitude = get_setting(f'Location{sys.argv[1]}Lat')
+    longitude = get_setting(f'Location{sys.argv[1]}Lon')
     try:
         location_in_use = location_in_use[0:location_in_use.index(',')]
     except ValueError:

--- a/weather.ozweather/resources/lib/locations.py
+++ b/weather.ozweather/resources/lib/locations.py
@@ -1,5 +1,5 @@
-from bossanova808.constants import ADDON, WEATHER_WINDOW
-from bossanova808.utilities import set_property
+from bossanova808.constants import WEATHER_WINDOW
+from bossanova808.utilities import set_property, get_setting
 from bossanova808.logger import Logger
 
 
@@ -9,12 +9,12 @@ def refresh_locations():
     """
     Logger.info("Refreshing weather locations from settings")
 
-    location1 = ADDON.getSetting('Location1BOM') or ""
-    location2 = ADDON.getSetting('Location2BOM') or ""
-    location3 = ADDON.getSetting('Location3BOM') or ""
-    location4 = ADDON.getSetting('Location4BOM') or ""
-    location5 = ADDON.getSetting('Location5BOM') or ""
-    location6 = ADDON.getSetting('Location6BOM') or ""	
+    location1 = get_setting('Location1BOM') or ""
+    location2 = get_setting('Location2BOM') or ""
+    location3 = get_setting('Location3BOM') or ""
+    location4 = get_setting('Location4BOM') or ""
+    location5 = get_setting('Location5BOM') or ""
+    location6 = get_setting('Location6BOM') or ""
 
     Logger.info(f"Location1: {location1}")
     Logger.info(f"Location2: {location2}")
@@ -53,12 +53,12 @@ def refresh_locations():
 
     Logger.info("Refreshing radar locations from settings")
 
-    radar1 = ADDON.getSetting('Radar1') or ADDON.getSetting('Location1ClosestRadar') or ""
-    radar2 = ADDON.getSetting('Radar2') or ADDON.getSetting('Location2ClosestRadar') or ""
-    radar3 = ADDON.getSetting('Radar3') or ADDON.getSetting('Location3ClosestRadar') or ""
-    radar4 = ADDON.getSetting('Radar4') or ADDON.getSetting('Location4ClosestRadar') or ""
-    radar5 = ADDON.getSetting('Radar5') or ADDON.getSetting('Location5ClosestRadar') or ""
-    radar6 = ADDON.getSetting('Radar6') or ADDON.getSetting('Location6ClosestRadar') or ""	
+    radar1 = get_setting('Radar1') or get_setting('Location1ClosestRadar') or ""
+    radar2 = get_setting('Radar2') or get_setting('Location2ClosestRadar') or ""
+    radar3 = get_setting('Radar3') or get_setting('Location3ClosestRadar') or ""
+    radar4 = get_setting('Radar4') or get_setting('Location4ClosestRadar') or ""
+    radar5 = get_setting('Radar5') or get_setting('Location5ClosestRadar') or ""
+    radar6 = get_setting('Radar6') or get_setting('Location6ClosestRadar') or ""
 
     Logger.info(f"Radar1: {radar1}")
     Logger.info(f"Radar2: {radar2}")


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: OzWeather
  - Add-on ID: weather.ozweather
  - Version number: 2.2.1
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/bossanova808/weather.ozweather
  
Weather forecasting and radar images for Australia using Bureau of Meteorology data.  For full features (animated radars & ABC weather videos) - make sure you install the replacement skin files - see information at the addon wiki (https://kodi.wiki/index.php?title=Add-on:Oz_Weather).

### Description of changes:

v2.2.1
- Fix log spam and garbled display text (RainChance, RainAmount, HighTemp, UVIndex, etc. showing "None") for the furthest-out forecast day when the BOM hasn't yet published its data
- Use shared bossanova808 helpers for settings access and error notifications, for consistency
    	

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
