### PR TITLE
[script.punchplay] 1.5.2

### DIFF
--- a/script.punchplay/README.md
+++ b/script.punchplay/README.md
@@ -4,14 +4,34 @@ PunchPlay is a background service addon that tracks movies and TV episodes you w
 
 It supports Kodi Nexus 20 and Omega 21.
 
-## What's New In 1.3.0
+## What's New In 1.5.2
 
-- Backend-assisted `/api/identify` matching for files without reliable Kodi IDs.
-- Stronger local parsing for movie years, season folders, anime absolute episodes, and multi-episode files.
-- Rating prompt delay plus `Later`, `Never for this title`, `Never for this show`, and `Disable rating prompts` actions.
-- Preview mode for Kodi library import before sending watched history.
-- Stricter backend URL validation with an explicit developer-mode override for insecure HTTP testing.
-- Richer status and debug export data, including queue endpoint summaries and identify-cache state.
+- Fixed the token-refresh request being rejected by the server's network edge (a missing User-Agent header), which broke reconnection for every user once their access token expired and forced repeated manual re-logins.
+- Fixed playback staying "now playing" on the server forever if Kodi was closed while something was still playing.
+- Fixed intermittent HTTP 401 errors during PunchPlay to Kodi sync when playback and the service refreshed an expired token at the same time.
+- Fixed live watched toggles being suppressed after resume syncs, lost on transient Kodi detail failures, mistaken for playback echoes, or still uploaded after being un-watched within the same debounce window.
+- Fixed the "never for this show" rating suppression still varying between episodes of the same show; it's now keyed on the show's title rather than per-episode ids or year, both of which change episode to episode.
+- Pull sync now reports and retries Kodi library write failures without allowing one bad item to block the checkpoint forever, resets incremental state when the account or enabled sync halves change, no longer lets a stale remote resume position overwrite a locally completed item, and no longer falls back to a stale checkpoint after a failed full pull.
+- Kodi shutdown now preserves queued and in-flight playback events for correctly ordered offline replay, and a queued offline event can no longer replay after it was already cleaned up by a stop event racing it, or reach the backend after a new playback's start — even under a full post queue, where the drain and the start now dispatch as a single unit instead of two that could be split apart.
+- A playback event can no longer overtake an earlier event from the same session that's still stuck in the offline queue — once one event for a session goes durable, later events for it stay durable too until a complete flush replays the backlog.
+- Live watched-toggle syncs no longer block the background service for up to 15-30s on a slow backend; they route through the same worker as every other network write, which also means offline-queue replay is now pinned to the account it was queued under.
+- A stop event that hits a full post queue still runs its full cleanup and rating prompt instead of only being persisted for retry.
+- Logout now discards old-account work still in memory, and device-code pollers no longer race after the QR window is dismissed.
+- Rating prompts can now be limited to movies while episode scrobbling continues normally.
+- Rating suppressions written under an earlier version's key format are migrated automatically on upgrade.
+
+1.5.1 improved large-library imports, moved scrobbles off Kodi's player callback thread, and made device-code login friendlier to shared connections.
+
+## What's New In 1.5.1
+
+- Large library imports now run to completion. Previously a full sync stopped being accepted after roughly 5,000 items and still reported success, silently dropping the rest.
+- A sync that hits errors now says how many items could not be sent, and stops after three consecutive failed batches instead of grinding on against an unreachable backend.
+- Scrobbles are sent from a background worker rather than on Kodi's player callback thread, so a slow or unreachable backend no longer stalls play, pause, resume, or the start of the next episode.
+- Login polling is friendlier to shared connections and now tells you when it has been rate limited instead of reporting a generic timeout.
+
+1.5.0 added live watched sync (marking a movie or episode watched in the Kodi library syncs to PunchPlay within seconds, and un-watching never deletes PunchPlay history) and pull sync on library scan, so newly added files inherit watched states and resume points.
+
+1.4.0 added two-way sync (PunchPlay watched history and resume points applied to the Kodi library), rewatch playcounts on library import, UTC-correct watch dates, non-blocking rating prompts, and several reliability fixes.
 
 ## Install
 
@@ -45,12 +65,14 @@ The addon sends these playback events to PunchPlay:
 | Progress heartbeat | `/api/scrobble/progress` | Updates continue-watching progress |
 | Stop or end | `/api/scrobble/stop` | Saves final progress and decides watched vs continue-watching |
 
-The default watched threshold is 70%. Playback only becomes watched when the final stop event crosses that threshold.
+The default watched threshold is 90%. Playback only becomes watched when the final stop event crosses that threshold.
 
 ## Current Features
 
 - Automatic movie and TV episode scrobbling.
 - Continue-watching progress on PunchPlay.
+- Two-way sync: PunchPlay watched history and resume points applied back to the Kodi library (manual or 6-hourly auto-sync).
+- Live watched sync: manual watched toggles in the Kodi library sync to PunchPlay within seconds.
 - Backend-assisted canonical matching when Kodi metadata is incomplete.
 - Post-watch rating dialog for movies and episodes with suppression options.
 - Preview and import of watched Kodi library items.
@@ -76,13 +98,20 @@ Open **Configure** from the addon details page.
 | Scrobble movies | On | Enables movie tracking. |
 | Scrobble TV shows | On | Enables episode tracking. |
 | Scrobble anime | On | Applies to episodes with the `anime` genre. |
+| Sync Kodi watched changes to PunchPlay | On | Pushes manual watched toggles in the Kodi library to PunchPlay within seconds. |
 | Anime episode format | Auto | `Auto`, `Season/Episode`, or `Absolute episodes` for anime-heavy libraries. |
 | Watched threshold (%) | 90 | Minimum progress needed to log a completed watch. |
 | Minimum file length (minutes) | 5 | Ignores trailers and short clips. |
 | Preview Library Import | - | Runs a dry preview and can optionally continue into a real import. |
 | Sync Kodi Library | - | Imports watched movies and episodes from Kodi's local library. |
+| Apply PunchPlay watched history to Kodi library | On | Lets pull sync mark local items watched. |
+| Apply PunchPlay resume points to Kodi library | On | Lets pull sync set local resume points. |
+| Auto-sync from PunchPlay every 6 hours | Off | Runs an incremental pull sync in the background. |
+| Sync From PunchPlay Now | - | Applies PunchPlay watched history and resume points to the Kodi library. |
 | Rate after watching | On | Shows the PunchPlay rating dialog after a completed scrobble. |
+| Rating prompts for | Movies and episodes | Choose whether completed episodes should also show a rating prompt. |
 | Rating prompt delay (seconds) | 2 | Lets Kodi settle before prompting, which avoids interrupting autoplay. |
+| Clear Rating Prompt Suppressions | - | Undoes previous "Never for this title/show" choices. |
 | Show scrobble notifications | On | Shows Kodi notifications for completed scrobbles. |
 | Show notifications during playback | Off | Keeps notifications quiet while another video is already playing. |
 | Export Debug Info | - | Writes a token-safe JSON status snapshot into addon data. |
@@ -117,6 +146,8 @@ If PunchPlay cannot be reached, scrobble events are written to a local SQLite qu
 
 The queue is capped at 500 events, stores retry metadata, and drops entries older than 30 days. When the queue is full, the addon drops older low-value progress events before it drops authoritative stop events.
 
+If the in-memory network worker queue itself fills, authoritative stop events are persisted directly to the offline queue rather than dropped.
+
 Completed playback sessions clear their older queued session events before the final stop is sent, which prevents stale progress from bringing a watched item back into continue-watching.
 
 Progress heartbeats are sent every 15 seconds internally. This is fixed by design so public installs do not accidentally hammer the backend with overly aggressive update intervals.
@@ -127,7 +158,29 @@ Use **Configure -> Library -> Preview Library Import** to preview what PunchPlay
 
 Real imports still use **Configure -> Library -> Sync Kodi Library**.
 
-The sync reads watched movies and episodes from Kodi's video library using JSON-RPC, sends them in batches, and reports imported, skipped duplicate, unmatched, and failed items. When the backend returns item-level diagnostics, the addon writes a JSON diagnostics file into addon data for support.
+The sync reads watched movies and episodes from Kodi's video library using JSON-RPC, sends them in batches, and reports imported, skipped duplicate, unmatched, and failed items. Items with a Kodi playcount above 1 import their rewatches too (capped at 10 per item; rewatches beyond the dated one are stored as date-unknown watches). When the backend returns item-level diagnostics, the addon writes a JSON diagnostics file into addon data for support.
+
+## Two-Way Sync (PunchPlay → Kodi)
+
+**Configure -> Library -> Sync From PunchPlay Now** pulls your PunchPlay history and applies it to the Kodi library:
+
+- Watched movies and episodes are marked watched (playcount + lastplayed), matched by TMDB id first, then IMDb id. Items already watched in Kodi are left alone — the sync never *un*-watches anything.
+- In-progress items become Kodi resume points. A local resume point is only overwritten when the PunchPlay progress is newer than Kodi's last playback, and positions in the first minute or final two minutes are ignored.
+
+Enable **Auto-sync from PunchPlay every 6 hours** for background incremental syncs (only activity since the previous sync is fetched). The watched and resume halves can be toggled independently.
+
+Items not present in the Kodi library are counted as unmatched and skipped — this sync never adds files or library entries, it only updates watched state and resume points on items Kodi already knows.
+
+## Live Watched Sync (Kodi → PunchPlay)
+
+With **Sync Kodi watched changes to PunchPlay** enabled (default), manually marking a movie or episode watched in the Kodi library logs it on PunchPlay within a few seconds. Bulk operations (marking a whole season watched) are batched into a single request, and duplicates are skipped server-side.
+
+Notes:
+
+- Un-watching an item in Kodi does **not** delete PunchPlay history.
+- Watched changes caused by normal playback or by the pull sync itself are recognised as echoes and skipped — only genuine manual toggles are pushed.
+- The movie/TV/anime scrobble toggles apply here too.
+- When auto-sync is enabled, finishing a library scan also triggers a pull sync (at most every 30 minutes) so newly added files inherit their watched state and resume points.
 
 ## Status And Debug
 
@@ -139,6 +192,7 @@ The sync reads watched movies and episodes from Kodi's video library using JSON-
 - offline queue size and queued endpoint summary
 - last successful scrobble and last error
 - identifier cache size and last identify result
+- configured movie/episode rating-prompt scope
 - addon version, Kodi version, platform, and Python version in debug export
 
 Basic debug export avoids tokens and file paths. Verbose debug export warns before including queued file paths.
@@ -233,6 +287,8 @@ zip -r /tmp/script.punchplay.zip "$repo_dir" \
   -x "$repo_dir/.git/*" \
      "$repo_dir/.github/*" \
      "$repo_dir/tests/*" \
+     "$repo_dir/docs/*" \
+     "$repo_dir/README.md" \
      "$repo_dir/__pycache__/*" \
      "$repo_dir/**/__pycache__/*" \
      "$repo_dir/.DS_Store" \

--- a/script.punchplay/addon.xml
+++ b/script.punchplay/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon id="script.punchplay"
        name="PunchPlay"
-       version="1.3.0"
+       version="1.5.2"
        provider-name="PunchPlay">
 
   <requires>
@@ -22,7 +22,7 @@
     <forum/>
     <website>https://punchplay.tv</website>
     <source>https://github.com/PunchPlay/kodi.addon.punchplay</source>
-    <news>1.3.0 - Add backend identify fallback, stronger movie/TV/anime parsing, library import preview, rating suppression options, stricter backend URL validation, and broader tests/docs</news>
+    <news>1.5.2 - Fixed a missing header that caused token refresh to fail outright, forcing repeated manual re-logins. Fixed playback staying "now playing" forever if Kodi closed mid-episode. Fixed concurrent token-refresh 401 errors, old-account work surviving logout, and watched toggles being lost, over-suppressed, or un-done watches still uploading. Fixed a queued offline event able to replay after it was already cleaned up by a stop event, or reach the backend after a new playback's start even under a full post queue. Live watched-toggle syncs and offline-queue replay now go through the same account-pinned worker as every other network write, instead of a separate thread. A playback event can no longer overtake an earlier event from the same session still stuck in the offline queue. Pull-sync checkpoints now follow the active account and enabled sync options, reset after a failed full pull instead of falling back to a stale cursor, and a stale remote resume position no longer overwrites a finished item. Rating prompts can be limited to movies, and the "never for this show" suppression is now keyed on the show's title instead of per-episode ids or year (existing suppressions from earlier versions are migrated automatically).</news>
     <assets>
       <icon>icon.png</icon>
       <fanart>fanart.jpg</fanart>

--- a/script.punchplay/changelog.txt
+++ b/script.punchplay/changelog.txt
@@ -1,3 +1,147 @@
+v1.5.2 (2026-08-24)
+- Fixed the token-refresh request being rejected outright by the server's
+  network edge, which silently broke reconnection for every user once their
+  hour-long access token expired and forced a repeated manual re-login. The
+  refresh call was missing the addon's User-Agent header that every other
+  request sends.
+- Fixed playback left "now playing" forever on the server if Kodi was closed
+  while something was still playing. Shutdown now always sends the stop event
+  for active playback instead of only clearing local state.
+- Fixed intermittent HTTP 401 errors during PunchPlay to Kodi sync. When a
+  playback heartbeat and a manual sync both observed an expired access token,
+  the delayed request could refresh the rotating token chain a second time and
+  invalidate the first request's retry. Delayed 401s now reuse the token that
+  the other thread already refreshed.
+- Fixed manual watched-toggles being silently dropped by live sync's echo
+  suppression. A pull-sync resume-point write (which never touches playcount)
+  no longer suppresses a later watched-toggle, and playback/pull echoes now
+  match the timestamp of the Kodi write instead of swallowing every manual
+  toggle for the same title during a blanket time window. Transient Kodi
+  detail lookup failures are requeued rather than losing the toggle.
+- Fixed un-watching an item within the same debounce window as marking it
+  watched still uploading the watch the user had just undone.
+- Fixed the "never rate this show" suppression key still varying between
+  episodes of the same show, which let rating prompts reappear for a show
+  already opted out. Kodi's per-episode ids and per-episode year are both
+  unstable across a show's episodes; the key is now built from the show's
+  title alone, the only field that's actually consistent show-to-show.
+- Fixed a stale remote resume position overwriting a locally completed item's
+  progress back to "in progress" during pull sync.
+- Fixed a queued offline event able to be replayed after it was already
+  cleaned up. Marking playback stopped now double-checks a queued event is
+  still pending immediately before resending it, instead of trusting a
+  snapshot that a concurrent stop could have already invalidated.
+- Fixed a stale offline event able to reach the backend after a new
+  playback's start, when connectivity returns right as a new item begins
+  playing. Starting playback now drains any leftover queued events first,
+  instead of relying solely on the independent 60-second background flush.
+- Fixed live watched-toggle syncs blocking the background service for up to
+  15-30s on a slow backend, and writing into the offline queue from a thread
+  independent of every other network write. They now route through the same
+  worker as playback events.
+- Fixed the pre-start offline-queue drain silently dropping instead of
+  retrying if the post queue was still full at that exact moment, which
+  could still let a stale event land after the new start under sustained
+  load. The drain and the start now dispatch as a single unit, so a full
+  queue can only reject them together.
+- Fixed a stop event hitting a full post queue skipping its session cleanup
+  and rating prompt — it now runs the same logic as a normal stop, just
+  without the network call, instead of only persisting the raw event.
+- Fixed "never rate this show" suppressions from earlier versions silently
+  losing effect after upgrading to this version; a one-time migration clears
+  suppressions written under the old key format.
+- Fixed the offline queue's replay not being pinned to the account it was
+  queued under, so a logout immediately followed by logging into a different
+  account mid-replay could send an old account's queued event under the new
+  account's credentials.
+- Malformed Kodi watch-date values are now logged instead of silently
+  discarded during library import.
+- Fixed unbounded memory growth in the live-sync echo-suppression tracker
+  for accounts with auto pull sync on but live watched sync off.
+- Fixed a playback event able to reach the backend ahead of an earlier event
+  from the same session that was still stuck in the offline queue. Once any
+  event for a session goes durable, every later event for that session now
+  stays durable too until a complete flush replays the whole backlog,
+  instead of a later event slipping out live while an older one waits.
+- Fixed a failed full pull sync (not filtered to changes since a checkpoint)
+  silently falling back to its previous incremental checkpoint on the next
+  automatic run, which could permanently miss whatever the failed run was
+  meant to catch up on. The checkpoint now clears so the next run is full
+  again too.
+- Pull sync now reports Kodi library write failures and retries each failed
+  item without letting one persistently bad item block newer changes forever.
+  Incremental checkpoints now reset after an account or enabled-setting change.
+- Shutdown now preserves both queued and in-flight playback events for ordered
+  offline replay when the network worker cannot finish within its grace period.
+- Authoritative stop events are persisted instead of dropped if the in-memory
+  network worker queue fills behind a slow backend.
+- Logout discards queued and in-flight work from the previous account, and QR
+  login no longer lets its background and fallback pollers race for a token.
+- "Never for this show" rating suppression now applies to every episode.
+- Rating prompts can now be limited to movies without disabling episode
+  scrobbling or watched sync.
+
+v1.5.1 (2026-07-26)
+- Library sync no longer claims success when batches failed. Entries that
+  never reached PunchPlay are counted and reported so the run can be
+  repeated, instead of being dropped from the total.
+- Library sync now stops after three consecutive failed batches rather than
+  grinding through the rest of the library against an unreachable backend.
+- Import batches raised from 50 to 100 entries (the backend maximum),
+  halving the number of requests a full library sync needs.
+- Together with the matching backend change removing the import rate limit,
+  large libraries now import completely; previously a sync stopped being
+  accepted after roughly 5,000 items and reported an under-counted total.
+- Playback is smoother: scrobble events are now sent from a background worker
+  instead of on Kodi's player callback thread, so a slow or unreachable
+  backend can no longer stall play, pause, resume, or the start of the next
+  episode. Events are still sent in order, and a queued stop event is
+  flushed before Kodi shuts down.
+- Removed a redundant offline-queue flush that ran when playback started; it
+  could replay hundreds of queued events before the video began.
+- Login is more reliable on shared connections: the approval poll now runs
+  every 5 seconds instead of every 3, no longer restarts its countdown when
+  the QR window is dismissed, and backs off when the server asks it to.
+  Being rate limited now says so instead of reporting a generic timeout.
+
+v1.5.0 (2026-07-10)
+- Live watched sync: manually marking a movie or episode watched in the
+  Kodi library now syncs to PunchPlay within seconds (batched through the
+  import pipeline, so dedup and rewatch playcounts apply). Un-watching in
+  Kodi never deletes PunchPlay history.
+- Echo suppression: playcount changes caused by our own pull sync or by
+  normal playback (already scrobbled at stop) are recognised and skipped,
+  as are library-scan updates.
+- Library scans now trigger a debounced full pull sync (when auto-sync is
+  enabled) so newly added files immediately inherit PunchPlay watched
+  states and resume points.
+- New "Sync Kodi watched changes to PunchPlay" toggle under Scrobbling
+  (on by default); respects the movie/TV/anime scrobble toggles.
+
+v1.4.0 (2026-07-09)
+- Two-way sync: new "Sync From PunchPlay Now" action applies PunchPlay
+  watched history (playcount + lastplayed) and resume points to the Kodi
+  library, matched by TMDB/IMDb ids. Never un-watches local items and only
+  overwrites local resume points when the PunchPlay progress is newer.
+- Optional auto-sync from PunchPlay every 6 hours (incremental, off by
+  default).
+- Library import now sends per-item playcounts so rewatches are imported
+  (capped, recorded as date-unknown watches) instead of collapsing to a
+  single watch.
+- Library import converts Kodi's local-time lastplayed to UTC before upload,
+  fixing watch dates shifted by the device timezone.
+- Rating prompts no longer block Kodi's player callbacks: the prompt is
+  queued and shown by the service loop after the configured delay.
+- Heartbeat progress updates survive transient errors instead of stopping
+  for the rest of playback (stops only after 3 consecutive failures).
+- Token refresh is now serialized behind a lock so concurrent 401s from the
+  heartbeat and service threads cannot race a rotating refresh token.
+- Offline queue entries are dropped after ~1 day of continuous failed
+  retries (previously retried for up to 30 days).
+- New "Clear Rating Prompt Suppressions" action undoes "Never for this
+  title/show" choices.
+- Rating dialog footer text is now localizable.
+
 v1.3.0 (2026-05-23)
 - Add backend-assisted `/api/identify` matching for items without reliable
   Kodi IDs, with confidence thresholds, safe fallback behavior, and local

--- a/script.punchplay/resources/language/resource.language.en_gb/strings.po
+++ b/script.punchplay/resources/language/resource.language.en_gb/strings.po
@@ -469,3 +469,107 @@ msgstr ""
 msgctxt "#32116"
 msgid "Library import preview failed: {0}"
 msgstr ""
+
+msgctxt "#32117"
+msgid "Sync From PunchPlay Now"
+msgstr ""
+
+msgctxt "#32118"
+msgid "Apply PunchPlay watched history to Kodi library"
+msgstr ""
+
+msgctxt "#32119"
+msgid "Apply PunchPlay resume points to Kodi library"
+msgstr ""
+
+msgctxt "#32120"
+msgid "Auto-sync from PunchPlay every 6 hours"
+msgstr ""
+
+msgctxt "#32121"
+msgid "Syncing From PunchPlay"
+msgstr ""
+
+msgctxt "#32122"
+msgid "Fetching PunchPlay history…"
+msgstr ""
+
+msgctxt "#32123"
+msgid "Updating Kodi library ({0}/{1})…"
+msgstr ""
+
+msgctxt "#32124"
+msgid "PunchPlay sync: {0} marked watched, {1} resume point(s) set"
+msgstr ""
+
+msgctxt "#32125"
+msgid "Kodi library already up to date with PunchPlay"
+msgstr ""
+
+msgctxt "#32126"
+msgid "PunchPlay sync failed: {0}"
+msgstr ""
+
+msgctxt "#32127"
+msgid "Last PunchPlay to Kodi sync: {0}"
+msgstr ""
+
+msgctxt "#32128"
+msgid "OK to confirm  ·  Back to skip"
+msgstr ""
+
+msgctxt "#32129"
+msgid "Clear Rating Prompt Suppressions"
+msgstr ""
+
+msgctxt "#32130"
+msgid "Cleared {0} rating prompt suppression(s)"
+msgstr ""
+
+msgctxt "#32131"
+msgid "No rating prompt suppressions to clear"
+msgstr ""
+
+msgctxt "#32132"
+msgid "Enable watched or resume sync in Library settings first"
+msgstr ""
+
+msgctxt "#32133"
+msgid "PunchPlay sync cancelled"
+msgstr ""
+
+msgctxt "#32134"
+msgid "Sync Kodi watched changes to PunchPlay"
+msgstr ""
+
+msgctxt "#32135"
+msgid "Partial sync — imported {0}. {1} item(s) could not be sent; run sync again."
+msgstr ""
+
+msgctxt "#32136"
+msgid "Too many login attempts from this network. Wait a few minutes, then try again."
+msgstr ""
+
+msgctxt "#32137"
+msgid "PunchPlay sync: {0} applied, {1} failed — will retry"
+msgstr ""
+
+msgctxt "#32138"
+msgid "{0} watched, {1} resume, {2} unmatched, {3} failed"
+msgstr ""
+
+msgctxt "#32139"
+msgid "Rating prompts for"
+msgstr ""
+
+msgctxt "#32140"
+msgid "Movies only"
+msgstr ""
+
+msgctxt "#32141"
+msgid "Movies and episodes"
+msgstr ""
+
+msgctxt "#32142"
+msgid "Rating prompts: {0}"
+msgstr ""

--- a/script.punchplay/resources/lib/api.py
+++ b/script.punchplay/resources/lib/api.py
@@ -35,6 +35,9 @@ from constants import (
     AUTH_ME_ENDPOINT,
     AUTH_REFRESH_ENDPOINT,
     DEFAULT_BACKEND_URL,
+    DEVICE_CODE_MAX_BACKOFF_SECS,
+    DEVICE_CODE_POLL_INTERVAL_SECS,
+    DEVICE_CODE_THROTTLED_BACKOFF_SECS,
     HEARTBEAT_INTERVAL_SECS,
     IDENTIFIER_NO_MATCH_CACHE_TTL_SECS,
     IDENTIFIER_SUCCESS_CACHE_TTL_SECS,
@@ -56,6 +59,23 @@ from constants import (
 
 class BackendConfigurationError(ValueError):
     """Raised when the configured backend URL is unsafe or malformed."""
+
+
+class AuthenticationChangedError(RuntimeError):
+    """Raised when a request outlives the login generation that created it."""
+
+
+def _retry_after_seconds(exc: urllib.error.HTTPError, default: int) -> int:
+    """Read a Retry-After header, clamped to a sane polling range."""
+    try:
+        raw = (exc.headers or {}).get("Retry-After")
+    except AttributeError:
+        raw = None
+    try:
+        value = int(raw) if raw else 0
+    except (TypeError, ValueError):
+        value = 0
+    return max(default, min(value or default, DEVICE_CODE_MAX_BACKOFF_SECS))
 
 
 def _sanitise_url_for_display(url: str) -> str:
@@ -142,6 +162,15 @@ class APIClient:
 
         self._tokens: dict[str, str] = self._load_tokens()
         self.device_id: str = self._get_or_create_device_id()
+        # Incremented whenever the user logs out. Playback posts snapshot this
+        # value so work created for one account can never be queued or replayed
+        # after a later login to another account.
+        self._auth_generation = 0
+
+        # Guards _do_refresh: the heartbeat thread and the service thread can
+        # both hit a 401 at the same time, and concurrent refreshes with a
+        # rotating refresh token would invalidate the first retry.
+        self._refresh_lock = threading.Lock()
 
     # ------------------------------------------------------------------
     # Internal helpers
@@ -195,6 +224,10 @@ class APIClient:
         except Exception as exc:
             xbmc.log(f"[PunchPlay] Status error update failed: {exc}", xbmc.LOGDEBUG)
 
+    @property
+    def auth_generation(self) -> int:
+        return self._auth_generation
+
     def _record_identify_result(
         self,
         *,
@@ -240,14 +273,14 @@ class APIClient:
         with os.fdopen(fd, "w") as f:
             json.dump(tokens, f, indent=2)
 
-    def _headers(self) -> dict[str, str]:
+    def _headers(self, access_token: str | None) -> dict[str, str]:
         headers = {
             "Content-Type": "application/json",
             "User-Agent": f"{ADDON_ID}/{self._client_version} Kodi",
             "Accept": "application/json",
         }
-        if self._tokens.get("access_token"):
-            headers["Authorization"] = f"Bearer {self._tokens['access_token']}"
+        if access_token:
+            headers["Authorization"] = f"Bearer {access_token}"
         return headers
 
     def _identify_cache_key(
@@ -430,16 +463,37 @@ class APIClient:
         *,
         retry_on_401: bool = True,
         timeout: int = REQUEST_TIMEOUT_SECS,
+        expected_auth_generation: int | None = None,
     ) -> dict[str, Any]:
         """
         Perform an HTTP request.  Returns the parsed JSON body.
         Raises ConnectionError on network failure, urllib.error.HTTPError on
         non-2xx responses.
         """
+        # Keep the credential that is actually sent with this request.  A
+        # different thread may rotate the token while this request is in
+        # flight; in that case its 401 must reuse the newer token rather than
+        # rotating the refresh chain a second time. Pair the token with the
+        # account generation under the refresh/logout lock so an old payload
+        # can never pick up credentials from a later login.
+        with self._refresh_lock:
+            auth_generation_at_request = self._auth_generation
+            if (
+                expected_auth_generation is not None
+                and expected_auth_generation != auth_generation_at_request
+            ):
+                raise AuthenticationChangedError(
+                    "Login changed before request could be sent"
+                )
+            access_token_at_request = self._tokens.get("access_token")
+
         url = f"{self._base_url()}{path}"
         body = json.dumps(payload).encode("utf-8") if payload is not None else None
         req = urllib.request.Request(
-            url, data=body, headers=self._headers(), method=method
+            url,
+            data=body,
+            headers=self._headers(access_token_at_request),
+            method=method,
         )
 
         try:
@@ -449,9 +503,17 @@ class APIClient:
         except urllib.error.HTTPError as exc:
             if exc.code == 401 and retry_on_401:
                 xbmc.log("[PunchPlay] 401 — attempting token refresh", xbmc.LOGDEBUG)
-                if self._do_refresh():
+                if self._do_refresh(
+                    access_token_at_request,
+                    auth_generation_at_request,
+                ):
                     return self._request(
-                        method, path, payload, retry_on_401=False, timeout=timeout
+                        method,
+                        path,
+                        payload,
+                        retry_on_401=False,
+                        timeout=timeout,
+                        expected_auth_generation=auth_generation_at_request,
                     )
             raise
         except (urllib.error.URLError, OSError, TimeoutError) as exc:
@@ -461,17 +523,44 @@ class APIClient:
     # Token refresh
     # ------------------------------------------------------------------
 
-    def _do_refresh(self) -> bool:
-        refresh_token = self._tokens.get("refresh_token")
-        if not refresh_token:
-            return False
+    def _do_refresh(
+        self,
+        stale_access_token: str | None,
+        expected_auth_generation: int,
+    ) -> bool:
+        with self._refresh_lock:
+            if self._auth_generation != expected_auth_generation:
+                raise AuthenticationChangedError(
+                    "Login changed while request was in flight"
+                )
+            # The request that produced the 401 may have been sent before
+            # another thread refreshed successfully.  Reuse that refresh
+            # result; refreshing again rotates the backend's access token and
+            # invalidates the other thread's retry.
+            current_access_token = self._tokens.get("access_token")
+            if current_access_token != stale_access_token:
+                return bool(current_access_token)
+
+            refresh_token = self._tokens.get("refresh_token")
+            if not refresh_token:
+                return False
+
+            return self._do_refresh_locked(refresh_token)
+
+    def _do_refresh_locked(self, refresh_token: str) -> bool:
         try:
             url = f"{self._base_url()}{AUTH_REFRESH_ENDPOINT}"
             body = json.dumps({"refresh_token": refresh_token}).encode("utf-8")
+            # Use the same headers as every other request. This call used to
+            # build its own minimal dict and skip the User-Agent that
+            # identifies every other request as coming from this addon — a
+            # bare `Python-urllib/x.x` is a common bot-mitigation signature,
+            # and edge protection in front of the backend was rejecting every
+            # refresh attempt with a 403 before it ever reached the route.
             req = urllib.request.Request(
                 url,
                 data=body,
-                headers={"Content-Type": "application/json", "Accept": "application/json"},
+                headers=self._headers(None),
                 method="POST",
             )
             with urllib.request.urlopen(req, timeout=15) as resp:
@@ -495,50 +584,100 @@ class APIClient:
     def _is_permanent_client_error(self, status_code: int) -> bool:
         return status_code in PERMANENT_HTTP_STATUS_CODES
 
-    def post(self, path: str, payload: dict[str, Any]) -> dict[str, Any] | None:
+    def post(
+        self,
+        path: str,
+        payload: dict[str, Any],
+        *,
+        expected_auth_generation: int | None = None,
+    ) -> dict[str, Any] | None:
         """
         POST *payload* to *path*.  On network error, writes the event to the
         offline queue — never silently drops it.  Returns the response dict on
         success, or None when the request was queued.
         """
+        auth_generation = (
+            self._auth_generation
+            if expected_auth_generation is None
+            else expected_auth_generation
+        )
+
+        def _discarded_by_logout() -> bool:
+            if self._auth_generation == auth_generation:
+                return False
+            xbmc.log(
+                f"[PunchPlay] Discarding {path} from a logged-out account",
+                xbmc.LOGDEBUG,
+            )
+            return True
+
         try:
-            result = self._request("POST", path, payload)
+            result = self._request(
+                "POST",
+                path,
+                payload,
+                expected_auth_generation=auth_generation,
+            )
             self._record_success(path, payload)
             return result
+        except AuthenticationChangedError:
+            xbmc.log(
+                f"[PunchPlay] Discarding {path} after the login changed",
+                xbmc.LOGDEBUG,
+            )
+            return None
         except BackendConfigurationError as exc:
+            if _discarded_by_logout():
+                return None
             xbmc.log(
                 f"[PunchPlay] Backend URL invalid ({exc}) — preserving {path}",
                 xbmc.LOGWARNING,
             )
             self._record_error(f"Backend configuration error: {exc}")
-            if self._cache is not None:
-                self._cache.enqueue_scrobble(path, payload)
+            self.preserve_post_for_retry(
+                path,
+                payload,
+                expected_auth_generation=auth_generation,
+            )
             return None
         except ConnectionError as exc:
+            if _discarded_by_logout():
+                return None
             xbmc.log(
                 f"[PunchPlay] Network error ({exc}) — queuing {path}", xbmc.LOGWARNING
             )
             self._record_error(f"Network error on {path}: {exc}")
-            if self._cache is not None:
-                self._cache.enqueue_scrobble(path, payload)
+            self.preserve_post_for_retry(
+                path,
+                payload,
+                expected_auth_generation=auth_generation,
+            )
             return None
         except urllib.error.HTTPError as exc:
+            if _discarded_by_logout():
+                return None
             if 500 <= exc.code < 600:
                 # Transient server error — queue for retry.
                 xbmc.log(
                     f"[PunchPlay] HTTP {exc.code} on {path} — queuing", xbmc.LOGWARNING
                 )
                 self._record_error(f"HTTP {exc.code} on {path}")
-                if self._cache is not None:
-                    self._cache.enqueue_scrobble(path, payload)
+                self.preserve_post_for_retry(
+                    path,
+                    payload,
+                    expected_auth_generation=auth_generation,
+                )
             elif not self._is_permanent_client_error(exc.code):
                 xbmc.log(
                     f"[PunchPlay] HTTP {exc.code} on {path} — preserving for retry",
                     xbmc.LOGWARNING,
                 )
                 self._record_error(f"HTTP {exc.code} on {path}")
-                if self._cache is not None:
-                    self._cache.enqueue_scrobble(path, payload)
+                self.preserve_post_for_retry(
+                    path,
+                    payload,
+                    expected_auth_generation=auth_generation,
+                )
             else:
                 # Permanent client error (4xx) — drop, retrying won't help.
                 xbmc.log(
@@ -562,14 +701,66 @@ class APIClient:
         self._record_success(path, payload)
         return result
 
+    def preserve_post_for_retry(
+        self,
+        path: str,
+        payload: dict[str, Any],
+        *,
+        expected_auth_generation: int,
+    ) -> bool:
+        """Persist a post only while its originating login is still active.
+
+        The generation check and SQLite write share the refresh/logout lock.
+        Logout therefore either clears this newly persisted event afterward,
+        or advances the generation first and prevents the write entirely.
+        """
+        with self._refresh_lock:
+            if (
+                self._auth_generation != expected_auth_generation
+                or self._cache is None
+            ):
+                return False
+            try:
+                self._cache.enqueue_scrobble(path, payload)
+            except Exception as exc:
+                xbmc.log(
+                    f"[PunchPlay] Could not preserve {path}: {exc}",
+                    xbmc.LOGWARNING,
+                )
+                return False
+        return True
+
+    def get(self, path: str, timeout: int = REQUEST_TIMEOUT_SECS) -> dict[str, Any]:
+        """GET *path*.  Raises on failure — no offline queue fallback."""
+        return self._request("GET", path, timeout=timeout)
+
     # ------------------------------------------------------------------
     # Offline queue flush
     # ------------------------------------------------------------------
 
-    def flush_queue(self) -> None:
-        """Replay pending offline scrobbles in insertion order."""
+    def flush_queue(self, *, expected_auth_generation: int | None = None) -> bool:
+        """Replay pending offline scrobbles in playback-event order.
+
+        *expected_auth_generation* pins every replayed row to the account
+        active when this flush was scheduled — the same guarantee every
+        other network write in this module carries. Queued rows have no
+        per-row account identity of their own (pending_scrobbles has no
+        auth_generation column), so without this a flush that spans a
+        logout+relogin to a different account could send an old account's
+        queued watch event under the new account's credentials.
+
+        Returns True only when the durable queue is empty at the end of the
+        attempt. A transient failure returns False so callers that require an
+        ordering barrier (notably a new playback start) do not send newer
+        state while older events are still waiting to replay.
+        """
         if self._cache is None:
-            return
+            return True
+        generation = (
+            self._auth_generation
+            if expected_auth_generation is None
+            else expected_auth_generation
+        )
         expired = self._cache.drop_expired_pending_scrobbles()
         if expired:
             xbmc.log(
@@ -579,7 +770,7 @@ class APIClient:
 
         pending = self._cache.get_pending_scrobbles()
         if not pending:
-            return
+            return True
         xbmc.log(
             f"[PunchPlay] Flushing {len(pending)} queued scrobble(s)", xbmc.LOGINFO
         )
@@ -587,14 +778,35 @@ class APIClient:
             scrobble_id = int(item["id"])
             endpoint = str(item["endpoint"])
             payload = dict(item["payload"])
+            if not self._cache.pending_scrobble_exists(scrobble_id):
+                # Removed since this flush's snapshot was taken — most
+                # likely delete_pending_scrobbles_for_session() clearing a
+                # now-superseded event as its playback session stopped.
+                # Replaying it here would resurrect stale state after the
+                # authoritative stop already landed.
+                continue
             try:
-                self._request("POST", endpoint, payload)
+                self._request(
+                    "POST", endpoint, payload, expected_auth_generation=generation
+                )
                 self._cache.delete_pending_scrobble(scrobble_id)
                 self._record_success(endpoint, payload)
                 xbmc.log(
                     f"[PunchPlay] Replayed queued scrobble id={scrobble_id} → {endpoint}",
                     xbmc.LOGDEBUG,
                 )
+            except AuthenticationChangedError:
+                # Logged out (or into a different account) since this flush
+                # started. The remaining rows in this snapshot all belong to
+                # the same stale generation, so stop rather than send any of
+                # them under whichever account is active now — they stay
+                # queued for the next flush, which will pick up the current
+                # generation.
+                xbmc.log(
+                    "[PunchPlay] Stopping queue flush — account changed mid-flush",
+                    xbmc.LOGDEBUG,
+                )
+                return False
             except BackendConfigurationError as exc:
                 self._cache.mark_pending_scrobble_attempt(
                     scrobble_id,
@@ -602,7 +814,7 @@ class APIClient:
                 )
                 self._record_error(f"Backend configuration error replaying {endpoint}: {exc}")
                 xbmc.log("[PunchPlay] Invalid backend URL — stopping queue flush", xbmc.LOGWARNING)
-                break
+                return False
             except ConnectionError as exc:
                 self._cache.mark_pending_scrobble_attempt(
                     scrobble_id,
@@ -610,7 +822,7 @@ class APIClient:
                 )
                 self._record_error(f"Network error replaying {endpoint}: {exc}")
                 xbmc.log("[PunchPlay] Still offline — stopping queue flush", xbmc.LOGDEBUG)
-                break  # remain offline; try again later
+                return False  # remain offline; try again later
             except urllib.error.HTTPError as exc:
                 if self._is_permanent_client_error(exc.code):
                     self._cache.mark_pending_scrobble_attempt(
@@ -634,7 +846,15 @@ class APIClient:
                     f"[PunchPlay] HTTP {exc.code} replaying id={scrobble_id} — keeping queued",
                     xbmc.LOGWARNING,
                 )
-                break
+                return False
+
+        # A callback can add another durable event while this worker is
+        # replaying its snapshot (for example a queue-full fallback). Treat
+        # that as an incomplete barrier too; the caller must not overtake it.
+        return not any(
+            self._cache.pending_scrobble_exists(int(item["id"]))
+            for item in self._cache.get_pending_scrobbles()
+        )
 
     # ------------------------------------------------------------------
     # Device-code login — QR dialog helpers
@@ -687,10 +907,16 @@ class APIClient:
         user_code: str,
         device_code: str,
         expires_in: int,
+        deadline: float,
+        status: dict[str, Any],
     ) -> bool | None:
         """
         Present the QR LoginDialog while polling for approval in the
         background.
+
+        *deadline* is the absolute monotonic time the device code expires —
+        shared with the fallback poll loop so the two never poll a dead code.
+        *status* is written back into: {"throttled": bool}.
 
         Returns:
           True  — login succeeded (dialog auto-closed on approval)
@@ -724,12 +950,12 @@ class APIClient:
 
             def poll_loop() -> None:
                 monitor = xbmc.Monitor()
-                deadline = time.monotonic() + expires_in
                 while (
                     not stop_event.is_set()
                     and time.monotonic() < deadline
                     and not monitor.abortRequested()
                 ):
+                    wait_secs = DEVICE_CODE_POLL_INTERVAL_SECS
                     try:
                         resp = self._request(
                             "POST",
@@ -756,14 +982,30 @@ class APIClient:
                             login_dialog.approve()
                             return
                     except urllib.error.HTTPError as exc:
-                        xbmc.log(f"[PunchPlay] QR poll: HTTP {exc.code}", xbmc.LOGDEBUG)
+                        if exc.code == 429:
+                            # Polling faster than the backend allows only digs
+                            # the hole deeper — back off and remember why.
+                            status["throttled"] = True
+                            wait_secs = _retry_after_seconds(
+                                exc, DEVICE_CODE_THROTTLED_BACKOFF_SECS
+                            )
+                            xbmc.log(
+                                f"[PunchPlay] QR poll rate limited — waiting {wait_secs}s",
+                                xbmc.LOGWARNING,
+                            )
+                        else:
+                            xbmc.log(
+                                f"[PunchPlay] QR poll: HTTP {exc.code}", xbmc.LOGDEBUG
+                            )
                     except Exception as exc:
                         xbmc.log(f"[PunchPlay] QR poll error: {exc}", xbmc.LOGWARNING)
                     # Sleep in short slices so we can react to stop_event.
-                    for _ in range(6):
+                    slept = 0.0
+                    while slept < wait_secs:
                         if stop_event.is_set():
                             return
                         time.sleep(0.5)
+                        slept += 0.5
 
             thread = threading.Thread(
                 target=poll_loop, name="PunchPlayQRPoll", daemon=True
@@ -773,8 +1015,13 @@ class APIClient:
             login_dialog.doModal()
 
             # Dialog closed — either by approve() or by the user.
+            login_dialog.mark_closed()
             stop_event.set()
-            thread.join(timeout=3)
+            # The request is bounded by REQUEST_TIMEOUT_SECS. Wait for that
+            # one outstanding poll to finish before starting the fallback
+            # poller: device tokens are one-time credentials, so two pollers
+            # must never race to consume the successful response.
+            thread.join()
 
             approved = login_dialog.was_approved
             del login_dialog
@@ -839,6 +1086,13 @@ class APIClient:
         #   True  → login completed, we're done
         #   None  → user dismissed manually, fall through to poll loop
         #   False → dialog failed to show, fall back to text dialog
+        # One absolute deadline for the whole attempt.  The QR dialog and the
+        # fallback poll loop run back to back, so giving each its own fresh
+        # `expires_in` window would poll an already-dead code for a second
+        # full period — and burn the per-IP token budget doing it.
+        deadline = time.monotonic() + expires_in
+        status: dict[str, Any] = {"throttled": False}
+
         qr_result: bool | None = False
         if verification_uri_qr:
             qr_path = self._write_qr_image(verification_uri_qr)
@@ -849,6 +1103,8 @@ class APIClient:
                     user_code=user_code,
                     device_code=device_code,
                     expires_in=expires_in,
+                    deadline=deadline,
+                    status=status,
                 )
 
         if qr_result is True:
@@ -868,7 +1124,6 @@ class APIClient:
         # Step 3 — poll for the token with a cancellable progress dialog.
         # (Only reached if QR dialog was dismissed manually or not shown.)
         monitor = xbmc.Monitor()
-        deadline = time.monotonic() + expires_in
         progress = xbmcgui.DialogProgress()
         progress.create(_s(32006), _s(32007))
 
@@ -881,6 +1136,7 @@ class APIClient:
                 remaining = max(0, int(deadline - time.monotonic()))
                 pct = int(100 * (1 - remaining / expires_in))
                 progress.update(pct, _s(32008).format(remaining))
+                wait_secs = DEVICE_CODE_POLL_INTERVAL_SECS
 
                 try:
                     token_resp = self._request(
@@ -908,6 +1164,21 @@ class APIClient:
                 except ConnectionError as exc:
                     xbmc.log(f"[PunchPlay] Poll network error: {exc}", xbmc.LOGDEBUG)
                 except urllib.error.HTTPError as exc:
+                    if exc.code == 429:
+                        # Distinct from authorization_pending: the request was
+                        # never evaluated.  Back off instead of spending the
+                        # remaining budget at the same rate.
+                        status["throttled"] = True
+                        wait_secs = _retry_after_seconds(
+                            exc, DEVICE_CODE_THROTTLED_BACKOFF_SECS
+                        )
+                        xbmc.log(
+                            f"[PunchPlay] Login poll rate limited — waiting {wait_secs}s",
+                            xbmc.LOGWARNING,
+                        )
+                        monitor.waitForAbort(wait_secs)
+                        continue
+
                     # The /token endpoint returns 400 for all non-success
                     # states.  Read the body to distinguish between
                     # "authorization_pending" (keep polling) and terminal
@@ -940,14 +1211,16 @@ class APIClient:
                         xbmc.LOGWARNING,
                     )
 
-                monitor.waitForAbort(5)
+                monitor.waitForAbort(wait_secs)
         finally:
             try:
                 progress.close()
             except Exception:
                 pass
 
-        dialog.ok(_s(32000), _s(32010))
+        # A run that spent its window being throttled is not the same failure
+        # as nobody approving the code — say which one happened.
+        dialog.ok(_s(32000), _s(32136) if status["throttled"] else _s(32010))
         return False
 
     # ------------------------------------------------------------------
@@ -971,16 +1244,28 @@ class APIClient:
             if not confirmed:
                 return False
 
-        if os.path.exists(self._token_file):
-            os.remove(self._token_file)
-        self._tokens = {}
+        # Serialize with token refresh. A refresh already in flight finishes
+        # first and is then cleared; a refresh arriving later sees no token.
+        # Increment the account generation before clearing persistence so an
+        # in-flight playback request cannot repopulate the queue afterward.
+        with self._refresh_lock:
+            self._auth_generation += 1
+            if os.path.exists(self._token_file):
+                os.remove(self._token_file)
+            self._tokens = {}
         if self._cache is not None:
             try:
                 self._cache.clear_pending_scrobbles()
-                self._cache.set_account_username(None)
                 xbmc.log("[PunchPlay] Offline queue cleared on logout", xbmc.LOGDEBUG)
             except Exception as exc:
                 xbmc.log(f"[PunchPlay] Queue clear error: {exc}", xbmc.LOGDEBUG)
+            try:
+                # Keep account/checkpoint invalidation independent of queue
+                # cleanup so one SQLite failure cannot leak the old account's
+                # incremental pull-sync position into the next login.
+                self._cache.set_account_username(None)
+            except Exception as exc:
+                xbmc.log(f"[PunchPlay] Account-state clear error: {exc}", xbmc.LOGDEBUG)
         xbmc.log("[PunchPlay] Tokens cleared (logged out)", xbmc.LOGINFO)
         xbmcgui.Dialog().notification(
             NOTIFICATION_TITLE, localize(32012),
@@ -1075,12 +1360,24 @@ class APIClient:
             "last_identify_status": runtime_status.get("last_identify_status"),
             "last_identify_title": runtime_status.get("last_identify_title"),
             "last_identify_confidence": runtime_status.get("last_identify_confidence"),
+            "last_pull_sync_at": runtime_status.get("last_pull_sync_at"),
+            "last_pull_sync_summary": runtime_status.get("last_pull_sync_summary"),
+            "rating_prompt_scope": self._rating_prompt_scope(),
             "identifier_cache_size": identifier_cache_size,
             "addon_version": self._client_version,
             "kodi_version": xbmc.getInfoLabel("System.BuildVersion") or localize(32071),
             "platform": platform.platform(),
             "python_version": sys.version.split()[0],
         }
+
+    def _rating_prompt_scope(self) -> str:
+        setting = get_addon().getSetting("rating_prompt_scope") or "1"
+        return {
+            "0": "movies",
+            "1": "all",
+            "movies": "movies",
+            "all": "all",
+        }.get(setting, "all")
 
     def _settings_summary(self) -> dict[str, Any]:
         addon = get_addon()
@@ -1102,6 +1399,7 @@ class APIClient:
             "min_length_minutes": addon.getSettingInt("min_length"),
             "heartbeat_interval": HEARTBEAT_INTERVAL_SECS,
             "rate_after_watching": addon.getSettingBool("rate_after_watching"),
+            "rating_prompt_scope": self._rating_prompt_scope(),
             "rating_prompt_delay_secs": addon.getSettingInt("rating_prompt_delay"),
             "show_notifications": addon.getSettingBool("show_notifications"),
             "notify_during_playback": addon.getSettingBool("notify_during_playback"),

--- a/script.punchplay/resources/lib/cache.py
+++ b/script.punchplay/resources/lib/cache.py
@@ -19,6 +19,7 @@ import xbmc
 
 from constants import (
     IDENTIFIER_CACHE_TTL_SECS,
+    MAX_QUEUE_ATTEMPTS,
     OFFLINE_QUEUE_MAX_ITEMS,
     QUEUE_ENTRY_MAX_AGE_SECS,
     SCROBBLE_PROGRESS_ENDPOINT,
@@ -58,6 +59,7 @@ class Cache:
                     endpoint        TEXT    NOT NULL,
                     payload         TEXT    NOT NULL,
                     created_at      INTEGER NOT NULL,
+                    event_created_at INTEGER,
                     attempt_count   INTEGER NOT NULL DEFAULT 0,
                     last_attempt_at INTEGER,
                     last_error      TEXT
@@ -74,7 +76,12 @@ class Cache:
                     last_identify_at           INTEGER,
                     last_identify_status       TEXT,
                     last_identify_title        TEXT,
-                    last_identify_confidence   REAL
+                    last_identify_confidence   REAL,
+                    last_pull_sync_at          INTEGER,
+                    last_pull_sync_summary     TEXT,
+                    pull_sync_held_runs        INTEGER,
+                    pull_sync_failure_counts   TEXT,
+                    pull_sync_context          TEXT
                 );
 
                 CREATE TABLE IF NOT EXISTS rating_suppressions (
@@ -90,6 +97,7 @@ class Cache:
             self._migrate_identifier_cache(conn)
             self._migrate_pending_scrobbles(conn)
             self._migrate_runtime_status(conn)
+            self._migrate_rating_suppression_keys(conn)
 
     def _migrate_identifier_cache(self, conn: sqlite3.Connection) -> None:
         existing_columns = {
@@ -124,6 +132,21 @@ class Cache:
                 "ALTER TABLE pending_scrobbles "
                 "ADD COLUMN last_error TEXT"
             )
+        if "event_created_at" not in existing_columns:
+            # Replay order must follow when each event actually happened, not
+            # the order it was written to this table — a later event can be
+            # persisted here before an earlier one that was still in flight
+            # (e.g. a slow request abandoned at Kodi shutdown). Backfill from
+            # created_at for pre-existing rows, which predate this column and
+            # have no better timestamp available.
+            conn.execute(
+                "ALTER TABLE pending_scrobbles "
+                "ADD COLUMN event_created_at INTEGER"
+            )
+            conn.execute(
+                "UPDATE pending_scrobbles SET event_created_at = created_at "
+                "WHERE event_created_at IS NULL"
+            )
 
     def _migrate_runtime_status(self, conn: sqlite3.Connection) -> None:
         existing_columns = {
@@ -135,6 +158,11 @@ class Cache:
             ("last_identify_status", "TEXT"),
             ("last_identify_title", "TEXT"),
             ("last_identify_confidence", "REAL"),
+            ("last_pull_sync_at", "INTEGER"),
+            ("last_pull_sync_summary", "TEXT"),
+            ("pull_sync_held_runs", "INTEGER"),
+            ("pull_sync_failure_counts", "TEXT"),
+            ("pull_sync_context", "TEXT"),
         ):
             if column_name not in existing_columns:
                 if not column_name.replace("_", "").isalnum():
@@ -145,6 +173,36 @@ class Cache:
                     f"ALTER TABLE runtime_status ADD COLUMN {column_name} {column_type}"
                 )
 
+    def _migrate_rating_suppression_keys(self, conn: sqlite3.Connection) -> None:
+        """One-time cleanup for the 1.5.2 show-suppression key format
+        change: `show:{id-or-title}:{title}:{year}` -> `show:{title}`.
+
+        The old key varied almost as much per episode as the field it
+        replaced (an episode-level id or year, not a show-level one), so
+        rows written under it rarely matched reliably in the first place.
+        There's no safe way to rewrite an old key into the new format when
+        a title itself may contain colons, so old rows are cleared rather
+        than migrated — the user re-suppresses if they still want to.
+
+        Gated on PRAGMA user_version so this runs exactly once rather than
+        on every launch (a real show:{title} key can itself contain extra
+        colons if the title does, and would otherwise match the old
+        format's pattern forever).
+        """
+        version = conn.execute("PRAGMA user_version").fetchone()[0]
+        if version >= 1:
+            return
+        deleted = conn.execute(
+            "DELETE FROM rating_suppressions WHERE key GLOB 'show:*:*:*'"
+        ).rowcount
+        if deleted:
+            xbmc.log(
+                f"[PunchPlay] Cleared {deleted} rating suppression(s) from "
+                "the old show-key format",
+                xbmc.LOGINFO,
+            )
+        conn.execute("PRAGMA user_version = 1")
+
     def _drop_expired_pending_scrobbles_locked(
         self,
         conn: sqlite3.Connection,
@@ -154,7 +212,12 @@ class Cache:
             "DELETE FROM pending_scrobbles WHERE created_at < ?",
             (cutoff,),
         )
-        return max(cur.rowcount or 0, 0)
+        dropped = max(cur.rowcount or 0, 0)
+        cur = conn.execute(
+            "DELETE FROM pending_scrobbles WHERE attempt_count >= ?",
+            (MAX_QUEUE_ATTEMPTS,),
+        )
+        return dropped + max(cur.rowcount or 0, 0)
 
     def _drop_one_low_value_pending_scrobble_locked(
         self,
@@ -255,6 +318,14 @@ class Cache:
     # ------------------------------------------------------------------
 
     def enqueue_scrobble(self, endpoint: str, payload: dict[str, Any]) -> None:
+        self.enqueue_scrobbles([(endpoint, payload)])
+
+    def enqueue_scrobbles(self, items: list[tuple[str, dict[str, Any]]]) -> None:
+        """Batched form of enqueue_scrobble — one connection/transaction for
+        several events, so draining several unsent posts at once (e.g. Kodi
+        shutdown) doesn't reconnect per item."""
+        if not items:
+            return
         now = int(time.time())
         with self._connect() as conn:
             expired = self._drop_expired_pending_scrobbles_locked(conn)
@@ -269,27 +340,34 @@ class Cache:
                     "SELECT COUNT(*) FROM pending_scrobbles"
                 ).fetchone()[0]
             )
-            while count >= OFFLINE_QUEUE_MAX_ITEMS:
-                if not self._drop_one_low_value_pending_scrobble_locked(conn):
-                    break
-                count -= 1
+            for endpoint, payload in items:
+                while count >= OFFLINE_QUEUE_MAX_ITEMS:
+                    if not self._drop_one_low_value_pending_scrobble_locked(conn):
+                        break
+                    count -= 1
 
-            conn.execute(
-                """
-                INSERT INTO pending_scrobbles (
-                    endpoint,
-                    payload,
-                    created_at,
-                    attempt_count,
-                    last_attempt_at,
-                    last_error
+                event_created_at = payload.get("event_created_at")
+                if not isinstance(event_created_at, int):
+                    event_created_at = now * 1000
+
+                conn.execute(
+                    """
+                    INSERT INTO pending_scrobbles (
+                        endpoint,
+                        payload,
+                        created_at,
+                        event_created_at,
+                        attempt_count,
+                        last_attempt_at,
+                        last_error
+                    )
+                    VALUES (?, ?, ?, ?, 0, NULL, NULL)
+                    """,
+                    (endpoint, json.dumps(payload), now, event_created_at),
                 )
-                VALUES (?, ?, ?, 0, NULL, NULL)
-                """,
-                (endpoint, json.dumps(payload), now),
-            )
+                count += 1
 
-        xbmc.log(f"[PunchPlay] Queued offline scrobble → {endpoint}", xbmc.LOGDEBUG)
+        xbmc.log(f"[PunchPlay] Queued {len(items)} offline scrobble(s)", xbmc.LOGDEBUG)
 
     def get_pending_scrobbles(self) -> list[dict[str, Any]]:
         with self._connect() as conn:
@@ -304,7 +382,7 @@ class Cache:
                     last_attempt_at,
                     last_error
                 FROM pending_scrobbles
-                ORDER BY id
+                ORDER BY event_created_at, id
                 """
             ).fetchall()
 
@@ -333,6 +411,14 @@ class Cache:
                 "DELETE FROM pending_scrobbles WHERE id = ?",
                 (scrobble_id,),
             )
+
+    def pending_scrobble_exists(self, scrobble_id: int) -> bool:
+        with self._connect() as conn:
+            row = conn.execute(
+                "SELECT 1 FROM pending_scrobbles WHERE id = ?",
+                (scrobble_id,),
+            ).fetchone()
+        return row is not None
 
     def mark_pending_scrobble_attempt(self, scrobble_id: int, error: str) -> None:
         with self._connect() as conn:
@@ -425,6 +511,11 @@ class Cache:
             ).fetchone()
         return bool(row)
 
+    def clear_rating_suppressions(self) -> int:
+        with self._connect() as conn:
+            cur = conn.execute("DELETE FROM rating_suppressions")
+        return max(cur.rowcount or 0, 0)
+
     # ------------------------------------------------------------------
     # Runtime status
     # ------------------------------------------------------------------
@@ -443,7 +534,10 @@ class Cache:
                     last_identify_at,
                     last_identify_status,
                     last_identify_title,
-                    last_identify_confidence
+                    last_identify_confidence,
+                    last_pull_sync_at,
+                    last_pull_sync_summary,
+                    pull_sync_held_runs
                 FROM runtime_status
                 WHERE singleton = 1
                 """
@@ -461,14 +555,66 @@ class Cache:
             "last_identify_status": row[7],
             "last_identify_title": row[8],
             "last_identify_confidence": row[9],
+            "last_pull_sync_at": row[10],
+            "last_pull_sync_summary": row[11],
+            "pull_sync_held_runs": row[12] or 0,
         }
 
     def set_account_username(self, username: str | None) -> None:
         with self._connect() as conn:
+            current = conn.execute(
+                "SELECT account_username FROM runtime_status WHERE singleton = 1"
+            ).fetchone()
+            account_changed = (
+                username is None
+                or current is None
+                or current[0] != username
+            )
+            if account_changed:
+                conn.execute(
+                    """
+                    UPDATE runtime_status
+                    SET account_username = ?,
+                        last_pull_sync_at = NULL,
+                        last_pull_sync_summary = NULL,
+                        pull_sync_held_runs = 0,
+                        pull_sync_failure_counts = NULL,
+                        pull_sync_context = NULL
+                    WHERE singleton = 1
+                    """,
+                    (username,),
+                )
+                return
             conn.execute(
                 "UPDATE runtime_status SET account_username = ? WHERE singleton = 1",
                 (username,),
             )
+
+    def ensure_pull_sync_context(self, context: str) -> bool:
+        """Reset incremental state when the enabled sync halves change.
+
+        Returns True when *context* already matched, False when a full sync is
+        now required.
+        """
+        with self._connect() as conn:
+            row = conn.execute(
+                "SELECT pull_sync_context FROM runtime_status WHERE singleton = 1"
+            ).fetchone()
+            if row and row[0] == context:
+                return True
+            conn.execute(
+                """
+                UPDATE runtime_status
+                SET pull_sync_context = ?,
+                    last_pull_sync_at = NULL,
+                    last_pull_sync_summary = NULL,
+                    pull_sync_held_runs = 0,
+                    pull_sync_failure_counts = NULL
+                WHERE singleton = 1
+                """,
+                (context,),
+            )
+        return False
 
     def record_success(self, endpoint: str, title: str = "") -> None:
         with self._connect() as conn:
@@ -494,6 +640,82 @@ class Cache:
                 """,
                 (int(time.time() * 1000), error[:500]),
             )
+
+    def record_pull_sync(self, summary: str) -> None:
+        with self._connect() as conn:
+            conn.execute(
+                """
+                UPDATE runtime_status
+                SET last_pull_sync_at = ?,
+                    last_pull_sync_summary = ?,
+                    pull_sync_held_runs = 0,
+                    pull_sync_failure_counts = NULL
+                WHERE singleton = 1
+                """,
+                (int(time.time() * 1000), summary[:300]),
+            )
+
+    def clear_pull_sync_checkpoint(self) -> None:
+        """Force the next automatic pull to run without a `since` filter.
+
+        Failure counters are deliberately preserved: clearing the timestamp
+        changes what the next run fetches, while the held-run policy still
+        decides when a persistently bad item may stop blocking progress.
+        """
+        with self._connect() as conn:
+            conn.execute(
+                """
+                UPDATE runtime_status
+                SET last_pull_sync_at = NULL
+                WHERE singleton = 1
+                """
+            )
+
+    def record_pull_sync_held(self, failed_items: set[str]) -> int:
+        """Record one failed pull run and return its minimum retry count.
+
+        Counts are consecutive per failed-item identity. Items that succeeded
+        on this run are removed, while newly failing items start at one, so an
+        unrelated failure cannot inherit another item's exhausted allowance.
+        `record_pull_sync` clears the state after a clean run or intentional
+        checkpoint advance.
+        """
+        if not failed_items:
+            # Defensive fallback for callers that only have an aggregate
+            # failure count (primarily old tests or third-party integrations).
+            failed_items = {"unknown-apply-failure"}
+        with self._connect() as conn:
+            row = conn.execute(
+                "SELECT pull_sync_failure_counts FROM runtime_status "
+                "WHERE singleton = 1"
+            ).fetchone()
+            previous: dict[str, int] = {}
+            if row and row[0]:
+                try:
+                    decoded = json.loads(row[0])
+                    if isinstance(decoded, dict):
+                        previous = {
+                            str(key): max(0, int(value))
+                            for key, value in decoded.items()
+                        }
+                except (TypeError, ValueError):
+                    previous = {}
+
+            current = {
+                item: previous.get(item, 0) + 1
+                for item in sorted(failed_items)
+            }
+            held_runs = min(current.values())
+            conn.execute(
+                """
+                UPDATE runtime_status
+                SET pull_sync_held_runs = ?,
+                    pull_sync_failure_counts = ?
+                WHERE singleton = 1
+                """,
+                (held_runs, json.dumps(current, sort_keys=True)),
+            )
+        return held_runs
 
     def record_identify_result(
         self,

--- a/script.punchplay/resources/lib/constants.py
+++ b/script.punchplay/resources/lib/constants.py
@@ -2,6 +2,10 @@
 
 from __future__ import annotations
 
+import time
+from datetime import datetime, timezone
+
+import xbmc
 import xbmcaddon
 import xbmcvfs
 
@@ -18,6 +22,7 @@ SCROBBLE_RESUME_ENDPOINT = "/api/scrobble/resume"
 SCROBBLE_STOP_ENDPOINT = "/api/scrobble/stop"
 SCROBBLE_RATE_ENDPOINT = "/api/scrobble/rate"
 SCROBBLE_IMPORT_ENDPOINT = "/api/scrobble/import"
+SCROBBLE_SYNC_ENDPOINT = "/api/scrobble/sync"
 
 AUTH_DEVICE_CODE_ENDPOINT = "/api/auth/device/code"
 AUTH_DEVICE_TOKEN_ENDPOINT = "/api/auth/device/token"
@@ -34,6 +39,8 @@ ACTION_PROPERTY_SHOW_STATUS = "punchplay_show_status"
 ACTION_PROPERTY_EXPORT_DEBUG = "punchplay_export_debug"
 ACTION_PROPERTY_EXPORT_VERBOSE_DEBUG = "punchplay_export_verbose_debug"
 ACTION_PROPERTY_CLEAR_QUEUE = "punchplay_clear_queue"
+ACTION_PROPERTY_PULL_SYNC = "punchplay_pull_sync"
+ACTION_PROPERTY_CLEAR_SUPPRESSIONS = "punchplay_clear_suppressions"
 
 HOME_WINDOW_ID = 10000
 
@@ -44,9 +51,70 @@ IDENTIFIER_SUCCESS_CACHE_TTL_SECS = 30 * 24 * 60 * 60
 IDENTIFIER_NO_MATCH_CACHE_TTL_SECS = 24 * 60 * 60
 QUEUE_ENTRY_MAX_AGE_SECS = 30 * 24 * 60 * 60
 OFFLINE_QUEUE_MAX_ITEMS = 500
-LIBRARY_SYNC_BATCH_SIZE = 50
+# Flush touches at most one failing entry per minute, so this cap (~1 day of
+# continuous failures) drops poison payloads the backend will never accept.
+MAX_QUEUE_ATTEMPTS = 1440
+LIBRARY_SYNC_BATCH_SIZE = 100
+# Give up on a library sync after this many batches fail back-to-back — the
+# backend is down or rejecting us, and grinding through the rest just reports
+# a success that never happened.
+LIBRARY_SYNC_MAX_CONSECUTIVE_FAILURES = 3
 STOP_COMPLETE_GRACE_SECS = 3
 HEARTBEAT_INTERVAL_SECS = 15
+HEARTBEAT_MAX_CONSECUTIVE_ERRORS = 3
+
+PULL_SYNC_INTERVAL_SECS = 6 * 60 * 60
+PULL_SYNC_OVERLAP_SECS = 60 * 60
+PULL_SYNC_TIMEOUT_SECS = 60
+AUTO_PULL_CHECK_INTERVAL_SECS = 60
+# A pull sync that can't apply one or more items holds back its incremental
+# checkpoint so they're retried next time (see _pull_sync in service.py).
+# After a failed item reaches this many consecutive held runs, it would
+# otherwise block the checkpoint — and every newer item behind it — forever.
+# Counts are per item so a newly failing item cannot inherit another item's
+# exhausted allowance.
+PULL_SYNC_MAX_HELD_RUNS = 3
+
+# Live watched-state sync (VideoLibrary.OnUpdate → PunchPlay import).
+LIVE_SYNC_DEBOUNCE_SECS = 2.0
+LIVE_SYNC_MAX_BATCH = 100
+LIVE_SYNC_DETAIL_RETRY_SECS = 30.0
+# An OnUpdate caused by one of our own writes should arrive almost
+# immediately. Keep bookkeeping for longer so delayed announcements can still
+# be compared, but only suppress events whose timestamps actually match the
+# write; otherwise a later manual "mark watched" would be swallowed.
+LIVE_SYNC_ECHO_MATCH_SECS = 5.0
+# Used both for the "just played this" echo guard (player.py) and the "we
+# just pull-synced this" echo guard (library_events.py) — one constant,
+# since both only need to bridge the same kind of gap: our own write
+# landing in Kodi's library before its OnUpdate announcement arrives. A wide
+# window here swallows a genuine manual toggle made shortly afterward.
+LIVE_SYNC_ECHO_SUPPRESS_SECS = 30
+# Library scan finished → wait for Kodi to settle, then pull sync at most
+# once per SCAN_SYNC_MIN_INTERVAL_SECS.
+SCAN_SYNC_DELAY_SECS = 60
+SCAN_SYNC_MIN_INTERVAL_SECS = 30 * 60
+
+# Device-code polling.  The backend allows 200 token polls per 10 minutes per
+# IP and a device code lives 600s, so a 5s interval fits one full login attempt
+# (120 polls) inside the budget with room for a second device on the same IP.
+DEVICE_CODE_POLL_INTERVAL_SECS = 5
+DEVICE_CODE_THROTTLED_BACKOFF_SECS = 30
+DEVICE_CODE_MAX_BACKOFF_SECS = 60
+
+# Scrobble posts are dispatched to a worker thread so Kodi's player callbacks
+# never block on the network.
+POST_QUEUE_MAX_ITEMS = 100
+POST_QUEUE_PUT_TIMEOUT_SECS = 2
+# A short grace period for the in-flight job to finish normally — not a
+# correctness guarantee. A 401 mid-shutdown can chain a refresh call plus a
+# retried request (each up to REQUEST_TIMEOUT_SECS) well past any timeout
+# reasonable to block Kodi's shutdown on, so jobs that don't finish in time
+# are persisted directly to the offline queue instead (see
+# PunchPlayPlayer._persist_unsent_queue). Replay order is safe either way —
+# it's sorted by each event's own timestamp, not by when it happened to be
+# written to the offline queue.
+POST_WORKER_JOIN_TIMEOUT_SECS = 5
 
 REQUEST_TIMEOUT_SECS = 15
 TEST_CONNECTION_TIMEOUT_SECS = 5
@@ -82,3 +150,57 @@ def mask_value(value: str, visible: int = 4) -> str:
     if len(value) <= visible * 2:
         return value
     return "{0}…{1}".format(value[:visible], value[-visible:])
+
+
+def kodi_datetime_to_utc_iso(value: str | None) -> str | None:
+    """Convert Kodi's local-time "YYYY-MM-DD HH:MM:SS" to a UTC ISO 8601 string."""
+    if not value:
+        return None
+    try:
+        parsed = time.strptime(value.strip(), "%Y-%m-%d %H:%M:%S")
+        epoch = time.mktime(parsed)  # interprets the struct as local time
+        return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(epoch))
+    except (ValueError, OverflowError):
+        xbmc.log(
+            f"[PunchPlay] Unparsable lastplayed value {value!r} — omitting watched_at",
+            xbmc.LOGWARNING,
+        )
+        return None
+
+
+def kodi_datetime_to_epoch(value: str | None) -> float | None:
+    """Convert Kodi's local-time "YYYY-MM-DD HH:MM:SS" to a Unix timestamp."""
+    if not value:
+        return None
+    try:
+        return time.mktime(time.strptime(value.strip(), "%Y-%m-%d %H:%M:%S"))
+    except (ValueError, OverflowError):
+        xbmc.log(
+            f"[PunchPlay] Unparsable Kodi datetime value {value!r}",
+            xbmc.LOGWARNING,
+        )
+        return None
+
+
+def iso_to_epoch(value: str | None) -> float | None:
+    """Parse an ISO 8601 timestamp (with Z or offset) to a Unix timestamp."""
+    if not value:
+        return None
+    text = value.strip()
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.timestamp()
+
+
+def iso_to_kodi_datetime(value: str | None) -> str | None:
+    """Convert an ISO 8601 timestamp to Kodi's local-time "YYYY-MM-DD HH:MM:SS"."""
+    epoch = iso_to_epoch(value)
+    if epoch is None:
+        return None
+    return time.strftime("%Y-%m-%d %H:%M:%S", time.localtime(epoch))

--- a/script.punchplay/resources/lib/library_events.py
+++ b/script.punchplay/resources/lib/library_events.py
@@ -1,0 +1,337 @@
+"""
+library_events.py — live watched-state sync (Kodi library → PunchPlay).
+
+Kodi announces `VideoLibrary.OnUpdate` whenever a library item changes; when
+the change is a watched toggle the payload carries a `playcount` field.  The
+service's onNotification callback pushes those into LiveWatchedSync (queueing
+only — it runs on Kodi's announce thread), and the service loop drains due
+events into batched /api/scrobble/import posts.
+
+Echo suppression — playcount bumps that are *not* manual user toggles:
+  • Our own pull sync setting playcounts   → record_pull_applied()
+  • Kodi bumping playcount after playback  → recently-played dbid guard
+  • Library scans (`added`/`transaction`)  → dropped at parse time
+  • Un-watching (playcount 0)              → ignored; never deletes history
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+import time
+from typing import Any
+
+import xbmc
+
+from constants import (
+    LIVE_SYNC_DEBOUNCE_SECS,
+    LIVE_SYNC_DETAIL_RETRY_SECS,
+    LIVE_SYNC_ECHO_MATCH_SECS,
+    LIVE_SYNC_MAX_BATCH,
+    LIVE_SYNC_ECHO_SUPPRESS_SECS,
+    kodi_datetime_to_utc_iso,
+)
+from pull_sync import _rpc
+
+
+class LibraryDetailLookupError(RuntimeError):
+    """Transient Kodi JSON-RPC failure while resolving a watched event."""
+
+
+def parse_video_library_update(data: str | None) -> dict[str, Any] | None:
+    """
+    Parse a VideoLibrary.OnUpdate payload into a playcount-change event, or
+    None when the update carries no playcount at all (metadata-only, not a
+    toggle of any kind). A playcount of 0 (un-watch) is still returned —
+    LiveWatchedSync.push_update needs to see it to cancel a not-yet-sent
+    watched toggle for the same item, even though it's never queued for
+    upload itself.
+    """
+    if not data:
+        return None
+    try:
+        payload = json.loads(data)
+    except (ValueError, TypeError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+
+    # Scan-driven updates are not user toggles.
+    if payload.get("added") or payload.get("transaction"):
+        return None
+
+    playcount = payload.get("playcount")
+    if not isinstance(playcount, int):
+        # Missing playcount = metadata-only update, not a toggle at all.
+        return None
+
+    # Kodi versions differ: item fields nested under "item" or at top level.
+    item = payload.get("item")
+    if not isinstance(item, dict):
+        item = payload
+    item_type = item.get("type")
+    library_id = item.get("id")
+    if item_type not in ("movie", "episode") or not isinstance(library_id, int):
+        return None
+
+    return {
+        "item_type": item_type,
+        "library_id": library_id,
+        "playcount": playcount,
+    }
+
+
+class LiveWatchedSync:
+    """Thread-safe queue of watched-toggle events with echo suppression."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._events: list[dict[str, Any]] = []
+        # (item_type, library_id) → monotonic time the pull sync touched it.
+        self._pull_applied: dict[tuple[str, int], float] = {}
+
+    def record_pull_applied(self, applied: set[tuple[str, int]]) -> None:
+        now = time.monotonic()
+        with self._lock:
+            for key in applied:
+                self._pull_applied[key] = now
+            # pop_due_events() also prunes this dict, but only runs when
+            # there's a live-toggle event to pop — a user with pull sync on
+            # and live watched sync off (or simply idle) would otherwise
+            # never hit that path, and this dict would grow for the
+            # lifetime of the service. Prune here too so it can't.
+            self._prune_pull_applied_locked(now)
+
+    def _prune_pull_applied_locked(self, now: float) -> None:
+        """Caller must hold self._lock."""
+        cutoff = now - LIVE_SYNC_ECHO_SUPPRESS_SECS
+        self._pull_applied = {
+            key: applied_at
+            for key, applied_at in self._pull_applied.items()
+            if applied_at >= cutoff
+        }
+
+    def push_update(self, data: str | None) -> None:
+        """Queue a raw OnUpdate payload.  Safe from Kodi's announce thread."""
+        event = parse_video_library_update(data)
+        if event is None:
+            return
+        key = (event["item_type"], event["library_id"])
+        with self._lock:
+            # Coalesce repeated toggles of the same item — keep the latest.
+            self._events = [
+                existing
+                for existing in self._events
+                if (existing["item_type"], existing["library_id"]) != key
+            ]
+            queued = event["playcount"] > 0
+            if queued:
+                event["at"] = time.monotonic()
+                self._events.append(event)
+        if queued:
+            xbmc.log(
+                "[PunchPlay] Watched toggle queued: {0} #{1} playcount={2}".format(
+                    event["item_type"], event["library_id"], event["playcount"]
+                ),
+                xbmc.LOGDEBUG,
+            )
+        else:
+            # We never delete PunchPlay history from a Kodi un-watch, but it
+            # must still cancel a not-yet-sent watched toggle for the same
+            # item queued moments earlier — otherwise marking something
+            # watched and reversing it within the debounce window still
+            # uploads the watch the user immediately undid.
+            xbmc.log(
+                "[PunchPlay] Un-watch cancelled pending toggle: {0} #{1}".format(
+                    event["item_type"], event["library_id"]
+                ),
+                xbmc.LOGDEBUG,
+            )
+
+    def pending_count(self) -> int:
+        with self._lock:
+            return len(self._events)
+
+    def requeue_events(self, events: list[dict[str, Any]]) -> None:
+        """Retry detail lookups after a bounded delay.
+
+        A newer OnUpdate for the same item wins; requeueing an older event
+        must never overwrite it. Missing/deleted library items are not passed
+        here—only transient JSON-RPC failures are retryable.
+        """
+        if not events:
+            return
+        now = time.monotonic()
+        with self._lock:
+            existing = {
+                (event["item_type"], event["library_id"])
+                for event in self._events
+            }
+            for event in events:
+                key = (event["item_type"], event["library_id"])
+                if key in existing:
+                    continue
+                retry = dict(event)
+                retry["at"] = now
+                retry["not_before"] = now + LIVE_SYNC_DETAIL_RETRY_SECS
+                self._events.append(retry)
+                existing.add(key)
+
+    def pop_due_events(
+        self,
+        recent_library_items: list[tuple[str, int, float]] | None = None,
+        *,
+        now: float | None = None,
+    ) -> list[dict[str, Any]]:
+        """
+        Return events older than the debounce window (so bulk "mark season
+        watched" operations batch up), dropping suppressed echoes.
+
+        `recent_library_items` is the player's list of (item_type, dbid,
+        monotonic_time) for items recently played — Kodi bumps their
+        playcount at stop, which our stop scrobble already covered.
+        """
+        current = time.monotonic() if now is None else now
+        with self._lock:
+            due = [
+                event
+                for event in self._events
+                if current - event["at"] >= LIVE_SYNC_DEBOUNCE_SECS
+                and current >= event.get("not_before", 0)
+            ]
+            if not due:
+                return []
+            due = due[:LIVE_SYNC_MAX_BATCH]
+            taken = {(event["item_type"], event["library_id"]) for event in due}
+            self._events = [
+                event
+                for event in self._events
+                if (event["item_type"], event["library_id"]) not in taken
+            ]
+
+            # Prune stale pull-applied suppressions while we hold the lock.
+            self._prune_pull_applied_locked(current)
+            pull_applied = dict(self._pull_applied)
+
+        recent = recent_library_items or []
+        result: list[dict[str, Any]] = []
+        for event in due:
+            key = (event["item_type"], event["library_id"])
+            pull_applied_at = pull_applied.get(key)
+            if (
+                pull_applied_at is not None
+                and abs(event["at"] - pull_applied_at) <= LIVE_SYNC_ECHO_MATCH_SECS
+            ):
+                xbmc.log(
+                    f"[PunchPlay] Watched toggle {key} suppressed (pull sync echo)",
+                    xbmc.LOGDEBUG,
+                )
+                continue
+            if any(
+                item_type == event["item_type"]
+                and library_id == event["library_id"]
+                and abs(event["at"] - played_at) <= LIVE_SYNC_ECHO_MATCH_SECS
+                for item_type, library_id, played_at in recent
+            ):
+                xbmc.log(
+                    f"[PunchPlay] Watched toggle {key} suppressed (recently played)",
+                    xbmc.LOGDEBUG,
+                )
+                continue
+            result.append(event)
+        return result
+
+    def clear(self) -> None:
+        with self._lock:
+            self._events = []
+
+
+# ----------------------------------------------------------------------
+# Import-entry builders (single items, mirrors the bulk library import)
+# ----------------------------------------------------------------------
+
+
+def _extract_ids(details: dict[str, Any]) -> dict[str, Any]:
+    ids: dict[str, Any] = {}
+    unique_ids = details.get("uniqueid") or {}
+    imdb = unique_ids.get("imdb") or details.get("imdbnumber") or None
+    tmdb = unique_ids.get("tmdb")
+    if imdb:
+        ids["imdb_id"] = imdb
+    if tmdb:
+        try:
+            ids["tmdb_id"] = int(tmdb)
+        except (ValueError, TypeError):
+            pass
+    return ids
+
+
+def build_movie_import_entry(
+    library_id: int,
+    playcount: int,
+) -> dict[str, Any] | None:
+    result = _rpc(
+        "VideoLibrary.GetMovieDetails",
+        {
+            "movieid": library_id,
+            "properties": ["title", "year", "imdbnumber", "uniqueid", "lastplayed", "genre"],
+        },
+    )
+    details = result.get("moviedetails")
+    if not isinstance(details, dict):
+        return None
+    entry: dict[str, Any] = {
+        "media_type": "movie",
+        "title": details.get("title", ""),
+        "year": details.get("year"),
+        "playcount": max(1, playcount),
+    }
+    entry.update(_extract_ids(details))
+    watched_at = kodi_datetime_to_utc_iso(details.get("lastplayed", ""))
+    if watched_at:
+        entry["watched_at"] = watched_at
+    genres = [genre.lower() for genre in (details.get("genre") or [])]
+    if "anime" in genres:
+        entry["anime"] = True
+    return entry
+
+
+def build_episode_import_entry(
+    library_id: int,
+    playcount: int,
+) -> dict[str, Any] | None:
+    result = _rpc(
+        "VideoLibrary.GetEpisodeDetails",
+        {
+            "episodeid": library_id,
+            "properties": ["showtitle", "season", "episode", "uniqueid", "lastplayed", "genre"],
+        },
+    )
+    details = result.get("episodedetails")
+    if not isinstance(details, dict):
+        return None
+    entry: dict[str, Any] = {
+        "media_type": "episode",
+        "title": details.get("showtitle", ""),
+        "season": details.get("season"),
+        "episode": details.get("episode"),
+        "playcount": max(1, playcount),
+    }
+    entry.update(_extract_ids(details))
+    watched_at = kodi_datetime_to_utc_iso(details.get("lastplayed", ""))
+    if watched_at:
+        entry["watched_at"] = watched_at
+    genres = [genre.lower() for genre in (details.get("genre") or [])]
+    if "anime" in genres:
+        entry["anime"] = True
+    return entry
+
+
+def build_import_entry(event: dict[str, Any]) -> dict[str, Any] | None:
+    try:
+        if event["item_type"] == "movie":
+            return build_movie_import_entry(event["library_id"], event["playcount"])
+        return build_episode_import_entry(event["library_id"], event["playcount"])
+    except (RuntimeError, KeyError, TypeError, ValueError) as exc:
+        xbmc.log(f"[PunchPlay] Watched toggle detail fetch failed: {exc}", xbmc.LOGWARNING)
+        raise LibraryDetailLookupError(str(exc)) from exc

--- a/script.punchplay/resources/lib/login_dialog.py
+++ b/script.punchplay/resources/lib/login_dialog.py
@@ -46,6 +46,7 @@ class LoginDialog(xbmcgui.WindowDialog):
         # Layout is authored at 1280x720; Kodi scales automatically.
 
         self._approved = threading.Event()
+        self._dismissed = threading.Event()
 
         # Backdrop (stretches the 32x32 dark PNG across the full screen).
         self.addControl(xbmcgui.ControlImage(0, 0, 1280, 720, bg_path))
@@ -139,6 +140,8 @@ class LoginDialog(xbmcgui.WindowDialog):
     def approve(self) -> None:
         """Called from the poll thread when tokens are received."""
         self._approved.set()
+        if self._dismissed.is_set():
+            return
         # Use executebuiltin to close the dialog on the main thread —
         # calling self.close() directly from a background thread is
         # unsafe in Kodi's UI framework.
@@ -146,6 +149,11 @@ class LoginDialog(xbmcgui.WindowDialog):
 
         xbmc.executebuiltin("Action(Back)")
 
+    def mark_closed(self) -> None:
+        """Prevent a late poll response from sending Back to another window."""
+        self._dismissed.set()
+
     def onAction(self, action) -> None:  # type: ignore[override]
         if action.getId() in _ACTION_CLOSE_IDS:
+            self._dismissed.set()
             self.close()

--- a/script.punchplay/resources/lib/player.py
+++ b/script.punchplay/resources/lib/player.py
@@ -15,17 +15,24 @@ A heartbeat thread fires every N seconds during active playback and POSTs
 from __future__ import annotations
 
 import os
+import queue
 import threading
 import time
 import uuid
-from typing import Any
+from typing import Any, Callable, NamedTuple
 
 import xbmc
 import xbmcgui
 
 from constants import (
     HEARTBEAT_INTERVAL_SECS,
+    HEARTBEAT_MAX_CONSECUTIVE_ERRORS,
+    LIVE_SYNC_ECHO_SUPPRESS_SECS,
     NOTIFICATION_TITLE,
+    POST_QUEUE_MAX_ITEMS,
+    POST_QUEUE_PUT_TIMEOUT_SECS,
+    POST_WORKER_JOIN_TIMEOUT_SECS,
+    SCROBBLE_IMPORT_ENDPOINT,
     SCROBBLE_PAUSE_ENDPOINT,
     SCROBBLE_PROGRESS_ENDPOINT,
     SCROBBLE_RATE_ENDPOINT,
@@ -68,16 +75,44 @@ def build_rating_suppression_keys(metadata: dict[str, Any]) -> dict[str, str]:
         )
     }
     if media_type == "episode":
-        keys["show"] = "show:{0}:{1}:{2}".format(
-            canonical_id or title,
-            title,
-            year,
-        )
+        # None of punchplay_id/tmdb_id/tvdb_id/imdb_id identify the show —
+        # they come from Kodi's per-episode uniqueid (or the backend's
+        # per-episode title record), so `canonical_id` differs from one
+        # episode to the next just like the old per-episode `year` did.
+        # `title` is the one field that's already show-level here: Kodi's
+        # info tag reports the show's title for every episode
+        # (getTVShowTitle()), not the episode's own title, so it's the only
+        # value in this metadata that's actually stable across a show.
+        keys["show"] = "show:{0}".format(title)
     return keys
 
 
 def has_reliable_rating_identity(metadata: dict[str, Any]) -> bool:
     return any(metadata.get(key) for key in ("punchplay_id", "tmdb_id", "tvdb_id", "imdb_id"))
+
+
+class _PostJob(NamedTuple):
+    """A queued scrobble post. `endpoint`/`payload` describe the network
+    write so a job that never got to run can still be persisted to the
+    offline queue at shutdown; `run` is what the worker actually executes.
+
+    `offline_fallback`, if set, runs instead of being silently dropped when
+    the post queue is full — it must never attempt a real network call
+    (it runs on whatever thread hit queue.Full, which must not block), only
+    cheap local work plus persisting to the offline queue for later replay.
+    """
+
+    endpoint: str
+    payload: dict[str, Any]
+    auth_generation: int
+    run: Callable[[], None]
+    offline_fallback: Callable[[], None] | None = None
+
+
+# Not a real endpoint — marks a queue-drain job (see dispatch_flush) so
+# _persist_unsent_queue can recognise and skip it instead of persisting a
+# bogus pending_scrobbles row with this as its "endpoint".
+_FLUSH_QUEUE_SENTINEL = "__internal_flush_offline_queue__"
 
 
 class PunchPlayPlayer(xbmc.Player):
@@ -91,6 +126,7 @@ class PunchPlayPlayer(xbmc.Player):
         self._metadata: dict[str, Any] | None = None
         self._is_playing: bool = False
         self._playback_session_id: str | None = None
+        self._playback_auth_generation: int | None = None
         self._stop_emitted: bool = False
 
         # Last known playback position — used as fallback in _emit_stop when
@@ -101,6 +137,39 @@ class PunchPlayPlayer(xbmc.Player):
         # Heartbeat thread management.
         self._hb_thread: threading.Thread | None = None
         self._hb_stop = threading.Event()
+
+        # Scrobble posts run on a single worker thread: Kodi's player
+        # callbacks must never block on the network, and one consumer keeps
+        # start → progress → pause → resume → stop in order.
+        self._post_queue: queue.Queue = queue.Queue(maxsize=POST_QUEUE_MAX_ITEMS)
+        self._post_thread: threading.Thread | None = None
+        self._post_thread_lock = threading.Lock()
+        self._post_state_lock = threading.Lock()
+        self._active_post_job: _PostJob | None = None
+        # Sessions in this set have at least one event in the durable queue.
+        # Every later event for the same session must stay durable until a
+        # complete flush succeeds, otherwise it could overtake the older row.
+        self._deferred_sessions_lock = threading.Lock()
+        self._deferred_sessions: set[str] = set()
+        self._deferred_sessions_revision = 0
+        # Set only after shutdown's grace period expires. It prevents the
+        # worker from taking another queued job while cleanup snapshots the
+        # active job and drains the backlog to SQLite.
+        self._post_abandon = threading.Event()
+
+        # Pending rating prompt — queued by the player callback thread and
+        # drained by the service loop so modal dialogs never block Kodi's
+        # player callbacks.
+        self._rating_lock = threading.Lock()
+        self._pending_rating: dict[str, Any] | None = None
+
+        # Library items played recently, as (item_type, dbid, monotonic).
+        # Kodi bumps their playcount when playback finishes; live watched
+        # sync must treat those OnUpdate events as echoes of our own stop
+        # scrobble, not manual toggles.
+        self._library_items_lock = threading.Lock()
+        self._recent_library_items: list[tuple[str, int, float]] = []
+        self._current_library_item: tuple[str, int] | None = None
 
     # ------------------------------------------------------------------
     # Settings helpers
@@ -117,6 +186,13 @@ class PunchPlayPlayer(xbmc.Player):
             "season_episode": "season_episode",
             "absolute": "absolute",
         }
+        rating_scope_setting = addon.getSetting("rating_prompt_scope") or "1"
+        rating_scope_map = {
+            "0": "movies",
+            "1": "all",
+            "movies": "movies",
+            "all": "all",
+        }
         return {
             "watched_threshold": addon.getSettingInt("watched_threshold") / 100.0,
             "min_length_secs": addon.getSettingInt("min_length") * 60,
@@ -128,6 +204,10 @@ class PunchPlayPlayer(xbmc.Player):
             "show_notifications": addon.getSettingBool("show_notifications"),
             "notify_during_playback": addon.getSettingBool("notify_during_playback"),
             "rate_after_watching": addon.getSettingBool("rate_after_watching"),
+            "rating_prompt_scope": rating_scope_map.get(
+                rating_scope_setting,
+                "all",
+            ),
             "rating_prompt_delay": addon.getSettingInt("rating_prompt_delay"),
         }
 
@@ -207,6 +287,39 @@ class PunchPlayPlayer(xbmc.Player):
             payload["anime"] = True
         return payload
 
+    def _remember_library_item(self, info_tag) -> None:
+        try:
+            dbid = info_tag.getDbId()
+            media_type = (info_tag.getMediaType() or "").lower()
+        except (AttributeError, RuntimeError):
+            return
+        if not isinstance(dbid, int) or dbid <= 0:
+            return
+        if media_type not in ("movie", "episode"):
+            return
+        self._current_library_item = (media_type, dbid)
+        self._stamp_library_item(media_type, dbid)
+
+    def _stamp_library_item(self, media_type: str, dbid: int) -> None:
+        now = time.monotonic()
+        cutoff = now - LIVE_SYNC_ECHO_SUPPRESS_SECS
+        with self._library_items_lock:
+            self._recent_library_items = [
+                item
+                for item in self._recent_library_items
+                if item[2] >= cutoff and (item[0], item[1]) != (media_type, dbid)
+            ]
+            self._recent_library_items.append((media_type, dbid, now))
+
+    def recent_library_items(self) -> list[tuple[str, int, float]]:
+        """Recently played library items — consumed by live watched sync."""
+        cutoff = time.monotonic() - LIVE_SYNC_ECHO_SUPPRESS_SECS
+        with self._library_items_lock:
+            self._recent_library_items = [
+                item for item in self._recent_library_items if item[2] >= cutoff
+            ]
+            return list(self._recent_library_items)
+
     def _capture_position(self) -> tuple[float, float] | None:
         """Read and cache the current Kodi playback position."""
         try:
@@ -217,6 +330,334 @@ class PunchPlayPlayer(xbmc.Player):
         self._last_position = position
         self._last_duration = duration
         return position, duration
+
+    # ------------------------------------------------------------------
+    # Post worker thread
+    # ------------------------------------------------------------------
+
+    def _ensure_post_worker(self) -> None:
+        with self._post_thread_lock:
+            if self._post_thread is not None and self._post_thread.is_alive():
+                return
+            self._post_thread = threading.Thread(
+                target=self._post_worker, name="PunchPlayPost", daemon=True
+            )
+            self._post_thread.start()
+
+    def _post_worker(self) -> None:
+        while True:
+            # Hold the state lock across dequeue + active assignment. Cleanup
+            # can therefore never observe a job in the tiny gap where it has
+            # left the queue but is not yet recorded as in flight. The short
+            # timeout bounds how long cleanup can wait when the queue is idle.
+            with self._post_state_lock:
+                if self._post_abandon.is_set():
+                    return
+                try:
+                    job = self._post_queue.get(timeout=0.25)
+                except queue.Empty:
+                    continue
+                if job is not None:
+                    self._active_post_job = job
+            if job is None:  # shutdown sentinel
+                self._post_queue.task_done()
+                return
+            try:
+                if job.auth_generation != self._api.auth_generation:
+                    xbmc.log(
+                        f"[PunchPlay] Discarding stale queued post {job.endpoint} "
+                        "after logout",
+                        xbmc.LOGDEBUG,
+                    )
+                else:
+                    job.run()
+            except Exception as exc:
+                xbmc.log(f"[PunchPlay] Post worker error: {exc}", xbmc.LOGWARNING)
+            finally:
+                with self._post_state_lock:
+                    if self._active_post_job is job:
+                        self._active_post_job = None
+                    should_abandon = self._post_abandon.is_set()
+                self._post_queue.task_done()
+            if should_abandon:
+                return
+
+    def _dispatch(self, job: _PostJob) -> None:
+        """Hand *job* to the worker thread.  Never raises."""
+        self._ensure_post_worker()
+        try:
+            # A short bounded wait beats a 15s network timeout on the callback
+            # thread, and still lets a briefly backed-up queue drain.
+            self._post_queue.put(job, timeout=POST_QUEUE_PUT_TIMEOUT_SECS)
+        except queue.Full:
+            if job.offline_fallback is not None:
+                try:
+                    job.offline_fallback()
+                except Exception as exc:
+                    xbmc.log(
+                        f"[PunchPlay] Post queue full — offline fallback for "
+                        f"{job.endpoint} failed: {exc}",
+                        xbmc.LOGWARNING,
+                    )
+                else:
+                    xbmc.log(
+                        f"[PunchPlay] Post queue full — ran offline fallback for "
+                        f"{job.endpoint}",
+                        xbmc.LOGWARNING,
+                    )
+                return
+            xbmc.log(
+                "[PunchPlay] Post queue full — dropping event to keep playback smooth",
+                xbmc.LOGWARNING,
+            )
+
+    def _mark_session_deferred(self, session_id: str | None) -> None:
+        if not session_id:
+            return
+        with self._deferred_sessions_lock:
+            self._deferred_sessions.add(session_id)
+            self._deferred_sessions_revision += 1
+
+    def _session_is_deferred(self, session_id: str | None) -> bool:
+        if not session_id:
+            return False
+        with self._deferred_sessions_lock:
+            return session_id in self._deferred_sessions
+
+    def _clear_deferred_sessions(self) -> None:
+        with self._deferred_sessions_lock:
+            self._deferred_sessions.clear()
+            self._deferred_sessions_revision += 1
+
+    def _deferred_sessions_snapshot(self) -> int:
+        with self._deferred_sessions_lock:
+            return self._deferred_sessions_revision
+
+    def _clear_deferred_sessions_if_unchanged(self, revision: int) -> None:
+        """Clear only when no callback deferred another event mid-flush."""
+        with self._deferred_sessions_lock:
+            if self._deferred_sessions_revision == revision:
+                self._deferred_sessions.clear()
+                self._deferred_sessions_revision += 1
+
+    def _preserve_playback_post(
+        self,
+        endpoint: str,
+        payload: dict[str, Any],
+        auth_generation: int,
+        session_id: str | None,
+    ) -> bool:
+        """Keep a playback event behind the durable ordering barrier."""
+        self._mark_session_deferred(session_id)
+        return self._api.preserve_post_for_retry(
+            endpoint,
+            payload,
+            expected_auth_generation=auth_generation,
+        )
+
+    def _flush_queue_safely(self, auth_generation: int) -> bool:
+        """Return False for any failed drain so ordering callers fail shut."""
+        try:
+            return self._api.flush_queue(
+                expected_auth_generation=auth_generation
+            )
+        except Exception as exc:
+            xbmc.log(
+                f"[PunchPlay] Offline queue flush failed: {exc}",
+                xbmc.LOGWARNING,
+            )
+            return False
+
+    def dispatch_flush(self) -> None:
+        """Drain any offline-queued events on the post worker.
+
+        This is the *only* code path that should call APIClient.flush_queue()
+        — both the service loop's periodic 60s timer and the pre-start drain
+        in onAVStarted go through this, so every flush lands on the same
+        single-threaded worker as every playback post. A second, independent
+        call site (e.g. the service loop calling flush_queue() directly on
+        its own thread) could run concurrently with a worker-thread flush:
+        both would see the same pending row via pending_scrobble_exists()
+        before either deletes it, and the independent thread's request could
+        land on the backend after a start the worker already sent, right
+        back to the ordering bug this exists to prevent. Funnelling
+        everything through the worker makes that impossible — flush and
+        start jobs simply queue up and run in enqueue order, and the worker
+        still executes them off Kodi's callback thread either way.
+        """
+        auth_generation = self._api.auth_generation
+
+        def _run() -> None:
+            revision = self._deferred_sessions_snapshot()
+            if self._flush_queue_safely(auth_generation):
+                self._clear_deferred_sessions_if_unchanged(revision)
+
+        self._dispatch(
+            _PostJob(
+                _FLUSH_QUEUE_SENTINEL,
+                {},
+                auth_generation,
+                _run,
+            )
+        )
+
+    def dispatch_import(self, entries: list[dict[str, Any]]) -> None:
+        """Push a batch of live watched-toggle entries through the post
+        worker instead of blocking the caller's thread.
+
+        The service loop used to call APIClient.post() for this directly on
+        its own thread — up to REQUEST_TIMEOUT_SECS (longer after a 401
+        retry) blocking that thread's login/logout handling, dispatch_flush's
+        periodic trigger, and rating-prompt draining, while also writing into
+        the offline queue from a thread independent of the post worker on
+        failure. Routing it here keeps every network write in this addon on
+        the single worker thread instead.
+        """
+        auth_generation = self._api.auth_generation
+
+        def _run() -> None:
+            resp = self._api.post(
+                SCROBBLE_IMPORT_ENDPOINT,
+                {"entries": entries},
+                expected_auth_generation=auth_generation,
+            )
+            if resp is not None:
+                xbmc.log(
+                    "[PunchPlay] Watched toggle import: {0} imported, {1} "
+                    "duplicate(s), {2} unmatched".format(
+                        resp.get("imported", 0),
+                        resp.get("skipped_duplicates", 0),
+                        resp.get("unmatched", 0),
+                    ),
+                    xbmc.LOGINFO,
+                )
+
+        self._dispatch(
+            _PostJob(
+                SCROBBLE_IMPORT_ENDPOINT,
+                {"entries": entries},
+                auth_generation,
+                _run,
+                offline_fallback=lambda: self._api.preserve_post_for_retry(
+                    SCROBBLE_IMPORT_ENDPOINT,
+                    {"entries": entries},
+                    expected_auth_generation=auth_generation,
+                ),
+            )
+        )
+
+    def _dispatch_start(self, payload: dict[str, Any]) -> None:
+        """Drain the offline queue before allowing a new start to overtake it.
+
+        Flush and start live in one worker job so queue saturation cannot
+        split the barrier. If the job cannot be enqueued, or the drain stops
+        on a transient failure, the start is persisted instead; later events
+        for its session stay durable until a complete flush succeeds.
+        """
+        auth_generation = self._playback_auth_generation
+        if auth_generation is None:
+            xbmc.log(
+                f"[PunchPlay] Discarding {SCROBBLE_START_ENDPOINT} without an "
+                "active login session",
+                xbmc.LOGDEBUG,
+            )
+            return
+        session_id = str(payload.get("playback_session_id") or "") or None
+
+        def _run() -> None:
+            # A queue-full fallback from a later callback may already have
+            # made this session durable before its start job reached the
+            # worker. Persist the start too, then replay the whole session in
+            # event_created_at order instead of sending the start last.
+            if self._session_is_deferred(session_id):
+                self._preserve_playback_post(
+                    SCROBBLE_START_ENDPOINT,
+                    payload,
+                    auth_generation,
+                    session_id,
+                )
+                revision = self._deferred_sessions_snapshot()
+                if self._flush_queue_safely(auth_generation):
+                    self._clear_deferred_sessions_if_unchanged(revision)
+                return
+
+            revision = self._deferred_sessions_snapshot()
+            if not self._flush_queue_safely(auth_generation):
+                # The old backlog is still live. Persist this start behind it
+                # and keep every following event from overtaking either one.
+                self._preserve_playback_post(
+                    SCROBBLE_START_ENDPOINT,
+                    payload,
+                    auth_generation,
+                    session_id,
+                )
+                return
+
+            self._clear_deferred_sessions_if_unchanged(revision)
+            response = self._api.post(
+                SCROBBLE_START_ENDPOINT,
+                payload,
+                expected_auth_generation=auth_generation,
+            )
+            if response is None:
+                self._mark_session_deferred(session_id)
+
+        self._dispatch(
+            _PostJob(
+                SCROBBLE_START_ENDPOINT,
+                payload,
+                auth_generation,
+                _run,
+                offline_fallback=lambda: self._preserve_playback_post(
+                    SCROBBLE_START_ENDPOINT,
+                    payload,
+                    auth_generation,
+                    session_id,
+                ),
+            )
+        )
+
+    def _dispatch_post(self, endpoint: str, payload: dict[str, Any]) -> None:
+        auth_generation = self._playback_auth_generation
+        if auth_generation is None:
+            xbmc.log(
+                f"[PunchPlay] Discarding {endpoint} without an active login session",
+                xbmc.LOGDEBUG,
+            )
+            return
+        session_id = str(payload.get("playback_session_id") or "") or None
+
+        def _run() -> None:
+            if self._session_is_deferred(session_id):
+                self._preserve_playback_post(
+                    endpoint,
+                    payload,
+                    auth_generation,
+                    session_id,
+                )
+                return
+            response = self._api.post(
+                endpoint,
+                payload,
+                expected_auth_generation=auth_generation,
+            )
+            if response is None:
+                self._mark_session_deferred(session_id)
+
+        self._dispatch(
+            _PostJob(
+                endpoint,
+                payload,
+                auth_generation,
+                _run,
+                offline_fallback=lambda: self._preserve_playback_post(
+                    endpoint,
+                    payload,
+                    auth_generation,
+                    session_id,
+                ),
+            )
+        )
 
     # ------------------------------------------------------------------
     # Heartbeat thread
@@ -237,6 +678,7 @@ class PunchPlayPlayer(xbmc.Player):
         self._hb_thread = None
 
     def _heartbeat_loop(self) -> None:
+        consecutive_errors = 0
         while not self._hb_stop.is_set():
             settings = self._settings()
             interval = max(1, settings["heartbeat_interval"])
@@ -270,15 +712,27 @@ class PunchPlayPlayer(xbmc.Player):
                     f"({payload['position_seconds']}s / {payload['duration_seconds']}s)",
                     xbmc.LOGDEBUG,
                 )
-                self._api.post(SCROBBLE_PROGRESS_ENDPOINT, payload)
+                self._dispatch_post(SCROBBLE_PROGRESS_ENDPOINT, payload)
+                consecutive_errors = 0
 
             except Exception as exc:
-                xbmc.log(f"[PunchPlay] Heartbeat error: {exc}", xbmc.LOGWARNING)
-                # Always stop the heartbeat on any unhandled error — avoids
-                # the thread spinning silently if the player enters a bad state.
-                self._hb_stop.set()
-                xbmc.log("[PunchPlay] Heartbeat stopping due to error", xbmc.LOGINFO)
-                return
+                # Tolerate transient errors (a single bad settings read or
+                # position capture) — one hiccup must not silence progress
+                # updates for the rest of playback.  Only stop once the
+                # player looks persistently broken.
+                consecutive_errors += 1
+                xbmc.log(
+                    f"[PunchPlay] Heartbeat error "
+                    f"({consecutive_errors}/{HEARTBEAT_MAX_CONSECUTIVE_ERRORS}): {exc}",
+                    xbmc.LOGWARNING,
+                )
+                if consecutive_errors >= HEARTBEAT_MAX_CONSECUTIVE_ERRORS:
+                    self._hb_stop.set()
+                    xbmc.log(
+                        "[PunchPlay] Heartbeat stopping after repeated errors",
+                        xbmc.LOGINFO,
+                    )
+                    return
 
     # ------------------------------------------------------------------
     # Playback events
@@ -291,6 +745,7 @@ class PunchPlayPlayer(xbmc.Player):
 
             if not self._api.is_authenticated():
                 return
+            auth_generation = self._api.auth_generation
 
             settings = self._settings()
 
@@ -302,6 +757,10 @@ class PunchPlayPlayer(xbmc.Player):
             path = self.getPlayingFile()
             info_tag = self.getVideoInfoTag()
             duration = self.getTotalTime()
+
+            # Remember the library dbid (if any) before content filters run,
+            # so even untracked plays suppress their playcount echo.
+            self._remember_library_item(info_tag)
 
             # Identify the media.
             from identifier import identify, is_anime
@@ -338,12 +797,30 @@ class PunchPlayPlayer(xbmc.Player):
                 )
                 return
 
+            # Identification can involve network I/O. If the user logged out
+            # while it was running, do not start a session for the old account.
+            if (
+                auth_generation != self._api.auth_generation
+                or not self._api.is_authenticated()
+            ):
+                xbmc.log(
+                    "[PunchPlay] Login changed during identification — skipping",
+                    xbmc.LOGDEBUG,
+                )
+                return
+
             self._metadata = metadata
             self._is_playing = True
             self._playback_session_id = str(uuid.uuid4())
+            self._playback_auth_generation = auth_generation
             self._stop_emitted = False
             self._last_position = 0.0
             self._last_duration = 0.0
+
+            # A new tracked playback cancels any not-yet-shown rating prompt
+            # (autoplay of the next episode).
+            with self._rating_lock:
+                self._pending_rating = None
 
             captured = self._capture_position()
             position = captured[0] if captured else 0.0
@@ -355,9 +832,12 @@ class PunchPlayPlayer(xbmc.Player):
                 xbmc.LOGINFO,
             )
 
-            # Attempt to flush any offline queue before the new event.
-            self._api.flush_queue()
-            self._api.post(SCROBBLE_START_ENDPOINT, payload)
+            # Drains the offline queue and posts the start as one atomic
+            # worker job (see _dispatch_start) so a stale leftover event
+            # can't land after this one, even under a full post queue. The
+            # service loop also flushes the offline queue every 60s, through
+            # dispatch_flush() on the same worker.
+            self._dispatch_start(payload)
             self._start_heartbeat()
 
         except Exception as exc:
@@ -377,7 +857,7 @@ class PunchPlayPlayer(xbmc.Player):
                 position, duration = captured
             payload = self._build_payload(self._metadata, position, duration)
             xbmc.log(f"[PunchPlay] Paused at {position:.0f}s", xbmc.LOGDEBUG)
-            self._api.post(SCROBBLE_PAUSE_ENDPOINT, payload)
+            self._dispatch_post(SCROBBLE_PAUSE_ENDPOINT, payload)
         except Exception as exc:
             xbmc.log(f"[PunchPlay] onPlayBackPaused error: {exc}", xbmc.LOGDEBUG)
 
@@ -394,7 +874,7 @@ class PunchPlayPlayer(xbmc.Player):
                 position, duration = captured
             payload = self._build_payload(self._metadata, position, duration)
             xbmc.log(f"[PunchPlay] Resumed at {position:.0f}s", xbmc.LOGDEBUG)
-            self._api.post(SCROBBLE_RESUME_ENDPOINT, payload)
+            self._dispatch_post(SCROBBLE_RESUME_ENDPOINT, payload)
             self._start_heartbeat()
         except Exception as exc:
             xbmc.log(f"[PunchPlay] onPlayBackResumed error: {exc}", xbmc.LOGDEBUG)
@@ -409,9 +889,80 @@ class PunchPlayPlayer(xbmc.Player):
     # Internal stop logic
     # ------------------------------------------------------------------
 
+    def _send_stop(
+        self,
+        *,
+        payload: dict[str, Any],
+        metadata: dict[str, Any],
+        settings: dict[str, Any],
+        session_id: str | None,
+        auth_generation: int,
+        watched: bool,
+        attempt_network: bool = True,
+    ) -> None:
+        """
+        Post the stop event and queue any rating prompt.  Runs on the post
+        worker, so it may block on the network and on SQLite.  Shows no UI —
+        the service loop drains the queued prompt and displays it.
+
+        *attempt_network* is False when this is the offline fallback for a
+        queue-full job, or when an earlier event from the same session is
+        already durable. In both cases this goes straight to the offline
+        queue. Everything else below (session cleanup and rating prompt)
+        still needs to run, which is why the fallback comes through here.
+        """
+        if session_id and self._cache is not None:
+            self._cache.delete_pending_scrobbles_for_session(session_id)
+
+        if self._session_is_deferred(session_id):
+            attempt_network = False
+
+        if attempt_network:
+            stop_resp = self._api.post(
+                SCROBBLE_STOP_ENDPOINT,
+                payload,
+                expected_auth_generation=auth_generation,
+            )
+            if stop_resp is None:
+                self._mark_session_deferred(session_id)
+        else:
+            self._preserve_playback_post(
+                SCROBBLE_STOP_ENDPOINT,
+                payload,
+                auth_generation,
+                session_id,
+            )
+            stop_resp = None
+
+        # logout() invalidates all work from the previous account. The HTTP
+        # request may already have completed, but its response must not create
+        # a rating prompt that could later submit under a different login.
+        if auth_generation != self._api.auth_generation:
+            xbmc.log(
+                "[PunchPlay] Discarding stop response after logout",
+                xbmc.LOGDEBUG,
+            )
+            return
+
+        if not watched:
+            return
+        if not settings["rate_after_watching"]:
+            xbmc.log("[PunchPlay] Rating disabled in settings", xbmc.LOGINFO)
+            return
+
+        # The backend resolves canonical IDs we may not have had locally.
+        merged_metadata = dict(metadata)
+        if stop_resp and isinstance(stop_resp, dict):
+            for key in ("tmdb_id", "tvdb_id", "imdb_id", "punchplay_id"):
+                if stop_resp.get(key) is not None:
+                    merged_metadata[key] = stop_resp[key]
+        self._queue_rating_prompt(merged_metadata, settings, stop_resp=stop_resp)
+
     def _emit_stop(self, settings: dict[str, Any]) -> None:
         """Post a stop event for the current item (without clearing state)."""
-        if self._metadata is None:
+        metadata = self._metadata
+        auth_generation = self._playback_auth_generation
+        if metadata is None or auth_generation is None:
             return
         try:
             captured = self._capture_position()
@@ -423,7 +974,7 @@ class PunchPlayPlayer(xbmc.Player):
                 position, duration = captured
             if duration > 0 and position + STOP_COMPLETE_GRACE_SECS >= duration:
                 position = duration
-            payload = self._build_payload(self._metadata, position, duration)
+            payload = self._build_payload(metadata, position, duration)
             payload["watched_threshold"] = settings["watched_threshold"]
             watched = duration > 0 and payload["progress"] >= settings["watched_threshold"]
             payload["watched"] = watched
@@ -434,20 +985,19 @@ class PunchPlayPlayer(xbmc.Player):
                     xbmc.LOGINFO,
                 )
             xbmc.log(
-                f"[PunchPlay] Stop: {self._metadata.get('title')!r} "
+                f"[PunchPlay] Stop: {metadata.get('title')!r} "
                 f"pos={payload['position_seconds']}s",
                 xbmc.LOGINFO,
             )
-            if self._playback_session_id and self._cache is not None:
-                self._cache.delete_pending_scrobbles_for_session(self._playback_session_id)
-            stop_resp = self._api.post(SCROBBLE_STOP_ENDPOINT, payload)
+            # Notify here, on the callback thread — Kodi wants UI calls off
+            # background threads, and this is cheap.
             if watched:
                 _s = localize
-                title = self._metadata.get("title", "")
-                media_type = self._metadata.get("media_type", "movie")
+                title = metadata.get("title", "")
+                media_type = metadata.get("media_type", "movie")
                 if media_type == "episode":
-                    season = self._metadata.get("season")
-                    episode = self._metadata.get("episode")
+                    season = metadata.get("season")
+                    episode = metadata.get("episode")
                     if isinstance(season, int) and isinstance(episode, int):
                         msg = _s(32014).format(title, f"{season:02d}", f"{episode:02d}")
                     else:
@@ -456,17 +1006,34 @@ class PunchPlayPlayer(xbmc.Player):
                     msg = _s(32013).format(title)
                 self._notify(msg, settings)
 
-                # Offer the rating dialog if enabled and not already playing
-                # something else (e.g. immediate next episode).
-                if not settings["rate_after_watching"]:
-                    xbmc.log("[PunchPlay] Rating disabled in settings", xbmc.LOGINFO)
-                else:
-                    merged_metadata = dict(self._metadata)
-                    if stop_resp and isinstance(stop_resp, dict):
-                        for key in ("tmdb_id", "tvdb_id", "imdb_id", "punchplay_id"):
-                            if stop_resp.get(key) is not None:
-                                merged_metadata[key] = stop_resp[key]
-                    self._maybe_prompt_for_rating(merged_metadata, settings, stop_resp=stop_resp)
+            # Snapshot everything the worker needs — _handle_stop clears this
+            # instance state as soon as we return.
+            metadata = dict(metadata)
+            session_id = self._playback_session_id
+            self._dispatch(
+                _PostJob(
+                    SCROBBLE_STOP_ENDPOINT,
+                    payload,
+                    auth_generation,
+                    lambda: self._send_stop(
+                        payload=payload,
+                        metadata=metadata,
+                        settings=settings,
+                        session_id=session_id,
+                        auth_generation=auth_generation,
+                        watched=watched,
+                    ),
+                    offline_fallback=lambda: self._send_stop(
+                        payload=payload,
+                        metadata=metadata,
+                        settings=settings,
+                        session_id=session_id,
+                        auth_generation=auth_generation,
+                        watched=watched,
+                        attempt_network=False,
+                    ),
+                )
+            )
         except Exception as exc:
             xbmc.log(f"[PunchPlay] Stop emit error: {exc}", xbmc.LOGDEBUG)
 
@@ -474,15 +1041,22 @@ class PunchPlayPlayer(xbmc.Player):
     # Rating dialog
     # ------------------------------------------------------------------
 
-    def _maybe_prompt_for_rating(
+    def _queue_rating_prompt(
         self,
         metadata: dict[str, Any],
         settings: dict[str, Any],
         *,
         stop_resp: dict[str, Any] | None,
     ) -> None:
-        if self.isPlayingVideo():
-            xbmc.log("[PunchPlay] Skipping rating — another video is playing", xbmc.LOGINFO)
+        """Store a pending rating request for the service loop to pick up."""
+        if (
+            metadata.get("media_type") == "episode"
+            and settings.get("rating_prompt_scope", "all") == "movies"
+        ):
+            xbmc.log(
+                "[PunchPlay] Skipping episode rating — prompts limited to movies",
+                xbmc.LOGINFO,
+            )
             return
         if stop_resp is None and not has_reliable_rating_identity(metadata):
             xbmc.log("[PunchPlay] Skipping rating — no reliable canonical ID", xbmc.LOGINFO)
@@ -499,18 +1073,35 @@ class PunchPlayPlayer(xbmc.Player):
                 return
 
         delay_secs = max(0, int(settings.get("rating_prompt_delay") or 0))
-        if delay_secs:
-            monitor = xbmc.Monitor()
-            deadline = time.monotonic() + delay_secs
-            while time.monotonic() < deadline:
-                if monitor.abortRequested():
-                    xbmc.log("[PunchPlay] Skipping rating — Kodi is shutting down", xbmc.LOGINFO)
-                    return
-                if self.isPlayingVideo():
-                    xbmc.log("[PunchPlay] Skipping rating — autoplay resumed", xbmc.LOGINFO)
-                    return
-                monitor.waitForAbort(0.25)
+        with self._rating_lock:
+            self._pending_rating = {
+                "metadata": metadata,
+                "suppression_keys": suppression_keys,
+                "not_before": time.monotonic() + delay_secs,
+            }
 
+    def pop_due_rating_prompt(self) -> dict[str, Any] | None:
+        """
+        Return the pending rating request once its delay has elapsed, or None.
+        Called by the service loop.  The delay lets Kodi settle so autoplay
+        of the next episode cancels the prompt instead of being interrupted.
+        """
+        with self._rating_lock:
+            pending = self._pending_rating
+            if pending is None or time.monotonic() < pending["not_before"]:
+                return None
+            self._pending_rating = None
+
+        if self.isPlayingVideo():
+            xbmc.log("[PunchPlay] Skipping rating — another video is playing", xbmc.LOGINFO)
+            return None
+        return pending
+
+    def prompt_for_rating(self, request: dict[str, Any]) -> None:
+        """Show the rating option dialog.  Must be called off the player
+        callback thread (the service loop)."""
+        metadata = request["metadata"]
+        suppression_keys = request["suppression_keys"]
         title = metadata.get("title", "")
         _s = localize
         options = [
@@ -572,6 +1163,7 @@ class PunchPlayPlayer(xbmc.Player):
             rate_dlg = RatingDialog(
                 bg_path=bg_path,
                 heading=heading,
+                footer=_s(32128),
                 initial=5,
             )
             rate_dlg.doModal()
@@ -610,6 +1202,17 @@ class PunchPlayPlayer(xbmc.Player):
             xbmc.log(f"[PunchPlay] Rating dialog error: {exc}", xbmc.LOGDEBUG)
 
     def _handle_stop(self) -> None:
+        # Kodi bumps the item's playcount around now — refresh the echo
+        # suppression window that started when playback began. This must run
+        # even when nothing was tracked (identify failed, or the play was
+        # filtered by min_length_minutes): those plays only ever got the
+        # start-time stamp, and without a stop-time refresh the suppression
+        # window could lapse before Kodi's own echo arrives, letting a
+        # filtered-out play leak into live sync as if it were a manual toggle.
+        if self._current_library_item is not None:
+            self._stamp_library_item(*self._current_library_item)
+            self._current_library_item = None
+
         if self._metadata is None or self._stop_emitted:
             return
         try:
@@ -620,15 +1223,135 @@ class PunchPlayPlayer(xbmc.Player):
         finally:
             self._metadata = None
             self._playback_session_id = None
+            self._playback_auth_generation = None
             self._stop_emitted = False
+
+    def handle_logout(self) -> None:
+        """Cancel playback work belonging to the account just logged out.
+
+        The API generation has already advanced when this is called. Queued
+        jobs from the old generation are discarded, while an in-flight job is
+        prevented by APIClient.post() from repopulating the cleared SQLite
+        queue if its request later fails.
+        """
+        self._is_playing = False
+        self._stop_heartbeat()
+        self._metadata = None
+        self._playback_session_id = None
+        self._playback_auth_generation = None
+        self._stop_emitted = False
+        self._clear_deferred_sessions()
+        with self._rating_lock:
+            self._pending_rating = None
+
+        discarded = 0
+        with self._post_state_lock:
+            while True:
+                try:
+                    job = self._post_queue.get_nowait()
+                except queue.Empty:
+                    break
+                if job is not None:
+                    discarded += 1
+                self._post_queue.task_done()
+        if discarded:
+            xbmc.log(
+                f"[PunchPlay] Discarded {discarded} queued post(s) on logout",
+                xbmc.LOGINFO,
+            )
 
     # ------------------------------------------------------------------
     # Cleanup (called on service shutdown)
     # ------------------------------------------------------------------
 
     def cleanup(self) -> None:
-        self._is_playing = False
-        self._stop_heartbeat()
-        self._metadata = None
-        self._playback_session_id = None
-        self._stop_emitted = False
+        # If something is still playing when Kodi quits, onPlayBackStopped/
+        # onPlayBackEnded never fire — they only cover playback ending while
+        # Kodi keeps running. Without this, the item is silently left in
+        # "now playing" state on the backend forever: _handle_stop is the
+        # only code path that actually emits the stop event, so shutdown
+        # must go through it instead of just clearing local state.
+        self._handle_stop()
+        with self._rating_lock:
+            self._pending_rating = None
+        self._stop_post_worker()
+
+    def _stop_post_worker(self) -> None:
+        """Let queued posts finish before shutdown — the last one is usually
+        the stop event for whatever was playing."""
+        with self._post_thread_lock:
+            thread = self._post_thread
+            self._post_thread = None
+        if thread is None or not thread.is_alive():
+            return
+        sentinel_enqueued = False
+        try:
+            self._post_queue.put_nowait(None)
+            sentinel_enqueued = True
+        except queue.Full:
+            xbmc.log(
+                "[PunchPlay] Post queue full at shutdown — will persist backlog",
+                xbmc.LOGDEBUG,
+            )
+        thread.join(timeout=POST_WORKER_JOIN_TIMEOUT_SECS)
+        if thread.is_alive():
+            xbmc.log(
+                "[PunchPlay] Post worker still busy at shutdown — abandoning it",
+                xbmc.LOGWARNING,
+            )
+            # Stop the worker from taking another job while the queue and its
+            # current in-flight job are snapshotted for offline replay.
+            with self._post_state_lock:
+                self._post_abandon.set()
+                active_job = self._active_post_job
+            if not sentinel_enqueued:
+                try:
+                    # Wake a worker that drained a previously-full queue and
+                    # is now blocked in get(). If the drain wins this race and
+                    # consumes the sentinel first, the leftover daemon thread
+                    # is harmless; all real jobs are still persisted below.
+                    self._post_queue.put_nowait(None)
+                except queue.Full:
+                    pass
+            self._persist_unsent_queue(active_job=active_job)
+
+    def _persist_unsent_queue(self, *, active_job: _PostJob | None = None) -> None:
+        """Drain any jobs still sitting in the queue straight into the
+        offline queue, bypassing the network and any side effects (e.g. a
+        rating prompt) — shutdown is time-boxed, so the goal is just to not
+        lose the watch.
+
+        Once `_post_abandon` is set, the worker cannot start another queued
+        job. The job it already popped is included too: it may still succeed
+        after being persisted, but `event_id` makes that duplicate replay
+        idempotent and is safer than losing it when the daemon is terminated.
+        Replay order follows each event's timestamp rather than this drain's
+        insertion order."""
+        if self._cache is None:
+            return
+        jobs: list[_PostJob] = []
+        while True:
+            try:
+                job = self._post_queue.get_nowait()
+            except queue.Empty:
+                break
+            if (
+                job is not None
+                and job.endpoint != _FLUSH_QUEUE_SENTINEL
+                and job.auth_generation == self._api.auth_generation
+            ):
+                jobs.append(job)
+            self._post_queue.task_done()
+        if (
+            active_job is not None
+            and active_job.endpoint != _FLUSH_QUEUE_SENTINEL
+            and active_job.auth_generation == self._api.auth_generation
+        ):
+            jobs.append(active_job)
+        if jobs:
+            self._cache.enqueue_scrobbles([(job.endpoint, job.payload) for job in jobs])
+            xbmc.log(
+                f"[PunchPlay] Persisted {len(jobs)} unsent event(s) to the "
+                "offline queue at shutdown",
+                xbmc.LOGINFO,
+            )

--- a/script.punchplay/resources/lib/pull_sync.py
+++ b/script.punchplay/resources/lib/pull_sync.py
@@ -1,0 +1,388 @@
+"""
+pull_sync.py — apply PunchPlay history back to the Kodi library.
+
+Fetches the authenticated user's watched history and in-progress items from
+/api/scrobble/sync and applies them to Kodi via JSON-RPC:
+
+  • Watched movies/episodes → playcount + lastplayed (never *un*-watches).
+  • In-progress items       → resume points (with staleness guards).
+
+Matching is by TMDB uniqueid first, then IMDb.  Items that are not in the
+Kodi library are counted as unmatched and skipped.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any
+
+import xbmc
+
+from constants import (
+    PULL_SYNC_TIMEOUT_SECS,
+    SCROBBLE_SYNC_ENDPOINT,
+    iso_to_epoch,
+    iso_to_kodi_datetime,
+    kodi_datetime_to_epoch,
+)
+
+# Resume points below this position are noise (credits skip, sampling).
+RESUME_MIN_POSITION_SECS = 60
+# Don't set a resume point that is basically "finished".
+RESUME_END_GUARD_SECS = 120
+# Skip when Kodi's resume point is already within this distance.
+RESUME_MIN_DELTA_SECS = 60
+
+
+def _rpc(method: str, params: dict[str, Any]) -> dict[str, Any]:
+    raw = xbmc.executeJSONRPC(
+        json.dumps({"jsonrpc": "2.0", "method": method, "params": params, "id": 1})
+    )
+    data = json.loads(raw)
+    if "error" in data:
+        raise RuntimeError(f"JSON-RPC {method} failed: {data['error']}")
+    return data.get("result", {}) or {}
+
+
+def _get_kodi_movies() -> list[dict[str, Any]]:
+    result = _rpc(
+        "VideoLibrary.GetMovies",
+        {"properties": ["uniqueid", "playcount", "lastplayed", "resume"]},
+    )
+    return result.get("movies", []) or []
+
+
+def _get_kodi_shows() -> list[dict[str, Any]]:
+    result = _rpc("VideoLibrary.GetTVShows", {"properties": ["uniqueid"]})
+    return result.get("tvshows", []) or []
+
+
+def _get_kodi_episodes() -> list[dict[str, Any]]:
+    result = _rpc(
+        "VideoLibrary.GetEpisodes",
+        {
+            "properties": [
+                "tvshowid", "season", "episode",
+                "playcount", "lastplayed", "resume",
+            ]
+        },
+    )
+    return result.get("episodes", []) or []
+
+
+def _index_by_unique_ids(items: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
+    """Index library items by "tmdb:<id>" and "imdb:<id>" uniqueid keys."""
+    index: dict[str, dict[str, Any]] = {}
+    for item in items:
+        unique_ids = item.get("uniqueid") or {}
+        tmdb = str(unique_ids.get("tmdb") or "").strip()
+        imdb = str(unique_ids.get("imdb") or "").strip()
+        if tmdb:
+            index.setdefault(f"tmdb:{tmdb}", item)
+        if imdb:
+            index.setdefault(f"imdb:{imdb}", item)
+    return index
+
+
+def _find_in_index(
+    index: dict[str, dict[str, Any]],
+    tmdb_id: Any,
+    imdb_id: Any,
+) -> dict[str, Any] | None:
+    if tmdb_id is not None:
+        found = index.get(f"tmdb:{tmdb_id}")
+        if found:
+            return found
+    if imdb_id:
+        found = index.get(f"imdb:{imdb_id}")
+        if found:
+            return found
+    return None
+
+
+class KodiLibraryIndex:
+    """Snapshot of the Kodi video library keyed for PunchPlay matching."""
+
+    def __init__(self) -> None:
+        self.movies = _index_by_unique_ids(_get_kodi_movies())
+        self.shows = _index_by_unique_ids(_get_kodi_shows())
+        episodes = _get_kodi_episodes()
+        self.episodes: dict[tuple[int, int, int], dict[str, Any]] = {}
+        for ep in episodes:
+            try:
+                key = (int(ep["tvshowid"]), int(ep["season"]), int(ep["episode"]))
+            except (KeyError, TypeError, ValueError):
+                continue
+            self.episodes.setdefault(key, ep)
+
+    def find_movie(self, remote: dict[str, Any]) -> dict[str, Any] | None:
+        return _find_in_index(self.movies, remote.get("tmdb_id"), remote.get("imdb_id"))
+
+    def find_episode(self, remote: dict[str, Any]) -> dict[str, Any] | None:
+        show = _find_in_index(
+            self.shows, remote.get("show_tmdb_id"), remote.get("show_imdb_id")
+        )
+        if not show:
+            return None
+        season = remote.get("season")
+        episode = remote.get("episode")
+        if season is None or episode is None:
+            return None
+        try:
+            key = (int(show["tvshowid"]), int(season), int(episode))
+        except (KeyError, TypeError, ValueError):
+            return None
+        return self.episodes.get(key)
+
+
+def should_apply_resume(
+    remote: dict[str, Any],
+    kodi_item: dict[str, Any],
+) -> bool:
+    """
+    Decide whether a remote in-progress position should overwrite the Kodi
+    resume point.  Pure function — unit-tested.
+    """
+    position = remote.get("position_seconds") or 0
+    duration = remote.get("duration_seconds") or 0
+    if position < RESUME_MIN_POSITION_SECS:
+        return False
+    if duration > 0 and duration - position < RESUME_END_GUARD_SECS:
+        return False
+
+    resume = kodi_item.get("resume") or {}
+    kodi_position = float(resume.get("position") or 0)
+    if abs(kodi_position - position) < RESUME_MIN_DELTA_SECS:
+        return False
+
+    # Only overwrite when the remote progress is newer. `lastplayed` updates
+    # whenever Kodi stops playback — including finishing an item, which
+    # clears its resume position to 0 — so it's a usable proxy for the local
+    # state's age regardless of the current resume position. Gating this on
+    # kodi_position > 0 would let a stale remote in-progress position
+    # resurrect a resume marker on an item already completed locally.
+    kodi_epoch = kodi_datetime_to_epoch(kodi_item.get("lastplayed"))
+    remote_epoch = iso_to_epoch(remote.get("updated_at"))
+    if kodi_epoch is not None and remote_epoch is not None and kodi_epoch >= remote_epoch:
+        return False
+    return True
+
+
+def _set_movie_watched(movie: dict[str, Any], remote: dict[str, Any]) -> None:
+    params: dict[str, Any] = {
+        "movieid": int(movie["movieid"]),
+        "playcount": max(1, int(remote.get("playcount") or 1)),
+    }
+    lastplayed = iso_to_kodi_datetime(remote.get("watched_at"))
+    if lastplayed:
+        params["lastplayed"] = lastplayed
+    _rpc("VideoLibrary.SetMovieDetails", params)
+
+
+def _set_episode_watched(episode: dict[str, Any], remote: dict[str, Any]) -> None:
+    params: dict[str, Any] = {
+        "episodeid": int(episode["episodeid"]),
+        "playcount": max(1, int(remote.get("playcount") or 1)),
+    }
+    lastplayed = iso_to_kodi_datetime(remote.get("watched_at"))
+    if lastplayed:
+        params["lastplayed"] = lastplayed
+    _rpc("VideoLibrary.SetEpisodeDetails", params)
+
+
+def _set_resume(kodi_item: dict[str, Any], remote: dict[str, Any]) -> None:
+    position = int(remote.get("position_seconds") or 0)
+    duration = int(remote.get("duration_seconds") or 0)
+    resume: dict[str, Any] = {"position": position}
+    if duration > 0:
+        resume["total"] = duration
+    if "movieid" in kodi_item:
+        _rpc(
+            "VideoLibrary.SetMovieDetails",
+            {"movieid": int(kodi_item["movieid"]), "resume": resume},
+        )
+    else:
+        _rpc(
+            "VideoLibrary.SetEpisodeDetails",
+            {"episodeid": int(kodi_item["episodeid"]), "resume": resume},
+        )
+
+
+def _record_failed_item(
+    failed_out: set[str] | None,
+    operation: str,
+    remote: dict[str, Any],
+) -> None:
+    """Add a stable, non-sensitive identity for a failed library write.
+
+    The service persists consecutive retry counts per identity, so a new
+    failure cannot inherit an unrelated item's exhausted retry allowance.
+    """
+    if failed_out is None:
+        return
+    identity_fields = (
+        "media_type",
+        "punchplay_id",
+        "tmdb_id",
+        "imdb_id",
+        "show_tmdb_id",
+        "show_imdb_id",
+        "season",
+        "episode",
+        "title",
+        "year",
+    )
+    identity = {
+        key: remote.get(key)
+        for key in identity_fields
+        if remote.get(key) is not None
+    }
+    if not identity:
+        identity = {"unidentified": True}
+    raw = json.dumps(
+        {"operation": operation, "identity": identity},
+        sort_keys=True,
+        separators=(",", ":"),
+        default=str,
+    ).encode("utf-8")
+    failed_out.add(hashlib.sha256(raw).hexdigest())
+
+
+def run_pull_sync(
+    api,
+    *,
+    apply_watched: bool,
+    apply_resume: bool,
+    since_ms: int | None = None,
+    progress_callback=None,
+    applied_out: set | None = None,
+    applied_callback=None,
+    failed_out: set[str] | None = None,
+) -> dict[str, int]:
+    """
+    Fetch PunchPlay state and apply it to the Kodi library.
+
+    Returns a summary dict:
+      movies_marked / episodes_marked / resume_set / unmatched /
+      already_synced / cancelled / apply_failed
+    When `applied_out` is given, ("movie"|"episode", library_id) tuples are
+    added for every watched state we set — live watched sync uses these to
+    suppress the resulting OnUpdate echoes.
+    `applied_callback`, when provided, is invoked with each tuple immediately
+    after the write so echo matching uses the write time rather than the end
+    of a potentially long library sync.
+    When `failed_out` is given, stable hashed identities are added for every
+    library write that failed so checkpoint retry counts can be scoped per
+    item without persisting media metadata.
+    Raises on fetch failure (callers surface the error).
+    """
+    path = SCROBBLE_SYNC_ENDPOINT
+    if since_ms:
+        path = f"{path}?since={int(since_ms)}"
+    remote = api.get(path, timeout=PULL_SYNC_TIMEOUT_SECS)
+
+    movies = remote.get("movies") or []
+    episodes = remote.get("episodes") or []
+    in_progress = remote.get("in_progress") or []
+
+    summary = {
+        "movies_marked": 0,
+        "episodes_marked": 0,
+        "resume_set": 0,
+        "unmatched": 0,
+        "already_synced": 0,
+        "cancelled": 0,
+        "apply_failed": 0,
+    }
+    total = (
+        (len(movies) + len(episodes) if apply_watched else 0)
+        + (len(in_progress) if apply_resume else 0)
+    )
+    if total == 0:
+        return summary
+
+    index = KodiLibraryIndex()
+    done = 0
+
+    def _tick() -> bool:
+        nonlocal done
+        done += 1
+        if progress_callback is not None and not progress_callback(done, total):
+            summary["cancelled"] = 1
+            return False
+        return True
+
+    if apply_watched:
+        for remote_movie in movies:
+            if not _tick():
+                return summary
+            movie = index.find_movie(remote_movie)
+            if movie is None:
+                summary["unmatched"] += 1
+                continue
+            if int(movie.get("playcount") or 0) > 0:
+                summary["already_synced"] += 1
+                continue
+            try:
+                _set_movie_watched(movie, remote_movie)
+                summary["movies_marked"] += 1
+                applied_item = ("movie", int(movie["movieid"]))
+                if applied_out is not None:
+                    applied_out.add(applied_item)
+                if applied_callback is not None:
+                    applied_callback(applied_item)
+            except (RuntimeError, KeyError, TypeError, ValueError) as exc:
+                summary["apply_failed"] += 1
+                _record_failed_item(failed_out, "movie_watched", remote_movie)
+                xbmc.log(f"[PunchPlay] Pull sync movie error: {exc}", xbmc.LOGWARNING)
+
+        for remote_episode in episodes:
+            if not _tick():
+                return summary
+            episode = index.find_episode(remote_episode)
+            if episode is None:
+                summary["unmatched"] += 1
+                continue
+            if int(episode.get("playcount") or 0) > 0:
+                summary["already_synced"] += 1
+                continue
+            try:
+                _set_episode_watched(episode, remote_episode)
+                summary["episodes_marked"] += 1
+                applied_item = ("episode", int(episode["episodeid"]))
+                if applied_out is not None:
+                    applied_out.add(applied_item)
+                if applied_callback is not None:
+                    applied_callback(applied_item)
+            except (RuntimeError, KeyError, TypeError, ValueError) as exc:
+                summary["apply_failed"] += 1
+                _record_failed_item(failed_out, "episode_watched", remote_episode)
+                xbmc.log(f"[PunchPlay] Pull sync episode error: {exc}", xbmc.LOGWARNING)
+
+    if apply_resume:
+        for remote_item in in_progress:
+            if not _tick():
+                return summary
+            if remote_item.get("media_type") == "episode":
+                kodi_item = index.find_episode(remote_item)
+            else:
+                kodi_item = index.find_movie(remote_item)
+            if kodi_item is None:
+                summary["unmatched"] += 1
+                continue
+            if not should_apply_resume(remote_item, kodi_item):
+                summary["already_synced"] += 1
+                continue
+            try:
+                _set_resume(kodi_item, remote_item)
+                summary["resume_set"] += 1
+                # Resume writes never touch playcount, so they must not enter
+                # the echo-suppression set — doing so would silently drop a
+                # genuine manual watched-toggle made shortly afterward.
+            except (RuntimeError, KeyError, TypeError, ValueError) as exc:
+                summary["apply_failed"] += 1
+                _record_failed_item(failed_out, "resume", remote_item)
+                xbmc.log(f"[PunchPlay] Pull sync resume error: {exc}", xbmc.LOGWARNING)
+
+    return summary

--- a/script.punchplay/resources/lib/rating_dialog.py
+++ b/script.punchplay/resources/lib/rating_dialog.py
@@ -32,6 +32,7 @@ class RatingDialog(xbmcgui.WindowDialog):
         *,
         bg_path: str,
         heading: str,
+        footer: str,
         initial: int = 5,
     ):
         self._rating = max(1, min(10, initial))
@@ -85,7 +86,7 @@ class RatingDialog(xbmcgui.WindowDialog):
         self.addControl(
             xbmcgui.ControlLabel(
                 0, 620, 1280, 30,
-                "OK to confirm  ·  Back to skip",
+                footer,
                 font="font12",
                 alignment=2,
                 textColor="FF777777",

--- a/script.punchplay/resources/lib/service.py
+++ b/script.punchplay/resources/lib/service.py
@@ -22,23 +22,33 @@ import xbmcgui
 
 from constants import (
     ACTION_PROPERTY_CLEAR_QUEUE,
+    ACTION_PROPERTY_CLEAR_SUPPRESSIONS,
     ACTION_PROPERTY_EXPORT_DEBUG,
     ACTION_PROPERTY_EXPORT_VERBOSE_DEBUG,
     ACTION_PROPERTY_LOGIN,
     ACTION_PROPERTY_LOGOUT,
     ACTION_PROPERTY_PREVIEW_LIBRARY,
+    ACTION_PROPERTY_PULL_SYNC,
     ACTION_PROPERTY_SHOW_STATUS,
     ACTION_PROPERTY_SYNC_LIBRARY,
     ACTION_PROPERTY_TEST_CONNECTION,
     ADDON_NAME,
+    AUTO_PULL_CHECK_INTERVAL_SECS,
     FLUSH_INTERVAL_SECS,
     HOME_WINDOW_ID,
     LIBRARY_SYNC_BATCH_SIZE,
+    LIBRARY_SYNC_MAX_CONSECUTIVE_FAILURES,
     NOTIFICATION_TITLE,
     PRUNE_INTERVAL_SECS,
+    PULL_SYNC_INTERVAL_SECS,
+    PULL_SYNC_MAX_HELD_RUNS,
+    PULL_SYNC_OVERLAP_SECS,
+    SCAN_SYNC_DELAY_SECS,
+    SCAN_SYNC_MIN_INTERVAL_SECS,
     SCROBBLE_IMPORT_ENDPOINT,
     get_addon,
     get_profile_dir,
+    kodi_datetime_to_utc_iso,
     localize,
 )
 
@@ -49,14 +59,19 @@ class PunchPlayService(xbmc.Monitor):
 
         from api import APIClient
         from cache import Cache
+        from library_events import LiveWatchedSync
         from player import PunchPlayPlayer
 
         self._cache = Cache()
         self._api = APIClient(cache=self._cache)
         self._player = PunchPlayPlayer(api=self._api, cache=self._cache)
+        self._live_sync = LiveWatchedSync()
 
         self._last_flush = 0.0
         self._last_prune = 0.0
+        self._last_auto_pull_check = 0.0
+        self._scan_sync_due_at: float | None = None
+        self._last_scan_sync = 0.0
 
     # ------------------------------------------------------------------
     # Monitor callbacks
@@ -64,6 +79,19 @@ class PunchPlayService(xbmc.Monitor):
 
     def onSettingsChanged(self) -> None:  # type: ignore[override]
         xbmc.log("[PunchPlay] Settings changed — will apply on next event", xbmc.LOGDEBUG)
+
+    def onNotification(self, sender: str, method: str, data: str) -> None:  # type: ignore[override]
+        # Runs on Kodi's announce thread — queue only, no I/O or dialogs.
+        _ = sender
+        try:
+            if method == "VideoLibrary.OnScanFinished":
+                self._scan_sync_due_at = time.monotonic() + SCAN_SYNC_DELAY_SECS
+                xbmc.log("[PunchPlay] Library scan finished — pull sync queued", xbmc.LOGDEBUG)
+                return
+            if method == "VideoLibrary.OnUpdate" and self._live_sync_enabled():
+                self._live_sync.push_update(data)
+        except Exception as exc:
+            xbmc.log(f"[PunchPlay] Notification handling error: {exc}", xbmc.LOGDEBUG)
 
     # ------------------------------------------------------------------
     # Main loop
@@ -106,7 +134,8 @@ class PunchPlayService(xbmc.Monitor):
                     )
                 else:
                     xbmc.log("[PunchPlay] Logout triggered from settings", xbmc.LOGINFO)
-                    self._api.logout()
+                    if self._api.logout():
+                        self._player.handle_logout()
 
             if home_window.getProperty(ACTION_PROPERTY_TEST_CONNECTION):
                 home_window.clearProperty(ACTION_PROPERTY_TEST_CONNECTION)
@@ -135,6 +164,15 @@ class PunchPlayService(xbmc.Monitor):
                 home_window.clearProperty(ACTION_PROPERTY_CLEAR_QUEUE)
                 self._clear_offline_queue()
 
+            if home_window.getProperty(ACTION_PROPERTY_CLEAR_SUPPRESSIONS):
+                home_window.clearProperty(ACTION_PROPERTY_CLEAR_SUPPRESSIONS)
+                self._clear_rating_suppressions()
+
+            if home_window.getProperty(ACTION_PROPERTY_PULL_SYNC):
+                home_window.clearProperty(ACTION_PROPERTY_PULL_SYNC)
+                xbmc.log("[PunchPlay] Pull sync triggered from settings", xbmc.LOGINFO)
+                self._pull_sync(manual=True)
+
             if home_window.getProperty(ACTION_PROPERTY_PREVIEW_LIBRARY):
                 home_window.clearProperty(ACTION_PROPERTY_PREVIEW_LIBRARY)
                 xbmc.log("[PunchPlay] Library preview triggered from settings", xbmc.LOGINFO)
@@ -145,14 +183,45 @@ class PunchPlayService(xbmc.Monitor):
                 xbmc.log("[PunchPlay] Library sync triggered from settings", xbmc.LOGINFO)
                 self._sync_kodi_library()
 
-            # Flush offline queue periodically.
+            # Flush offline queue periodically. Routed through the player's
+            # post worker (not called on this thread) so it can never run
+            # concurrently with a flush the worker is already doing ahead of
+            # a playback start — see PunchPlayPlayer.dispatch_flush().
             if self._api.is_authenticated() and (now - self._last_flush >= FLUSH_INTERVAL_SECS):
+                self._player.dispatch_flush()
+                self._last_flush = now
+
+            # Show a queued rating prompt once its delay has elapsed.  The
+            # player queues these instead of blocking its callback thread.
+            rating_request = self._player.pop_due_rating_prompt()
+            if rating_request is not None:
                 try:
-                    self._api.flush_queue()
+                    self._player.prompt_for_rating(rating_request)
                 except Exception as exc:
-                    xbmc.log(f"[PunchPlay] Queue flush error: {exc}", xbmc.LOGWARNING)
-                else:
-                    self._last_flush = now
+                    xbmc.log(f"[PunchPlay] Rating prompt error: {exc}", xbmc.LOGWARNING)
+
+            # Push manual Kodi watched toggles to PunchPlay.
+            try:
+                self._push_watched_toggles()
+            except Exception as exc:
+                xbmc.log(f"[PunchPlay] Live watched sync error: {exc}", xbmc.LOGWARNING)
+
+            # Library scan finished → pull sync so new items inherit
+            # watched states and resume points.
+            if self._scan_sync_due_at is not None and now >= self._scan_sync_due_at:
+                self._scan_sync_due_at = None
+                try:
+                    self._maybe_scan_pull_sync(now)
+                except Exception as exc:
+                    xbmc.log(f"[PunchPlay] Scan pull sync error: {exc}", xbmc.LOGWARNING)
+
+            # Periodic PunchPlay → Kodi sync when enabled.
+            if now - self._last_auto_pull_check >= AUTO_PULL_CHECK_INTERVAL_SECS:
+                self._last_auto_pull_check = now
+                try:
+                    self._maybe_auto_pull_sync()
+                except Exception as exc:
+                    xbmc.log(f"[PunchPlay] Auto pull sync error: {exc}", xbmc.LOGWARNING)
 
             # Prune stale identifier cache entries once a day.
             if now - self._last_prune >= PRUNE_INTERVAL_SECS:
@@ -182,6 +251,17 @@ class PunchPlayService(xbmc.Monitor):
             return _s(32082).format(max(1, age_secs // 3600))
         return _s(32083).format(max(1, age_secs // 86400))
 
+    def _format_pull_sync_status(self, snapshot: dict[str, Any]) -> str:
+        last_at = snapshot.get("last_pull_sync_at")
+        if not last_at:
+            return localize(32070)
+        age_secs = max(0, int(time.time() - int(last_at) / 1000))
+        text = self._format_relative_age(age_secs)
+        summary = snapshot.get("last_pull_sync_summary")
+        if summary:
+            text = f"{text} — {summary}"
+        return text
+
     def _show_status(self) -> None:
         snapshot = self._api.get_status_snapshot()
         _s = localize
@@ -200,6 +280,11 @@ class PunchPlayService(xbmc.Monitor):
         last_identify = snapshot.get("last_identify_status") or _s(32070)
         if snapshot.get("last_identify_title"):
             last_identify = "{0} — {1}".format(last_identify, snapshot["last_identify_title"])
+        rating_scope = (
+            _s(32140)
+            if snapshot.get("rating_prompt_scope") == "movies"
+            else _s(32141)
+        )
 
         lines = [
             _s(32060).format(status_label),
@@ -214,6 +299,8 @@ class PunchPlayService(xbmc.Monitor):
             _s(32103).format(last_identify),
             _s(32066).format(last_success),
             _s(32067).format(last_error),
+            _s(32127).format(self._format_pull_sync_status(snapshot)),
+            _s(32142).format(rating_scope),
             _s(32068).format(snapshot.get("addon_version") or _s(32071)),
             _s(32069).format(snapshot.get("kodi_version") or _s(32071)),
         ]
@@ -268,6 +355,288 @@ class PunchPlayService(xbmc.Monitor):
             3000,
         )
 
+    def _clear_rating_suppressions(self) -> None:
+        _s = localize
+        cleared = self._cache.clear_rating_suppressions()
+        if cleared <= 0:
+            message = _s(32131)
+        else:
+            message = _s(32130).format(cleared)
+        xbmcgui.Dialog().notification(
+            NOTIFICATION_TITLE, message, xbmcgui.NOTIFICATION_INFO, 3000
+        )
+
+    # ------------------------------------------------------------------
+    # Live watched sync (Kodi → PunchPlay)
+    # ------------------------------------------------------------------
+
+    def _live_sync_enabled(self) -> bool:
+        return get_addon().getSettingBool("live_watched_sync")
+
+    def _push_watched_toggles(self) -> None:
+        if self._live_sync.pending_count() == 0:
+            return
+        if not self._api.is_authenticated():
+            self._live_sync.clear()
+            return
+
+        events = self._live_sync.pop_due_events(self._player.recent_library_items())
+        if not events:
+            return
+
+        from library_events import LibraryDetailLookupError, build_import_entry
+
+        addon = get_addon()
+        scrobble_settings = {
+            "movie": addon.getSettingBool("scrobble_movies"),
+            "episode": addon.getSettingBool("scrobble_tv"),
+            "anime": addon.getSettingBool("scrobble_anime"),
+        }
+
+        entries = []
+        retry_events = []
+        for event in events:
+            try:
+                entry = build_import_entry(event)
+            except LibraryDetailLookupError:
+                retry_events.append(event)
+                continue
+            if entry is None or not entry.get("title"):
+                continue
+            # Anime is a separate toggle only for episodes. Movies always
+            # follow the movie setting, matching PunchPlayPlayer._should_track.
+            content_key = entry["media_type"]
+            if content_key == "episode" and entry.get("anime"):
+                content_key = "anime"
+            if not scrobble_settings.get(content_key, True):
+                xbmc.log(
+                    f"[PunchPlay] Watched toggle skipped — {content_key} scrobbling disabled",
+                    xbmc.LOGDEBUG,
+                )
+                continue
+            entries.append(entry)
+
+        if retry_events:
+            self._live_sync.requeue_events(retry_events)
+            xbmc.log(
+                f"[PunchPlay] Requeued {len(retry_events)} watched toggle(s) "
+                "after detail lookup failure",
+                xbmc.LOGWARNING,
+            )
+
+        if not entries:
+            return
+
+        xbmc.log(
+            f"[PunchPlay] Pushing {len(entries)} watched toggle(s) to PunchPlay",
+            xbmc.LOGINFO,
+        )
+        # Routed through the player's post worker rather than posted here —
+        # this runs on the service loop's own thread, which must stay free
+        # for login/logout handling, dispatch_flush()'s periodic trigger, and
+        # rating-prompt draining, not blocked on a network round trip.
+        self._player.dispatch_import(entries)
+
+    def _maybe_scan_pull_sync(self, now: float) -> None:
+        settings = self._pull_sync_settings()
+        if not settings["auto"]:
+            return
+        if not (settings["watched"] or settings["resume"]):
+            return
+        if not self._api.is_authenticated():
+            return
+        if now - self._last_scan_sync < SCAN_SYNC_MIN_INTERVAL_SECS:
+            xbmc.log("[PunchPlay] Scan pull sync skipped (ran recently)", xbmc.LOGDEBUG)
+            return
+        self._last_scan_sync = now
+        # Full sync, not incremental — a scan may have added files whose
+        # watched history on PunchPlay is arbitrarily old.
+        xbmc.log("[PunchPlay] Scan-triggered pull sync starting", xbmc.LOGINFO)
+        self._pull_sync(manual=False)
+
+    # ------------------------------------------------------------------
+    # PunchPlay → Kodi sync (pull)
+    # ------------------------------------------------------------------
+
+    def _pull_sync_settings(self) -> dict[str, bool]:
+        addon = get_addon()
+        return {
+            "watched": addon.getSettingBool("pull_watched"),
+            "resume": addon.getSettingBool("pull_resume"),
+            "auto": addon.getSettingBool("pull_sync_auto"),
+        }
+
+    def _pull_sync_context(self, settings: dict[str, bool]) -> str:
+        """Stable key for the enabled halves of automatic pull sync."""
+        return "watched={0};resume={1}".format(
+            int(settings["watched"]),
+            int(settings["resume"]),
+        )
+
+    def _maybe_auto_pull_sync(self) -> None:
+        settings = self._pull_sync_settings()
+        if not settings["auto"]:
+            return
+        if not (settings["watched"] or settings["resume"]):
+            return
+        if not self._api.is_authenticated():
+            return
+        self._cache.ensure_pull_sync_context(self._pull_sync_context(settings))
+        last_ms = self._cache.get_runtime_status().get("last_pull_sync_at") or 0
+        now_ms = int(time.time() * 1000)
+        if now_ms - int(last_ms) < PULL_SYNC_INTERVAL_SECS * 1000:
+            return
+        since_ms = None
+        if last_ms:
+            since_ms = max(0, int(last_ms) - PULL_SYNC_OVERLAP_SECS * 1000)
+        xbmc.log("[PunchPlay] Auto pull sync starting", xbmc.LOGINFO)
+        self._pull_sync(manual=False, since_ms=since_ms)
+
+    def _pull_sync(self, *, manual: bool, since_ms: int | None = None) -> None:
+        _s = localize
+
+        if not self._api.is_authenticated():
+            if manual:
+                xbmcgui.Dialog().notification(
+                    NOTIFICATION_TITLE, _s(32032), xbmcgui.NOTIFICATION_WARNING, 4000
+                )
+            return
+
+        settings = self._pull_sync_settings()
+        if not (settings["watched"] or settings["resume"]):
+            if manual:
+                xbmcgui.Dialog().notification(
+                    NOTIFICATION_TITLE, _s(32132), xbmcgui.NOTIFICATION_WARNING, 4000
+                )
+            return
+        self._cache.ensure_pull_sync_context(self._pull_sync_context(settings))
+
+        from pull_sync import run_pull_sync
+
+        progress = None
+        if manual:
+            progress = xbmcgui.DialogProgress()
+            progress.create(_s(32121), _s(32122))
+
+        def _progress_callback(done: int, total: int) -> bool:
+            if progress is None:
+                return not self.abortRequested()
+            if progress.iscanceled():
+                return False
+            progress.update(
+                int(100 * done / max(total, 1)),
+                _s(32123).format(done, total),
+            )
+            return True
+
+        failed_items: set[str] = set()
+        try:
+            summary = run_pull_sync(
+                self._api,
+                apply_watched=settings["watched"],
+                apply_resume=settings["resume"],
+                since_ms=since_ms,
+                progress_callback=_progress_callback,
+                applied_callback=lambda item: self._live_sync.record_pull_applied({item}),
+                failed_out=failed_items,
+            )
+        except Exception as exc:
+            if progress is not None:
+                progress.close()
+            if since_ms is None:
+                # A manual/scan-triggered full pull may have been needed to
+                # apply history older than the previous incremental cursor.
+                # Keep the next automatic run full too instead of silently
+                # falling back to that stale cursor after this failure.
+                self._cache.clear_pull_sync_checkpoint()
+            xbmc.log(f"[PunchPlay] Pull sync failed: {exc}", xbmc.LOGWARNING)
+            if manual:
+                xbmcgui.Dialog().notification(
+                    NOTIFICATION_TITLE, _s(32126).format(str(exc)[:80]),
+                    xbmcgui.NOTIFICATION_ERROR, 5000
+                )
+            return
+
+        if progress is not None:
+            progress.close()
+
+        marked = summary["movies_marked"] + summary["episodes_marked"]
+        apply_failed = summary.get("apply_failed") or 0
+        summary_text = _s(32138).format(
+            marked,
+            summary["resume_set"],
+            summary["unmatched"],
+            apply_failed,
+        )
+
+        if summary.get("cancelled"):
+            # Don't record a cancelled run — the next auto-sync must not
+            # treat the unfinished remainder as already synced.
+            xbmc.log(
+                f"[PunchPlay] Pull sync cancelled after: {summary_text}",
+                xbmc.LOGINFO,
+            )
+            if manual:
+                xbmcgui.Dialog().notification(
+                    NOTIFICATION_TITLE, _s(32133), xbmcgui.NOTIFICATION_INFO, 4000
+                )
+            return
+
+        if apply_failed:
+            # Some items failed to write to the Kodi library — hold back the
+            # incremental checkpoint so they're retried next time, rather
+            # than letting the next sync's `since` filter treat them as
+            # already covered. But a persistently-failing item must not
+            # block the checkpoint (and every newer item behind it) forever.
+            # Retry counts are tracked per failed item, so only advance once
+            # every item failing on this run has exhausted its own allowance;
+            # a new or unrelated failure always starts at run one.
+            held_runs = self._cache.record_pull_sync_held(failed_items)
+            if held_runs < PULL_SYNC_MAX_HELD_RUNS:
+                if since_ms is None:
+                    # A failed item in a full pull can predate the previous
+                    # incremental checkpoint. Clearing it ensures the next
+                    # automatic run fetches that item again.
+                    self._cache.clear_pull_sync_checkpoint()
+                xbmc.log(
+                    f"[PunchPlay] Pull sync finished with {apply_failed} apply "
+                    f"failure(s) ({held_runs}/{PULL_SYNC_MAX_HELD_RUNS}), "
+                    f"checkpoint not advanced: {summary_text}",
+                    xbmc.LOGWARNING,
+                )
+            else:
+                xbmc.log(
+                    f"[PunchPlay] Pull sync still has {apply_failed} apply "
+                    f"failure(s) after {held_runs} held run(s) — advancing "
+                    f"checkpoint anyway so future syncs aren't blocked: "
+                    f"{summary_text}",
+                    xbmc.LOGWARNING,
+                )
+                self._cache.record_pull_sync(summary_text)
+        else:
+            self._cache.record_pull_sync(summary_text)
+            xbmc.log(f"[PunchPlay] Pull sync finished: {summary_text}", xbmc.LOGINFO)
+
+        changed = marked + summary["resume_set"]
+        if manual:
+            if apply_failed:
+                message = _s(32137).format(changed, apply_failed)
+                icon = xbmcgui.NOTIFICATION_WARNING
+            elif changed:
+                message = _s(32124).format(marked, summary["resume_set"])
+                icon = xbmcgui.NOTIFICATION_INFO
+            else:
+                message = _s(32125)
+                icon = xbmcgui.NOTIFICATION_INFO
+            xbmcgui.Dialog().notification(NOTIFICATION_TITLE, message, icon, 5000)
+        elif changed and get_addon().getSettingBool("show_notifications"):
+            xbmcgui.Dialog().notification(
+                NOTIFICATION_TITLE,
+                _s(32124).format(marked, summary["resume_set"]),
+                xbmcgui.NOTIFICATION_INFO,
+                5000,
+            )
+
     def _write_library_diagnostics(
         self,
         filename: str,
@@ -285,6 +654,78 @@ class PunchPlayService(xbmc.Monitor):
     # ------------------------------------------------------------------
     # Kodi library sync
     # ------------------------------------------------------------------
+
+    def _post_library_batches(
+        self,
+        entries: list[dict[str, Any]],
+        *,
+        endpoint: str,
+        dry_run: bool,
+        progress: Any,
+        progress_base: int,
+        progress_span: int,
+        message_id: int,
+        totals: dict[str, int],
+        diagnostics: list[dict[str, Any]],
+    ) -> str:
+        """
+        POST *entries* in batches, accumulating counts into *totals*.
+
+        Returns "done", "cancelled", or "failed".  A failed batch is counted
+        and retried on the next run rather than silently forgotten; after
+        LIBRARY_SYNC_MAX_CONSECUTIVE_FAILURES in a row we stop, because the
+        rest of the run would only pile up more of the same error.
+        """
+        _s = localize
+        total = len(entries)
+        consecutive_failures = 0
+
+        for start in range(0, total, LIBRARY_SYNC_BATCH_SIZE):
+            if progress.iscanceled():
+                return "cancelled"
+
+            batch = entries[start : start + LIBRARY_SYNC_BATCH_SIZE]
+            done = min(start + LIBRARY_SYNC_BATCH_SIZE, total)
+            progress.update(
+                progress_base + int(progress_span * done / max(total, 1)),
+                _s(message_id).format(done, total),
+            )
+
+            try:
+                resp = self._api.post_immediate(
+                    endpoint,
+                    {"entries": batch},
+                    timeout=55,
+                )
+            except Exception as exc:
+                # A preview exists to surface problems — fail loudly.
+                if dry_run:
+                    raise RuntimeError(_s(32116).format(str(exc)[:80])) from exc
+                consecutive_failures += 1
+                totals["failed_batches"] += 1
+                totals["not_sent"] += len(batch)
+                xbmc.log(
+                    f"[PunchPlay] Library batch failed "
+                    f"({consecutive_failures}/{LIBRARY_SYNC_MAX_CONSECUTIVE_FAILURES}): {exc}",
+                    xbmc.LOGWARNING,
+                )
+                if consecutive_failures >= LIBRARY_SYNC_MAX_CONSECUTIVE_FAILURES:
+                    totals["not_sent"] += total - done
+                    xbmc.log(
+                        "[PunchPlay] Library sync aborted after repeated batch failures",
+                        xbmc.LOGWARNING,
+                    )
+                    return "failed"
+                continue
+
+            consecutive_failures = 0
+            totals["imported"] += resp.get("would_import", resp.get("imported", 0))
+            totals["skipped_duplicates"] += resp.get("skipped_duplicates", 0)
+            totals["unmatched"] += resp.get("unmatched", 0)
+            totals["rejected_items"] += resp.get("failed", 0)
+            diagnostics.extend(resp.get("items", []) or [])
+
+        return "done"
 
     def _sync_kodi_library(self, dry_run: bool = False) -> None:
         """Import all watched items from the Kodi library into PunchPlay."""
@@ -313,13 +754,14 @@ class PunchPlayService(xbmc.Monitor):
                 )
                 return
 
-            total_movies = len(movies)
-            total_episodes = len(episodes)
-            importable_movies = 0
-            importable_episodes = 0
-            skipped_duplicates = 0
-            unmatched = 0
-            failed = 0
+            totals = {
+                "imported": 0,
+                "skipped_duplicates": 0,
+                "unmatched": 0,
+                "rejected_items": 0,
+                "failed_batches": 0,
+                "not_sent": 0,
+            }
             diagnostics: list[dict[str, Any]] = []
             endpoint = (
                 SCROBBLE_IMPORT_ENDPOINT + "?dry_run=true"
@@ -327,75 +769,37 @@ class PunchPlayService(xbmc.Monitor):
                 else SCROBBLE_IMPORT_ENDPOINT
             )
 
-            # ── Sync movies in batches of 50 ────────────────────────────
-            cancelled = False
-            for i in range(0, total_movies, LIBRARY_SYNC_BATCH_SIZE):
-                if progress.iscanceled():
-                    cancelled = True
-                    break
-                batch = movies[i : i + LIBRARY_SYNC_BATCH_SIZE]
-                progress.update(
-                    int(50 * min(i + LIBRARY_SYNC_BATCH_SIZE, total_movies) / max(total_movies, 1)),
-                    _s(32025).format(
-                        min(i + LIBRARY_SYNC_BATCH_SIZE, total_movies), total_movies
-                    ),
+            outcome = self._post_library_batches(
+                movies,
+                endpoint=endpoint,
+                dry_run=dry_run,
+                progress=progress,
+                progress_base=0,
+                progress_span=50,
+                message_id=32025,
+                totals=totals,
+                diagnostics=diagnostics,
+            )
+            if outcome == "done":
+                outcome = self._post_library_batches(
+                    episodes,
+                    endpoint=endpoint,
+                    dry_run=dry_run,
+                    progress=progress,
+                    progress_base=50,
+                    progress_span=50,
+                    message_id=32026,
+                    totals=totals,
+                    diagnostics=diagnostics,
                 )
-                try:
-                    resp = self._api.post_immediate(
-                        endpoint,
-                        {"entries": batch},
-                        timeout=55,
-                    )
-                    importable_movies += resp.get("would_import", resp.get("imported", 0))
-                    skipped_duplicates += resp.get("skipped_duplicates", 0)
-                    unmatched += resp.get("unmatched", 0)
-                    failed += resp.get("failed", 0)
-                    diagnostics.extend(resp.get("items", []) or [])
-                except Exception as exc:
-                    if dry_run:
-                        raise RuntimeError(_s(32116).format(str(exc)[:80])) from exc
-                    xbmc.log(f"[PunchPlay] Movie batch error: {exc}", xbmc.LOGWARNING)
-
-            # ── Sync episodes in batches of 50 ──────────────────────────
-            if not cancelled:
-                for i in range(0, total_episodes, LIBRARY_SYNC_BATCH_SIZE):
-                    if progress.iscanceled():
-                        cancelled = True
-                        break
-                    batch = episodes[i : i + LIBRARY_SYNC_BATCH_SIZE]
-                    pct = 50 + int(
-                        50
-                        * min(i + LIBRARY_SYNC_BATCH_SIZE, total_episodes)
-                        / max(total_episodes, 1)
-                    )
-                    progress.update(
-                        pct,
-                        _s(32026).format(
-                            min(i + LIBRARY_SYNC_BATCH_SIZE, total_episodes),
-                            total_episodes,
-                        ),
-                    )
-                    try:
-                        resp = self._api.post_immediate(
-                            endpoint,
-                            {"entries": batch},
-                            timeout=55,
-                        )
-                        importable_episodes += resp.get("would_import", resp.get("imported", 0))
-                        skipped_duplicates += resp.get("skipped_duplicates", 0)
-                        unmatched += resp.get("unmatched", 0)
-                        failed += resp.get("failed", 0)
-                        diagnostics.extend(resp.get("items", []) or [])
-                    except Exception as exc:
-                        if dry_run:
-                            raise RuntimeError(_s(32116).format(str(exc)[:80])) from exc
-                        xbmc.log(f"[PunchPlay] Episode batch error: {exc}", xbmc.LOGWARNING)
+            elif outcome == "failed":
+                totals["not_sent"] += len(episodes)
 
             progress.close()
-            if cancelled:
+            if outcome == "cancelled":
                 xbmc.log(
-                    f"[PunchPlay] Library sync cancelled. "
-                    f"Processed {importable_movies} movies, {importable_episodes} episodes before cancel.",
+                    f"[PunchPlay] Library sync cancelled after importing "
+                    f"{totals['imported']} item(s).",
                     xbmc.LOGINFO,
                 )
             else:
@@ -405,45 +809,52 @@ class PunchPlayService(xbmc.Monitor):
                         "library-import-preview.json" if dry_run else "library-import-diagnostics.json",
                         {
                             "dry_run": dry_run,
-                            "movies": total_movies,
-                            "episodes": total_episodes,
-                            "would_import" if dry_run else "imported": (
-                                importable_movies + importable_episodes
-                            ),
-                            "skipped_duplicates": skipped_duplicates,
-                            "unmatched": unmatched,
-                            "failed": failed,
+                            "movies": len(movies),
+                            "episodes": len(episodes),
+                            "would_import" if dry_run else "imported": totals["imported"],
+                            "skipped_duplicates": totals["skipped_duplicates"],
+                            "unmatched": totals["unmatched"],
+                            "failed": totals["rejected_items"],
+                            "failed_batches": totals["failed_batches"],
+                            "not_sent": totals["not_sent"],
                             "items": diagnostics,
                         },
                     )
 
                 if dry_run:
                     msg = _s(32107).format(
-                        importable_movies + importable_episodes,
-                        skipped_duplicates,
-                        unmatched,
+                        totals["imported"],
+                        totals["skipped_duplicates"],
+                        totals["unmatched"],
                     )
+                    icon = xbmcgui.NOTIFICATION_INFO
+                elif totals["not_sent"]:
+                    # Some entries never reached the backend — say so rather
+                    # than reporting a total that quietly excludes them.
+                    msg = _s(32135).format(totals["imported"], totals["not_sent"])
+                    icon = xbmcgui.NOTIFICATION_WARNING
                 else:
                     msg = _s(32027).format(
-                        importable_movies + importable_episodes,
-                        skipped_duplicates,
-                        unmatched,
+                        totals["imported"],
+                        totals["skipped_duplicates"],
+                        totals["unmatched"],
                     )
-                if failed:
+                    icon = xbmcgui.NOTIFICATION_INFO
+
+                if totals["rejected_items"]:
                     xbmc.log(
-                        f"[PunchPlay] Library sync finished with {failed} failed item(s)",
+                        f"[PunchPlay] Library sync: backend rejected "
+                        f"{totals['rejected_items']} item(s)",
                         xbmc.LOGWARNING,
                     )
-                xbmcgui.Dialog().notification(
-                    NOTIFICATION_TITLE, msg, xbmcgui.NOTIFICATION_INFO, 6000
-                )
+                xbmcgui.Dialog().notification(NOTIFICATION_TITLE, msg, icon, 6000)
                 xbmc.log(f"[PunchPlay] Library sync: {msg}", xbmc.LOGINFO)
                 if diagnostics_path:
                     xbmc.log(
                         f"[PunchPlay] Library diagnostics written to {diagnostics_path}",
                         xbmc.LOGINFO,
                     )
-                if dry_run and (importable_movies + importable_episodes) > 0:
+                if dry_run and totals["imported"] > 0:
                     if xbmcgui.Dialog().yesno(ADDON_NAME, _s(32108)):
                         self._sync_kodi_library(dry_run=False)
 
@@ -495,9 +906,12 @@ class PunchPlayService(xbmc.Monitor):
                     entry["tmdb_id"] = int(tmdb)
                 except (ValueError, TypeError):
                     pass
-            last_played = movie.get("lastplayed", "")
-            if last_played:
-                entry["watched_at"] = last_played
+            watched_at = kodi_datetime_to_utc_iso(movie.get("lastplayed", ""))
+            if watched_at:
+                entry["watched_at"] = watched_at
+            playcount = int(movie.get("playcount") or 0)
+            if playcount > 0:
+                entry["playcount"] = playcount
             results.append(entry)
         return results
 
@@ -538,8 +952,11 @@ class PunchPlayService(xbmc.Monitor):
                     entry["tmdb_id"] = int(tmdb)
                 except (ValueError, TypeError):
                     pass
-            last_played = ep.get("lastplayed", "")
-            if last_played:
-                entry["watched_at"] = last_played
+            watched_at = kodi_datetime_to_utc_iso(ep.get("lastplayed", ""))
+            if watched_at:
+                entry["watched_at"] = watched_at
+            playcount = int(ep.get("playcount") or 0)
+            if playcount > 0:
+                entry["playcount"] = playcount
             results.append(entry)
         return results

--- a/script.punchplay/resources/settings.xml
+++ b/script.punchplay/resources/settings.xml
@@ -12,6 +12,7 @@
     <setting id="scrobble_movies"        type="bool"   label="32038"  default="true"/>
     <setting id="scrobble_tv"            type="bool"   label="32039"  default="true"/>
     <setting id="scrobble_anime"         type="bool"   label="32040"  default="true"/>
+    <setting id="live_watched_sync"      type="bool"   label="32134"  default="true"/>
     <setting id="anime_episode_format"   type="enum" label="32090" lvalues="32091|32111|32112" default="0"/>
     <setting id="watched_threshold"      type="slider" label="32043"  default="90" range="50,5,95" option="int"/>
     <setting id="min_length"             type="number" label="32044"  default="5"/>
@@ -20,11 +21,17 @@
   <category label="32046">
     <setting id="preview_library_btn" type="action" label="32109" action="SetProperty(punchplay_preview_library,1,10000)" option="action"/>
     <setting id="sync_library_btn" type="action" label="32024" action="SetProperty(punchplay_sync_library,1,10000)" option="action"/>
+    <setting id="pull_watched" type="bool" label="32118" default="true"/>
+    <setting id="pull_resume" type="bool" label="32119" default="true"/>
+    <setting id="pull_sync_auto" type="bool" label="32120" default="false"/>
+    <setting id="pull_sync_btn" type="action" label="32117" action="SetProperty(punchplay_pull_sync,1,10000)" option="action"/>
   </category>
 
   <category label="32048">
     <setting id="rate_after_watching" type="bool" label="32020" default="true"/>
+    <setting id="rating_prompt_scope" type="enum" label="32139" lvalues="32140|32141" default="1"/>
     <setting id="rating_prompt_delay" type="number" label="32110" default="2"/>
+    <setting id="clear_rating_suppressions" type="action" label="32129" action="SetProperty(punchplay_clear_suppressions,1,10000)" option="action"/>
   </category>
 
   <category label="32049">


### PR DESCRIPTION
### Changes

Updates the addon from 1.3.0 (currently on the official repo) to 1.5.2. Summary of what changed across that range:

**Sync**
- Two-way sync: "Sync From PunchPlay Now" applies PunchPlay watched history (playcount + lastplayed) and resume points to the Kodi library, matched by TMDB/IMDb ids. Never un-watches local items, and a stale remote resume position can no longer overwrite an item already finished locally.
- Optional auto-sync from PunchPlay every 6 hours (incremental, off by default), with per-item retry so one persistently failing item can't block newer changes forever, and checkpoints that reset after an account or setting change.
- Live watched sync: manually marking a movie/episode watched in the Kodi library now syncs to PunchPlay within seconds, with echo suppression so our own pull-sync and playback writes aren't re-imported. Un-watching an item within the same debounce window as marking it watched now correctly cancels the pending upload instead of still sending it.
- Library import now sends per-item playcounts (rewatches) and converts local-time lastplayed to UTC before upload.
- Import batch size raised from 50 to 100 (the backend maximum), fixing large libraries that previously stopped importing after roughly 5,000 items. A sync that hits errors reports how many items failed instead of claiming success, and stops after three consecutive failed batches instead of grinding through an unreachable backend.

**Reliability**
- Fixed the token-refresh request being rejected outright by the backend's network edge — it was missing the User-Agent header every other request sends, which silently broke reconnection for every user once their access token expired and forced a manual re-login each time.
- Fixed intermittent HTTP 401 errors during sync: token refresh is serialized behind a lock so a heartbeat and a background sync racing on an expired token can no longer invalidate each other's retry.
- Fixed playback left "now playing" on the server forever if Kodi was closed while something was still playing — shutdown now always sends the stop event instead of only clearing local state, and preserves queued/in-flight playback events for ordered offline replay.
- Scrobble events are now sent from a background worker instead of on Kodi's player callback thread, so a slow or unreachable backend can no longer stall play/pause/resume.
- Logout discards queued and in-flight work from the previous account instead of letting it retry with the wrong account's credentials.
- Offline queue entries are dropped after ~1 day of continuous failed retries (previously up to 30 days).

**Ratings**
- Rating prompts no longer block Kodi's player callbacks; the approval poll backs off correctly when the server rate-limits it.
- "Never for this show" suppression is now keyed on the show's canonical id instead of its per-episode year, so it no longer stops matching once a show crosses into a new year.
- Rating prompts can now be limited to movies without disabling episode scrobbling or watched sync.

113 unit tests passing, `kodi-addon-checker --branch omega` clean.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project.
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [script.foo.bar] 1.0.0
