### PR TITLE
[script.module.libard] 6.0.3

### DIFF
--- a/script.module.libard/addon.xml
+++ b/script.module.libard/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.module.libard" name="libard" version="6.0.2" provider-name="sarbes">
+<addon id="script.module.libard" name="libard" version="6.0.3" provider-name="sarbes">
   <requires>
     <import addon="xbmc.python" version="3.0.0"/>
     <import addon="script.module.libmediathek4" version="1.0.0"/>

--- a/script.module.libard/lib/libardnewjsonparser.py
+++ b/script.module.libard/lib/libardnewjsonparser.py
@@ -117,15 +117,47 @@ class parser:
 	"""
 
 	def parseVideo(self,clipId='Y3JpZDovL2JyLmRlL3ZpZGVvL2NkNzBjODMwLTM2ZTAtNDljNC1iMDJiLTQyNWNhMWIyZDg3NA',client="ard"):
-		j = requests.get(f'{apiUrl}/mediacollection/{clipId}?devicetype={self.deviceType}',headers=headers).json()
-		for item in j['_mediaArray'][0]['_mediaStreamArray']:
-			if item['_quality'] == 'auto':
-				url = item['_stream']
-		if url.startswith('//'): 
-			url = 'http:' + url
+		response = requests.get(
+			f'{apiUrl}/pages/ard/item/{clipId}?embedded=false&mcV6=true&devicetype={self.deviceType}',
+			headers=headers
+		)
+		response.raise_for_status()
+		j = response.json()
+
+		mediaCollection = next(
+			widget['mediaCollection']['embedded']
+			for widget in j['widgets']
+			if 'mediaCollection' in widget
+		)
+
+		url = None
+		for stream in mediaCollection.get('streams', []):
+			for media in stream.get('media', []):
+				if media.get('mimeType') == 'application/vnd.apple.mpegurl':
+					url = media['url']
+					break
+			if url:
+				break
+
+		if not url:
+			raise RuntimeError('ARD: no HLS stream found')
+
 		d = {'media':[{'url':url, 'stream':'HLS'}]}
-		if '_subtitleUrl' in j:
-			d['subtitle'] = [{'url':j['_subtitleUrl'], 'type':'ttml', 'lang':'de', 'colour':True}]
+
+		subtitles = []
+		for subtitle in mediaCollection.get('subtitles', []):
+			for source in subtitle.get('sources', []):
+				if source.get('kind') == 'webvtt':
+					subtitles.append({
+						'url': source['url'],
+						'type': 'webvtt',
+						'lang': subtitle.get('languageCode', 'deu'),
+						'colour': True
+					})
+
+		if subtitles:
+			d['subtitle'] = subtitles
+
 		return d
 
 


### PR DESCRIPTION
### Description
Fix ARD Mediathek and Sportschau playback after changes to the ARD API.

The old `/page-gateway/mediacollection/{id}` endpoint now returns HTTP 404.

This update:
- uses the current `/page-gateway/pages/ard/item/{id}` endpoint with mediaCollection v6
- parses HLS streams from the new `streams/media` structure
- updates subtitle parsing to use the new WebVTT subtitle sources

Tested playback with:
- plugin.video.ardmediathek_de
- plugin.video.sportschau

### Checklist:
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project.
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [script.foo.bar] 1.0.0