### PR TITLE
[weather.ozweather@matrix] 2.2.2

### DIFF
--- a/weather.ozweather/addon.xml
+++ b/weather.ozweather/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="weather.ozweather" name="OzWeather" version="2.2.1" provider-name="Bossanova808">
+<addon id="weather.ozweather" name="OzWeather" version="2.2.2" provider-name="Bossanova808">
 	<requires>
 		<import addon="xbmc.python" version="3.0.0"/>
     	<import addon="script.module.requests" version="2.22.0+matrix.1"/>
@@ -23,9 +23,8 @@
        		<icon>icon.png</icon>
        		<fanart>fanart.jpg</fanart>
 		</assets>
-		<news>v2.2.1
-- Fix log spam and garbled display text (RainChance, RainAmount, HighTemp, UVIndex, etc. showing "None") for the furthest-out forecast day when the BOM hasn't yet published its data
-- Use shared bossanova808 helpers for settings access and error notifications, for consistency
+		<news>v2.2.2
+- Fix blank Outlook/Condition text on any day where the BOM omits short_text (falls back to the first sentence of extended_text, then the icon descriptor)
     	</news>
 	</extension>
 </addon>

--- a/weather.ozweather/changelog.txt
+++ b/weather.ozweather/changelog.txt
@@ -1,3 +1,6 @@
+v2.2.2 (2026-08-26)
+- Fix blank Outlook/Condition text on any day where the BOM omits short_text (falls back to the first sentence of extended_text, then the icon descriptor)
+
 v2.2.1 (2026-08-15)
 - Fix log spam and garbled display text (RainChance, RainAmount, HighTemp, UVIndex, etc. showing "None") for the furthest-out forecast day when the BOM hasn't yet published its data
 - Use shared bossanova808 helpers for settings access and error notifications, for consistency

--- a/weather.ozweather/resources/lib/bom/bom_forecast.py
+++ b/weather.ozweather/resources/lib/bom/bom_forecast.py
@@ -303,8 +303,21 @@ def bom_forecast(geohash):
             # Date (Apr 4)
             set_key(weather_data, i, "ShortDate", forecast_datetime.strftime('%b ') + forecast_datetime.strftime('%d').lstrip('0'))
             # Outlook / Condition (same thing)
-            set_key(weather_data, i, "Outlook", forecast_seven_days[i]['short_text'] or "")
-            set_key(weather_data, i, "Condition", forecast_seven_days[i]['short_text'] or "")
+            # BOM sometimes omits short_text for a whole forecast region (seen for "West and South
+            # Gippsland", for example) even while extended_text and/or icon_descriptor are still
+            # present - fall back to those in turn rather than showing nothing
+            if forecast_seven_days[i]['short_text']:
+                outlook_text = forecast_seven_days[i]['short_text']
+            elif forecast_seven_days[i]['extended_text']:
+                outlook_text = forecast_seven_days[i]['extended_text'].split('. ')[0].strip()
+                if outlook_text and not outlook_text.endswith('.'):
+                    outlook_text += '.'
+            elif forecast_seven_days[i]['icon_descriptor']:
+                outlook_text = forecast_seven_days[i]['icon_descriptor'].replace('_', ' ').capitalize() + '.'
+            else:
+                outlook_text = ""
+            set_key(weather_data, i, "Outlook", outlook_text)
+            set_key(weather_data, i, "Condition", outlook_text)
             #  See end of loop for the extended forecast (OutlookLong, ConditionLong)
             #  as we add warnings and sun protection info.OutlookLong / ConditionLong (same thing) - extended text forecast -
 
@@ -334,7 +347,10 @@ def bom_forecast(geohash):
                 else:
                     Logger.error(f'Could not find icon code for BOM icon_descriptor: {forecast_seven_days[i]["icon_descriptor"]} and from short text {descriptor_from_short_text}')
                     # Pop the missing icon descriptor into the outlook to make it easier for people to report in the forum thread
-                    set_key(weather_data, i, "Outlook", f"[{forecast_seven_days[i]['icon_descriptor']}] {forecast_seven_days[i]['short_text']}")
+                    # (using outlook_text, not the possibly-None short_text, so this can't clobber the fallback above with literal "None")
+                    debug_outlook_text = f"[{forecast_seven_days[i]['icon_descriptor']}] {outlook_text}"
+                    set_key(weather_data, i, "Outlook", debug_outlook_text)
+                    set_key(weather_data, i, "Condition", debug_outlook_text)
 
             Logger.debug(f"Icon descriptor is: {icon_descriptor}, icon code is {icon_code}")
             set_keys(weather_data, i, ["OutlookIcon", "ConditionIcon"], f'{icon_code}.png')


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: OzWeather
  - Add-on ID: weather.ozweather
  - Version number: 2.2.2
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/bossanova808/weather.ozweather
  
Weather forecasting and radar images for Australia using Bureau of Meteorology data.  For full features (animated radars & ABC weather videos) - make sure you install the replacement skin files - see information at the addon wiki (https://kodi.wiki/index.php?title=Add-on:Oz_Weather).

### Description of changes:

v2.2.2
- Fix blank Outlook/Condition text on any day where the BOM omits short_text (falls back to the first sentence of extended_text, then the icon descriptor)
    	

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
